### PR TITLE
Add defaults to `Remote.prototype.push`

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -35,6 +35,8 @@ Remote.prototype.setCallbacks = function(callbacks) {
  */
 Remote.prototype.push = function(refSpecs, options, signature, message) {
   options = normalizeOptions(options, NodeGit.PushOptions);
+  signature = signature || this.owner().defaultSignature();
+  message = message || 'Push to ' + this.name();
 
   return push.call(this, refSpecs, options, signature, message);
 };

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -36,7 +36,7 @@ Remote.prototype.setCallbacks = function(callbacks) {
 Remote.prototype.push = function(refSpecs, options, signature, message) {
   options = normalizeOptions(options, NodeGit.PushOptions);
   signature = signature || this.owner().defaultSignature();
-  message = message || 'Push to ' + this.name();
+  message = message || "Push to " + this.name();
 
   return push.call(this, refSpecs, options, signature, message);
 };


### PR DESCRIPTION
Instead of forcing the user to pass in a signature and message
each time they call push we can derive a good default for them.