### PR TITLE
Default signature always returns valid signature

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -539,7 +539,13 @@ Repository.prototype.treeBuilder = function() {
  * @return {Signature}
  */
 Repository.prototype.defaultSignature = function() {
-  return NodeGit.Signature.default(this);
+  var result = NodeGit.Signature.default(this);
+
+  if (!result.name()) {
+    result = NodeGit.Signature.now("unknown", "unknown@unknown.com");
+  }
+
+  return result;
 };
 
 /**
@@ -589,10 +595,12 @@ Repository.prototype.getRemote = function(remote, callback) {
  * Fetches from a remote
  *
  * @param {String|Remote} remote
+ * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
  */
 Repository.prototype.fetch = function(
   remote,
   remoteCallbacks,
+
   callback)
 {
   var repo = this;
@@ -613,6 +621,7 @@ Repository.prototype.fetch = function(
 
 /**
  * Fetches from all remotes
+ * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
  */
 Repository.prototype.fetchAll = function(
   remoteCallbacks,


### PR DESCRIPTION
If the user name or email wasn't set then `repo.defaultSignature`
would return an invalid signature that couldn't be used in other
operations. Now the method will return a signature of an "unknown"
user that can be used anywhere.

This fixes #431