### PR TITLE
WIP: Template proto functions

### DIFF
--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -324,6 +324,9 @@ var Helpers = {
       }
     }).value();
 
+    if ("git_" + typeDef.typeName == fnDef.cFunctionName) {
+      fnDef.useAsOnRootProto = true;
+    }
     _.merge(fnDef, _.omit(fnOverrides, "args", "return"));
   },
 

--- a/generate/templates/templates/enums.js
+++ b/generate/templates/templates/enums.js
@@ -4,7 +4,8 @@ NodeGit.Enums = {};
 {% each . as enumerable %}
   {% if not enumerable.ignore %}
     {% if enumerable.type == "enum" %}
-      NodeGit.{{ enumerable.owner }}.{{ enumerable.JsName }} = {
+      NodeGit.{{ enumerable.owner }}.{{ enumerable.JsName }} =
+        NodeGit.{{ enumerable.owner }}.__proto__.{{ enumerable.JsName }} = {
         {% each enumerable.values as value %}
           {{ value.JsName }}: {{ value.value }},
         {% endeach %}

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -1,7 +1,5 @@
 var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
-var path = require("path");
-var local = path.join.bind(path, __dirname);
 var rawApi;
 
 // Attempt to load the production release first, if it fails fall back to the
@@ -54,7 +52,7 @@ exports.__proto__ = rawApi;
 
 var importExtension = function(name) {
   try {
-    require(local(name));
+    require("./" + name);
   }
   catch (unhandledException) {
     if (unhandledException.code != "MODULE_NOT_FOUND") {
@@ -65,14 +63,14 @@ var importExtension = function(name) {
 
 // Load up utils
 rawApi.Utils = {};
-require(local("utils", "lookup_wrapper"));
-require(local("utils", "normalize_options"));
+require("./utils/lookup_wrapper");
+require("./utils/normalize_options");
 
 // Load up extra types;
-require(local("convenient_hunk"));
-require(local("convenient_patch"));
-require(local("status_file"));
-require(local("enums.js"));
+require("./convenient_hunk");
+require("./convenient_patch");
+require("./status_file");
+require("./enums.js");
 
 // Import extensions
 {% each %}

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -66,6 +66,29 @@ var importExtension = function(name) {
 //must go last!
 require("./enums");
 
+/* jshint ignore:start */
+{% each . as idef %}
+  {% if idef.type != "enum" %}
+    {% each idef.functions as fn %}
+
+      {% if fn.useAsOnRootProto %}
+        // Inherit directly from the original {{idef.jsClassName}} object.
+        _{{ idef.jsClassName }}.{{ fn.jsFunctionName }}.__proto__ =
+          _{{ idef.jsClassName }};
+
+        // Ensure we're using the correct prototype.
+        _{{ idef.jsClassName }}.{{ fn.jsFunctionName }}.prototype =
+          _{{ idef.jsClassName }}.prototype;
+
+        // Assign the function as the root
+        rawApi.{{idef.jsClassName}} =
+          _{{ idef.jsClassName }}.{{ fn.jsFunctionName }};
+      {% endif %}
+    {% endeach %}
+  {% endif %}
+{% endeach %}
+/* jshint ignore:end */
+
 // Wrap asynchronous methods to return promises.
 promisify(exports);
 

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -70,8 +70,8 @@ require("./enums");
 {% each . as idef %}
   {% if idef.type != "enum" %}
     {% each idef.functions as fn %}
-
       {% if fn.useAsOnRootProto %}
+
         // Inherit directly from the original {{idef.jsClassName}} object.
         _{{ idef.jsClassName }}.{{ fn.jsFunctionName }}.__proto__ =
           _{{ idef.jsClassName }};
@@ -83,6 +83,7 @@ require("./enums");
         // Assign the function as the root
         rawApi.{{idef.jsClassName}} =
           _{{ idef.jsClassName }}.{{ fn.jsFunctionName }};
+
       {% endif %}
     {% endeach %}
   {% endif %}

--- a/lib/attr.js
+++ b/lib/attr.js
@@ -1,5 +1,0 @@
-var NodeGit = require("../");
-
-var Attr = NodeGit.Attr;
-
-module.exports = Attr;

--- a/lib/blob.js
+++ b/lib/blob.js
@@ -1,8 +1,8 @@
 var NodeGit = require("../");
-var TreeEntry = require("./tree_entry");
-var LookupWrapper = require("./util/lookupWrapper");
-
 var Blob = NodeGit.Blob;
+var LookupWrapper = NodeGit.Utils.lookupWrapper;
+var TreeEntry = NodeGit.TreeEntry;
+
 
 /**
 * Retrieves the blob pointed to by the oid
@@ -41,5 +41,3 @@ Blob.prototype.filemode = function() {
 
   return this.isBinary() ? FileMode.EXECUTABLE : FileMode.BLOB;
 };
-
-module.exports = Blob;

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,5 +1,0 @@
-var NodeGit = require("../");
-
-var Branch = NodeGit.Branch;
-
-module.exports = Branch;

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Checkout = NodeGit.Checkout;
 var head = Checkout.head;
@@ -33,5 +33,3 @@ Checkout.tree = function(repo, treeish, options) {
 
   return tree.call(this, repo, treeish, options);
 };
-
-module.exports = Checkout;

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -45,10 +45,4 @@ Clone.clone = function(url, local_path, options) {
     .then(openRepository);
 };
 
-// Inherit directly from the original clone object.
-Clone.clone.__proto__ = Clone;
-
-// Ensure we're using the correct prototype.
-Clone.clone.prototype = Clone.prototype;
-
 module.exports = Clone.clone;

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Clone = NodeGit.Clone;
 var clone = Clone.clone;
@@ -44,5 +44,3 @@ Clone.clone = function(url, local_path, options) {
     .then(freeRepository)
     .then(openRepository);
 };
-
-module.exports = Clone.clone;

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -1,9 +1,8 @@
 var events = require("events");
 var Promise = require("nodegit-promise");
 var NodeGit = require("../");
-var LookupWrapper = require("./util/lookupWrapper");
-
 var Commit = NodeGit.Commit;
+var LookupWrapper = NodeGit.Utils.lookupWrapper;
 
 /**
  * Retrieves the commit pointed to by the oid
@@ -207,5 +206,3 @@ Commit.prototype.getDiff = function(callback) {
 Commit.prototype.toString = function() {
   return this.sha();
 };
-
-module.exports = Commit;

--- a/lib/convenient_hunk.js
+++ b/lib/convenient_hunk.js
@@ -1,3 +1,5 @@
+var NodeGit = require("../");
+
 function ConvenientHunk(raw, i) {
   this.raw = raw;
   this.i = i;
@@ -32,4 +34,4 @@ ConvenientHunk.prototype.lines = function() {
   return result;
 };
 
-module.exports = ConvenientHunk;
+NodeGit.ConvenientHunk = ConvenientHunk;

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -1,12 +1,11 @@
-var git = require("../");
-var Diff = git.Diff;
-var ConvenientHunk = require("./convenient_hunk");
+var NodeGit = require("../");
+var Diff = NodeGit.Diff;
+var ConvenientHunk = NodeGit.ConvenientHunk;
 
 function ConvenientPatch(delta, patch) {
   this.delta = delta;
   this.patch = patch;
 }
-
 
 /**
  * Old name of the file
@@ -126,4 +125,4 @@ ConvenientPatch.prototype.isTypeChange = function() {
   return this.status() == Diff.DELTA.TYPECHANGE;
 };
 
-module.exports = ConvenientPatch;
+NodeGit.ConvenientPatch = ConvenientPatch;

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,9 +1,9 @@
 var NodeGit = require("../");
-var Patch = require("./patch");
-var ConvenientPatch = require("./convenient_patch");
-var normalizeOptions = require("./util/normalize_options");
-
 var Diff = NodeGit.Diff;
+var ConvenientPatch = NodeGit.ConvenientPatch;
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+var Patch = NodeGit.Patch;
+
 
 /**
  * Retrieve patches in this difflist
@@ -62,5 +62,3 @@ Diff.prototype.findSimilar = function(opts) {
   opts = normalizeOptions(opts, NodeGit.DiffFindOptions);
   return findSimilar.call(this, opts);
 };
-
-module.exports = Diff;

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,5 +31,3 @@ var updateAll = Index.prototype.updateAll;
 Index.prototype.updateAll = function(pathspec, matchedCallback) {
   return updateAll.call(this, pathspec || "*", matchedCallback, null);
 };
-
-module.exports = Index;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 var Promise = require("nodegit-promise");
 
 var Merge = NodeGit.Merge;
@@ -24,5 +24,3 @@ Merge.commits = function(repo, ourCommit, theirCommit, options) {
     return mergeCommits.call(this, repo, commits[0], commits[1], options);
   });
 };
-
-module.exports = Merge;

--- a/lib/object.js
+++ b/lib/object.js
@@ -33,5 +33,3 @@ Obj.prototype.isBlob = function() {
 Obj.prototype.isTag = function() {
   return this.type() == Obj.TYPE.TAG;
 };
-
-module.exports = Obj;

--- a/lib/odb.js
+++ b/lib/odb.js
@@ -1,6 +1,6 @@
-var git = require("../");
+var NodeGit = require("../");
 
-var Odb = git.Odb;
+var Odb = NodeGit.Odb;
 var read = Odb.prototype.read;
 
 Odb.prototype.read = function(oid, callback) {
@@ -12,5 +12,3 @@ Odb.prototype.read = function(oid, callback) {
     return odbObject;
   }, callback);
 };
-
-module.exports = Odb;

--- a/lib/odb_object.js
+++ b/lib/odb_object.js
@@ -7,5 +7,3 @@ OdbObject.prototype.toString = function(size) {
 
   return this.data().toBuffer(size).toString();
 };
-
-module.exports = OdbObject;

--- a/lib/oid.js
+++ b/lib/oid.js
@@ -17,5 +17,3 @@ Object.defineProperties(Oid.prototype, {
 Oid.prototype.inspect = function() {
   return "[Oid " + this.allocfmt() + "]";
 };
-
-module.exports = Oid;

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,5 +1,0 @@
-var NodeGit = require("../");
-
-var Patch = NodeGit.Patch;
-
-module.exports = Patch;

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var LookupWrapper = require("./util/lookupWrapper");
+var LookupWrapper = NodeGit.Utils.lookupWrapper;
 
 var Reference = NodeGit.Reference;
 var Branch = NodeGit.Branch;
@@ -63,5 +63,3 @@ Reference.prototype.toString = function() {
 Reference.prototype.isHead = function() {
   return Branch.isHead(this);
 };
-
-module.exports = Reference;

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,6 +1,6 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
-var lookupWrapper = require("./util/lookupWrapper");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+var lookupWrapper = NodeGit.Utils.lookupWrapper;
 
 var Remote = NodeGit.Remote;
 var setCallbacks = Remote.prototype.setCallbacks;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1,19 +1,18 @@
-var NodeGit = require("../");
-var Blob = require("./blob");
-var Tree = require("./tree");
-var Tag = require("./tag");
-var Reference = require("./reference");
-var Revwalk = require("./revwalk");
-var Commit = require("./commit");
-var Remote = require("./remote");
 var Promise = require("nodegit-promise");
-var normalizeOptions = require("./util/normalize_options");
-var Status = require("./status");
-var StatusFile = require("./status_file");
-var StatusList = require("./status_list");
-
-var TreeBuilder = NodeGit.Treebuilder;
+var NodeGit = require("../");
+var Blob = NodeGit.Blob;
+var Commit = NodeGit.Commit;
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+var Reference = NodeGit.Reference;
+var Remote = NodeGit.Remote;
 var Repository = NodeGit.Repository;
+var Revwalk = NodeGit.Revwalk;
+var Status = NodeGit.Status;
+var StatusFile = NodeGit.StatusFile;
+var StatusList = NodeGit.StatusList;
+var Tag = NodeGit.Tag;
+var Tree = NodeGit.Tree;
+var TreeBuilder = NodeGit.Treebuilder;
 
 Object.defineProperty(Repository.prototype, "openIndex", {
   enumerable: false,

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -2,29 +2,17 @@ var NodeGit = require("../");
 var normalizeOptions = require("./util/normalize_options");
 
 var Reset = NodeGit.Reset;
-
 var defaultFn = Reset.default;
+
 Reset.default = function(repo, target, pathspecs) {
   return defaultFn.call(this, repo, target, pathspecs);
 };
 
 var reset = Reset.reset;
-Reset.reset = function( repo,
-                        target,
-                        resetType,
-                        checkoutOpts,
-                        signature,
-                        logMessage) {
-  checkoutOpts = normalizeOptions(checkoutOpts, NodeGit.CheckoutOptions);
+Reset.reset = function(repo, target, resetType, opts, signature, logMessage) {
+  opts = normalizeOptions(opts, NodeGit.CheckoutOptions);
 
-  return reset.call(
-    this,
-    repo,
-    target,
-    resetType,
-    checkoutOpts,
-    signature,
-    logMessage);
+  return reset.call(this, repo, target, resetType, opts, signature, logMessage);
 };
 
 module.exports = Reset;

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Reset = NodeGit.Reset;
 var defaultFn = Reset.default;

--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -112,5 +112,3 @@ Revwalk.prototype.getCommits = function(count) {
     return Promise.all(promises);
   });
 };
-
-module.exports = Revwalk;

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -9,5 +9,3 @@ var Signature = NodeGit.Signature;
 Signature.prototype.toString = function() {
   return this.name().toString() + " <" + this.email().toString() + ">";
 };
-
-module.exports = Signature;

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Status = NodeGit.Status;
 
@@ -15,5 +15,3 @@ Status.foreachExt = function(repo, opts, callback) {
   opts = normalizeOptions(opts, NodeGit.StatusOptions);
   return foreachExt(repo, opts, callback, null);
 };
-
-module.exports = Status;

--- a/lib/status_file.js
+++ b/lib/status_file.js
@@ -87,4 +87,6 @@ var StatusFile = function(args) {
   };
 };
 
+NodeGit.StatusFile = StatusFile;
+
 module.exports = StatusFile;

--- a/lib/status_file.js
+++ b/lib/status_file.js
@@ -1,5 +1,4 @@
 var NodeGit = require("../");
-
 var Status = NodeGit.Status;
 
 var StatusFile = function(args) {
@@ -88,5 +87,3 @@ var StatusFile = function(args) {
 };
 
 NodeGit.StatusFile = StatusFile;
-
-module.exports = StatusFile;

--- a/lib/status_list.js
+++ b/lib/status_list.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var normalizeOptions = require("./util/normalize_options");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var StatusList = NodeGit.StatusList;
 
@@ -9,5 +9,3 @@ StatusList.create = function(repo, opts) {
   opts = normalizeOptions(opts, NodeGit.StatusOptions);
   return create(repo, opts);
 };
-
-module.exports = StatusList;

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,7 +1,6 @@
-var git = require("../");
-var LookupWrapper = require("./util/lookupWrapper");
-
-var Tag = git.Tag;
+var NodeGit = require("../");
+var LookupWrapper = NodeGit.Utils.lookupWrapper;
+var Tag = NodeGit.Tag;
 
 /**
 * Retrieves the tag pointed to by the oid
@@ -11,5 +10,3 @@ var Tag = git.Tag;
 * @return {Tag}
 */
 Tag.lookup = LookupWrapper(Tag);
-
-module.exports = Tag;

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,9 +1,10 @@
-var git = require("../");
-var Tree = git.Tree;
-var Treebuilder = git.Treebuilder;
-var Diff = git.Diff;
 var events = require("events");
-var LookupWrapper = require("./util/lookupWrapper");
+var NodeGit = require("../");
+var Diff = NodeGit.Diff;
+var LookupWrapper = NodeGit.Utils.lookupWrapper;
+var Tree = NodeGit.Tree;
+var Treebuilder = NodeGit.Treebuilder;
+
 
 /**
 * Retrieves the tree pointed to by the oid
@@ -166,5 +167,3 @@ Tree.prototype.builder = function() {
 
   return builder;
 };
-
-module.exports = Tree;

--- a/lib/tree_entry.js
+++ b/lib/tree_entry.js
@@ -1,6 +1,5 @@
 var path = require("path");
 var NodeGit = require("../");
-
 var Tree = NodeGit.Tree;
 var TreeEntry = NodeGit.TreeEntry;
 
@@ -93,5 +92,3 @@ TreeEntry.prototype.toString = function() {
 TreeEntry.prototype.oid = function() {
   return Tree.entryId(this).toString();
 };
-
-module.exports = TreeEntry;

--- a/lib/utils/lookup_wrapper.js
+++ b/lib/utils/lookup_wrapper.js
@@ -1,4 +1,5 @@
 var Promise = require("nodegit-promise");
+var NodeGit = require("../../");
 
 /**
 * Wraps a method so that you can pass in either a string, OID or the object
@@ -8,9 +9,9 @@ var Promise = require("nodegit-promise");
 *                                   object. Defaults to `objectType.lookup`.
 * @return {Function}
 */
-module.exports = function(objectType, lookupFunction) {
+function lookupWrapper(objectType, lookupFunction) {
   lookupFunction = lookupFunction || objectType.lookup;
-  
+
   return function(repo, id, callback) {
     if (id instanceof objectType) {
       return Promise.resolve(id).then(function(obj) {
@@ -34,4 +35,6 @@ module.exports = function(objectType, lookupFunction) {
       return obj;
     }, callback);
   };
-};
+}
+
+NodeGit.Utils.lookupWrapper = lookupWrapper;

--- a/lib/utils/normalize_options.js
+++ b/lib/utils/normalize_options.js
@@ -1,3 +1,5 @@
+var NodeGit = require("../../");
+
 /**
  * Normalize an object to match a struct.
  *
@@ -18,4 +20,4 @@ function normalizeOptions(options, Ctor) {
   return instance;
 }
 
-module.exports = normalizeOptions;
+NodeGit.Utils.normalizeOptions = normalizeOptions;

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -3,11 +3,9 @@ var promisify = require("promisify-node");
 var path = require("path");
 var fs = require("fs");
 
-var local = path.join.bind(path, __dirname);
-
-var checkPrepared = require(local("checkPrepared"));
+var checkPrepared = require("./checkPrepared");
 var whichNativeNodish = require("which-native-nodish");
-var prepareForBuild = require(local("prepareForBuild"));
+var prepareForBuild = require("./prepareForBuild");
 
 var exec = promisify(function(command, opts, callback) {
   return require("child_process").exec(command, opts, callback);
@@ -15,7 +13,7 @@ var exec = promisify(function(command, opts, callback) {
 var nwVersion = null;
 var asVersion = null;
 
-return whichNativeNodish(local(".."))
+return whichNativeNodish("..")
   .then(function(results) {
     nwVersion = results.nwVersion;
     asVersion = results.asVersion;
@@ -29,7 +27,7 @@ return whichNativeNodish(local(".."))
       console.info("[nodegit] Must build for atom-shell");
       return checkAndBuild();
     }
-    if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
+    if (fs.existsSync("../.didntcomefromthenpmregistry")) {
       return checkAndBuild();
     }
     if (process.env.BUILD_DEBUG) {
@@ -85,7 +83,7 @@ function build() {
   }
 
   var opts = {
-    cwd: local(".."),
+    cwd: ".",
     maxBuffer: Number.MAX_VALUE
   };
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,11 @@
 var fork = require("child_process").fork;
 var path = require("path");
-var local = path.join.bind(path, __dirname);
 
 var args = [
   "cover",
   process.platform != "win32" ?
     "_mocha" :
-    local("../node_modules/mocha/bin/_mocha"),
+    "../node_modules/mocha/bin/_mocha",
   "--",
   "runner",
   "tests",
@@ -14,7 +13,7 @@ var args = [
   "--expose-gc"
 ];
 
-fork(local("../node_modules/istanbul/lib/cli.js"), args, {
+fork("../node_modules/istanbul/lib/cli.js", args, {
   cwd: __dirname
 }).on("close", function(code) {
   process.exit(code);

--- a/test/tests/attr.js
+++ b/test/tests/attr.js
@@ -3,9 +3,10 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Attr", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Attr = require(local("../../lib/attr"));
-  var Status = require(local("../../lib/status"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Attr = NodeGit.Attr;
+  var Status = NodeGit.Status;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/attr.js
+++ b/test/tests/attr.js
@@ -3,12 +3,12 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Attr", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Attr = NodeGit.Attr;
   var Status = NodeGit.Status;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/blob.js
+++ b/test/tests/blob.js
@@ -3,9 +3,11 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Blob", function() {
-  var Oid = require(local("../../lib/oid"));
-  var Repository = require(local("../../lib/repository"));
-  var FileMode = require(local("../../lib/tree_entry")).FILEMODE;
+  var NodeGit = require(local("../../"));
+
+  var Oid = NodeGit.Oid;
+  var Repository = NodeGit.Repository;
+  var FileMode = NodeGit.TreeEntry.FILEMODE;
 
   var reposPath = local("../repos/workdir/.git");
   var oid = "111dd657329797f6165f52f5085f61ac976dcf04";

--- a/test/tests/blob.js
+++ b/test/tests/blob.js
@@ -3,13 +3,13 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Blob", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
 
   var Oid = NodeGit.Oid;
   var Repository = NodeGit.Repository;
   var FileMode = NodeGit.TreeEntry.FILEMODE;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var oid = "111dd657329797f6165f52f5085f61ac976dcf04";
 
   beforeEach(function() {

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -4,8 +4,9 @@ var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Branch", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Branch = require(local("../../lib/branch"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Branch = NodeGit.Branch;
   var branchName = "test-branch";
   var fullBranchName = "refs/heads/" + branchName;
 

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -4,13 +4,13 @@ var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Branch", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Branch = NodeGit.Branch;
   var branchName = "test-branch";
   var fullBranchName = "refs/heads/" + branchName;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -3,12 +3,12 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Checkout", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Checkout = NodeGit.Checkout;
 
   var packageJsonOid = "0fa56e90e096a4c24c785206b826ab914ea3de1e";
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -3,8 +3,9 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Checkout", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Checkout = require(local("../../lib/checkout"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Checkout = NodeGit.Checkout;
 
   var packageJsonOid = "0fa56e90e096a4c24c785206b826ab914ea3de1e";
   var reposPath = local("../repos/workdir/.git");

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -5,7 +5,7 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Clone", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Clone = NodeGit.Clone;
 

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -5,9 +5,9 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Clone", function() {
-  var Repository = require(local("../../lib/repository"));
-  var clone = require(local("../../lib/clone"));
   var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Clone = NodeGit.Clone;
 
   var clonePath = local("../repos/clone");
 
@@ -29,7 +29,7 @@ describe("Clone", function() {
     var test = this;
     var url = "http://git.tbranyen.com/smart/site-content";
 
-    return clone(url, clonePath).then(function(repo) {
+    return Clone(url, clonePath).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -46,7 +46,24 @@ describe("Clone", function() {
       }
     };
 
-    return clone(url, clonePath, opts).then(function(repo) {
+    return Clone(url, clonePath, opts).then(function(repo) {
+      assert.ok(repo instanceof Repository);
+      test.repository = repo;
+    });
+  });
+
+  it("can clone using nested function", function() {
+    var test = this;
+    var url = "https://github.com/nodegit/test.git";
+    var opts = {
+      remoteCallbacks: {
+        certificateCheck: function() {
+          return 1;
+        }
+      }
+    };
+
+    return Clone.clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -66,7 +83,7 @@ describe("Clone", function() {
       }
     };
 
-    return clone(url, clonePath, opts).then(function(repo) {
+    return Clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -90,7 +107,7 @@ describe("Clone", function() {
       }
     };
 
-    return clone(url, clonePath, opts).then(function(repo) {
+    return Clone(url, clonePath, opts).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -107,7 +124,7 @@ describe("Clone", function() {
       }
     };
 
-    return clone(url, clonePath, opts).then(function(repo) {
+    return Clone(url, clonePath, opts).then(function(repo) {
       test.repository = repo;
       assert.ok(repo instanceof Repository);
     });
@@ -118,7 +135,7 @@ describe("Clone", function() {
     var prefix = process.platform === "win32" ? "" : "file://";
     var url = prefix + local("../repos/empty");
 
-    return clone(url, clonePath).then(function(repo) {
+    return Clone(url, clonePath).then(function(repo) {
       assert.ok(repo instanceof Repository);
       test.repository = repo;
     });
@@ -127,7 +144,7 @@ describe("Clone", function() {
   it("will not segfault when accessing a url without username", function() {
     var url = "https://github.com/nodegit/private";
 
-    return clone(url, clonePath, {
+    return Clone(url, clonePath, {
       remoteCallbacks: {
         certificateCheck: function() {
           return 1;

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -108,13 +108,12 @@ describe("Commit", function() {
     })
     .then(function(parentResult) {
       parent = parentResult;
-
       return Promise.all([
         NodeGit.Signature.create("Foo Bar", "foo@bar.com", 123456789, 60),
         NodeGit.Signature.create("Foo A Bar", "foo@bar.com", 987654321, 90)
       ]);
     })
-    .then(function(signatures){
+    .then(function(signatures) {
       var author = signatures[0];
       var committer = signatures[1];
 

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -6,10 +6,10 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Commit", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";
 
   function reinitialize(test) {

--- a/test/tests/cred.js
+++ b/test/tests/cred.js
@@ -3,7 +3,7 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Cred", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   
   var sshPublicKey = local("../id_rsa.pub");
   var sshPrivateKey = local("../id_rsa");

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -6,11 +6,11 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Diff", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Diff = NodeGit.Diff;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";
   var diffFilename = "wddiff.txt";
   var diffFilepath = local("../repos/workdir", diffFilename);

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -6,8 +6,9 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Diff", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Diff = require(local("../../lib/diff"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Diff = NodeGit.Diff;
 
   var reposPath = local("../repos/workdir/.git");
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -10,10 +10,10 @@ var writeFile = promisify(function(filename, data, callback) {
 });
 
 describe("Index", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -10,8 +10,9 @@ var writeFile = promisify(function(filename, data, callback) {
 });
 
 describe("Index", function() {
-  var Repository = require(local("../../lib/repository"));
-
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  
   var reposPath = local("../repos/workdir/.git");
 
   beforeEach(function() {

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -7,7 +7,7 @@ var local = path.join.bind(path, __dirname);
 fse.ensureDir = promisify(fse.ensureDir);
 
 describe("Merge", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
 
   var reposPath = local("../repos/merge");
   var ourBranchName = "ours";

--- a/test/tests/odb.js
+++ b/test/tests/odb.js
@@ -3,9 +3,10 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Odb", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Oid = require(local("../../lib/oid"));
-  var Obj = require(local("../../lib/object"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Oid = NodeGit.Oid;
+  var Obj = NodeGit.Object;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/odb.js
+++ b/test/tests/odb.js
@@ -3,12 +3,12 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Odb", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Oid = NodeGit.Oid;
   var Obj = NodeGit.Object;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/oid.js
+++ b/test/tests/oid.js
@@ -1,9 +1,7 @@
 var assert = require("assert");
-var path = require("path");
-var local = path.join.bind(path, __dirname);
 
 describe("Oid", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Oid = NodeGit.Oid;
 
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";

--- a/test/tests/oid.js
+++ b/test/tests/oid.js
@@ -3,7 +3,8 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Oid", function() {
-  var Oid = require(local("../../lib/oid"));
+  var NodeGit = require(local("../../"));
+  var Oid = NodeGit.Oid;
 
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";
 

--- a/test/tests/refs.js
+++ b/test/tests/refs.js
@@ -9,8 +9,9 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Reference", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Reference = require(local("../../lib/reference"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Reference = NodeGit.Reference;
 
   var reposPath = local("../repos/workdir");
 

--- a/test/tests/refs.js
+++ b/test/tests/refs.js
@@ -9,7 +9,7 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Reference", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Reference = NodeGit.Reference;
 

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -4,11 +4,11 @@ var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Remote", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Remote = NodeGit.Remote;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var url = "https://github.com/nodegit/test";
   var url2 = "https://github.com/nodegit/test2";
 

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -203,8 +203,7 @@ describe("Remote", function() {
           new Error("should not be able to push to the repository"));
       }, function(err) {
         if (err.message.indexOf(401) === -1) {
-          return Promise.reject(
-            new Error("failed to return unauthorized status code"));
+          throw err;
         } else {
           return Promise.resolve();
         }

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -5,8 +5,8 @@ var local = path.join.bind(path, __dirname);
 
 describe("Remote", function() {
   var NodeGit = require(local("../../"));
-  var Repository = require(local("../../lib/repository"));
-  var Remote = require(local("../../lib/remote"));
+  var Repository = NodeGit.Repository;
+  var Remote = NodeGit.Remote;
 
   var reposPath = local("../repos/workdir/.git");
   var url = "https://github.com/nodegit/test";

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -6,12 +6,12 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Repository", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Index = NodeGit.Index;
   var Signature = NodeGit.Signature;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var newRepo = local("../repos/newrepo");
 
   beforeEach(function() {

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -6,12 +6,13 @@ var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 
 describe("Repository", function() {
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Index = NodeGit.Index;
+  var Signature = NodeGit.Signature;
+
   var reposPath = local("../repos/workdir/.git");
   var newRepo = local("../repos/newrepo");
-
-  var Repository = require(local("../../lib/repository"));
-  var Index = require(local("../../lib/index"));
-  var Signature = require(local("../../lib/signature"));
 
   beforeEach(function() {
     var test = this;

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -5,11 +5,11 @@ var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 
 describe("Reset", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Reset = NodeGit.Reset;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var currentCommitOid = "32789a79e71fbc9e04d3eff7425e1771eb595150";
   var previousCommitOid = "c82fb078a192ea221c9f1093c64321c60d64aa0d";
   var filePath = "package.json";

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -134,7 +134,7 @@ describe("Reset", function() {
       assert(resetContents == currentCommitContents);
       assert(resetContents != previousCommitContents);
 
-      return Reset.reset(test.repo, test.currentCommit, Reset.TYPE.HARD);
+      return Reset(test.repo, test.currentCommit, Reset.TYPE.HARD);
     });
   });
 

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -5,8 +5,9 @@ var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 
 describe("Reset", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Reset = require(local("../../lib/reset"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Reset = NodeGit.Reset;
 
   var reposPath = local("../repos/workdir/.git");
   var currentCommitOid = "32789a79e71fbc9e04d3eff7425e1771eb595150";

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -3,12 +3,12 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Revwalk", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Revwalk = NodeGit.Revwalk;
   var Oid = NodeGit.Oid;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   // Set a reasonable timeout here now that our repository has grown.
   this.timeout(60000);

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -3,9 +3,10 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("Revwalk", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Revwalk = require(local("../../lib/revwalk"));
-  var Oid = require(local("../../lib/oid"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Revwalk = NodeGit.Revwalk;
+  var Oid = NodeGit.Oid;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -10,11 +10,11 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Signature", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Signature = NodeGit.Signature;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   var name = "Bob Gnarley";
   var email = "gnarlee@bob.net";

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -10,8 +10,9 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Signature", function() {
-  var Signature = require(local("../../lib/signature"));
-  var Repository = require(local("../../lib/repository"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Signature = NodeGit.Signature;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/status.js
+++ b/test/tests/status.js
@@ -9,11 +9,11 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Status", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Status = NodeGit.Status;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   before(function() {
     var test = this;
@@ -75,7 +75,7 @@ describe("Status", function() {
     var fileContent = "new file from status tests";
     var repo = this.repository;
     var filePath = path.join(repo.workdir(), fileName);
-    return exec("git clean -xdf", {cwd: local("../repos/workdir")})
+    return exec("git clean -xdf", {cwd: reposPath})
       .then(function() {
         return fse.writeFile(filePath, fileContent);
       })

--- a/test/tests/status.js
+++ b/test/tests/status.js
@@ -9,8 +9,9 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("Status", function() {
-  var Status = require(local("../../lib/status"));
-  var Repository = require(local("../../lib/repository"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Status = NodeGit.Status;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/status_file.js
+++ b/test/tests/status_file.js
@@ -1,9 +1,7 @@
 var assert = require("assert");
-var path = require("path");
-var local = path.join.bind(path, __dirname);
 
 describe("StatusFile", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Status = NodeGit.Status;
   var StatusFile = NodeGit.StatusFile;
 

--- a/test/tests/status_file.js
+++ b/test/tests/status_file.js
@@ -3,8 +3,9 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("StatusFile", function() {
-  var Status = require(local("../../lib/status"));
-  var StatusFile = require(local("../../lib/status_file"));
+  var NodeGit = require(local("../../"));
+  var Status = NodeGit.Status;
+  var StatusFile = NodeGit.StatusFile;
 
   var pathName = "README.md";
   var statusCode = Status.STATUS.WT_NEW;

--- a/test/tests/status_list.js
+++ b/test/tests/status_list.js
@@ -9,12 +9,12 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("StatusList", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Status = NodeGit.Status;
   var StatusList = NodeGit.StatusList;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
 
   before(function() {
     var test = this;
@@ -29,7 +29,7 @@ describe("StatusList", function() {
     var fileContent = "new file from status tests";
     var repo = this.repository;
     var filePath = path.join(repo.workdir(), fileName);
-    return exec("git clean -xdf", {cwd: local("../repos/workdir")})
+    return exec("git clean -xdf", {cwd: reposPath})
       .then(function() {
         return fse.writeFile(filePath, fileContent);
       })

--- a/test/tests/status_list.js
+++ b/test/tests/status_list.js
@@ -9,9 +9,10 @@ var exec = promisify(function(command, opts, callback) {
 });
 
 describe("StatusList", function() {
-  var Status = require(local("../../lib/status"));
-  var StatusList = require(local("../../lib/status_list"));
-  var Repository = require(local("../../lib/repository"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Status = NodeGit.Status;
+  var StatusList = NodeGit.StatusList;
 
   var reposPath = local("../repos/workdir/.git");
 

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -1,14 +1,15 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
+var Promise = require("nodegit-promise");
 
 describe("Tag", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Tag = require(local("../../lib/tag"));
-  var Obj = require(local("../../lib/object"));
-  var Oid = require(local("../../lib/oid"));
-  var Reference = require(local("../../lib/reference"));
-  var Promise = require("nodegit-promise");
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Tag = NodeGit.Tag;
+  var Obj = NodeGit.Object;
+  var Oid = NodeGit.Oid;
+  var Reference = NodeGit.Reference;
 
   var reposPath = local("../repos/workdir/.git");
   var tagName = "annotated-tag";

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -4,14 +4,14 @@ var local = path.join.bind(path, __dirname);
 var Promise = require("nodegit-promise");
 
 describe("Tag", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Tag = NodeGit.Tag;
   var Obj = NodeGit.Object;
   var Oid = NodeGit.Oid;
   var Reference = NodeGit.Reference;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var tagName = "annotated-tag";
   var tagFullName = "refs/tags/" + tagName;
   var tagOid = "dc800017566123ff3c746b37284a24a66546667e";

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -3,8 +3,9 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("TreeEntry", function() {
-  var Repository = require(local("../../lib/repository"));
-  var Tree = require(local("../../lib/tree"));
+  var NodeGit = require(local("../../"));
+  var Repository = NodeGit.Repository;
+  var Tree = NodeGit.Tree;
 
   var reposPath = local("../repos/workdir/.git");
   var oid = "5716e9757886eaf38d51c86b192258c960d9cfea";

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -3,11 +3,11 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 
 describe("TreeEntry", function() {
-  var NodeGit = require(local("../../"));
+  var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Tree = NodeGit.Tree;
 
-  var reposPath = local("../repos/workdir/.git");
+  var reposPath = local("../repos/workdir");
   var oid = "5716e9757886eaf38d51c86b192258c960d9cfea";
 
   beforeEach(function() {


### PR DESCRIPTION
This makes functions that share typenames available under the type. Eg instead of Clone.clone, you can just call Clone, or Reset instead of Reset.reset, etc.

Also disables the ability to require specific files, requiring you to load nodegit proper. 