### PR TITLE
Updated API documentation link to work with NPM's markdown renderer. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Nick Kallen [@nk](http://twitter.com/nk)
 
 ## API Documentation. ##
 
-http://www.nodegit.org/
+[http://www.nodegit.org/](http://www.nodegit.org/)
 
 ## Getting started. ##
 


### PR DESCRIPTION
The link to the API documentation isn't clickable on NPM - apparently it needs to be explicitly marked up as a link!