### PR TITLE
Added NodeGit.Checkout.index

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -260,7 +260,15 @@
           }
         },
         "git_checkout_index": {
-          "ignore": true
+          "args": {
+            "opts": {
+              "isOptional": true
+            }
+          },
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_checkout_tree": {
           "args": {

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -2,8 +2,9 @@ var NodeGit = require("../");
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Checkout = NodeGit.Checkout;
-var head = Checkout.head;
-var tree = Checkout.tree;
+var _head = Checkout.head;
+var _index = Checkout.index;
+var _tree = Checkout.tree;
 
 /**
 * Patch head checkout to automatically coerce objects.
@@ -16,7 +17,22 @@ var tree = Checkout.tree;
 Checkout.head = function(url, options) {
   options = normalizeOptions(options, NodeGit.CheckoutOptions);
 
-  return head.call(this, url, options);
+  return _head.call(this, url, options);
+};
+
+/**
+* Patch index checkout to automatically coerce objects.
+*
+* @async
+* @param {Repository} repo The repo to checkout an index
+* @param {Index} The index to checkout
+* @param {CheckoutOptions} [options] Options for the checkout
+* @return {Void} checkout complete
+*/
+Checkout.index = function(repo, index, options) {
+  options = normalizeOptions(options, NodeGit.CheckoutOptions);
+
+  return _index.call(this, repo, index, options);
 };
 
 /**
@@ -31,5 +47,5 @@ Checkout.head = function(url, options) {
 Checkout.tree = function(repo, treeish, options) {
   options = normalizeOptions(options, NodeGit.CheckoutOptions);
 
-  return tree.call(this, repo, treeish, options);
+  return _tree.call(this, repo, treeish, options);
 };

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -142,7 +142,8 @@ describe("Checkout", function() {
 
       var signature = test.repository.defaultSignature();
 
-      return test.repository.createCommit("refs/heads/" + testBranchName, signature, signature, "we made breaking changes", oid, [ourCommit]);
+      return test.repository.createCommit("refs/heads/" + testBranchName,
+        signature, signature, "we made breaking changes", oid, [ourCommit]);
     })
     .then(function(commit) {
       return Promise.all([
@@ -151,7 +152,8 @@ describe("Checkout", function() {
       ]);
     })
     .then(function(commits) {
-      return NodeGit.Merge.commits(test.repository, commits[0], commits[1], null);
+      return NodeGit.Merge.commits(test.repository, commits[0], commits[1],
+        null);
     })
     .then(function(index) {
       assert.ok(index);
@@ -178,6 +180,6 @@ describe("Checkout", function() {
     .then(function() {
       var finalContent = fse.readFileSync(packageJsonPath, "utf-8");
       assert.equal(finalContent, "\n");
-    })
+    });
   });
 });

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -1,5 +1,6 @@
 var assert = require("assert");
 var path = require("path");
+var Promise = require("nodegit-promise");
 var fse = require("fs-extra");
 var local = path.join.bind(path, __dirname);
 
@@ -106,5 +107,77 @@ describe("Checkout", function() {
 
       assert.ok(~packageContent.indexOf("\"ejs\": \"~1.0.0\","));
     });
+  });
+
+  it("can checkout an index with conflicts", function() {
+    var test = this;
+
+    var testBranchName = "test";
+    var ourCommit;
+
+    return test.repository.getBranchCommit(checkoutBranchName)
+    .then(function(commit) {
+      ourCommit = commit;
+
+      return test.repository.createBranch(testBranchName, commit.id());
+    })
+    .then(function() {
+      return test.repository.checkoutBranch(testBranchName);
+    })
+    .then(function(branch) {
+      fse.writeFileSync(packageJsonPath, "\n");
+
+      return test.repository.openIndex()
+        .then(function(index) {
+          index.read(1);
+          index.addByPath(packageJsonName);
+          index.write();
+
+          return index.writeTree();
+        });
+    })
+    .then(function(oid) {
+      assert.equal(oid.toString(),
+        "85135ab398976a4d5be6a8704297a45f2b1e7ab2");
+
+      var signature = test.repository.defaultSignature();
+
+      return test.repository.createCommit("refs/heads/" + testBranchName, signature, signature, "we made breaking changes", oid, [ourCommit]);
+    })
+    .then(function(commit) {
+      return Promise.all([
+        test.repository.getBranchCommit(testBranchName),
+        test.repository.getBranchCommit("master")
+      ]);
+    })
+    .then(function(commits) {
+      return NodeGit.Merge.commits(test.repository, commits[0], commits[1], null);
+    })
+    .then(function(index) {
+      assert.ok(index);
+      assert.ok(index.hasConflicts && index.hasConflicts());
+
+      return NodeGit.Checkout.index(test.repository, index);
+    })
+    .then(function() {
+      // Verify that the conflict has been written to disk
+      var conflictedContent = fse.readFileSync(packageJsonPath, "utf-8");
+
+      assert.ok(~conflictedContent.indexOf("<<<<<<< ours"));
+      assert.ok(~conflictedContent.indexOf("======="));
+      assert.ok(~conflictedContent.indexOf(">>>>>>> theirs"));
+
+      // Cleanup
+      var opts = {
+        checkoutStrategy: Checkout.STRATEGY.FORCE,
+        paths: packageJsonName
+      };
+
+      return Checkout.head(test.repository, opts);
+    })
+    .then(function() {
+      var finalContent = fse.readFileSync(packageJsonPath, "utf-8");
+      assert.equal(finalContent, "\n");
+    })
   });
 });


### PR DESCRIPTION
+ updated `descriptor.json` for `git_checkout_index` (was previously ignored)
+ added normalize option convenience method
+ added a test to make sure an index with conflicts will write to disk when checked out

This function is useful for easily writing merge conflicts to disk since both merge and rebase will throw the index when there are merge conflicts