### PR TITLE
Fix atom-shell build on windows

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -463,6 +463,9 @@
             "libssh2/win32",
             "libssh2/include"
           ],
+          "defines!": [
+            "HAVE_POLL"
+          ],
           "direct_dependent_settings": {
             "include_dirs": [
               "libssh2/src",


### PR DESCRIPTION
When compiling against the latest (0.22.1 currently) atom-shell
something was defining `HAVE_POLL` which is a linux system header
file. This was breaking the atom-shell build on windows.