### PR TITLE
Added checkout head method and tests

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -182,6 +182,27 @@
         }
       }
     },
+    "checkout": {
+      "functions": {
+        "git_checkout_head": {
+          "args": {
+            "opts": {
+              "isOptional": true
+            }
+          },
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_checkout_index": {
+          "ignore": true
+        },
+        "git_checkout_tree": {
+          "ignore": true
+        }
+      }
+    },
     "clone": {
       "functions": {
         "git_clone": {

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -1,15 +1,32 @@
+var assert = require("assert");
 var path = require("path");
 
 describe("Checkout", function() {
+  var packageJsonOid = "0fa56e90e096a4c24c785206b826ab914ea3de1e";
   var reposPath = path.resolve("test/repos/workdir/.git");
 
   var Repository = require("../../lib/repository");
+  var Checkout = require("../../lib/checkout");
 
   before(function() {
     var test = this;
 
-    return Repository.open(reposPath).then(function(repository) {
-      test.repository = repository;
+    return Repository.open(reposPath).then(function(repo) {
+      test.repo = repo;
+    });
+  });
+
+  it("can checkout the head", function() {
+    var repo = this.repo;
+
+    Checkout.head(repo)
+    .then(function() {
+      return repo.getBlob(packageJsonOid);
+    })
+    .then(function(blob) {
+      var packageJson = blob.toString();
+
+      assert.ok(~packageJson.indexOf("\"ejs\": \"~1.0.0\","));
     });
   });
 });


### PR DESCRIPTION
This exposes the libgit2 `git_checkout_head` method and adds a test. This method will let the user put whatever is in the index that's pointed to by HEAD into the passed repository.