### PR TITLE
Add option to `fetch` to prune the remote afterwards

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -596,10 +596,12 @@ Repository.prototype.getRemote = function(remote, callback) {
  *
  * @param {String|Remote} remote
  * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
+ * @param {Bool} pruneAfter will perform a prune after the fetch if true
  */
 Repository.prototype.fetch = function(
   remote,
   remoteCallbacks,
+  pruneAfter,
   callback)
 {
   var repo = this;
@@ -608,6 +610,11 @@ Repository.prototype.fetch = function(
     remote.setCallbacks(remoteCallbacks);
 
     return remote.fetch(null, repo.defaultSignature(), "Fetch from " + remote)
+    .then(function() {
+      if (pruneAfter) {
+        remote.prune();
+      }
+    })
     .then(function() {
       return remote.disconnect();
     }).then(function() {
@@ -621,9 +628,11 @@ Repository.prototype.fetch = function(
 /**
  * Fetches from all remotes
  * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
+ * @param {Bool} pruneAfter will perform a prune after the fetch if true
  */
 Repository.prototype.fetchAll = function(
   remoteCallbacks,
+  pruneAfter,
   callback)
 {
   var repo = this;
@@ -633,7 +642,7 @@ Repository.prototype.fetchAll = function(
 
     remotes.forEach(function(remote) {
       fetchPromises.push(
-        repo.fetch(remote, remoteCallbacks, callback));
+        repo.fetch(remote, remoteCallbacks, pruneAfter, callback));
     });
 
     return Promise.all(fetchPromises);


### PR DESCRIPTION
Since pruning a remote is very common after a fetch I figured
having it be an option would be very convenient for the user.