### PR TITLE
Fix gitter badge for npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,7 @@ NodeGit
 
 ## Have a problem? Come chat with us! ##
 
-[![Gitter](http://www.nodegit.org/img/gitterbadge.svg)]
-(https://gitter.im/nodegit/nodegit)
+[![Gitter](http://www.nodegit.org/img/gitterbadge.svg)](https://gitter.im/nodegit/nodegit)
 
 ## Maintained by ##
 Tim Branyen [@tbranyen](http://twitter.com/tbranyen),


### PR DESCRIPTION
This newline is breaking the link for the gitter badge on npm.