### PR TITLE
Rewrite test for statusFile

### DIFF
--- a/test/tests/status_file.js
+++ b/test/tests/status_file.js
@@ -7,37 +7,79 @@ describe("StatusFile", function() {
 
   var pathName = "README.md";
 
-  var checkStatusFile = function(status) {
-    it("identifies the proper statuses for " + status, function() {
-      var statusFile = new StatusFile({
-        path: pathName,
-        status: Status.STATUS[status]
-      });
-      var specialFunction = status.replace(/^(WT|INDEX)_/, "");
-      specialFunction = "is" +
-        specialFunction[0] +
-        specialFunction.substring(1).toLowerCase();
-      if (/^WT_/.test(status)) {
-        assert.ok(statusFile.inWorkingTree());
-        assert.ok(!statusFile.inIndex());
-      }
-      if (/^INDEX_/.test(status)) {
-        assert.ok(!statusFile.inWorkingTree());
-        assert.ok(statusFile.inIndex());
-      }
-      assert.equal(statusFile.path(), pathName);
-      assert.equal(statusFile.statusBit(), Status.STATUS[status]);
-      assert.equal(statusFile.status(), status);
-      assert.ok(statusFile[specialFunction]());
+  function testStatusFile(status) {
+    var statusFile = new StatusFile({
+      path: pathName,
+      status: Status.STATUS[status]
     });
-  };
-
-  for (var status in Status.STATUS) {
-    if (status === "CURRENT" || status === "WT_UNREADABLE") {
-      continue;
+    var specialFunction = status.replace(/^(WT|INDEX)_/, "");
+    specialFunction = "is" +
+      specialFunction[0] +
+      specialFunction.substring(1).toLowerCase();
+    if (/^WT_/.test(status)) {
+      assert.ok(statusFile.inWorkingTree());
+      assert.ok(!statusFile.inIndex());
     }
-    checkStatusFile(status);
+    if (/^INDEX_/.test(status)) {
+      assert.ok(!statusFile.inWorkingTree());
+      assert.ok(statusFile.inIndex());
+    }
+    assert.equal(statusFile.path(), pathName);
+    assert.equal(statusFile.statusBit(), Status.STATUS[status]);
+    assert.equal(statusFile.status(), status);
+    assert.ok(statusFile[specialFunction]());
   }
 
+  it.skip("identifies the proper statuses for CURRENT", function() {
+    testStatusFile("CURRENT");
+  });
+
+  it.skip("identifies the proper statuses for WT_UNREADABLE", function() {
+    testStatusFile("WT_UNREADABLE");
+  });
+
+  it("identifies the proper statuses for WT_NEW", function() {
+    testStatusFile("WT_NEW");
+  });
+
+  it("identifies the proper statuses for WT_MODIFIED", function() {
+    testStatusFile("WT_MODIFIED");
+  });
+
+  it("identifies the proper statuses for WT_DELETED", function() {
+    testStatusFile("WT_DELETED");
+  });
+
+  it("identifies the proper statuses for WT_TYPECHANGE", function() {
+    testStatusFile("WT_TYPECHANGE");
+  });
+
+  it("identifies the proper statuses for WT_RENAMED", function() {
+    testStatusFile("WT_RENAMED");
+  });
+
+  it("identifies the proper statuses for IGNORED", function() {
+    testStatusFile("IGNORED");
+  });
+
+  it("identifies the proper statuses for INDEX_NEW", function() {
+    testStatusFile("INDEX_NEW");
+  });
+
+  it("identifies the proper statuses for INDEX_MODIFIED", function() {
+    testStatusFile("INDEX_MODIFIED");
+  });
+
+  it("identifies the proper statuses for INDEX_DELETED", function() {
+    testStatusFile("INDEX_DELETED");
+  });
+
+  it("identifies the proper statuses for INDEX_TYPECHANGE", function() {
+    testStatusFile("INDEX_TYPECHANGE");
+  });
+
+  it("identifies the proper statuses for INDEX_RENAMED", function() {
+    testStatusFile("INDEX_RENAMED");
+  });
 
 });

--- a/test/tests/status_file.js
+++ b/test/tests/status_file.js
@@ -6,23 +6,38 @@ describe("StatusFile", function() {
   var StatusFile = NodeGit.StatusFile;
 
   var pathName = "README.md";
-  var statusCode = Status.STATUS.WT_NEW;
 
-  before(function() {
-    this.status = new StatusFile({path: pathName, status: statusCode});
-  });
+  var checkStatusFile = function(status) {
+    it("identifies the proper statuses for " + status, function() {
+      var statusFile = new StatusFile({
+        path: pathName,
+        status: Status.STATUS[status]
+      });
+      var specialFunction = status.replace(/^(WT|INDEX)_/, "");
+      specialFunction = "is" +
+        specialFunction[0] +
+        specialFunction.substring(1).toLowerCase();
+      if (/^WT_/.test(status)) {
+        assert.ok(statusFile.inWorkingTree());
+        assert.ok(!statusFile.inIndex());
+      }
+      if (/^INDEX_/.test(status)) {
+        assert.ok(!statusFile.inWorkingTree());
+        assert.ok(statusFile.inIndex());
+      }
+      assert.equal(statusFile.path(), pathName);
+      assert.equal(statusFile.statusBit(), Status.STATUS[status]);
+      assert.equal(statusFile.status(), status);
+      assert.ok(statusFile[specialFunction]());
+    });
+  };
 
-  it("passes the path to the working function", function() {
-    assert.equal(this.status.path(), pathName);
-  });
+  for (var status in Status.STATUS) {
+    if (status === "CURRENT" || status === "WT_UNREADABLE") {
+      continue;
+    }
+    checkStatusFile(status);
+  }
 
-  it("identifies the proper statuses", function() {
-    assert.ok(this.status.isNew());
-    assert.ok(!this.status.isModified());
-  });
 
-  it("detects working tree and index statuses", function() {
-    assert.ok(this.status.inWorkingTree());
-    assert.ok(!this.status.inIndex());
-  });
 });


### PR DESCRIPTION
I'm adding test to check all Statuses, that have NodeGit.Status object. Currently, I skip statuses 'CURRENT' and 'WP_UNREADABLE', because it fails tests. Are they needed to implement different logic, then in checkStatusFile function?