### PR TITLE
Fixed TreeBuilder.write's missing repo argument to match its documentation

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -2,6 +2,7 @@ var git = require('../'),
     util = require('./util.js'),
     Repo = git.Repo,
     Tree = git.Tree,
+    TreeBuilder = git.TreeBuilder,
     Reference = git.Reference;
 
 /**
@@ -195,4 +196,17 @@ Repo.prototype.createCommit = function(updateRef, author, committer, message, tr
 var oldCreateBlobFromBuffer = Repo.prototype.createBlobFromBuffer;
 Repo.prototype.createBlobFromBuffer = function(buffer, callback) {
   oldCreateBlobFromBuffer.call(this, buffer, buffer.length, callback);
+};
+
+/**
+ * Create a new tree builder.
+ *
+ * @param {Tree} tree
+ * @param {Function} callback
+ */
+Repo.prototype.treeBuilder = function(callback) {
+  var builder = TreeBuilder.create(null);
+  builder.root = builder;
+  builder.repo = this;
+  return builder;
 };


### PR DESCRIPTION
I guess TreeBuilder was not yet used to create a bare repository's first commit. In the following example TreeBuilder.write throws an exception with the old code:

```
git.Repo.init('repo', true, function(err,repo) {
    if (err) { return cb(err); }
    repo.createBlobFromFile('README.md',function(err,blobId) {
        if (err) { return cb(err); }
        var treeBuilder = git.TreeBuilder.create(null); // null -> this is key
        treeBuilder.insert('README.md', blobId, 0100644);
        treeBuilder.write(repo, function(err,treeId) { // This threw an exception
            var signature = git.Signature.now('The Dude', 'thedude@dude.com');
            repo.createCommit(null, signature, signature, null, 'Initial commit', treeId, 0, [], function(err,commitId) {
                if (err) { return cb(err); }
                cb(null, repo);
            });
        });
    });
});
```

The documentation said the first argument of 'write' is the repo (http://www.nodegit.org/nodegit/#TreeBuilder-write), so this change should match the code with the documentation.
This is however a breaking change, so any code that depended on TreeBuilder.write needs to be altered. Alternatively we could potentially use something like 'repo || self.repo'.
