### PR TITLE
Download all dev dependencies before build

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -110,7 +110,7 @@ function build() {
     target = "--target=" + nwVersion;
   }
 
-  return exec("npm install " + builder)
+  return exec("npm install --ignore-scripts")
     .then(function() {
       builder = path.resolve(".", "node_modules", ".bin", builder);
       builder = builder.replace(/\s/g, "\\$&");


### PR DESCRIPTION
Some dev dependencies were slipping through the cracks during an
atom-shell or nw.js install. For now we'll just download all
dev dependencies before a build just in case.