### PR TITLE
Fix freeing a `GitOid` that was passed as a string

### DIFF
--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -82,7 +82,7 @@ from_{{ arg.name }}
 {%each args|argsInfo as arg %}
   {%if arg | isOid %}
   if (args[{{ arg.jsArg }}]->IsString()) {
-    free(&from_{{ arg.name }});
+    free((void *)from_{{ arg.name }});
   }
   {%endif%}
 {%endeach%}

--- a/test/tests/oid.js
+++ b/test/tests/oid.js
@@ -1,4 +1,6 @@
 var assert = require("assert");
+var path = require("path");
+var local = path.join.bind(path, __dirname);
 
 describe("Oid", function() {
   var NodeGit = require("../../");
@@ -25,5 +27,20 @@ describe("Oid", function() {
     var inspect = this.oid.inspect();
 
     assert.equal(inspect, "[Oid " + oid + "]");
+  });
+
+  it("can convert strings to oids in parameters", function() {
+    return NodeGit.Repository.open(local("../repos/workdir"))
+      .then(function(repo) {
+        var revwalk = repo.createRevWalk();
+        revwalk.sorting(NodeGit.Revwalk.SORT.TIME);
+
+        revwalk.push(oid);
+
+        return revwalk.getCommits(1);
+      })
+      .then(function(commits) {
+        assert.equal(commits[0].toString(), oid);
+      });
   });
 });


### PR DESCRIPTION
We will allow a user to pass a string as a valid parameter for any parameter that is a `GitOid`. In the function will will then convert that parameter to a `GitOid` and then free it after it's no longer in use. In a synchronous function we just did `free(&arg)` which was causing an issue in Windows. Now we'll appropriately cast that to a `void *` that will allow MSBUILD to free it without crashing.