### PR TITLE
Added git_diff_delta_dup to git_diff_get_patch to fix a memory issue whe...

### DIFF
--- a/src/diff_list.cc
+++ b/src/diff_list.cc
@@ -211,6 +211,9 @@ Handle<Value> GitDiffList::Patch(const Arguments& args) {
     toReturn->Set(String::NewSymbol("patch"), to);
 
       if (delta_out != NULL) {
+    delta_out = (const git_diff_delta * )git_diff_delta_dup(delta_out);
+  }
+  if (delta_out != NULL) {
     to = GitDelta::New((void *)delta_out);
   } else {
     to = Null();

--- a/v0.18.0.json
+++ b/v0.18.0.json
@@ -3689,6 +3689,7 @@
             "name": "delta_out",
             "jsName": "delta",
             "cType": "const git_diff_delta **",
+            "copy": "git_diff_delta_dup",
             "cppClassName": "GitDelta",
             "jsClassName": "Delta",
             "isReturn": true,


### PR DESCRIPTION
...n accessing DiffList patches.
