### PR TITLE
Guide navigation is currently confusing

### DIFF
--- a/guides/cloning/README.md
+++ b/guides/cloning/README.md
@@ -8,7 +8,7 @@ description: How to clone with HTTP/HTTPS
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../)
 
 * * *
 

--- a/guides/cloning/gh-two-factor/README.md
+++ b/guides/cloning/gh-two-factor/README.md
@@ -8,7 +8,7 @@ description: How to clone with GitHub Two Factor Authorization
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/cloning/ssh-with-agent/README.md
+++ b/guides/cloning/ssh-with-agent/README.md
@@ -8,7 +8,7 @@ description: How to clone with SSH using an agent
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/install/README.md
+++ b/guides/install/README.md
@@ -5,7 +5,7 @@ title: Install Basics
 description: How to install NodeGit
 ---
 
-[Return to install guides](../)
+[Return to all guides](../)
 
 * * *
 

--- a/guides/install/atom-shell/README.md
+++ b/guides/install/atom-shell/README.md
@@ -5,7 +5,7 @@ title: Atom Shell
 description: How to install NodeGit with Atom Shell
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/install/from-source/README.md
+++ b/guides/install/from-source/README.md
@@ -5,7 +5,7 @@ title: From source
 description: How to build NodeGit from source
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/install/nw.js/README.md
+++ b/guides/install/nw.js/README.md
@@ -5,7 +5,7 @@ title: NW.js
 description: How to install NodeGit with NW.js
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/repositories/initializing/README.md
+++ b/guides/repositories/initializing/README.md
@@ -8,7 +8,7 @@ description: How to initialize a repository
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to repository guides](../)
+[Return to all guides](../../)
 
 * * *
 


### PR DESCRIPTION
When you click on install basics you get a return to install guides, but
that is actually the root guides.  If you click on install atom shell
and return to install guides it actually brings you back to install
basics.  This is super confusing, I've updated it so that every section
returns to the main list.