### PR TITLE
Update documented commands needed to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,9 @@ Running tests
 
 __`nodegit` library code is written adhering to a modified `JSHint`. Run these checks with `make lint` in the project root.__
 
-__To run unit tests ensure the submodules `nodeunit` and `rimraf` are located in the `vendor/` subdirectory.__
+__To run unit tests ensure to update the submodules with `git submodule update --init` and install the development dependencies nodeunit and rimraf with `npm install`.__
 
-If they are not, `cd` into the `nodegit` dir and run the following `git` commands to automatically fetch them:
-    $ cd nodegit
-    $ git submodule update --init
-
-Then simply run `make test` in the project root.
+Then simply run `npm test` in the project root.
 
 Generating documentation
 ------------------------


### PR DESCRIPTION
I was following the instructions to run the tests and `make test` gave me this: `make: Nothing to be done for test.`

I was able to run the tests using

```
git submodule update --init
npm install
npm test
```

so I assume the readme is just needs an update.

Thanks!
