### PR TITLE
Automatically free repositories post clone

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -28,7 +28,21 @@ Clone.clone = function(url, local_path, options) {
       normalizeOptions(remoteCallbacks, NodeGit.RemoteCallbacks);
   }
 
-  return clone.call(this, url, local_path, options);
+  // This is required to clean up after the clone to avoid file locking
+  // issues in Windows and potentially other issues we don't know about.
+  var freeRepository = function(repository) {
+    repository.free();
+  };
+
+  // We want to provide a valid repository object, so reopen the repository
+  // after clone and cleanup.
+  var openRepository = function() {
+    return NodeGit.Repository.open(local_path);
+  };
+
+  return clone.call(this, url, local_path, options)
+    .then(freeRepository)
+    .then(openRepository);
 };
 
 module.exports = Clone;

--- a/test/runner.js
+++ b/test/runner.js
@@ -47,14 +47,6 @@ beforeEach(function() {
 });
 
 afterEach(function(done) {
-  // In Windows if you do not clean up the repository, there may become a
-  // conflict with file locking.
-  if (this.repository && process.platform === "win32") {
-    this.repository.stateCleanup();
-    this.repository.free();
-    delete this.repository;
-  }
-
   process.nextTick(function() {
     global.gc();
     done();

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -17,21 +17,6 @@ describe("Clone", function() {
   // Set a reasonable timeout here now that our repository has grown.
   this.timeout(30000);
 
-  beforeEach(function(done) {
-    // In Windows if you do not clean up the repository, there may become a
-    // conflict with file locking.
-    if (this.repository && process.platform === "win32") {
-      this.repository.stateCleanup();
-      this.repository.free();
-      delete this.repository;
-    }
-
-    process.nextTick(function() {
-      global.gc();
-      done();
-    });
-  });
-
   beforeEach(function() {
     return fse.remove(clonePath).catch(function(err) {
       console.log(err);


### PR DESCRIPTION
Once a repository has been successfully cloned, free the internal
structure to avoid file locking.  Then open the repository again to
providea repository opbject.