### PR TITLE
Fix rebase convenience method for fast-forward and no-op situations

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -798,13 +798,16 @@ Repository.prototype.rebaseBranches = function(
   signature)
 {
   var repo = this;
+  var branchCommit;
+  var upstreamCommit;
+  var ontoCommit;
 
   signature = signature || repo.defaultSignature();
 
   return Promise.all([
     repo.getReference(branch),
     upstream ? repo.getReference(upstream) : null,
-    onto ? repo.getReference(upstream) : null
+    onto ? repo.getReference(onto) : null
   ])
   .then(function(refs) {
     return Promise.all([
@@ -814,17 +817,38 @@ Repository.prototype.rebaseBranches = function(
     ]);
   })
   .then(function(annotatedCommits) {
-    return NodeGit.Rebase.init(repo, annotatedCommits[0], annotatedCommits[1],
-      annotatedCommits[2], signature, null);
+    branchCommit = annotatedCommits[0];
+    upstreamCommit = annotatedCommits[1];
+    ontoCommit = annotatedCommits[2];
+
+    return NodeGit.Merge.base(repo, branchCommit.id(), upstreamCommit.id());
   })
-  .then(function(rebase) {
-    return performRebase(repo, rebase, signature);
-  })
-  .then(function(error) {
-    if (error) {
-      throw error;
+  .then(function(oid) {
+    if (oid.toString() === branchCommit.id().toString()) {
+      // we just need to fast-forward
+      return repo.mergeBranches(branch, upstream)
+        .then(function() {
+          // checkout 'branch' to match the behavior of rebase
+          return repo.checkoutBranch(branch);
+        });
+    } else if (oid.toString() === upstreamCommit.id().toString()) {
+      // 'branch' is already on top of 'upstream'
+      // checkout 'branch' to match the behavior of rebase
+      return repo.checkoutBranch(branch);
     }
 
+    return NodeGit.Rebase.init(repo, branchCommit, upstreamCommit, ontoCommit,
+      signature, null)
+      .then(function(rebase) {
+        return performRebase(repo, rebase, signature);
+      })
+      .then(function(error) {
+        if (error) {
+          throw error;
+        }
+      });
+  })
+  .then(function() {
     return repo.getBranchCommit("HEAD");
   });
 };

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -707,6 +707,108 @@ describe("Rebase", function() {
       });
   });
 
+  it("can fast-forward via rebase using the convenience methods", function() {
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+          ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+          ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var theirBranch;
+
+    return fse.writeFile(path.join(repository.workdir(), ourFileName),
+        ourFileContent)
+      // Load up the repository index and make our initial commit to HEAD
+      .then(function() {
+        return addFileToIndex(repository, ourFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "11ead82b1135b8e240fb5d61e703312fb9cc3d6a");
+
+        return repository.createCommit("HEAD", ourSignature,
+          ourSignature, "we made a commit", oid, []);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "91a183f87842ebb7a9b08dad8bc2473985796844");
+
+        return repository.getCommit(commitOid).then(function(commit) {
+          ourCommit = commit;
+        }).then(function() {
+          return repository.createBranch(ourBranchName, commitOid)
+            .then(function(branch) {
+              return repository.createBranch(theirBranchName, commitOid);
+            });
+        });
+      })
+      .then(function(branch) {
+        theirBranch = branch;
+        return fse.writeFile(path.join(repository.workdir(), theirFileName),
+          theirFileContent);
+      })
+      .then(function() {
+        return addFileToIndex(repository, theirFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "76631cb5a290dafe2959152626bb90f2a6d8ec94");
+
+        return repository.createCommit(theirBranch.name(), theirSignature,
+          theirSignature, "they made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+      })
+      .then(function() {
+        // unstage changes so that we can begin a rebase
+        return removeFileFromIndex(repository, theirFileName);
+      })
+      .then(function() {
+        return Promise.all([
+          repository.getReference(ourBranchName),
+          repository.getReference(theirBranchName)
+        ]);
+      })
+      .then(function(refs) {
+        assert.equal(refs.length, 2);
+
+        return Promise.all([
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[0]),
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[1])
+        ]);
+      })
+      .then(function(annotatedCommits) {
+        assert.equal(annotatedCommits.length, 2);
+
+        var ourAnnotatedCommit = annotatedCommits[0];
+        var theirAnnotatedCommit = annotatedCommits[1];
+
+        assert.equal(ourAnnotatedCommit.id().toString(),
+          "91a183f87842ebb7a9b08dad8bc2473985796844");
+        assert.equal(theirAnnotatedCommit.id().toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+
+        return fse.remove(path.join(repository.workdir(), theirFileName));
+      })
+      .then(function() {
+        return repository.rebaseBranches(ourBranchName, theirBranchName, null,
+          ourSignature);
+      })
+      .then(function(commit) {
+        assert.equal(commit.id().toString(),
+          "0e9231d489b3f4303635fc4b0397830da095e7e7");
+      });
+  });
+
   it("can rebase using the convenience method", function() {
     var baseFileName = "baseNewFile.txt";
     var ourFileName = "ourNewFile.txt";


### PR DESCRIPTION
The rebase convenience method (`repo.rebaseBranches()`) was not behaving as expect in fast-forward or no-op situations.

- For fast-forward, it was throwing an error, since `rebase.next()` throws an error if there's nothing to rebase. Now it checks to see if it can fast-forward before attempting the rebase, and if it can, it'll fast-forward.
- For no-ops ('ours' was already on top of 'theirs'), instead of doing nothing, it would rebase anyway, creating a new set of commits. Now it checks if it's already on top, and if it is, it won't rebase.

In both of situations, the 'ours' branch will be checked out, to match the behavior of rebase.