### PR TITLE
Fix symbolic reference handling in getReferences

### DIFF
--- a/examples/general.js
+++ b/examples/general.js
@@ -343,23 +343,18 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // references such as branches, tags and remote references (everything in
     // the .git/refs directory).
 
-    return repo.getReferenceNames(nodegit.Reference.TYPE.ALL);
+    return nodegit.Repository.getReferences(repo,
+      nodegit.Reference.TYPE.LISTALL, false, true);
   })
 
-  .then(function(referenceNames) {
-    var promises = [];
-
-    referenceNames.forEach(function(referenceName) {
-      promises.push(repo.getReference(referenceName).then(function(reference) {
-        if (reference.isConcrete()) {
-          console.log("Reference:", referenceName, reference.target());
-        } else if (reference.isSymbolic()) {
-          console.log("Reference:", referenceName, reference.symbolicTarget());
-        }
-      }));
+  .then(function(references) {
+    references.forEach(function(reference) {
+      if (reference.isConcrete()) {
+        console.log("Reference:", reference.name(), reference.target());
+      } else if (reference.isSymbolic()) {
+        console.log("Reference:", reference.name(), reference.symbolicTarget());
+      }
     });
-
-    return Promise.all(promises);
   })
 
   .done(function() {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -145,7 +145,12 @@ Repository.prototype.getReference = function(name, callback) {
   }, callback);
 };
 
-Repository.getReferences = function(repo, type, refNamesOnly, callback) {
+Repository.getReferences =
+function(repo, type, refNamesOnly, includeSymbolic, callback) {
+  if (!callback && typeof includeSymbolic === "function") {
+    callback = includeSymbolic;
+    includeSymbolic = false;
+  }
   return Reference.list(repo).then(function(refList) {
     var refFilterPromises = [];
     var filteredRefs = [];
@@ -153,21 +158,14 @@ Repository.getReferences = function(repo, type, refNamesOnly, callback) {
     refList.forEach(function(refName) {
       refFilterPromises.push(Reference.lookup(repo, refName)
         .then(function(ref) {
-          if (type == Reference.TYPE.ALL || ref.type() == type) {
-            if (refNamesOnly) {
-              filteredRefs.push(refName);
-              return;
-            }
-
-            if (ref.isSymbolic()) {
-              return ref.resolve().then(function(resolvedRef) {
-                resolvedRef.repo = repo;
-
-                filteredRefs.push(resolvedRef);
-              });
-            }
-            else {
-              filteredRefs.push(ref);
+          if (type == Reference.TYPE.LISTALL || ref.type() == type) {
+            if (!ref.isSymbolic() || includeSymbolic) {
+              if (refNamesOnly) {
+                filteredRefs.push(refName);
+              }
+              else {
+                filteredRefs.push(ref);
+              }
             }
           }
         })
@@ -192,7 +190,7 @@ Repository.getReferences = function(repo, type, refNamesOnly, callback) {
  * @return {Array<Reference>}
  */
 Repository.prototype.getReferences = function(type, callback) {
-  return Repository.getReferences(this, type, false, callback);
+  return Repository.getReferences(this, type, false, false, callback);
 };
 
 /**
@@ -203,7 +201,7 @@ Repository.prototype.getReferences = function(type, callback) {
  * @return {Array<String>}
  */
 Repository.prototype.getReferenceNames = function(type, callback) {
-  return Repository.getReferences(this, type, true, callback);
+  return Repository.getReferences(this, type, true, false, callback);
 };
 
 /**


### PR DESCRIPTION
I also updated the example in `general.js` so that it would return symbolic references as expected.