### PR TITLE
Improve coverage

### DIFF
--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -9,39 +9,3 @@ const git_error *git_error_dup(const git_error *arg) {
   result->message = strdup(arg->message);
   return result;
 }
-
-const git_oid *git_oid_dup(const git_oid *arg) {
-  git_oid *result = (git_oid *)malloc(sizeof(git_oid));
-  git_oid_cpy(result, arg);
-  return result;
-}
-
-const git_index_entry *git_index_entry_dup(const git_index_entry *arg) {
-  git_index_entry *result = (git_index_entry *)malloc(sizeof(git_index_entry));
-  *result = *arg;
-  return result;
-}
-
-const git_index_time *git_index_time_dup(const git_index_time *arg) {
-  git_index_time *result = (git_index_time *)malloc(sizeof(git_index_time));
-  *result = (const git_index_time) *arg;
-  return result;
-}
-
-const git_time *git_time_dup(const git_time *arg) {
-  git_time *result = (git_time *)malloc(sizeof(git_time));
-  *result = *arg;
-  return result;
-}
-
-const git_diff_delta *git_diff_delta_dup(const git_diff_delta *arg) {
-  git_diff_delta *result = (git_diff_delta *)malloc(sizeof(git_diff_delta));
-  *result = *arg;
-  return result;
-}
-
-const git_diff_file *git_diff_file_dup(const git_diff_file *arg) {
-  git_diff_file *result = (git_diff_file *)malloc(sizeof(git_diff_file));
-  *result = *arg;
-  return result;
-}

--- a/package.json
+++ b/package.json
@@ -84,9 +84,10 @@
   "scripts": {
     "lint": "jshint lib test/tests examples lifecycleScripts",
     "coveralls": "cat ./test/coverage/merged.lcov | coveralls",
-    "cppcov": "mkdir -p test/coverage/cpp && lcov --gcov-tool $(which gcov) --capture --directory build/Release/obj.target/nodegit/src --output-file test/coverage/cpp/lcov.info",
+    "filtercov": "lcov --extract test/coverage/cpp/lcov_full.info $(pwd)/src/* $(pwd)/src/**/* $(pwd)/include/* $(pwd)/include/**/* --output-file test/coverage/cpp/lcov.info && rm test/coverage/cpp/lcov_full.info",
+    "cppcov": "mkdir -p test/coverage/cpp && lcov --gcov-tool $(which gcov) --capture --directory build/Release/obj.target/nodegit/src --output-file test/coverage/cpp/lcov_full.info",
     "mergecov": "lcov-result-merger 'test/**/*.info' 'test/coverage/merged.lcov' && genhtml test/coverage/merged.lcov --output-directory test/coverage/report",
-    "cov": "npm run cppcov && npm run mergecov",
+    "cov": "npm run cppcov && npm run filtercov && npm run mergecov",
     "mocha": "mocha test/runner test/tests",
     "mochaDebug": "mocha --debug-brk test/runner test/tests",
     "test": "npm run lint && iojs --expose-gc test || node --expose-gc test",


### PR DESCRIPTION
This removes files that we didn't author from our coverage report (nan, gyp, etc).  I removed some dead code from `src/functions/copy` and then added some Note tests to boost up some 0 coverage files.