### PR TITLE
cmake 2.8 is required to build nodegit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Building and installing
 
 ### Dependencies ###
 
-To install `nodegit` you need `Node.js`, `python` and `cmake`.
+To install `nodegit` you need `Node.js`, `python` and `cmake` (>=2.8).
 
 ### Easy install (Recommended) ###
 This will install and configure everything you need to use `nodegit`.


### PR DESCRIPTION
The "--build" option appeared in 2.8, some distros such as rhel provide cmake 2.6 by default and it can take a while to figure why the build fails.
