### PR TITLE
Add 2 convenience methods to revwalk

### DIFF
--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -1,5 +1,6 @@
 var NodeGit = require("../");
 var Revwalk = NodeGit.Revwalk;
+var Promise = require("nodegit-promise");
 
 var oldSorting = Revwalk.prototype.sorting;
 
@@ -53,6 +54,63 @@ Revwalk.prototype.walk = function(oid, callback) {
   }
 
   walk();
+};
+
+
+/**
+ * Walk the history grabbing commits until the checkFn called with the
+ * current commit returns false.
+ *
+ * @param  {Function} checkFn
+ * @return {Array}
+ */
+Revwalk.prototype.getCommitsUntil = function(checkFn) {
+  var commits = [];
+  var walker = this;
+
+  function walkCommitsCb() {
+    return walker.next().then(function(oid) {
+      if (!oid) { return; }
+
+      return walker.repo.getCommit(oid).then(function(commit) {
+        commits.push(commit);
+        if (checkFn(commit)) {
+          return walkCommitsCb();
+        }
+      });
+    });
+  }
+
+  return walkCommitsCb().then(function() {
+    return commits;
+  });
+};
+
+/**
+ * Get some of commits.
+ *
+ * @param  {Number} count (default: 10)
+ * @return {Array}
+ */
+Revwalk.prototype.getCommits = function(count) {
+  count = count || 10;
+  var promises = [];
+  var walker = this;
+
+  function walkCommitsCount(count) {
+    if (count === 0) { return; }
+
+    return walker.next().then(function(oid) {
+      if (!oid) { return; }
+
+      promises.push(walker.repo.getCommit(oid));
+      return walkCommitsCount(count - 1);
+    });
+  }
+
+  return walkCommitsCount(count).then(function() {
+    return Promise.all(promises);
+  });
 };
 
 module.exports = Revwalk;

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -84,6 +84,26 @@ describe("Revwalk", function() {
     });
   });
 
+  it.only("can get a specified number of commits", function() {
+    var test = this;
+    var storedCommits;
+    return test.walker.getCommits()
+      .then(function(commits) {
+        assert.equal(commits.length, 10);
+        storedCommits = commits;
+        test.walker = test.repository.createRevWalk();
+        test.walker.push(test.commit.id());
+
+        return test.walker.getCommits(8);
+      })
+      .then(function(commits) {
+        assert.equal(commits.length, 8);
+        for (var i = 0; i < 8; i++) {
+          assert.equal(commits[i].toString(), storedCommits[i].toString());
+        }
+      });
+  });
+
   // This test requires forcing garbage collection, so mocha needs to be run
   // via node rather than npm, with a la `node --expose-gc [pathtohmoca]
   // [testglob]`

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -84,7 +84,7 @@ describe("Revwalk", function() {
     });
   });
 
-  it.only("can get a specified number of commits", function() {
+  it("can get a specified number of commits", function() {
     var test = this;
     var storedCommits;
     return test.walker.getCommits()
@@ -101,6 +101,21 @@ describe("Revwalk", function() {
         for (var i = 0; i < 8; i++) {
           assert.equal(commits[i].toString(), storedCommits[i].toString());
         }
+      });
+  });
+
+  it("can get commits until you tell it not to", function() {
+    var test = this;
+    var magicSha = "b8a94aefb22d0534cc0e5acf533989c13d8725dc";
+
+    function checkCommit(commit) {
+      return commit.toString() != magicSha;
+    }
+
+    return test.walker.getCommitsUntil(checkCommit)
+      .then(function(commits) {
+        assert.equal(commits.length, 4);
+        assert.equal(commits[commits.length-1].toString(), magicSha);
       });
   });
 


### PR DESCRIPTION
Adds getCommits() which takes in a number (or defaults to 10) and grabs that many commits from the walker. 
Also adds getCommitsUntil which takes in a check function, and grabs commits until the function returns false called against a commit;