### PR TITLE
Fix Rebase issues

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1297,6 +1297,9 @@
             }
           }
         },
+        "git_rebase_free": {
+          "ignore": true
+        },
         "git_rebase_init": {
           "args": {
             "upstream": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1278,6 +1278,43 @@
         }
       }
     },
+    "rebase": {
+      "functions": {
+        "git_rebase_commit": {
+          "args": {
+            "id": {
+              "isReturn": true,
+              "shouldAlloc": true
+            },
+            "author": {
+              "isOptional": true
+            },
+            "message_encoding": {
+              "isOptional": true
+            },
+            "message": {
+              "isOptional": true
+            }
+          }
+        },
+        "git_rebase_init": {
+          "args": {
+            "upstream": {
+              "isOptional": true
+            },
+            "onto": {
+              "isOptional": true
+            },
+            "signature": {
+              "isOptional": true
+            },
+            "opts": {
+              "isOptional": true
+            }
+          }
+        }
+      }
+    },
     "refdb": {
       "functions": {
         "git_refdb_backend_fs": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1297,6 +1297,13 @@
             }
           }
         },
+        "git_rebase_finish": {
+          "args": {
+            "signature": {
+              "isOptional": true
+            }
+          }
+        },
         "git_rebase_free": {
           "ignore": true
         },

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -175,7 +175,7 @@
     },
     "groups": [
       [
-        "annotated",
+        "annotated_commit",
         [
           "git_annotated_commit_free",
           "git_annotated_commit_from_fetchhead",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -108,6 +108,28 @@
   },
   "new" : {
     "functions": {
+      "git_rebase_next": {
+        "type": "function",
+        "file": "rebase.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_rebase_operation **"
+          },
+          {
+            "name": "rebase",
+            "type": "git_rebase *"
+          },
+          {
+            "name": "checkout_opts",
+            "type": "git_checkout_options *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "rebase"
+      },
       "git_reset": {
         "type": "function",
         "file": "reset.h",
@@ -498,6 +520,9 @@
     }
   },
   "groups": {
+    "rebase": [
+      "git_rebase_next"
+    ],
     "reset": [
       "git_reset"
     ],

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -1,0 +1,23 @@
+var NodeGit = require("../");
+var Rebase = NodeGit.Rebase;
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+
+// Override Rebase.prototype.finish to normalize opts
+var finish = Rebase.prototype.finish;
+Rebase.prototype.finish = function(signature, opts) {
+  opts = normalizeOptions(opts || {}, NodeGit.RebaseOptions);
+  return finish.call(this, signature, opts);
+};
+
+// Override Rebase.prototype.next to normalize opts and provide good defaults
+var next = Rebase.prototype.next;
+Rebase.prototype.next = function(checkoutOpts) {
+  if (!checkoutOpts) {
+    checkoutOpts = {
+      checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE_CREATE
+    };
+  }
+
+  checkoutOpts = normalizeOptions(checkoutOpts, NodeGit.CheckoutOptions);
+  return next.call(this, checkoutOpts);
+};

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -747,6 +747,117 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
   });
 };
 
+/**
+ * Goes through a rebase's rebase operations and commits them if there are
+ * no merge conflicts
+ *
+ * @param {Repository}  repository  The repository that the rebase is being
+ *                                  performed in
+ * @param {Rebase}      rebase      The current rebase being performed
+ * @param {Signature}   signature   Identity of the one performing the rebase
+ * @return  {Int|Index} An error code for an unsuccesful rebase or an index for
+ *                      a rebase with conflicts
+ */
+function performRebase(repository, rebase, signature) {
+  return rebase.next()
+    .then(function(rebaseOperation) {
+      return repository.openIndex()
+        .then(function(index) {
+          if (index.hasConflicts()) {
+            throw index;
+          }
+
+          if (rebaseOperation) {
+            rebase.commit(null, signature);
+
+            return performRebase(repository, rebase, signature);
+          }
+
+          return rebase.finish(signature);
+        });
+    });
+}
+
+/**
+ * Rebases a branch onto another branch
+ *
+ * @param {String}    branch
+ * @param {String}    upstream
+ * @param {String}    onto
+ * @param {Signature} signature Identity of the one performing the rebase
+ * @return {Oid|Index}  A commit id for a succesful merge or an index for a
+ *                      rebase with conflicts
+ */
+Repository.prototype.rebaseBranches = function(
+  branch,
+  upstream,
+  onto,
+  signature)
+{
+  var repo = this;
+
+  signature = signature || repo.defaultSignature();
+
+  return Promise.all([
+    repo.getReference(branch),
+    upstream ? repo.getReference(upstream) : null,
+    onto ? repo.getReference(upstream) : null
+  ])
+  .then(function(refs) {
+    return Promise.all([
+      NodeGit.AnnotatedCommit.fromRef(repo, refs[0]),
+      upstream ? NodeGit.AnnotatedCommit.fromRef(repo, refs[1]) : null,
+      onto ? NodeGit.AnnotatedCommit.fromRef(repo, refs[2]) : null
+    ]);
+  })
+  .then(function(annotatedCommits) {
+    return NodeGit.Rebase.init(repo, annotatedCommits[0], annotatedCommits[1],
+      annotatedCommits[2], signature, null);
+  })
+  .then(function(rebase) {
+    return performRebase(repo, rebase, signature);
+  })
+  .then(function(error) {
+    if (error) {
+      throw error;
+    }
+
+    return repo.getBranchCommit("HEAD");
+  });
+};
+
+/**
+ * Continues an existing rebase
+ *
+ * @param {Signature} signature Identity of the one performing the rebase
+ * @return {Oid|Index}  A commit id for a succesful merge or an index for a
+ *                      rebase with conflicts
+ */
+Repository.prototype.continueRebase = function(signature) {
+  var repo = this;
+
+  return repo.openIndex()
+    .then(function(index) {
+      if (index.hasConflicts()) {
+        throw index;
+      }
+
+      return NodeGit.Rebase.open(repo);
+    })
+    .then(function(rebase) {
+      rebase.commit(null, signature);
+
+      return performRebase(repo, rebase, signature);
+    })
+    .then(function(error) {
+      if (error) {
+        throw error;
+      }
+
+      return repo.getBranchCommit("HEAD");
+    });
+};
+
 // Override Repository.initExt to normalize initoptions
 var initExt = Repository.initExt;
 Repository.initExt = function(repo_path, opts) {

--- a/lib/utils/normalize_options.js
+++ b/lib/utils/normalize_options.js
@@ -7,11 +7,11 @@ var NodeGit = require("../../");
  * @return {Object} An Oid instance.
  */
 function normalizeOptions(options, Ctor) {
-  var instance = options instanceof Ctor ? options : new Ctor();
-
   if (!options) {
     return null;
   }
+
+  var instance = options instanceof Ctor ? options : new Ctor();
 
   Object.keys(options).forEach(function(key) {
     instance[key] = options[key];

--- a/lib/utils/normalize_options.js
+++ b/lib/utils/normalize_options.js
@@ -11,7 +11,11 @@ function normalizeOptions(options, Ctor) {
     return null;
   }
 
-  var instance = options instanceof Ctor ? options : new Ctor();
+  if (options instanceof Ctor) {
+    return options;
+  }
+
+  var instance = new Ctor();
 
   Object.keys(options).forEach(function(key) {
     instance[key] = options[key];

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -12,6 +12,28 @@ describe("Rebase", function() {
   var ourBranchName = "ours";
   var theirBranchName = "theirs";
 
+  var addFileToIndex = function(repository, fileName) {
+    return repository.openIndex()
+      .then(function(index) {
+        index.read(1);
+        index.addByPath(fileName);
+        index.write();
+
+        return index.writeTree();
+      });
+  };
+
+  var removeFileFromIndex = function(repository, fileName) {
+    return repository.openIndex()
+      .then(function(index) {
+        index.read(1);
+        index.removeByPath(fileName);
+        index.write();
+
+        return index.writeTree();
+      });
+  };
+
   beforeEach(function() {
     var test = this;
     return fse.remove(repoPath)
@@ -50,14 +72,7 @@ describe("Rebase", function() {
         ourFileContent)
       // Load up the repository index and make our initial commit to HEAD
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.addByPath(ourFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return addFileToIndex(repository, ourFileName);
       })
       .then(function(oid) {
         assert.equal(oid.toString(),
@@ -85,14 +100,7 @@ describe("Rebase", function() {
           theirFileContent);
       })
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.addByPath(theirFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return addFileToIndex(repository, theirFileName);
       })
       .then(function(oid) {
         assert.equal(oid.toString(),
@@ -107,14 +115,7 @@ describe("Rebase", function() {
       })
       .then(function() {
         // unstage changes so that we can begin a rebase
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.removeByPath(theirFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return removeFileFromIndex(repository, theirFileName);
       })
       .then(function() {
         return Promise.all([
@@ -183,16 +184,9 @@ describe("Rebase", function() {
 
     return fse.writeFile(path.join(repository.workdir(), baseFileName),
       baseFileContent)
+      // Load up the repository index and make our initial commit to HEAD
       .then(function() {
-        // Load up the repository index and make our initial commit to HEAD
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.addByPath(baseFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return addFileToIndex(repository, baseFileName);
       })
       .then(function(oid) {
         assert.equal(oid.toString(),
@@ -221,14 +215,7 @@ describe("Rebase", function() {
           theirFileContent);
       })
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.addByPath(theirFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return addFileToIndex(repository, theirFileName);
       })
       .then(function(oid) {
         assert.equal(oid.toString(),
@@ -243,14 +230,7 @@ describe("Rebase", function() {
           "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
       })
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.removeByPath(theirFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return removeFileFromIndex(repository, theirFileName);
       })
       .then(function() {
         return fse.remove(path.join(repository.workdir(), theirFileName));
@@ -260,14 +240,7 @@ describe("Rebase", function() {
           ourFileContent);
       })
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.addByPath(ourFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return addFileToIndex(repository, ourFileName);
       })
       .then(function(oid) {
         assert.equal(oid.toString(),
@@ -281,14 +254,7 @@ describe("Rebase", function() {
           "e7f37ee070837052937e24ad8ba66f6d83ae7941");
       })
       .then(function() {
-        return repository.openIndex()
-          .then(function(index) {
-            index.read(1);
-            index.removeByPath(ourFileName);
-            index.write();
-
-            return index.writeTree();
-          });
+        return removeFileFromIndex(repository, ourFileName);
       })
       .then(function() {
         return fse.remove(path.join(repository.workdir(), ourFileName));

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -314,7 +314,7 @@ describe("Rebase", function() {
         // should be 0.
         assert.equal(rebase.operationCurrent(), 0);
 
-        return rebase.finish(ourSignature, new NodeGit.RebaseOptions());
+        return rebase.finish(ourSignature, {});
       })
       .then(function(result) {
         assert.equal(result, 0);
@@ -468,10 +468,7 @@ describe("Rebase", function() {
         // there should only be 1 rebase operation to perform
         assert.equal(rebase.operationEntrycount(), 1);
 
-        var opts = new NodeGit.CheckoutOptions();
-        opts.checkoutStrategy = NodeGit.Checkout.STRATEGY.SAFE_CREATE;
-
-        return rebase.next(opts);
+        return rebase.next();
       })
       .then(function(rebaseOperation) {
         assert.equal(rebaseOperation.type(),
@@ -508,7 +505,7 @@ describe("Rebase", function() {
         assert.equal(commitOid.toString(),
           "ef6d0e95167435b3d58f51ab165948c72f6f94b6");
 
-        return rebase.finish(ourSignature, new NodeGit.RebaseOptions());
+        return rebase.finish(ourSignature);
       })
       .then(function(result) {
         assert.equal(result, 0);
@@ -660,10 +657,7 @@ describe("Rebase", function() {
         // there should only be 1 rebase operation to perform
         assert.equal(rebase.operationEntrycount(), 1);
 
-        var opts = new NodeGit.CheckoutOptions();
-        opts.checkoutStrategy = NodeGit.Checkout.STRATEGY.SAFE_CREATE;
-
-        return rebase.next(opts);
+        return rebase.next();
       })
       .then(function(rebaseOperation) {
         assert.equal(rebaseOperation.type(),

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -132,6 +132,7 @@ describe("Rebase", function() {
       })
       .then(function(annotatedCommits) {
         assert.equal(annotatedCommits.length, 2);
+
         var ourAnnotatedCommit = annotatedCommits[0];
         var theirAnnotatedCommit = annotatedCommits[1];
 
@@ -156,6 +157,218 @@ describe("Rebase", function() {
       .then(function(commit) {
         assert.equal(commit.id().toString(),
           "0e9231d489b3f4303635fc4b0397830da095e7e7");
+      });
+  });
+
+  it("can cleanly rebase a branch onto another branch", function() {
+    var baseFileName = "baseNewFile.txt";
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var baseFileContent = "How do you feel about Toll Roads?";
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+          ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+          ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var theirCommitOid;
+    var ourBranch;
+    var theirBranch;
+    var rebase;
+
+    return fse.writeFile(path.join(repository.workdir(), baseFileName),
+      baseFileContent)
+      .then(function() {
+        // Load up the repository index and make our initial commit to HEAD
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.addByPath(baseFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "b5cdc109d437c4541a13fb7509116b5f03d5039a");
+
+        return repository.createCommit("HEAD", ourSignature,
+          ourSignature, "initial commit", oid, []);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "be03abdf0353d05924c53bebeb0e5bb129cda44a");
+
+        return repository.getCommit(commitOid).then(function(commit) {
+          ourCommit = commit;
+        }).then(function() {
+          return repository.createBranch(ourBranchName, commitOid)
+            .then(function(branch) {
+              ourBranch = branch;
+              return repository.createBranch(theirBranchName, commitOid);
+            });
+        });
+      })
+      .then(function(branch) {
+        theirBranch = branch;
+        return fse.writeFile(path.join(repository.workdir(), theirFileName),
+          theirFileContent);
+      })
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.addByPath(theirFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "be5f0fd38a39a67135ad68921c93cd5c17fefb3d");
+
+        return repository.createCommit(theirBranch.name(), theirSignature,
+          theirSignature, "they made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        theirCommitOid = commitOid;
+        assert.equal(commitOid.toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+      })
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.removeByPath(theirFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), theirFileName));
+      })
+      .then(function() {
+        return fse.writeFile(path.join(repository.workdir(), ourFileName),
+          ourFileContent);
+      })
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.addByPath(ourFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "77867fc0bfeb3f80ab18a78c8d53aa3a06207047");
+
+          return repository.createCommit(ourBranch.name(), ourSignature,
+            ourSignature, "we made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+      })
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.removeByPath(ourFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), ourFileName));
+      })
+      .then(function() {
+        return repository.checkoutBranch(ourBranchName);
+      })
+      .then(function() {
+        return Promise.all([
+          repository.getReference(ourBranchName),
+          repository.getReference(theirBranchName)
+        ]);
+      })
+      .then(function(refs) {
+        assert.equal(refs.length, 2);
+
+        return Promise.all([
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[0]),
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[1])
+        ]);
+      })
+      .then(function(annotatedCommits) {
+        assert.equal(annotatedCommits.length, 2);
+
+        var ourAnnotatedCommit = annotatedCommits[0];
+        var theirAnnotatedCommit = annotatedCommits[1];
+
+        assert.equal(ourAnnotatedCommit.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+        assert.equal(theirAnnotatedCommit.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+
+        return NodeGit.Rebase.init(repository, ourAnnotatedCommit,
+          theirAnnotatedCommit, null, ourSignature, null);
+      })
+      .then(function(newRebase) {
+        rebase = newRebase;
+
+        // there should only be 1 rebase operation to perform
+        assert.equal(rebase.operationEntrycount(), 1);
+
+        var opts = new NodeGit.CheckoutOptions();
+        opts.checkoutStrategy = NodeGit.Checkout.STRATEGY.SAFE_CREATE;
+
+        return rebase.next(opts);
+      })
+      .then(function(rebaseOperation) {
+        assert.equal(rebaseOperation.type(),
+          NodeGit.RebaseOperation.REBASE_OPERATION.PICK);
+        assert.equal(rebaseOperation.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        return rebase.commit(null, ourSignature);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "b937100ee0ea17ef20525306763505a7fe2be29e");
+
+        // git_rebase_operation_current returns the index of the rebase
+        // operation that was last applied, so after the first operation, it
+        // should be 0.
+        assert.equal(rebase.operationCurrent(), 0);
+
+        return rebase.finish(ourSignature, new NodeGit.RebaseOptions());
+      })
+      .then(function(result) {
+        assert.equal(result, 0);
+
+        return repository.getBranchCommit(ourBranchName);
+      })
+      .then(function(commit) {
+        assert.equal(commit.id().toString(),
+          "b937100ee0ea17ef20525306763505a7fe2be29e");
+
+        return commit.parent(0);
+      })
+      .then(function(commit) {
+        // verify that we are on top of "their commit"
+        assert.equal(commit.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
       });
   });
 });

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -1,0 +1,161 @@
+var assert = require("assert");
+var path = require("path");
+var local = path.join.bind(path, __dirname);
+var Promise = require("nodegit-promise");
+var promisify = require("promisify-node");
+var fse = promisify(require("fs-extra"));
+
+describe("Rebase", function() {
+  var NodeGit = require("../../");
+
+  var repoPath = local("../repos/rebase");
+  var ourBranchName = "ours";
+  var theirBranchName = "theirs";
+
+  beforeEach(function() {
+    var test = this;
+    return fse.remove(repoPath)
+      .then(function() {
+        return fse.ensureDir(repoPath);
+      })
+      .then(function() {
+        return NodeGit.Repository.init(repoPath, 0);
+      })
+      .then(function(repo) {
+        test.repository = repo;
+      });
+  });
+
+  after(function() {
+    return fse.remove(repoPath);
+  });
+
+  it("can cleanly fast-forward via rebase", function() {
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+          ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+          ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var theirBranch;
+
+    return fse.writeFile(path.join(repository.workdir(), ourFileName),
+        ourFileContent)
+      // Load up the repository index and make our initial commit to HEAD
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.addByPath(ourFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "11ead82b1135b8e240fb5d61e703312fb9cc3d6a");
+
+        return repository.createCommit("HEAD", ourSignature,
+          ourSignature, "we made a commit", oid, []);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "91a183f87842ebb7a9b08dad8bc2473985796844");
+
+        return repository.getCommit(commitOid).then(function(commit) {
+          ourCommit = commit;
+        }).then(function() {
+          return repository.createBranch(ourBranchName, commitOid)
+            .then(function(branch) {
+              return repository.createBranch(theirBranchName, commitOid);
+            });
+        });
+      })
+      .then(function(branch) {
+        theirBranch = branch;
+        return fse.writeFile(path.join(repository.workdir(), theirFileName),
+          theirFileContent);
+      })
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.addByPath(theirFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "76631cb5a290dafe2959152626bb90f2a6d8ec94");
+
+        return repository.createCommit(theirBranch.name(), theirSignature,
+          theirSignature, "they made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+      })
+      .then(function() {
+        // unstage changes so that we can begin a rebase
+        return repository.openIndex()
+          .then(function(index) {
+            index.read(1);
+            index.removeByPath(theirFileName);
+            index.write();
+
+            return index.writeTree();
+          });
+      })
+      .then(function() {
+        return Promise.all([
+          repository.getReference(ourBranchName),
+          repository.getReference(theirBranchName)
+        ]);
+      })
+      .then(function(refs) {
+        assert.equal(refs.length, 2);
+
+        return Promise.all([
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[0]),
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[1])
+        ]);
+      })
+      .then(function(annotatedCommits) {
+        assert.equal(annotatedCommits.length, 2);
+        var ourAnnotatedCommit = annotatedCommits[0];
+        var theirAnnotatedCommit = annotatedCommits[1];
+
+        assert.equal(ourAnnotatedCommit.id().toString(),
+          "91a183f87842ebb7a9b08dad8bc2473985796844");
+        assert.equal(theirAnnotatedCommit.id().toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+
+        return NodeGit.Rebase.init(repository, ourAnnotatedCommit,
+          theirAnnotatedCommit, theirAnnotatedCommit, ourSignature,
+          new NodeGit.RebaseOptions());
+      })
+      .then(function(rebase) {
+        assert.equal(rebase.operationEntrycount(), 0);
+        assert.equal(rebase.operationCurrent(), 0);
+
+        return rebase.finish(ourSignature, new NodeGit.RebaseOptions());
+      })
+      .then(function() {
+        return repository.getBranchCommit(ourBranchName);
+      })
+      .then(function(commit) {
+        assert.equal(commit.id().toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+      });
+  });
+});


### PR DESCRIPTION
+ `annotated_commit` was mistakenly named `annotated` in libgit2-supplement.json, and was thus not appearing in the NodeGit due to `annotated` being one of the removed groups. fixed the name.
+ added the `git_rebase_next` function to libgit2-supplment.json
+ updated descriptor.json for `git_rebase_commit`, `git_rebase_finish`, `git_rebase_free`, and `git_rebase_init`
+ fixed an issue with normalize_options.js causing errors if an instance of the Ctor was passed in
+ added Rebase convenience methods for normalizing options
+ added `rebaseBranches` and `continueRebase` convenience methods to `Repository` to help automate the rebase steps
+ added `/tests/rebase.js` for testing rebasing with and without the convenience methods