### PR TITLE
Allow for saving of props to an object

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1348,6 +1348,13 @@
         "git_remote_rename": {
           "ignore": true
         },
+        "git_remote_set_callbacks": {
+          "args": {
+            "callbacks": {
+              "saveArg": true
+            }
+          }
+        },
         "git_remote_set_fetch_refspecs": {
           "ignore": true
         },

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -18,6 +18,18 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
         {%if not arg.isCallbackFunction %}
           {%if not arg.payloadFor %}
             {%partial convertFromV8 arg %}
+            {%if arg.saveArg %}
+  Persistent<Object> {{ arg.name }};
+  Handle<Object> {{ arg.name }}Handle(args[{{ arg.jsArg }}]->ToObject());
+  NanAssignPersistent({{ arg.name }}, {{ arg.name }}Handle);
+  {{ cppClassName }} *thisObj = ObjectWrap::Unwrap<{{ cppClassName }}>(args.This());
+
+  if (thisObj->{{ cppFunctionName }}_{{ arg.name }} != NULL) {
+    NanDisposePersistent(*thisObj->{{ cppFunctionName }}_{{ arg.name }});
+  }
+
+  thisObj->{{ cppFunctionName }}_{{ arg.name }} = &{{ arg.name }};
+            {%endif%}
           {%endif%}
         {%endif%}
       {%endif%}

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -73,11 +73,25 @@ class {{ cppClassName }} : public ObjectWrap {
         {% endeach %}
       {% endif %}
     {% endeach %}
+
+
   private:
+
+
     {%if cType%}
     {{ cppClassName }}({{ cType }} *raw, bool selfFreeing);
     ~{{ cppClassName }}();
     {%endif%}
+
+    {% each functions as function %}
+      {% if not function.ignore %}
+        {% each function.args as arg %}
+          {% if arg.saveArg %}
+    Persistent<Object> *{{ function.cppFunctionName }}_{{ arg.name }};
+          {% endif %}
+        {% endeach %}
+      {% endif %}
+    {% endeach %}
 
     static NAN_METHOD(JSNewFunction);
 


### PR DESCRIPTION
Some properties were being set on the libgit2 C struct but would
be destroyed after the function is completed. The problem was that
C struct would still assume that the memory it had was valid and
would try to use it resulting in random segfaults.

Now you can mark an argument as `saveArg` and then that argument
will be persisted to the parent object and disposed of when the
parent is deleted.

Currently this only works in sync functions since I couldn't find
an async method that would need this. If this changes it shouldn't
be too hard to implement.

Another thing to note is that the if the parent object is marked
as `!selfFreeing` then we're still going to dispose of the
persisted objects because if not then they will memory leak all
over the place. This might need to be looked into more later. I
currently couldn't find a situation where this would happen but
the code is pretty complicated at this point and I certainly could
have missed something