### PR TITLE
Fix building when a space is in the path

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -111,6 +111,7 @@ function build() {
   }
 
   builder = path.resolve(".", "node_modules", ".bin", builder);
+  builder = builder.replace(/\s/g, "\\$&");
   var cmd = [prefix, builder, "rebuild", target, debug, distUrl]
     .join(" ").trim();
 

--- a/lifecycleScripts/retrieveExternalDependencies.js
+++ b/lifecycleScripts/retrieveExternalDependencies.js
@@ -78,7 +78,7 @@ function getVendorLib(name) {
             if ((name == "libssh2") && (process.platform !== "win32")) {
               return new Promise(function(resolve, reject) {
                 console.info("[nodegit] Configuring libssh2.");
-                cp.exec(
+                cp.execFile(
                   rooted(vendorPath) + "configure",
                   {cwd: rooted(vendorPath)},
                   function(err, stdout, stderr) {


### PR DESCRIPTION
Building nodegit was breaking if a space was anywhere in the path because `child_process.exec` treats spaces as a delimiter. See http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback.