### PR TITLE
Fix atom-shell install on windows

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -95,7 +95,7 @@ function build() {
 
   if (asVersion) {
     prefix = (process.platform == "win32" ?
-      "SET HOME=\"~/.atom-shell-gyp\" && " :
+      "SET HOME=%HOME%\\.atom-shell-gyp && " :
       "HOME=~/.atom-shell-gyp");
 
     target = "--target=" + asVersion;


### PR DESCRIPTION
The home directory wasn't being set correctly for atom-shell
install in a windows environment. Now things should work again.