### PR TITLE
Better cloning with NodeGit

### DIFF
--- a/examples/clone.js
+++ b/examples/clone.js
@@ -6,7 +6,7 @@ var path = "/tmp/nodegit-clone-demo";
 fse.remove(path).then(function() {
   var entry;
 
-  nodegit.Clone.clone(
+  nodegit.Clone(
     "https://github.com/nodegit/nodegit.git",
     path,
     {

--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -36,7 +36,7 @@ var opts = {
 };
 
 fse.remove(path).then(function() {
-  nodegit.Clone.clone(repoUrl, path, opts)
+  nodegit.Clone(repoUrl, path, opts)
     .done(function(repo) {
       if (repo instanceof nodegit.Repository) {
         console.info("We cloned the repo!");

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -45,4 +45,10 @@ Clone.clone = function(url, local_path, options) {
     .then(openRepository);
 };
 
-module.exports = Clone;
+// Inherit directly from the original clone object.
+Clone.clone.__proto__ = Clone;
+
+// Ensure we're using the correct prototype.
+Clone.clone.prototype = Clone.prototype;
+
+module.exports = Clone.clone;

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -4,7 +4,7 @@ var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
-describe.only("Clone", function() {
+describe("Clone", function() {
   var Repository = require(local("../../lib/repository"));
   var clone = require(local("../../lib/clone"));
   var NodeGit = require(local("../../"));

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -4,9 +4,9 @@ var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
-describe("Clone", function() {
+describe.only("Clone", function() {
   var Repository = require(local("../../lib/repository"));
-  var Clone = require(local("../../lib/clone"));
+  var clone = require(local("../../lib/clone"));
   var NodeGit = require(local("../../"));
 
   var clonePath = local("../repos/clone");
@@ -29,7 +29,7 @@ describe("Clone", function() {
     var test = this;
     var url = "http://git.tbranyen.com/smart/site-content";
 
-    return Clone.clone(url, clonePath).then(function(repo) {
+    return clone(url, clonePath).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -46,7 +46,7 @@ describe("Clone", function() {
       }
     };
 
-    return Clone.clone(url, clonePath, opts).then(function(repo) {
+    return clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -66,7 +66,7 @@ describe("Clone", function() {
       }
     };
 
-    return Clone.clone(url, clonePath, opts).then(function(repo) {
+    return clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -90,7 +90,7 @@ describe("Clone", function() {
       }
     };
 
-    return Clone.clone(url, clonePath, opts).then(function(repo) {
+    return clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -107,7 +107,7 @@ describe("Clone", function() {
       }
     };
 
-    return Clone.clone(url, clonePath, opts).then(function(repo) {
+    return clone(url, clonePath, opts).then(function(repo) {
       test.repository = repo;
       assert.ok(repo instanceof Repository);
     });
@@ -118,7 +118,7 @@ describe("Clone", function() {
     var prefix = process.platform === "win32" ? "" : "file://";
     var url = prefix + local("../repos/empty");
 
-    return Clone.clone(url, clonePath).then(function(repo) {
+    return clone(url, clonePath).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -127,7 +127,7 @@ describe("Clone", function() {
   it("will not segfault when accessing a url without username", function() {
     var url = "https://github.com/nodegit/private";
 
-    return Clone.clone(url, clonePath, {
+    return clone(url, clonePath, {
       remoteCallbacks: {
         certificateCheck: function() {
           return 1;


### PR DESCRIPTION
Right now we have the current call mechanism for clone:

``` javascript
var Git = require('nodegit');

Git.Clone.clone('https://github.com/nodegit/nodegit', 'nodegit').then(function(repo) {
  /* work with the repository */
});
```

This is pretty verbose, compared to:

``` javascript
var Git = require('nodegit');

Git.Clone('https://github.com/nodegit/nodegit', 'nodegit').then(function(repo) {
  /* work with the repository */
});
```

So I've fixed that in the JS-side.  The top-level `NodeGit.Clone` Object is now a Function that behaves like an Object.

This is not a backwards-breaking change, so hopefully we're all in favor?