### PR TITLE
Revert "Guide navigation is currently confusing"

### DIFF
--- a/guides/cloning/README.md
+++ b/guides/cloning/README.md
@@ -5,7 +5,7 @@ title: HTTP/HTTPS Guide
 description: How to clone with HTTP/HTTPS
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../install)
 first.**
 
 [Return to all guides](../)

--- a/guides/cloning/README.md
+++ b/guides/cloning/README.md
@@ -8,7 +8,7 @@ description: How to clone with HTTP/HTTPS
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../)
 
 * * *
 

--- a/guides/cloning/gh-two-factor/README.md
+++ b/guides/cloning/gh-two-factor/README.md
@@ -8,7 +8,7 @@ description: How to clone with GitHub Two Factor Authorization
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/cloning/gh-two-factor/README.md
+++ b/guides/cloning/gh-two-factor/README.md
@@ -5,7 +5,7 @@ title: GitHub Two Factor Auth Guide
 description: How to clone with GitHub Two Factor Authorization
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)

--- a/guides/cloning/ssh-with-agent/README.md
+++ b/guides/cloning/ssh-with-agent/README.md
@@ -5,7 +5,7 @@ title: SSH w/ Agent Guide
 description: How to clone with SSH using an agent
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)

--- a/guides/cloning/ssh-with-agent/README.md
+++ b/guides/cloning/ssh-with-agent/README.md
@@ -8,7 +8,7 @@ description: How to clone with SSH using an agent
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to cloning guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/install/README.md
+++ b/guides/install/README.md
@@ -5,7 +5,7 @@ title: Install Basics
 description: How to install NodeGit
 ---
 
-[Return to install guides](../)
+[Return to all guides](../)
 
 * * *
 

--- a/guides/install/atom-shell/README.md
+++ b/guides/install/atom-shell/README.md
@@ -5,7 +5,7 @@ title: Atom Shell
 description: How to install NodeGit with Atom Shell
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/install/from-source/README.md
+++ b/guides/install/from-source/README.md
@@ -5,7 +5,7 @@ title: From source
 description: How to build NodeGit from source
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 
@@ -54,7 +54,7 @@ Note that GCC/G++ 4.7+ are required, as the library makes use of some c++11 std 
 - [Download and install Python 2](https://www.python.org/download/windows).
 - [Download and install VS Community](https://www.visualstudio.com/products/visual-studio-community-vs).
 
-You may have to add a build flag to the installation process to successfully install.  
+You may have to add a build flag to the installation process to successfully install.
 Try first without, if the build fails, try again with the flag.
 
 *Allegedly the order in which you install Visual Studio could trigger this error.*

--- a/guides/install/nw.js/README.md
+++ b/guides/install/nw.js/README.md
@@ -5,7 +5,7 @@ title: NW.js
 description: How to install NodeGit with NW.js
 ---
 
-[Return to install guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/repositories/README.md
+++ b/guides/repositories/README.md
@@ -5,7 +5,7 @@ title: Opening a Repository
 description: How to open and free a repository
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../install)
 first.**
 
 [Return to all guides](../)

--- a/guides/repositories/initializing/README.md
+++ b/guides/repositories/initializing/README.md
@@ -8,7 +8,7 @@ description: How to initialize a repository
 **In order to run examples, you will need to [Install NodeGit](../../install/basics)
 first.**
 
-[Return to repository guides](../)
+[Return to all guides](../../)
 
 * * *
 

--- a/guides/repositories/initializing/README.md
+++ b/guides/repositories/initializing/README.md
@@ -5,7 +5,7 @@ title: Initializing
 description: How to initialize a repository
 ---
 
-**In order to run examples, you will need to [Install NodeGit](../../install/basics)
+**In order to run examples, you will need to [Install NodeGit](../../install)
 first.**
 
 [Return to all guides](../../)


### PR DESCRIPTION
Fixes nodegit/nodegit#494

Not sure what happened, but it doesn't look like the documentation changes made it into `master`?

- Add fixes from nodegit/nodegit@2fe55cc.
- Fix basic install links at the top of the guide pages.