### PR TITLE
Do not double free during callbacks.

### DIFF
--- a/generate/combyne/partials/async_function.cc
+++ b/generate/combyne/partials/async_function.cc
@@ -118,9 +118,13 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       {%if arg.shouldAlloc %}
         {%if not arg.isCppClassStringOrArray %}
         {%elsif arg | isOid %}
-    baton->{{ arg.name}}NeedsFree = false;
-        {%endif%}
+    if (baton->{{ arg.name}}NeedsFree) {
+      baton->{{ arg.name}}NeedsFree = false;
+      free((void*)baton->{{ arg.name }});
+    }
+        {%else%}
     free((void*)baton->{{ arg.name }});
+        {%endif%}
       {%endif%}
     {%endeach%}
   }
@@ -138,6 +142,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       {%endif%}
     {%elsif arg | isOid %}
   if (baton->{{ arg.name}}NeedsFree) {
+    baton->{{ arg.name}}NeedsFree = false;
     free((void *)baton->{{ arg.name }});
   }
     {%endif%}

--- a/generate/combyne/partials/async_function.cc
+++ b/generate/combyne/partials/async_function.cc
@@ -114,8 +114,12 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       callback->Call(0, NULL);
     }
 
-    {%each args as arg %}
+    {%each args|argsInfo as arg %}
       {%if arg.shouldAlloc %}
+        {%if not arg.isCppClassStringOrArray %}
+        {%elsif arg | isOid %}
+    baton->{{ arg.name}}NeedsFree = false;
+        {%endif%}
     free((void*)baton->{{ arg.name }});
       {%endif%}
     {%endeach%}


### PR DESCRIPTION
Continuing from https://github.com/nodegit/nodegit/issues/331, as it is a different issue.

Here is the backtrace obtained via lldb:
```
* thread #1: tid = 0xdd2c0, 0x00007fff973f219f libsystem_malloc.dylib`malloc_error_break, queue = 'com.apple.main-thread', stop reason = breakpoint 1.1
  * frame #0: 0x00007fff973f219f libsystem_malloc.dylib`malloc_error_break
    frame #1: 0x00007fff973e38c5 libsystem_malloc.dylib`free + 314
    frame #2: 0x000000010327f77b nodegit.node`GitCommit::LookupWorker::HandleOKCallback(this=0x0000000100d09790) + 859 at commit.cc:689
    frame #3: 0x000000010324d812 nodegit.node`NanAsyncWorker::WorkComplete(this=0x0000000100d09790) + 66 at nan.h:1881
    frame #4: 0x000000010324e2d1 nodegit.node`NanAsyncExecuteComplete(req=0x0000000100d09798) + 33 at nan.h:1948
    frame #5: 0x00000001004598da node`uv__work_done + 168
    frame #6: 0x0000000100450717 node`uv__async_event + 62
    frame #7: 0x000000010045088a node`uv__async_io + 136
    frame #8: 0x000000010045d256 node`uv__io_poll + 1463
    frame #9: 0x0000000100450cd1 node`uv_run + 239
    frame #10: 0x0000000100409e6a node`node::Start(int, char**) + 365
    frame #11: 0x0000000100000b74 node`start + 52
```

Here is the relevant part of commit.cc in which the error happen:

```
void GitCommit::LookupWorker::HandleOKCallback() {
  TryCatch try_catch;

  if (baton->error_code == GIT_OK) {
    Handle<Value> to;
// start convert_to_v8 block
  
  if (baton->commit != NULL) {
    // GitCommit baton->commit
       to = GitCommit::New((void *)baton->commit, false);
   }
  else {
    to = NanNull();
  }

 // end convert_to_v8 block
    Handle<Value> result = to;
    Handle<Value> argv[2] = {
      NanNull(),
      result
    };
    callback->Call(2, argv);
  } else {
    if (baton->error) {
      Handle<Value> argv[1] = {
        NanError(baton->error->message)
      };
      callback->Call(1, argv);
      if (baton->error->message)
        free((void *)baton->error->message);
      free((void *)baton->error);
    } else {
      callback->Call(0, NULL);
    }

    free((void*)baton->id); // here is the first free
  }

  if (try_catch.HasCaught()) {
    node::FatalException(try_catch);
  }

  if (baton->idNeedsFree) {
    free((void *)baton->id); // here happens the problem, the second free
  }

  delete baton;
}
```

Adding this line before the first free fixes it.
```
baton->idNeedsFree = false;
```

I did that in the templates. Let me know if it is ok, or if I should change something.

I can even add a unit test, but I might need some pointers in how catch the issue in the smallest case.