### PR TITLE
require --documentation flag to include text in idefs

### DIFF
--- a/generate/setup.js
+++ b/generate/setup.js
@@ -121,5 +121,9 @@ output.forEach(function (def) {
   });
 });
 
+if (process.argv[2] != "--documentation") {
+  utils.filterDocumentation(output);
+}
+
 fs.writeFileSync(path.join(__dirname, "idefs.json"),
   JSON.stringify(output, null, 2));

--- a/generate/utils.js
+++ b/generate/utils.js
@@ -125,7 +125,7 @@ var Utils = {
       _.merge(field, callbackDefs[field.type]);
     }
     else {
-      console.log("WARNGING: Couldn't find callback definition for " + field.type);
+      console.log("WARNING: Couldn't find callback definition for " + field.type);
     }
   },
 
@@ -319,6 +319,48 @@ var Utils = {
     }
 
     _.merge(fnDef, _.omit(fnOverrides, "args", "return"));
+  },
+
+  filterIgnored: function (arr, callback) {
+    for (var i = arr.length - 1; i >= 0; i--) {
+      if (arr[i].ignore) {
+        arr.splice(i, 1);
+      }
+      else if (callback) {
+        callback(arr[i]);
+      }
+    }
+  },
+
+  deleteProperties: function(obj) {
+    delete obj.line;
+    delete obj.lineto;
+    delete obj.block;
+    delete obj.description;
+    delete obj.comments;
+    delete obj.tdef;
+    delete obj.decl;
+    delete obj.comments;
+    delete obj.argline;
+    delete obj.sig;
+  },
+
+  filterDocumentation: function(idefs) {
+    Utils.filterIgnored(idefs, function (idef) {
+      Utils.deleteProperties(idef);
+
+      Utils.filterIgnored(idef.fields, Utils.deleteProperties);
+
+
+      Utils.filterIgnored(idef.functions, function (fn) {
+        Utils.deleteProperties(fn);
+
+        Utils.filterIgnored(fn.args, function(arg) {
+          Utils.deleteProperties(arg);
+          delete arg.functions;
+        });
+      });
+    });
   }
 };
 


### PR DESCRIPTION
If you pass --generate as an arg to setup.js it should behave as previously, but now a normal build will reduce the size of idefs by almost 2/3
