### PR TITLE
Add Diff.prototype.findSimilar

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -524,7 +524,20 @@
           "ignore": true
         },
         "git_diff_find_similar": {
-          "ignore": true
+          "args": {
+            "diff": {
+              "isSelf": true
+            },
+            "options": {
+              "isOptional": true
+            }
+          },
+          "return": {
+            "cppClassName": "Number",
+            "jsClassName": "Number",
+            "isErrorCode": true
+          },
+          "isAsync": true
         },
         "git_diff_foreach": {
           "ignore": true
@@ -639,12 +652,12 @@
       }
     },
     "diff_find_options": {
+      "hasConstructor": true,
       "fields": {
         "git_diff_similarity_metric": {
           "ignore": true
         }
-      },
-      "ignore": true
+      }
     },
     "diff_format_email_options": {
       "ignore": true

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -56,4 +56,11 @@ Diff.treeToWorkdirWithIndex = function(repo, tree, opts) {
   return treeToWorkdirWithIndex(repo, tree, opts);
 };
 
+// Override Diff.findSimilar to normalize opts
+var findSimilar = Diff.prototype.findSimilar;
+Diff.prototype.findSimilar = function(opts) {
+  opts = normalizeOptions(opts, NodeGit.DiffFindOptions);
+  return findSimilar.call(this, opts);
+};
+
 module.exports = Diff;


### PR DESCRIPTION
Also DiffFindOptions.

This allows a diff of additions and deletions to be rewritten as renames, or to split a heavily modified file into separate file deletions and additions rather than one modification.