### PR TITLE
Confirm builder exists before building

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -108,12 +108,15 @@ function build() {
     target = "--target=" + nwVersion;
   }
 
-  builder = path.resolve(".", "node_modules", ".bin", builder);
-  builder = builder.replace(/\s/g, "\\$&");
-  var cmd = [prefix, builder, "rebuild", target, debug, distUrl]
-    .join(" ").trim();
+  return exec("npm install " + builder)
+    .then(function() {
+      builder = path.resolve(".", "node_modules", ".bin", builder);
+      builder = builder.replace(/\s/g, "\\$&");
+      var cmd = [prefix, builder, "rebuild", target, debug, distUrl]
+        .join(" ").trim();
 
-  return exec(cmd, opts)
+      return exec(cmd, opts);
+    })
     .then(function() {
       console.info("[nodegit] Compilation complete.");
       console.info("[nodegit] Completed installation successfully.");


### PR DESCRIPTION
When not using Node 0.10.x we would sometimes have a missing
builder (i.e. pangyp or nw-gyp). We'll now do an `npm install` for
whatever builder we're using to make sure it exists.