### PR TITLE
Standard merge

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -972,7 +972,14 @@
     "merge": {
       "functions": {
         "git_merge": {
-          "ignore": true
+          "args": {
+            "their_heads": {
+              "cType": "const git_annotated_commit **",
+              "cppClassName": "Array",
+              "jsClassName": "Array",
+              "arrayElementCppClassName": "GitAnnotatedCommit"
+            }
+          }
         },
         "git_merge_analysis": {
           "ignore": true

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -4,6 +4,7 @@ var Promise = require("nodegit-promise");
 
 var Merge = NodeGit.Merge;
 var mergeCommits = Merge.commits;
+var mergeMerge = Merge.merge;
 
 /**
  * Merge 2 commits together and create an new index that can
@@ -23,4 +24,25 @@ Merge.commits = function(repo, ourCommit, theirCommit, options) {
   ]).then(function(commits) {
     return mergeCommits.call(this, repo, commits[0], commits[1], options);
   });
+};
+
+/**
+ * Merge a commit into HEAD and writes the results to the working directory.
+ *
+ * @param {Repository} repo Repository that contains the given commits
+ * @param {Commit} theirHead The annotated to merge into HEAD
+ * @param {MergeOptions} [mergeOpts] The merge tree options (null for default)
+ * @param {CheckoutOptions} [checkoutOpts] The checkout options
+ *                                         (null for default)
+ */
+Merge.merge = function(repo, theirHead, mergeOpts, checkoutOpts) {
+  mergeOpts = normalizeOptions(mergeOpts || {}, NodeGit.MergeOptions);
+  checkoutOpts = normalizeOptions(checkoutOpts || {}, NodeGit.CheckoutOptions);
+
+  // Even though git_merge takes an array of annotated_commits, it expects
+  // exactly one to have been passed in or it will throw an error...  ¯\_(ツ)_/¯
+  var theirHeads = [theirHead];
+
+  return mergeMerge.call(this, repo, theirHeads, theirHeads.length,
+    mergeOpts, checkoutOpts);
 };

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -526,7 +526,8 @@ describe("Merge", function() {
       });
   });
 
-  it("standard merge puts repository in a MERGE state", function() {
+  it("leaves repo in MERGE state after a standard merge with conflicts fails",
+  function() {
     var fileName = "everyonesFile.txt";
 
     var baseFileContent = "How do you feel about Toll Roads?\n";
@@ -662,11 +663,7 @@ describe("Merge", function() {
         return NodeGit.AnnotatedCommit.fromRef(repository, theirRef);
       })
       .then(function(theirAnnotatedCommit) {
-        var mergeOpts = new NodeGit.MergeOptions();
-        var checkoutOpts = new NodeGit.CheckoutOptions();
-
-        return NodeGit.Merge(repository, [theirAnnotatedCommit], 1, mergeOpts,
-          checkoutOpts);
+        return NodeGit.Merge(repository, theirAnnotatedCommit);
       })
       .then(function(result) {
         assert.equal(result, 0);


### PR DESCRIPTION
Enabled `git_merge` (NodeGit.Merge() and NodeGit.Merge.merge) and added a convenience method.

`git_merge` is the standard merge that merges into HEAD and writes the MERGE_* to the git repo which is the indicator that the repo is currently in a merge state. (`git_repository_state` looks for those files to determine if it's in a merge state)

Other merge methods, such as `Merge.commits` don't actually leave the repo in a merge state