### PR TITLE
Update dependency fs-extra to ~0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "find-parent-dir": "^0.3.0",
-    "fs-extra": "^0.12.0",
+    "fs-extra": "~0.14.0",
     "node-pre-gyp": "~0.5.27",
     "nodegit-promise": "~1.0.0",
     "promisify-node": "~0.1.2"


### PR DESCRIPTION
Looks like nodegit works fine with fs-extra v0.14, would you like to merge this PR, thanks.