### PR TITLE
Removed references to node_events.h

### DIFF
--- a/include/commit.h
+++ b/include/commit.h
@@ -8,7 +8,7 @@
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
@@ -23,7 +23,7 @@ using namespace v8;
 /**
  * Class wrapper for libgit2 git_commit
  */
-class GitCommit : public EventEmitter {
+class GitCommit : public ObjectWrap {
   public:
     /**
      * v8::FunctionTemplate used to create Node.js constructor

--- a/include/error.h
+++ b/include/error.h
@@ -7,7 +7,7 @@
 #define ERROR_H
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/include/index.h
+++ b/include/index.h
@@ -7,8 +7,7 @@
 #define INDEX_H
 
 #include <node.h>
-#include <node_events.h>
-
+#include <node_object_wrap.h>
 #include "../vendor/libgit2/include/git2.h"
 
 using namespace node;

--- a/include/object.h
+++ b/include/object.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
@@ -19,7 +19,7 @@ using namespace node;
 /**
  * Class wrapper for libgit2 git_object
  */
-class GitObject : public EventEmitter {
+class GitObject : public ObjectWrap {
   public:
     /**
      * v8::FunctionTemplate used to create Node.js constructor

--- a/include/odb.h
+++ b/include/odb.h
@@ -7,7 +7,7 @@
 #define ODB_H
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/include/odb_backend.h
+++ b/include/odb_backend.h
@@ -7,7 +7,7 @@
 #define ODB_BACKEND_H
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/include/oid.h
+++ b/include/oid.h
@@ -7,14 +7,14 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
 using namespace node;
 using namespace v8;
 
-class GitOid : public EventEmitter {
+class GitOid : public ObjectWrap {
   public:
     static Persistent<FunctionTemplate> constructor_template;
     static void Initialize (Handle<v8::Object> target);

--- a/include/reference.h
+++ b/include/reference.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <string>
 
 #include "../vendor/libgit2/include/git2.h"
@@ -18,7 +18,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 using namespace node;
 using namespace v8;
 
-class GitReference : public EventEmitter {
+class GitReference : public ObjectWrap {
   public:
     static Persistent<FunctionTemplate> constructor_template;
     static void Initialize(Handle<v8::Object> target);

--- a/include/repo.h
+++ b/include/repo.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <string>
 
 #include "../vendor/libgit2/include/git2.h"
@@ -17,7 +17,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 using namespace node;
 using namespace v8;
 
-class GitRepo : public EventEmitter {
+class GitRepo : public ObjectWrap {
   public:
     static Persistent<FunctionTemplate> constructor_template;
     static void Initialize(Handle<v8::Object> target);

--- a/include/revwalk.h
+++ b/include/revwalk.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
@@ -17,7 +17,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 using namespace node;
 using namespace v8;
 
-class GitRevWalk : public EventEmitter {
+class GitRevWalk : public ObjectWrap {
   public:
     static Persistent<FunctionTemplate> constructor_template;
     static void Initialize(Handle<v8::Object> target);

--- a/include/sig.h
+++ b/include/sig.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
@@ -16,7 +16,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 using namespace v8;
 using namespace node;
 
-class GitSig : public EventEmitter {
+class GitSig : public ObjectWrap {
   public:
     static Persistent<FunctionTemplate> constructor_template;
     static void Initialize(Handle<v8::Object> target);

--- a/include/tag.h
+++ b/include/tag.h
@@ -7,7 +7,7 @@
 #define TAG_H
 
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/include/tree.h
+++ b/include/tree.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <string>
 
 #include "../vendor/libgit2/include/git2.h"
@@ -21,7 +21,7 @@ using namespace node;
 /**
  * Class wrapper for libgit2 git_tree
  */
-class GitTree : public EventEmitter {
+class GitTree : public ObjectWrap {
   public:
     /**
      * v8::FunctionTemplate used to create Node.js constructor

--- a/include/tree_entry.h
+++ b/include/tree_entry.h
@@ -7,7 +7,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 
@@ -22,7 +22,7 @@ using namespace node;
 /**
  * Class wrapper for libgit2 git_tree_entry
  */
-class GitTreeEntry : EventEmitter {
+class GitTreeEntry : ObjectWrap {
   public:
     /**
      * v8::FunctionTemplate used to create Node.js constructor

--- a/src/base.cc
+++ b/src/base.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/commit.cc
+++ b/src/commit.cc
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/error.cc
+++ b/src/error.cc
@@ -5,7 +5,7 @@
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/object.cc
+++ b/src/object.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/oid.cc
+++ b/src/oid.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/reference.cc
+++ b/src/reference.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <string>
 
 #include "../vendor/libgit2/include/git2.h"

--- a/src/repo.cc
+++ b/src/repo.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 #include <string>
 
 #include "../vendor/libgit2/include/git2.h"

--- a/src/revwalk.cc
+++ b/src/revwalk.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/sig.cc
+++ b/src/sig.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/tree.cc
+++ b/src/tree.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 

--- a/src/tree_entry.cc
+++ b/src/tree_entry.cc
@@ -4,7 +4,7 @@ Copyright (c) 2011, Tim Branyen @tbranyen <tim@tabdeveloper.com>
 
 #include <v8.h>
 #include <node.h>
-#include <node_events.h>
+#include <node_object_wrap.h>
 
 #include "../vendor/libgit2/include/git2.h"
 


### PR DESCRIPTION
It looks to me like this solves the compilation problem through 0.5.3 that was caused by the removal of node_events.h from node.js. Same tests pass/fail before and after this change.
