### PR TITLE
Fix path function in tree_entry (fix for issue #570)

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,3 +1,4 @@
+var pathmod = require("path");
 var events = require("events");
 var NodeGit = require("../");
 var Diff = NodeGit.Diff;
@@ -69,6 +70,7 @@ Tree.prototype.getEntry = function(path, callback) {
 
   return this.entryByPath(path).then(function(entry) {
     entry.parent = tree;
+    entry.dirtoparent = pathmod.dirname(path);
 
     if (typeof callback === "function") {
       callback(null, entry);

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -1,4 +1,4 @@
-var pathmod = require("path");
+var path = require("path");
 var events = require("events");
 var NodeGit = require("../");
 var Diff = NodeGit.Diff;
@@ -62,15 +62,15 @@ Tree.prototype.entryByName = function(name) {
  * Get an entry at a path. Unlike by name, this takes a fully
  * qualified path, like `/foo/bar/baz.javascript`
  *
- * @param {String} path
+ * @param {String} filePath
  * @return {TreeEntry}
  */
-Tree.prototype.getEntry = function(path, callback) {
+Tree.prototype.getEntry = function(filePath, callback) {
   var tree = this;
 
-  return this.entryByPath(path).then(function(entry) {
+  return this.entryByPath(filePath).then(function(entry) {
     entry.parent = tree;
-    entry.dirtoparent = pathmod.dirname(path);
+    entry.dirtoparent = path.dirname(filePath);
 
     if (typeof callback === "function") {
       callback(null, entry);

--- a/lib/tree_entry.js
+++ b/lib/tree_entry.js
@@ -79,7 +79,7 @@ TreeEntry.prototype.getBlob = function(callback) {
  * @return {String}
  */
 TreeEntry.prototype.path = function(callback) {
-  return path.join(this.parent.path(), this.filename());
+  return path.join(this.parent.path(), this.dirtoparent, this.filename());
 };
 
 /**

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -45,6 +45,13 @@ describe("TreeEntry", function() {
     });
   });
 
+  it("provides the full path", function() {
+    return this.commit.getEntry("test/raw-commit.js")
+      .then(function(entry) {
+        assert.equal(entry.path(), "test/raw-commit.js");
+      });
+  });
+
   it("provides the blob representation of the entry", function() {
     return this.commit.getEntry("test/raw-commit.js")
       .then(function(entry) {


### PR DESCRIPTION
Fix for issue #570
If the entry path goes beyond the immediate children (a file in a subdir for instance) then path would return a path missing the subdir name

As an example:
getEntry("test/rawcommit.js") => entry path will be returned as "rawcommit.js"