### PR TITLE
Fix #311

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -115,7 +115,7 @@ Repository.prototype.getReference = function(name, callback) {
 
   return Reference.lookup(this, name).then(function(reference) {
     if (reference.isSymbolic()) {
-      return reference.resolve(function (error, reference) {
+      return reference.resolve().then(function(reference) {
         reference.repo = repository;
 
         if (typeof callback === "function") {
@@ -123,7 +123,7 @@ Repository.prototype.getReference = function(name, callback) {
         }
 
         return reference;
-      });
+      }, callback);
     } else {
       reference.repo = repository;
       if (typeof callback === "function") {


### PR DESCRIPTION
When getting a symbolic reference we were doing another call to resolve the reference and that call broke the promise chain. Now we don't treat it like a callback but rather as a promise which is what it is.
