### PR TITLE
Tree Entry getBlob() should also support the callback pattern.

### DIFF
--- a/lib/tree_entry.js
+++ b/lib/tree_entry.js
@@ -64,8 +64,6 @@ TreeEntry.prototype.getTree = function(callback) {
  * @return {Blob}
  */
 TreeEntry.prototype.getBlob = function(callback) {
-  var entry = this;
-
   return this.parent.repo.getBlob(this.oid()).then(function(blob) {
     if (typeof callback === "function") {
       callback(null, blob);

--- a/lib/tree_entry.js
+++ b/lib/tree_entry.js
@@ -63,8 +63,16 @@ TreeEntry.prototype.getTree = function(callback) {
  * Retrieve the tree for this entry. Make sure to call `isTree` first!
  * @return {Blob}
  */
-TreeEntry.prototype.getBlob = function() {
-  return this.parent.repo.getBlob(this.oid());
+TreeEntry.prototype.getBlob = function(callback) {
+  var entry = this;
+
+  return this.parent.repo.getBlob(this.oid()).then(function(blob) {
+    if (typeof callback === "function") {
+      callback(null, blob);
+    }
+
+    return blob;
+  }, callback);
 };
 
 /**

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -54,6 +54,15 @@ describe("TreeEntry", function() {
       });
   });
 
+  it("provides the blob representation of the entry via a callback", function() {
+    return this.commit.getEntry("test/raw-commit.js")
+      .then(function(entry) {
+        entry.getBlob(function (error, blob) {
+          assert.equal(blob.rawsize(), 2736);
+        });
+      });
+  });
+
   it("provides the tree the entry is part of", function() {
     return this.commit.getEntry("test")
       .then(function(entry) {

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -54,7 +54,7 @@ describe("TreeEntry", function() {
       });
   });
 
-  it("provides the blob representation viacallback", function() {
+  it("provides the blob representation via callback", function() {
     return this.commit.getEntry("test/raw-commit.js")
       .then(function(entry) {
         entry.getBlob(function (error, blob) {

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -54,7 +54,7 @@ describe("TreeEntry", function() {
       });
   });
 
-  it("provides the blob representation of the entry via a callback", function() {
+  it("provides the blob representation viacallback", function() {
     return this.commit.getEntry("test/raw-commit.js")
       .then(function(entry) {
         entry.getBlob(function (error, blob) {


### PR DESCRIPTION
Hi,
As this is my first contribution to this project, let me know what I can change, i.e. should I merge to a new branch name or is a direct-to-master preferred. (Contributing.MD didn't have a ton of info on the logistics of moving changes around)

## Change Background

While moving code from the older v0.1.x codebase to the latest, I tried making minimal changes and renames in some functions. A majority of my Node code at this time is not using promises. While calling `getBlob(callback)` on a tree_entry, nothing happened.

I simply mimicked the format used for `getTree` in tree_entry to be consistent (although I'm not setting the `entry` instance on a property like the tree function does).

## Tests

All `mocha` tests passing related to this change. However...

- Clone."can clone with ssh" is a failing test, both before and after the change, on Windows 8.1 x64 with Node v0.12.0.