### PR TITLE
Add checkoutBranch convenience method

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1,6 +1,7 @@
 var Promise = require("nodegit-promise");
 var NodeGit = require("../");
 var Blob = NodeGit.Blob;
+var Checkout = NodeGit.Checkout;
 var Commit = NodeGit.Commit;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
 var Reference = NodeGit.Reference;
@@ -599,7 +600,6 @@ Repository.prototype.getRemote = function(remote, callback) {
 Repository.prototype.fetch = function(
   remote,
   remoteCallbacks,
-
   callback)
 {
   var repo = this;
@@ -783,6 +783,33 @@ Repository.prototype.getStatusExt = function(opts) {
     }
 
     return statuses;
+  });
+};
+
+/**
+ * This will set the HEAD to point to the local branch and then attempt
+ * to update the index and working tree to match the content of the
+ * latest commit on that branch
+ * @param {String|Reference} branch the branch to checkout
+ * @param {Object|CheckoutOptions} opts the options to use for the checkout
+ */
+Repository.prototype.checkoutBranch = function(branch, opts) {
+  var repo = this;
+
+  opts = opts || {};
+  opts.checkoutStrategy = opts.checkoutStrategy || Checkout.STRATEGY.SAFE;
+
+  return repo.getReference(branch)
+  .then(function(ref) {
+    if (!ref.isBranch()) {
+      return false;
+    }
+
+    var name = ref.name();
+
+    repo.setHead(name, repo.defaultSignature(), "Switch HEAD to " + name);
+
+    return Checkout.head(repo, opts);
   });
 };
 

--- a/test/runner.js
+++ b/test/runner.js
@@ -28,6 +28,9 @@ before(function() {
       return exec("git checkout rev-walk", {cwd: workdirPath});
     })
     .then(function() {
+      return exec("git checkout checkout-test", {cwd: workdirPath});
+    })
+    .then(function() {
       return exec("git checkout master", {cwd: workdirPath});
     })
     .then(function() {
@@ -41,9 +44,12 @@ before(function() {
 
 beforeEach(function() {
   return exec("git clean -xdf", {cwd: workdirPath})
-    .then(function() {
-      return exec("git reset --hard", {cwd: workdirPath});
-    });
+  .then(function() {
+    return exec("git checkout master", {cwd: workdirPath});
+  })
+  .then(function() {
+    return exec("git reset --hard", {cwd: workdirPath});
+  });
 });
 
 afterEach(function(done) {

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -10,10 +10,10 @@ describe("Checkout", function() {
 
   var readMeName = "README.md";
   var packageJsonName = "package.json";
-  var packageJsonOid = "0fa56e90e096a4c24c785206b826ab914ea3de1e";
   var reposPath = local("../repos/workdir");
   var readMePath = local("../repos/workdir/" + readMeName);
   var packageJsonPath = local("../repos/workdir/" + packageJsonName);
+  var checkoutBranchName = "checkout-test";
 
   beforeEach(function() {
     var test = this;
@@ -28,13 +28,10 @@ describe("Checkout", function() {
     var test = this;
 
     return Checkout.head(test.repository)
-    .then(function() {
-      return test.repository.getBlob(packageJsonOid);
-    })
     .then(function(blob) {
-      var packageJson = blob.toString();
+      var packageContent = fse.readFileSync(packageJsonPath, "utf-8");
 
-      assert.ok(~packageJson.indexOf("\"ejs\": \"~1.0.0\","));
+      assert.ok(~packageContent.indexOf("\"ejs\": \"~1.0.0\","));
     });
   });
 
@@ -83,6 +80,29 @@ describe("Checkout", function() {
       return test.repository.getHeadCommit();
     }).then(function(commit) {
       assert.equal(commit, "32789a79e71fbc9e04d3eff7425e1771eb595150");
+    });
+  });
+
+  it("can checkout a branch", function() {
+    var test = this;
+
+    return test.repository.checkoutBranch(checkoutBranchName, {
+      checkoutStrategy: Checkout.STRATEGY.FORCE
+    })
+    .then(function() {
+      var packageContent = fse.readFileSync(packageJsonPath, "utf-8");
+
+      assert.ok(!~packageContent.indexOf("\"ejs\": \"~1.0.0\","));
+    })
+    .then(function() {
+      return test.repository.checkoutBranch("master", {
+        checkoutStrategy: Checkout.STRATEGY.FORCE
+      });
+    })
+    .then(function() {
+      var packageContent = fse.readFileSync(packageJsonPath, "utf-8");
+
+      assert.ok(~packageContent.indexOf("\"ejs\": \"~1.0.0\","));
     });
   });
 });


### PR DESCRIPTION
A very common thing to do in git is to checkout a new branch.
Instead of having to manually do both steps this convenience
function will now combine both into 1 command. Also added a test
for the new method.