### PR TITLE
Update `Repository.prototype.getReferences` to use changed libgit2 enum

### DIFF
--- a/examples/general.js
+++ b/examples/general.js
@@ -343,7 +343,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // references such as branches, tags and remote references (everything in
     // the .git/refs directory).
 
-    return repo.getReferenceNames(nodegit.Reference.TYPE.ALL);
+    return repo.getReferenceNames(nodegit.Reference.TYPE.LISTALL);
   })
 
   .then(function(referenceNames) {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -153,7 +153,7 @@ Repository.getReferences = function(repo, type, refNamesOnly, callback) {
     refList.forEach(function(refName) {
       refFilterPromises.push(Reference.lookup(repo, refName)
         .then(function(ref) {
-          if (type == Reference.TYPE.ALL || ref.type() == type) {
+          if (type == Reference.TYPE.LISTALL || ref.type() == type) {
             if (refNamesOnly) {
               filteredRefs.push(refName);
               return;
@@ -164,6 +164,9 @@ Repository.getReferences = function(repo, type, refNamesOnly, callback) {
                 resolvedRef.repo = repo;
 
                 filteredRefs.push(resolvedRef);
+              })
+              .catch(function() {
+                // If we can't resolve the ref then just ignore it.
               });
             }
             else {


### PR DESCRIPTION
An enum value in libgit2 changed from `Reference.TYPE.ALL` to `Reference.TYPE.LISTALL`. Updated the example and the helper method to reflect that.

Also added in a catch to prevent an unresolvable symbolic ref from taking down the whole method.