### PR TITLE
Removes Node 0.11 testing completely

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 env:
   matrix:
     - export NODE_VERSION="0.10"
-    - export NODE_VERSION="0.11"
 before_install:
   - git clone https://github.com/creationix/nvm.git ./.nvm
   - source ./.nvm/nvm.sh


### PR DESCRIPTION
Doesn't make sense to just remove on Windows.  Lets just drop 0.11 completely for now.