### PR TITLE
Allow null trees on Diff.treeToTree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /include/
 /lib/enums.js
 /lib/nodegit.js
+/coverage/
 
 
 /vendor/Release

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -483,6 +483,12 @@
         },
         "git_diff_tree_to_tree": {
           "args": {
+            "old_tree": {
+              "isOptional": true
+            },
+            "new_tree": {
+              "isOptional": true
+            },
             "opts": {
               "isOptional": true
             }

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -169,16 +169,21 @@ Commit.prototype.parents = function() {
 Commit.prototype.getDiff = function(callback) {
   var commit = this;
 
-  return commit.getParents().then(function(parents) {
-    var diffs = parents.map(function(parent) {
-      return parent.getTree().then(function(parentTree) {
-        return commit.getTree().then(function(thisTree) {
-          return thisTree.diff(parentTree);
+  return commit.getTree().then(function(thisTree) {
+    return commit.getParents().then(function(parents) {
+      var diffs;
+      if (parents.length) {
+        diffs = parents.map(function(parent) {
+          return parent.getTree().then(function(parentTree) {
+            return thisTree.diff(parentTree);
+          });
         });
-      });
-    });
+      } else {
+        diffs = [thisTree.diff(null)];
+      }
 
-    return Promise.all(diffs);
+      return Promise.all(diffs);
+    });
   }).then(function(diffs) {
     if (typeof callback === "function") {
       callback(null, diffs);

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -109,4 +109,27 @@ describe("Diff", function() {
       "1 line\n"
     );
   });
+
+  it("can diff with a null tree", function(done) {
+    var repo = this.repository;
+    var tree = this.masterCommitTree;
+    Diff.treeToTree(repo, null, tree, null).then(function(diff) {
+      assert.equal(diff.patches().length, 85);
+      done();
+    }, function(error) {
+      console.log(error);
+      done(error);
+    });
+  });
+
+  it("can diff the initial commit of a repository", function(done) {
+    var repo = this.repository;
+    var oid = "99c88fd2ac9c5e385bd1fe119d89c83dce326219"; // First commit
+    repo.getCommit(oid).then(function(commit) {
+      commit.getDiff().then(function(diffs) {
+        assert.equal(diffs[0].patches().length, 8);
+        done();
+      }, function (error) { done(error); });
+    }, function(error) { done(error); });
+  });
 });

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -110,26 +110,21 @@ describe("Diff", function() {
     );
   });
 
-  it("can diff with a null tree", function(done) {
+  it("can diff with a null tree", function() {
     var repo = this.repository;
     var tree = this.masterCommitTree;
-    Diff.treeToTree(repo, null, tree, null).then(function(diff) {
+    return Diff.treeToTree(repo, null, tree, null).then(function(diff) {
       assert.equal(diff.patches().length, 85);
-      done();
-    }, function(error) {
-      console.log(error);
-      done(error);
     });
   });
 
-  it("can diff the initial commit of a repository", function(done) {
+  it("can diff the initial commit of a repository", function() {
     var repo = this.repository;
     var oid = "99c88fd2ac9c5e385bd1fe119d89c83dce326219"; // First commit
-    repo.getCommit(oid).then(function(commit) {
-      commit.getDiff().then(function(diffs) {
+    return repo.getCommit(oid).then(function(commit) {
+      return commit.getDiff().then(function(diffs) {
         assert.equal(diffs[0].patches().length, 8);
-        done();
-      }, function (error) { done(error); });
-    }, function(error) { done(error); });
+      });
+    });
   });
 });


### PR DESCRIPTION
Also, update Commit.getDiff to diff when no parents exists eg. the initial commit of a repository.