### PR TITLE
Removed the superflous "line" argument

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -181,10 +181,6 @@
         "cType": "const git_diff_hunk *"
       },
       {
-        "name": "line",
-        "cType": "const git_diff_line *"
-      },
-      {
         "name": "payload",
         "cType": "void *"
       }


### PR DESCRIPTION
The nodegit `git_diff_hunk_cb` wrapper had a definition for a `line` argument that is not present in the libgit2 API:
https://libgit2.github.com/libgit2/#HEAD/group/callback/git_diff_hunk_cb

This PR removes that `line` argument.