### PR TITLE
Don't assign enums to __proto__

### DIFF
--- a/generate/templates/templates/enums.js
+++ b/generate/templates/templates/enums.js
@@ -4,11 +4,10 @@ NodeGit.Enums = {};
 {% each . as enumerable %}
   {% if not enumerable.ignore %}
     {% if enumerable.type == "enum" %}
-      NodeGit.{{ enumerable.owner }}.{{ enumerable.JsName }} =
-        NodeGit.{{ enumerable.owner }}.__proto__.{{ enumerable.JsName }} = {
-        {% each enumerable.values as value %}
-          {{ value.JsName }}: {{ value.value }},
-        {% endeach %}
+      NodeGit.{{ enumerable.owner }}.{{ enumerable.JsName }} = {
+      {% each enumerable.values as value %}
+        {{ value.JsName }}: {{ value.value }},
+      {% endeach %}
       };
     {% endif %}
   {% endif %}


### PR DESCRIPTION
This fixes callstack errors with `apm`. I think the __proto__ assignment is a recent thing, maybe added by @maxkorp? Tests pass without, so not sure the reason for the addition.

What think ye?