### PR TITLE
Skip transfer progress test until it's fixed

### DIFF
--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -112,7 +112,7 @@ describe("Remote", function() {
       });
   });
 
-  it("can monitor transfer progress while downloading", function() {
+  it.skip("can monitor transfer progress while downloading", function() {
     // Set a reasonable timeout here now that our repository has grown.
     this.timeout(600000);
 


### PR DESCRIPTION
Currently the transfer progress test is breaking on windows
randomly. @tbranyen and I have been looking into it and it seems
like a libuv issue. I'm going to skip this now so that other
potential PR's aren't held up by it until we can get a good
resolution and fix it in another PR