### PR TITLE
Add details-for-tree-entry

### DIFF
--- a/example/details-for-tree-entry.js
+++ b/example/details-for-tree-entry.js
@@ -1,0 +1,29 @@
+var nodegit = require('../');
+var path = require('path');
+
+/**
+ * This shows how to get details from a tree entry or a blob
+**/
+
+nodegit.Repository.open(path.resolve(__dirname, '../.git'))
+.then(function(repo) {
+  return repo.getTree(
+    nodegit.Oid.fromString("e1b0c7ea57bfc5e30ec279402a98168a27838ac9"))
+  .then(function(tree) {
+    var treeEntry = tree.entryByIndex(0);
+
+    // Tree entry doesn't have any data associated with the actual entry
+    // To get that we need to get the index entry that this points to
+    return repo.openIndex().then(function(index) {
+      var indexEntry = index.getByPath(treeEntry.path());
+
+      // With the index entry we can now view the details for the tree entry
+      console.log("Entry path: " + indexEntry.path());
+      console.log("Entry time in seconds: " + indexEntry.mtime().seconds());
+      console.log("Entry oid: " + indexEntry.id().toString());
+      console.log("Entry size: " + indexEntry.fileSize());
+    });
+  })
+}).done(function() {
+  console.log("Done!");
+});

--- a/generate/descriptor.json
+++ b/generate/descriptor.json
@@ -598,6 +598,13 @@
         "git_index_free": {
           "ignore": true
         },
+        "git_index_get_bypath": {
+          "args": {
+            "stage": {
+              "isOptional": true
+            }
+          }
+        },
         "git_index_new": {
           "ignore": true
         },


### PR DESCRIPTION
This adds an example which shows how to retrieve details for a
tree entry. You have to go into the index and get the details
since they aren't stored on the tree entry itself. This is the same
for a blob entry as well.

This helps with #221
