### PR TITLE
Fix libuv threading issue

### DIFF
--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -57,15 +57,14 @@ class {{ cppClassName }} : public ObjectWrap {
             {% endeach %}
     );
 
-    static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncWork(uv_work_t* req);
-    static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncAfter(uv_work_t* req, int status);
-    static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncPromisePolling(uv_work_t* req, int status);
+    static void {{ function.cppFunctionName }}_{{ arg.name }}_async(uv_async_t* req, int status);
+    static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncPromisePolling(uv_async_t* req, int status);
     struct {{ function.cppFunctionName }}_{{ arg.name|titleCase }}Baton {
       {% each arg.args|argsInfo as cbArg %}
       {{ cbArg.cType }} {{ cbArg.name }};
       {% endeach %}
 
-      uv_work_t req;
+      uv_async_t req;
       {{ arg.return.type }} result;
       Persistent<Object> promise;
       bool done;

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -44,15 +44,14 @@ class {{ cppClassName }} : public ObjectWrap {
             {% endeach %}
           );
 
-          static void {{ field.name }}_asyncWork(uv_work_t* req);
-          static void {{ field.name }}_asyncAfter(uv_work_t* req, int status);
-          static void {{ field.name }}_asyncPromisePolling(uv_work_t* req, int status);
+          static void {{ field.name }}_async(uv_async_t* req, int status);
+          static void {{ field.name }}_asyncPromisePolling(uv_async_t* req, int status);
           struct {{ field.name|titleCase }}Baton {
             {% each field.args|argsInfo as arg %}
               {{ arg.cType }} {{ arg.name}};
             {% endeach %}
 
-            uv_work_t req;
+            uv_async_t req;
             {{ field.return.type }} result;
             Persistent<Object> promise;
             bool done;

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -112,7 +112,7 @@ describe("Remote", function() {
       });
   });
 
-  it.skip("can monitor transfer progress while downloading", function() {
+  it("can monitor transfer progress while downloading", function() {
     // Set a reasonable timeout here now that our repository has grown.
     this.timeout(600000);
 


### PR DESCRIPTION
`uv_queue_work` is [not thread safe]
(http://docs.libuv.org/en/v1.x/threadpool.html)

This means that all callbacks are in a highly unstable
state and can bring the system down at any time.

Now we're using an [Async handle]
(http://docs.libuv.org/en/latest/async.html#c.uv_async_t)

That should make out callbacks thread safe and consistent
across platforms again