### PR TITLE
Update moar dependencies.

### DIFF
--- a/generate/scripts/generateJson.js
+++ b/generate/scripts/generateJson.js
@@ -210,7 +210,7 @@ module.exports = function generateJson() {
     _.merge(enumerable, _.omit(override, ["values"]));
 
     output.push(enumerable);
-  });
+  }).value();
 
   output = _.sortBy(output, "typeName");
 

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -314,7 +314,7 @@ var Helpers = {
       if (fnDef.jsFunctionName == utils.camelCase(collidingName)) {
         fnDef.jsFunctionName = utils.camelCase(newName);
       }
-    });
+    }).value();
 
     _.merge(fnDef, _.omit(fnOverrides, "args", "return"));
   },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "istanbul": "~0.3.2",
     "js-beautify": "^1.5.4",
     "jshint": "^2.6.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.1.0",
     "mocha": "~2.1.0",
     "nan": "^1.6.2",
     "node-gyp": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "fs-extra": "^0.15.0",
+    "fs-extra": "^0.16.3",
     "node-pre-gyp": "~0.6.1",
     "nodegit-promise": "~1.0.0",
     "npm": "^2.1.18",

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -132,7 +132,7 @@ describe("Commit", function() {
     }, function(reason) {
       return reinitialize(test)
         .then(function() {
-          return Promise.reject();
+          return Promise.reject(reason);
         });
     });
   });


### PR DESCRIPTION
Updates the lodash version. As of 3.0.0, lodash chainable foreach is lazy, and you have to call .value() at the end of the chain for it to evaluate. 