### PR TITLE
Change Repository.prototype.setHead to be asynchronous

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1463,6 +1463,12 @@
         },
         "git_repository_message": {
           "ignore": true
+        },
+        "git_repository_set_head": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -807,8 +807,11 @@ Repository.prototype.checkoutBranch = function(branch, opts) {
 
     var name = ref.name();
 
-    repo.setHead(name, repo.defaultSignature(), "Switch HEAD to " + name);
-
+    return repo.setHead(name, 
+      repo.defaultSignature(), 
+      "Switch HEAD to " + name);
+  })
+  .then(function() {
     return Checkout.head(repo, opts);
   });
 };


### PR DESCRIPTION
Changes the descriptor file to convert setHead to be asynchronous and
return an error code. Also modifies the createBranch method to
waterfall promises from setHead into Checkout.head.