### PR TITLE
Add convenience methods to status file

### DIFF
--- a/lib/status_file.js
+++ b/lib/status_file.js
@@ -82,6 +82,20 @@ var StatusFile = function(args) {
     },
     isIgnored: function() {
       return data.statusBit & codes.IGNORED;
+    },
+    inWorkingTree: function() {
+      return status & codes.WT_NEW ||
+             status & codes.WT_MODIFIED ||
+             status & codes.WT_DELETED ||
+             status & codes.WT_TYPECHANGE ||
+             status & codes.WT_RENAMED;
+    },
+    inIndex: function() {
+      return status & codes.INDEX_NEW ||
+             status & codes.INDEX_MODIFIED ||
+             status & codes.INDEX_DELETED ||
+             status & codes.INDEX_TYPECHANGE ||
+             status & codes.INDEX_RENAMED;
     }
   };
 };

--- a/test/tests/status_file.js
+++ b/test/tests/status_file.js
@@ -20,4 +20,9 @@ describe("StatusFile", function() {
     assert.ok(this.status.isNew());
     assert.ok(!this.status.isModified());
   });
+
+  it("detects working tree and index statuses", function() {
+    assert.ok(this.status.inWorkingTree());
+    assert.ok(!this.status.inIndex());
+  });
 });


### PR DESCRIPTION
Adds methods `inWorkingTree` and `inIndex` to StatusFiles. These just check it the status contains any WT_xxx status codes (or INDEX_xxx). It's very possible that a status could have both (eg if you've done a patch stage). 