### PR TITLE
Fix erroneous OS detection for installation in OS X.

### DIFF
--- a/install.js
+++ b/install.js
@@ -129,7 +129,7 @@ var dependencies = Q.allSettled([
   var flags = ['-DTHREADSAFE=ON', '-DBUILD_CLAR=OFF'];
 
   // Windows flags.
-  if (process.platform.indexOf('win') > -1) {
+  if (process.platform === 'win32') {
     flags.push.apply(flags, [
       '-DSTDCALL=OFF',
       '-DBUILD_SHARED_LIBS=OFF',


### PR DESCRIPTION
For some reason I thought there was a `win64`.
