### PR TITLE
StrArray memory fix

### DIFF
--- a/generate/templates/manual/include/str_array_converter.h
+++ b/generate/templates/manual/include/str_array_converter.h
@@ -16,6 +16,7 @@ class StrArrayConverter {
   private:
     static git_strarray *ConvertArray(Array *val);
     static git_strarray *ConvertString(Handle<String> val);
+    static git_strarray *AllocStrArray(const size_t count);
     static git_strarray *ConstructStrArray(int argc, char** argv);
 };
 

--- a/generate/templates/manual/src/str_array_converter.cc
+++ b/generate/templates/manual/src/str_array_converter.cc
@@ -25,7 +25,7 @@ git_strarray *StrArrayConverter::Convert(Handle<v8::Value> val) {
 }
 
 git_strarray *StrArrayConverter::ConvertArray(Array *val) {
-  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray*));
+  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray));
   result->count = val->Length();
   result->strings = (char **)malloc(sizeof(char*) * result->count);
 
@@ -47,7 +47,7 @@ git_strarray* StrArrayConverter::ConvertString(Handle<String> val) {
 }
 
 git_strarray *StrArrayConverter::ConstructStrArray(int argc, char** argv) {
-  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray*));
+  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray));
   result->count = argc;
   result->strings = (char **)malloc(sizeof(char*) * result->count);
 

--- a/generate/templates/manual/src/str_array_converter.cc
+++ b/generate/templates/manual/src/str_array_converter.cc
@@ -24,7 +24,7 @@ git_strarray *StrArrayConverter::Convert(Handle<v8::Value> val) {
   }
 }
 
-static git_strarray * AllocGitStrArray(const size_t count) {
+static git_strarray * StrArrayConverter::AllocStrArray(const size_t count) {
   const size_t size = sizeof(git_strarray) + (sizeof(char*) * count);
   uint8_t* memory = reinterpret_cast<uint8_t*>(malloc(size));
   git_strarray *result = reinterpret_cast<git_strarray *>(memory);
@@ -34,7 +34,7 @@ static git_strarray * AllocGitStrArray(const size_t count) {
 }
 
 git_strarray *StrArrayConverter::ConvertArray(Array *val) {
-  git_strarray *result = AllocGitStrArray(val->Length());
+  git_strarray *result = AllocStrArray(val->Length());
 
   for(size_t i = 0; i < result->count; i++) {
     NanUtf8String entry(val->Get(i));
@@ -54,7 +54,7 @@ git_strarray* StrArrayConverter::ConvertString(Handle<String> val) {
 }
 
 git_strarray *StrArrayConverter::ConstructStrArray(int argc, char** argv) {
-  git_strarray *result = AllocGitStrArray(argc);
+  git_strarray *result = AllocStrArray(argc);
 
   for(size_t i = 0; i < result->count; i++) {
     result->strings[i] = strdup(argv[i]);

--- a/generate/templates/manual/src/str_array_converter.cc
+++ b/generate/templates/manual/src/str_array_converter.cc
@@ -24,10 +24,17 @@ git_strarray *StrArrayConverter::Convert(Handle<v8::Value> val) {
   }
 }
 
+static git_strarray * AllocGitStrArray(const size_t count) {
+  const size_t size = sizeof(git_strarray) + (sizeof(char*) * count);
+  uint8_t* memory = reinterpret_cast<uint8_t*>(malloc(size));
+  git_strarray *result = reinterpret_cast<git_strarray *>(memory);
+  result->count = count;
+  result->strings = reinterpret_cast<char**>(memory + sizeof(git_strarray));
+  return result;
+}
+
 git_strarray *StrArrayConverter::ConvertArray(Array *val) {
-  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray));
-  result->count = val->Length();
-  result->strings = (char **)malloc(sizeof(char*) * result->count);
+  git_strarray *result = AllocGitStrArray(val->Length());
 
   for(size_t i = 0; i < result->count; i++) {
     NanUtf8String entry(val->Get(i));
@@ -47,9 +54,7 @@ git_strarray* StrArrayConverter::ConvertString(Handle<String> val) {
 }
 
 git_strarray *StrArrayConverter::ConstructStrArray(int argc, char** argv) {
-  git_strarray *result = (git_strarray *)malloc(sizeof(git_strarray));
-  result->count = argc;
-  result->strings = (char **)malloc(sizeof(char*) * result->count);
+  git_strarray *result = AllocGitStrArray(argc);
 
   for(size_t i = 0; i < result->count; i++) {
     result->strings[i] = strdup(argv[i]);


### PR DESCRIPTION
We were only allocating enough memory for a `git_strarray` memory pointer rather than the structure.  1a74a2d fixes that.

 7c81612 changes the code to allocate the memory for the structure and the string pointers all in one go to reduce fragmentation. Complete micro-optimisation, happy for it to not get merged but thought I'd do it anyway.