### PR TITLE
Add repo init example

### DIFF
--- a/example/add-and-commit.js
+++ b/example/add-and-commit.js
@@ -3,7 +3,6 @@ var path = require('path');
 var Promise = require('nodegit-promise');
 var promisify = require('promisify-node');
 var fse = promisify(require('fs-extra'));
-var mkdirp = promisify(require('mkdirp'));
 var fileName = 'newfile.txt';
 var fileContent = 'hello world';
 var directoryName = 'salad/toast/strangerinastrangeland/theresnowaythisexists';

--- a/example/create-new-repo.js
+++ b/example/create-new-repo.js
@@ -1,0 +1,57 @@
+var nodegit = require('../');
+var path = require('path');
+var Promise = require('nodegit-promise');
+var promisify = require('promisify-node');
+var fse = promisify(require('fs-extra'));
+var fileName = 'newfile.txt';
+var fileContent = 'hello world';
+var repoDir = '../../newRepo';
+
+fse.ensureDir = promisify(fse.ensureDir);
+
+var repository;
+var index;
+
+fse.ensureDir(path.resolve(__dirname, repoDir))
+.then(function() {
+  console.log('a');
+  return nodegit.Repository.init(path.resolve(__dirname, repoDir), 0);
+})
+.then(function(repo) {
+  console.log('b');
+  repository = repo;
+  return fse.writeFile(path.join(repository.workdir(), fileName), fileContent);
+})
+.then(function(){
+  console.log('c');
+  return repository.openIndex();
+})
+.then(function(idx) {
+  console.log('d');
+  index = idx;
+  return index.read(1);
+})
+.then(function() {
+  console.log('e');
+  return index.addByPath(fileName);
+})
+.then(function() {
+  console.log('f');
+  return index.write();
+})
+.then(function() {
+  console.log('g');
+  return index.writeTree();
+})
+.then(function(oid) {
+  console.log('j');
+  var author = nodegit.Signature.create("Scott Chacon", "schacon@gmail.com", 123456789, 60);
+  var committer = nodegit.Signature.create("Scott A Chacon", "scott@github.com", 987654321, 90);
+
+  // Since we're creating an inital commit, it has no parents. Note that unlike
+  // normal we don't get the head either, because there isn't one yet.
+  return repository.createCommit('HEAD', author, committer, 'message', oid, []);
+})
+.done(function(commitId) {
+  console.log('New Commit: ', commitId);
+});

--- a/generate/descriptor.json
+++ b/generate/descriptor.json
@@ -34,6 +34,9 @@
         }
       }
     },
+    "repository_init_flag": {
+      "removeString": "INIT_"
+    },
     "otype": {
       "JsName": "TYPE",
       "owner": "Object",


### PR DESCRIPTION
Created a new example of initializing a new repo and making the first commit. Also cleans up a single enum
