### PR TITLE
INCLUDE_UNTRACKED option not working for diffs

### DIFF
--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -279,6 +279,70 @@
             ]
           }
         }
+      ],
+      [
+        "git_diff_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "uint32_t",
+              "name": "flags"
+            },
+            {
+              "type": "git_submodule_ignore_t",
+              "name": "ignore_submodules"
+            },
+            {
+              "type": "git_strarray",
+              "name": "pathspec"
+            },
+            {
+              "type": "git_diff_notify_cb",
+              "name": "notify_cb"
+            },
+            {
+              "type": "void *",
+              "name": "notify_payload"
+            },
+            {
+              "type": "uint32_t",
+              "name": "context_lines"
+            },
+            {
+              "type": "uint32_t",
+              "name": "interhunk_lines"
+            },
+            {
+              "type": "uint16_t",
+              "name": "id_abbrev"
+            },
+            {
+              "type": "git_off_t",
+              "name": "max_size"
+            },
+            {
+              "type": "const char *",
+              "name": "old_prefix"
+            },
+            {
+              "type": "const char *",
+              "name": "new_prefix"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_diff_init_options",
+              "git_diff_tree_to_workdir",
+              "git_diff_tree_to_workdirext",
+              "git_diff_tree_to_tree"
+            ]
+          }
+        }
       ]
     ],
     "groups": [

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -43,6 +43,10 @@
 
       {% elsif field.isCallbackFunction %}
         if (value->IsFunction()) {
+          if (!wrapper->raw->{{ field.name }}) {
+            wrapper->raw->{{ field.name }} = ({{ field.cType }}){{ field.name }}_cppCallback;
+          }
+
           wrapper->{{ field.name }} = new NanCallback(value.As<Function>());
         }
 

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -63,7 +63,7 @@ void {{ cppClassName }}::ConstructFields() {
 
           // Set the static method call and set the payload for this function to be
           // the current instance
-          this->raw->{{ field.name }} = ({{ field.cType }}){{ field.name }}_cppCallback;
+          this->raw->{{ field.name }} = NULL;
           this->raw->{{ fields|payloadFor field.name }} = (void *)this;
           this->{{ field.name }} = new NanCallback();
         {% elsif field.payloadFor %}

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -3,6 +3,8 @@ var path = require("path");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var Diff = require("../../lib/diff");
+var normalizeOptions = require("../../lib/util/normalize_options");
+var NodeGit = require("../../");
 
 describe("Diff", function() {
   var Repository = require("../../lib/repository");
@@ -33,32 +35,16 @@ describe("Diff", function() {
 
               fse.writeFile(diffFilepath, "1 line\n2 line\n3 line\n\n4")
               .then(function() {
-                return test.repository.openIndex();
-              })
-              .then(function(indexResult) {
-                test.index = indexResult;
-                return test.index.read(1);
-              })
-              .then(function() {
-                return test.index.addByPath(diffFilename);
-              })
-              .then(function() {
-                return test.index.write();
-              })
-              .then(function() {
-                return test.index.writeTree();
-              })
-              .then(function() {
                 Diff.treeToWorkdirWithIndex(
                   test.repository,
                   test.masterCommitTree,
-                  null
+                  normalizeOptions({ flags: Diff.OPTION.INCLUDE_UNTRACKED }, NodeGit.DiffOptions)
                 )
                 .then(function(workdirDiff) {
                   test.workdirDiff = workdirDiff;
                   done();
                 });
-              });
+              })
             });
           });
         });

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -38,13 +38,15 @@ describe("Diff", function() {
                 Diff.treeToWorkdirWithIndex(
                   test.repository,
                   test.masterCommitTree,
-                  normalizeOptions({ flags: Diff.OPTION.INCLUDE_UNTRACKED }, NodeGit.DiffOptions)
+                  normalizeOptions({
+                    flags: Diff.OPTION.INCLUDE_UNTRACKED
+                  }, NodeGit.DiffOptions)
                 )
                 .then(function(workdirDiff) {
                   test.workdirDiff = workdirDiff;
                   done();
                 });
-              })
+              });
             });
           });
         });

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -85,7 +85,7 @@ describe("Diff", function() {
     assert.equal(lines[4].contentLen(), 162);
   });
 
-  it.only("can diff the workdir with index", function() {
+  it("can diff the workdir with index", function() {
     var patches = this.workdirDiff.patches();
     assert.equal(patches.length, 1);
     assert(patches[0].isUntracked());

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -85,7 +85,7 @@ describe("Diff", function() {
     assert.equal(lines[4].contentLen(), 162);
   });
 
-  it("can diff the workdir with index", function() {
+  it.only("can diff the workdir with index", function() {
     var patches = this.workdirDiff.patches();
     assert.equal(patches.length, 1);
 

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -44,11 +44,11 @@ describe("Diff", function() {
     .then(function() {
       return Diff.treeToWorkdirWithIndex(
         test.repository,
-        null,
+        test.masterCommitTree,
         normalizeOptions({
           flags: Diff.OPTION.INCLUDE_UNTRACKED
         }, NodeGit.DiffOptions)
-      )
+      );
     })
     .then(function(workdirDiff) {
       test.workdirDiff = workdirDiff;

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -88,15 +88,15 @@ describe("Diff", function() {
   it.only("can diff the workdir with index", function() {
     var patches = this.workdirDiff.patches();
     assert.equal(patches.length, 1);
+    assert(patches[0].isUntracked());
 
-    var hunks = patches[0].hunks();
-    assert.equal(hunks.length, 1);
+    var oldFile = patches[0].delta.oldFile();
+    assert.equal(oldFile.path(), "wddiff.txt");
+    assert.equal(oldFile.size(), 0);
 
-    var lines = hunks[0].lines();
-    assert.equal(
-      lines[0].content().substr(0, lines[0].contentLen()),
-      "1 line\n"
-    );
+    var newFile = patches[0].delta.newFile();
+    assert.equal(newFile.path(), "wddiff.txt");
+    assert.equal(newFile.size(), 23);
   });
 
   it("can diff with a null tree", function() {

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -55,6 +55,12 @@ describe("Diff", function() {
     });
   });
 
+  after(function(done) {
+    return fse.unlink(diffFilepath).then(function() {
+      done();
+    });
+  });
+
   it("can walk a DiffList", function() {
     var patch = this.diff[0].patches()[0];
 


### PR DESCRIPTION
libgit2 provides `diff_options` flags to `git_diff_tree_to_workdir_with_index` such as including untracked (unstaged) files in a diff. I've added that here using the `normalizeOptions` pattern and it does not seem to be working. I think being able to pass these flags in increases nodegit's usefulness to a wider range of use cases, so I'd like to get this working here.