### PR TITLE
Fix trailing space in atom-shell windows install

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -95,7 +95,7 @@ function build() {
 
   if (asVersion) {
     prefix = (process.platform == "win32" ?
-      "SET HOME=%HOME%\\.atom-shell-gyp && " :
+      "SET HOME=%HOME%\\.atom-shell-gyp&& " :
       "HOME=~/.atom-shell-gyp");
 
     target = "--target=" + asVersion;


### PR DESCRIPTION
When installing on atom-shell in windows it would add a trailing
space to the .atom-shell-gyp directory. Removing that directory is
a pain since windows doesn't handle trailing spaces too well.

This is an attempt to fix that.