### PR TITLE
Make all cred generators sync.

### DIFF
--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -7,6 +7,10 @@ var token = "{Your GitHub user token}";
 var repoOwner = "{The orgname or username that owns the repo}";
 var repoName = "{The name of the repo}";
 
+// To clone with 2 factor auth enabled, you have to use a github oauth token
+// over https, it can't be done with actual 2 factor.
+// https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
+
 // The token has to be included in the URL if the repo is private.
 // Otherwise, github just wont respond, so a normal credential callback
 // wont work.
@@ -24,14 +28,12 @@ var opts = {
   ignoreCertErrors: 1,
   remoteCallbacks: {
     credentials: function() {
-      return NodeGit.Cred.userpassPlaintextNew (token, "x-oauth-basic");
+      return nodegit.Cred.userpassPlaintextNew (token, "x-oauth-basic");
     }
   }
-}
+};
 
 fse.remove(path).then(function() {
-  var entry;
-
   nodegit.Clone.clone(repoUrl, path, opts)
     .done(function(repo) {
       if (repo instanceof nodegit.Repository) {

--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -1,0 +1,44 @@
+var nodegit = require("../");
+var promisify = require("promisify-node");
+var fse = promisify(require("fs-extra"));
+var path = "/tmp/nodegit-github-2factor-demo";
+
+var token = "{Your GitHub user token}";
+var repoOwner = "{The orgname or username that owns the repo}";
+var repoName = "{The name of the repo}";
+
+// The token has to be included in the URL if the repo is private.
+// Otherwise, github just wont respond, so a normal credential callback
+// wont work.
+var repoUrl = "https://" + token +
+  ":-oauth-basic@github.com/" +
+  repoOwner + "/" +
+  repoName + ".git";
+
+var opts = { ignoreCertErrors: 1};
+
+// If the repo is public, you can use a callback instead
+var repoUrl = "https://github.com/" + repoOwner + "/" + repoName + ".git";
+
+var opts = {
+  ignoreCertErrors: 1,
+  remoteCallbacks: {
+    credentials: function() {
+      return NodeGit.Cred.userpassPlaintextNew (token, "x-oauth-basic");
+    }
+  }
+}
+
+fse.remove(path).then(function() {
+  var entry;
+
+  nodegit.Clone.clone(repoUrl, path, opts)
+    .done(function(repo) {
+      if (repo instanceof nodegit.Repository) {
+        console.info("We cloned the repo!");
+      }
+      else {
+        console.error("Something borked :(");
+      }
+    });
+});

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -364,13 +364,16 @@
     "cred": {
       "cType": "git_cred",
       "functions": {
+        "git_cred_default_new": {
+          "isAsync": false
+        },
         "git_cred_ssh_custom_new": {
           "ignore": true
         },
         "git_cred_ssh_interactive_new": {
           "ignore": true
         },
-        "git_cred_ssh_key_from_agent":{
+        "git_cred_ssh_key_from_agent": {
           "isAsync": false
         },
         "git_cred_ssh_key_new": {
@@ -378,6 +381,9 @@
         },
         "git_cred_userpass": {
           "ignore": true
+        },
+        "git_cred_userpass_plaintext_new": {
+          "isAsync": false
         }
       }
     },

--- a/test/tests/cred.js
+++ b/test/tests/cred.js
@@ -7,9 +7,8 @@ describe("Cred", function() {
   var sshPrivateKey = path.resolve("./id_rsa");
 
   it("can create default credentials", function() {
-    NodeGit.Cred.defaultNew().then(function (defaultCreds) {
-      assert(defaultCreds instanceof NodeGit.Cred);
-    });
+    var defaultCreds = NodeGit.Cred.defaultNew();
+    assert(defaultCreds instanceof NodeGit.Cred);
   });
 
   it("can create ssh credentials using passed keys", function() {
@@ -23,9 +22,8 @@ describe("Cred", function() {
   });
 
   it("can create credentials using plaintext", function() {
-    NodeGit.Cred.userpassPlaintextNew("username", "password")
-    .then(function (plaintextCreds) {
-      assert(plaintextCreds instanceof NodeGit.Cred);
-    });
+    var plaintextCreds = NodeGit.Cred.userpassPlaintextNew
+      ("username", "password");
+    assert(plaintextCreds instanceof NodeGit.Cred);
   });
 });


### PR DESCRIPTION
This was causing weird segfault issues, no idea why any of them were this way (rather, why we didn't override them when we noticed they were async). Also added an example of 2factor auth.

https://github.com/nodegit/nodegit/pull/375
https://github.com/nodegit/nodegit/issues/323
https://github.com/nodegit/nodegit/issues/321
