### PR TITLE
Str array converter fix

### DIFF
--- a/generate/templates/manual/src/str_array_converter.cc
+++ b/generate/templates/manual/src/str_array_converter.cc
@@ -25,17 +25,15 @@ git_strarray *StrArrayConverter::Convert(Handle<v8::Value> val) {
 }
 
 git_strarray *StrArrayConverter::ConvertArray(Array *val) {
-  int count = val->Length();
-  char **strings = (char **)malloc(sizeof(char*) * count);
-  git_strarray *result;
+  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray*));
+  result->count = val->Length();
+  result->strings = (char **)malloc(sizeof(char*) * result->count);
 
-  for(size_t i = 0; i < count; i++) {
+  for(size_t i = 0; i < result->count; i++) {
     NanUtf8String entry(val->Get(i));
-    strings[i] = *entry;
+    result->strings[i] = strdup(*entry);
   }
 
-  result = ConstructStrArray(count, strings);
-  free(strings);
   return result;
 }
 

--- a/generate/templates/manual/src/str_array_converter.cc
+++ b/generate/templates/manual/src/str_array_converter.cc
@@ -29,7 +29,7 @@ git_strarray *StrArrayConverter::ConvertArray(Array *val) {
   char **strings = (char **)malloc(sizeof(char*) * count);
   git_strarray *result;
 
-  for(int i = 0; i < count; i++) {
+  for(size_t i = 0; i < count; i++) {
     NanUtf8String entry(val->Get(i));
     strings[i] = *entry;
   }


### PR DESCRIPTION
This fixes up the conversion of string arrays. The problem is that the `ConvertArray` function was setting the string pointer to the internals of `NanUtf8String` but the class was being destroyed freeing the memory.

I also removed the need to call `ConstructStrArray` as that just does more string duplications (`strdup`) that aren't really needed.

The commits on this branch provide a clean transistion between the two methods that are more obvious that the complete branch diff.