### PR TITLE
Issue 35: repo has no method 'branch'

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -11,7 +11,7 @@ exports.repo = function(dir, async) {
 
   if (dir && async) {
     self.repo.open(dir, function() {
-      git.util().asyncComplete.call(this, arguments, async);
+      git.util().asyncComplete.call(self, arguments, async);
     });
   }
   else if (dir) {


### PR DESCRIPTION
the example snippet (from readme.md) is not working anymore. It complains
about a missing method 'branch'. According to aaberg this is due a wrong
argument for git.util().asyncComplete(). In repo.js:14 the callback gets called
with this instead of self.
