### PR TITLE
Fix `createCommitOnHead`

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -484,14 +484,14 @@ Repository.prototype.createCommitOnHead = function(
   message,
   callback){
   var repo = this;
+  var index;
 
-  return repo.openIndex().then(function(index) {
-    index.read(true);
-
-    filesToAdd.forEach(function(filePath) {
-      index.addByPath(filePath);
-    });
-
+  return repo.openIndex().then(function(index_) {
+    index = index_;
+    index.read(1);
+    return index.addAll();
+  })
+  .then(function() {
     index.write();
 
     return index.writeTree();
@@ -643,8 +643,8 @@ Repository.prototype.fetchAll = function(
 /**
  * Merge a branch onto another branch
  *
- * @param {String|Ref}  from
  * @param {String|Ref}  to
+ * @param {String|Ref}  from
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      merge with conflicts
  */
@@ -807,8 +807,8 @@ Repository.prototype.checkoutBranch = function(branch, opts) {
 
     var name = ref.name();
 
-    return repo.setHead(name, 
-      repo.defaultSignature(), 
+    return repo.setHead(name,
+      repo.defaultSignature(),
       "Switch HEAD to " + name);
   })
   .then(function() {


### PR DESCRIPTION
The convenience method `createCommitOnHead` was adding files being
ignored via `.gitignore` which is really bad. Now it's changed to
use the `Index.prototype.addAll` method since it's available now
and it wasn't when that method was written.