### PR TITLE
git_create_tag doesn't have the correct descriptor

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,7 @@
   "unused": "vars",
   "undef": true,
   "validthis": true,
+  "futurehostile": true,
   "globals": {
     "global": true,
     "define": true,

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1657,6 +1657,12 @@
               "isReturn": true
             }
           }
+        },
+        "git_tag_delete": {
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
         }
       }
     },

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1616,6 +1616,9 @@
           },
           "isAsync": true
         },
+        "git_tag_create_frombuffer": {
+          "ignore": true
+        },
         "git_tag_create_lightweight": {
           "args": {
             "oid": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1605,6 +1605,39 @@
         "git_tag_foreach": {
           "ignore": true
         },
+        "git_tag_create": {
+          "args": {
+            "oid": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
+        },
+        "git_tag_create_lightweight": {
+          "args": {
+            "oid": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
+        },
+        "git_tag_annotation_create": {
+          "args": {
+            "oid": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
+        },
         "git_tag_list": {
           "args": {
             "tag_names": {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -269,6 +269,30 @@ Repository.prototype.getTree = function(oid, callback) {
 };
 
 /**
+ * Creates a new annotated tag
+ *
+ * @async
+ * @param {String|Oid} String sha or Oid
+ * @param {String} name the name of the tag
+ * @param {String} message the description that will be attached to the
+ * annotated tag
+ * @return {Tag}
+ */
+Repository.prototype.createTag = function(oid, name, message, callback) {
+  var repository = this;
+  var signature = repository.defaultSignature();
+
+  return Commit.lookup(repository, oid)
+    .then(function(commit) {
+      // Final argument is `force` which overwrites any previous tag
+      return Tag.create(repository, name, commit, signature, message, 0);
+    })
+    .then(function(tagOid) {
+      return repository.getTag(tagOid, callback);
+    });
+};
+
+/**
  * Retrieve the tag represented by the oid.
  *
  * @async

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -293,6 +293,27 @@ Repository.prototype.createTag = function(oid, name, message, callback) {
 };
 
 /**
+ * Creates a new lightweight tag
+ *
+ * @async
+ * @param {String|Oid} String sha or Oid
+ * @param {String} name the name of the tag
+ * @return {Reference}
+ */
+Repository.prototype.createLightweightTag = function(oid, name, callback) {
+  var repository = this;
+
+  return Commit.lookup(repository, oid)
+    .then(function(commit) {
+      // Final argument is `force` which overwrites any previous tag
+      return Tag.createLightweight(repository, name, commit, 0);
+    })
+    .then(function() {
+      return Reference.lookup(repository, "refs/tags/" + name);
+    });
+};
+
+/**
  * Retrieve the tag represented by the oid.
  *
  * @async

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -315,6 +315,20 @@ Repository.prototype.getTagByName = function(name, callback) {
 };
 
 /**
+ * Deletes a tag from a repository by the tag name.
+ *
+ * @async
+ * @param {String} Short or full tag name
+ */
+Repository.prototype.deleteTagByName = function(name) {
+  var repository = this;
+
+  name = ~name.indexOf("refs/tags/") ? name.substr(10) : name;
+
+  return Tag.delete(repository, name);
+};
+
+/**
  * Instantiate a new revision walker for browsing the Repository"s history.
  * See also `Commit.prototype.history()`
  *

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -15,8 +15,8 @@ describe("Tag", function() {
   var commitPointedTo = "32789a79e71fbc9e04d3eff7425e1771eb595150";
   var tagMessage = "This is an annotated tag\n";
 
-  function testTag(tag) {
-    assert.equal(tag.name(), tagName);
+  function testTag(tag, name) {
+    assert.equal(tag.name(), name || tagName);
     assert.equal(tag.targetType(), Obj.TYPE.COMMIT);
     assert.equal(tag.message(), tagMessage);
 

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -109,4 +109,39 @@ describe("Tag", function() {
         return Promise.resolve();
       });
   });
+
+  it("can create a new lightweight tag in a repo and delete it", function() {
+    var oid = Oid.fromString(commitPointedTo);
+    var name = "created-lightweight-tag";
+    var repository = this.repository;
+
+    return repository.createLightweightTag(oid, name)
+      .then(function(reference) {
+        return reference.target();
+      })
+      .then(function(refOid) {
+        assert.equal(refOid.toString(), oid.toString());
+      })
+      .then(function() {
+        return repository.createLightweightTag(oid, name);
+      })
+      .then(function() {
+        return Promise.reject(new Error("should not be able to create the '" +
+          name + "' tag twice"));
+      }, function() {
+        return Promise.resolve();
+      })
+      .then(function() {
+        return repository.deleteTagByName(name);
+      })
+      .then(function() {
+        return Reference.lookup(repository, "refs/tags/" + name);
+      })
+      .then(function() {
+        return Promise.reject(new Error("the tag '" + name +
+          "' should not exist"));
+      }, function() {
+        return Promise.resolve();
+      });
+  });
 });


### PR DESCRIPTION
The following code doesn't work:

```js
// Commit the bower.json file
.then(function() {
  return repository.createCommitOnHead(['bower.json'], identity, identity, 'release ' + version);
})

// Tag the new commit
.then(function(oid) {
  return nodegit.Commit.lookup(repository, oid);
})
.then(function(commit) {
  return nodegit.Tag.create(null, repository, version, commit, identity, 'version ' + version, 0);
})
```

This is because the `git_create_tag` needs to have the following descriptor:

```json
"git_tag_create": {
  "isAsync": true,
  "args": {
    "oid": {
    "isReturn": true,
    "isSelf": false,
    "shouldAlloc": true
  },
  "return": {
    "cppClassName": "Number",
    "jsClassName": "Number",
    "isErrorCode": true
  }
},
```
