### PR TITLE
Update Checkout and Merge

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -661,15 +661,18 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
   var repo = this;
   var fromBranch;
   var toBranch;
+  var headCommit;
 
   signature = signature || repo.defaultSignature();
 
   return Promise.all([
     repo.getBranch(to),
-    repo.getBranch(from)
-  ]).then(function(branches) {
-    toBranch = branches[0];
-    fromBranch = branches[1];
+    repo.getBranch(from),
+    repo.getHeadCommit()
+  ]).then(function(objects) {
+    toBranch = objects[0];
+    fromBranch = objects[1];
+    headCommit = objects[2];
 
     return Promise.all([
       repo.getBranchCommit(toBranch),
@@ -694,13 +697,26 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
           " to branch " +
           fromBranch.shorthand();
 
-        return toBranch.setTarget(
-          fromCommitOid,
-          signature,
-          message)
+        return branchCommits[1].getTree()
+        .then(function(tree) {
+          if (headCommit.toString() == toCommitOid) {
+            // Checkout the tree if we're on the branch
+            var opts = {checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE};
+            return NodeGit.Checkout.tree(repo, tree, opts);
+          } else {
+            // Otherwise, just point the ref
+            return;
+          }
+        })
         .then(function() {
-          return fromCommitOid;
-        });
+          return toBranch.setTarget(
+            fromCommitOid,
+            signature,
+            message)
+          .then(function() {
+            return fromCommitOid;
+          });
+        })
       }
       else {
         // We have to merge. Lets do it!

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -804,24 +804,29 @@ Repository.prototype.getStatusExt = function(opts) {
  */
 Repository.prototype.checkoutBranch = function(branch, opts) {
   var repo = this;
-
+  var reference;
   opts = opts || {};
-  opts.checkoutStrategy = opts.checkoutStrategy || Checkout.STRATEGY.SAFE;
-
+  opts.checkoutStrategy = opts.checkoutStrategy ||
+    Checkout.STRATEGY.SAFE_CREATE;
   return repo.getReference(branch)
   .then(function(ref) {
     if (!ref.isBranch()) {
       return false;
     }
-
-    var name = ref.name();
-
+    reference = ref;
+    return repo.getBranchCommit(ref.name());
+  })
+  .then(function(commit) {
+    return commit.getTree();
+  })
+  .then(function(tree) {
+    return Checkout.tree(repo, tree, opts);
+  })
+  .then(function() {
+    var name = reference.name();
     return repo.setHead(name,
       repo.defaultSignature(),
       "Switch HEAD to " + name);
-  })
-  .then(function() {
-    return Checkout.head(repo, opts);
   });
 };
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -661,24 +661,22 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
   var repo = this;
   var fromBranch;
   var toBranch;
-  var headCommit;
 
   signature = signature || repo.defaultSignature();
 
   return Promise.all([
-    repo.getBranch(to),
-    repo.getBranch(from),
-    repo.getHeadCommit()
+      repo.getBranch(to),
+      repo.getBranch(from)
   ]).then(function(objects) {
     toBranch = objects[0];
     fromBranch = objects[1];
-    headCommit = objects[2];
 
     return Promise.all([
       repo.getBranchCommit(toBranch),
       repo.getBranchCommit(fromBranch)
     ]);
-  }).then(function(branchCommits) {
+  })
+  .then(function(branchCommits) {
     var toCommitOid = branchCommits[0].toString();
     var fromCommitOid = branchCommits[1].toString();
 
@@ -699,13 +697,12 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
 
         return branchCommits[1].getTree()
         .then(function(tree) {
-          if (headCommit.toString() == toCommitOid) {
+          if (toBranch.isHead()) {
             // Checkout the tree if we're on the branch
-            var opts = {checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE};
+            var opts = {
+              checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE_CREATE
+            };
             return NodeGit.Checkout.tree(repo, tree, opts);
-          } else {
-            // Otherwise, just point the ref
-            return;
           }
         })
         .then(function() {
@@ -716,7 +713,7 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
           .then(function() {
             return fromCommitOid;
           });
-        })
+        });
       }
       else {
         // We have to merge. Lets do it!

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -83,7 +83,7 @@ describe("Checkout", function() {
     });
   });
 
-  it.only("can checkout a branch", function() {
+  it("can checkout a branch", function() {
     var test = this;
 
     return test.repository.checkoutBranch(checkoutBranchName)

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -83,21 +83,23 @@ describe("Checkout", function() {
     });
   });
 
-  it("can checkout a branch", function() {
+  it.only("can checkout a branch", function() {
     var test = this;
 
-    return test.repository.checkoutBranch(checkoutBranchName, {
-      checkoutStrategy: Checkout.STRATEGY.FORCE
-    })
+    return test.repository.checkoutBranch(checkoutBranchName)
     .then(function() {
       var packageContent = fse.readFileSync(packageJsonPath, "utf-8");
 
       assert.ok(!~packageContent.indexOf("\"ejs\": \"~1.0.0\","));
     })
     .then(function() {
-      return test.repository.checkoutBranch("master", {
-        checkoutStrategy: Checkout.STRATEGY.FORCE
-      });
+      return test.repository.getStatus();
+    })
+    .then(function(statuses) {
+      assert.equal(statuses.length, 0);
+    })
+    .then(function() {
+      return test.repository.checkoutBranch("master");
     })
     .then(function() {
       var packageContent = fse.readFileSync(packageJsonPath, "utf-8");

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -215,6 +215,10 @@ describe("Merge", function() {
       });
     })
     .then(function() {
+      var opts = {checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE};
+      return repository.checkoutBranch(ourBranchName, opts);
+    })
+    .then(function() {
       return repository.mergeBranches(
         ourBranchName,
         theirBranchName,
@@ -228,6 +232,13 @@ describe("Merge", function() {
         .then(function(branchCommit) {
           assert.equal(oid.toString(), branchCommit.toString());
         });
+    })
+    .then(function() {
+      return repository.getStatus();
+    })
+    .then(function(statuses) {
+      // make sure we didn't change the index
+      assert.equal(statuses.length, 0);
     });
   });
 


### PR DESCRIPTION
Checkout.head manipulates the index, where in these scenarios we only want to update the working tree. Tests now verify the index isn't changed when merging and checking out.