### PR TITLE
Fix Load-Order Bug

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -58,7 +58,7 @@ var _Tree = function( obj, tree ) {
           prerequisites++;
 
           !tree.error && tree.walk( repo ).on( 'entry', function( i, entry ) {
-            entry.dir += dir + '/';
+            entry.dir = dir + '/' + entry.dir;
             event.emit( 'entry', i, entry );
           }).on( 'end' , function( ) {
             prerequisites--;


### PR DESCRIPTION
Hey guys-

To be honest, I'm not sure if this is a bug or not. I've found it inconvenient behavior in my own use, so I've changed it in my local fork. Currently, when a nested directory is iterated over, the 'end' event is only called when all the root entries have loaded, meaning that it is impossible to know when all sub-entries are complete.

This patch requires that all sub-queries load before the root directory is to load. (There's a line in here, "tree.error" that I'm not sure I understand — right now the "end" event will not fire if this the case.)
