### PR TITLE
Make index.addAll use status to increase performance

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1182,9 +1182,6 @@
       "functions": {
         "git_pathspec_match_list_free": {
           "ignore": true
-        },
-        "git_pathspec_new": {
-          "ignore": true
         }
       }
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,8 @@
 var NodeGit = require("../");
 
 var Index = NodeGit.Index;
-
+var Status = NodeGit.Status;
+var Promise = require("nodegit-promise");
 /**
  * Return an array of the entries in this index.
  * @return {Array<IndexEntry>} an array of IndexEntrys
@@ -19,7 +20,21 @@ Index.prototype.entries = function() {
 
 var addAll = Index.prototype.addAll;
 Index.prototype.addAll = function(pathspec, flags, matchedCallback) {
-  return addAll.call(this, pathspec || "*", flags, matchedCallback, null);
+  // This status path code is here to speedup addall, which currently is
+  // excessively slow due to adding every single unignored file to the index
+  // even if it has no changes. Remove this when it's fixed in libgit2
+  // https://github.com/libgit2/libgit2/issues/2687
+  var paths = [];
+  var statusCB = function(path) {
+    paths.push(path);
+  };
+  return Status.foreach(this.owner(), statusCB)
+    .then(function() {
+      return Promise.resolve(paths);
+    })
+    .then(function(paths) {
+      return addAll.call(this, pathspec || "*", flags, matchedCallback, null);
+    });
 };
 
 var removeAll = Index.prototype.removeAll;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var NodeGit = require("../");
 
 var Index = NodeGit.Index;
 var Status = NodeGit.Status;
+var Pathspec = NodeGit.Pathspec;
 var Promise = require("nodegit-promise");
 /**
  * Return an array of the entries in this index.
@@ -25,15 +26,24 @@ Index.prototype.addAll = function(pathspec, flags, matchedCallback) {
   // even if it has no changes. Remove this when it's fixed in libgit2
   // https://github.com/libgit2/libgit2/issues/2687
   var paths = [];
+  var repo = this.owner();
   var statusCB = function(path) {
     paths.push(path);
   };
-  return Status.foreach(this.owner(), statusCB)
+  var idx = this;
+  return Pathspec.create(pathspec || "*")
+    .then(function(ps) {
+      pathspec = ps;
+      return Status.foreach(repo, statusCB);
+    })
     .then(function() {
       return Promise.resolve(paths);
     })
     .then(function(paths) {
-      return addAll.call(this, pathspec || "*", flags, matchedCallback, null);
+      paths = paths.filter(function(path) {
+        return !!(pathspec.matchesPath(0, path));
+      });
+      return addAll.call(idx, paths, flags, matchedCallback, null);
     });
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ Index.prototype.addAll = function(pathspec, flags, matchedCallback) {
       return Status.foreach(repo, statusCB);
     })
     .then(function() {
-      return Promise.resolve(paths);
+      return paths;
     })
     .then(function(paths) {
       paths = paths.filter(function(path) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var NodeGit = require("../");
 var Index = NodeGit.Index;
 var Status = NodeGit.Status;
 var Pathspec = NodeGit.Pathspec;
-var Promise = require("nodegit-promise");
+
 /**
  * Return an array of the entries in this index.
  * @return {Array<IndexEntry>} an array of IndexEntrys

--- a/test/tests/pathspec.js
+++ b/test/tests/pathspec.js
@@ -1,0 +1,50 @@
+var assert = require("assert");
+
+describe("Pathspec", function() {
+  var NodeGit = require("../../");
+  var Pathspec = NodeGit.Pathspec;
+
+  it("can accept just about anything against a * pathspec", function() {
+    return Pathspec.create("*")
+      .then(function(pathspec) {
+        assert.equal(pathspec.matchesPath(0, "burritoooo"), 1);
+        assert.equal(pathspec.matchesPath(0, "bob/ted/yoghurt.mp3"), 1);
+      });
+  });
+
+  it("can take a * in an array", function() {
+    return Pathspec.create(["*"])
+      .then(function(pathspec) {
+        assert.equal(pathspec.matchesPath(0, "burritoooo"), 1);
+        assert.equal(pathspec.matchesPath(0, "bob/ted/yoghurt.mp3"), 1);
+      });
+  });
+
+  it("can take a single file", function() {
+    return Pathspec.create(["myDir/burritoSupreme.mp4"])
+      .then(function(pathspec) {
+        assert.equal(pathspec.matchesPath(0, "myDir/burritoSupreme.mp4"), 1);
+        assert.equal(pathspec.matchesPath(0, "bob/ted/yoghurt.mp3"), 0);
+      });
+  });
+
+  it("can take files in an array", function() {
+    return Pathspec.create(["gwendoline.txt", "sausolito.ogg"])
+      .then(function(pathspec) {
+        assert.equal(pathspec.matchesPath(0, "gwendoline.txt"), 1);
+        assert.equal(pathspec.matchesPath(0, "sausolito.ogg"), 1);
+        assert.equal(pathspec.matchesPath(0, "sausolito.txt"), 0);
+      });
+  });
+
+  it("can handle dirs", function() {
+    return Pathspec.create(["myDir/", "bob.js"])
+      .then(function(pathspec) {
+        assert.equal(pathspec.matchesPath(0, "bob.js"), 1);
+        assert.equal(pathspec.matchesPath(0, "myDir/bob2.js"), 1);
+        assert.equal(pathspec.matchesPath(0, "bob2.js"), 0);
+        assert.equal(pathspec.matchesPath(0, "herDir/bob.js"), 0);
+      });
+  });
+
+});


### PR DESCRIPTION
See here: https://github.com/libgit2/libgit2/issues/2687
Doing this speeds things up from around 2500-3500ms for a small-medium repo to around 180-200ms. We should remove this once it's fixed in libgit2, but until then, this seems silly not to add. 

This also adds pathspec.create (since we need that to actually compare pathspecs)