### PR TITLE
Try requiring build/Debug/nodegit if build/Release/nodegit wasn't found.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,12 @@ if (~os.type().indexOf('CYGWIN') && !~path.indexOf(root)) {
 }
 
 // Assign raw api to module
-var rawApi = require('./build/Release/nodegit');
+var rawApi;
+try {
+  rawApi = require('./build/Release/nodegit');
+} catch (e) {
+  rawApi = require('./build/Debug/nodegit');
+}
 for (var key in rawApi) {
   exports[key] = rawApi[key];
 }


### PR DESCRIPTION
I just spent half an hour trying to figure out why nodegit couldn't require `build/Release/nodegit.node`. Turns out I was running version of node that was built with `./configure --debug`, which for some reason makes node-gyp put the compiled binary in another directory, `build/Debug/`.

This fix falls back to looking in the `Debug` directory if `nodegit.node` couldn't be found in the `Release` directory.
