### PR TITLE
voidcheck string pointers and reenable attr test

### DIFF
--- a/generate/descriptor.json
+++ b/generate/descriptor.json
@@ -3,6 +3,14 @@
     "functions": {
       "git_attr_foreach": {
         "ignore": true
+      },
+      "git_attr_get": {
+        "isAsync": true,
+        "args": {
+          "value_out": {
+            "isReturn": true
+          }
+        }
       }
     }
   },

--- a/generate/partials/convert_to_v8.cc
+++ b/generate/partials/convert_to_v8.cc
@@ -1,12 +1,18 @@
 // start convert_to_v8 block
 {%if cppClassName == 'String' %}
+  if ({{= parsedName =}}){
   {%if size %}
-to = NanNew<String>({{= parsedName =}}, {{ size }});
+    to = NanNew<String>({{= parsedName =}}, {{ size }});
   {%elsif cType == 'char **' %}
-to = NanNew<String>(*{{= parsedName =}});
+
+    to = NanNew<String>(*{{= parsedName =}});
   {%else%}
-to = NanNew<String>({{= parsedName =}});
+    to = NanNew<String>({{= parsedName =}});
   {%endif%}
+  }
+  else {
+    to = NanNull();
+  }
 
   {%if freeFunctionName %}
 {{ freeFunctionName }}({{= parsedName =}});

--- a/test/tests/attr.js
+++ b/test/tests/attr.js
@@ -25,15 +25,8 @@ describe("Attr", function() {
     Attr.cacheFlush(this.repository);
   });
 
-  // FIXME Currently segfaults.
-  it.skip("can lookup the value of a git attribute", function() {
+  it("can lookup the value of a git attribute", function() {
     var flags = Attr.Check.NO_SYSTEM;
-    var getAttr = Attr.get(this.repository, flags, ".gitattributes", "test");
-
-    return getAttr.then(function(val) {
-      console.log(val);
-    }).catch(function(ex) {
-      console.log(ex);
-    });
+    Attr.get(this.repository, flags, ".gitattributes", "test");
   });
 });


### PR DESCRIPTION
The attr test was failing (and being skipped) because of a segfault. Some libgit2 functions that output to char*\* just don't even allocate the inner string if they have no output, so we need to voidcheck the inner pointer. Combined with a tweak to make git_attr_get async and to make the templates recognize its return, the test passes. 
