### PR TITLE
Added the autoTag option to the Repository.fetch method

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -599,11 +599,13 @@ Repository.prototype.getRemote = function(remote, callback) {
  *
  * @param {String|Remote} remote
  * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
+ * @param {Number|autoTagOption} set the AUTO_TAG option for remote
  * @param {Bool} pruneAfter will perform a prune after the fetch if true
  */
 Repository.prototype.fetch = function(
   remote,
   remoteCallbacks,
+  autoTag,
   pruneAfter,
   callback)
 {
@@ -611,6 +613,9 @@ Repository.prototype.fetch = function(
 
   return repo.getRemote(remote).then(function(remote) {
     remote.setCallbacks(remoteCallbacks);
+    if(autoTag) {
+      remote.setAutotag(autoTag);
+    }
 
     return remote.fetch(null, repo.defaultSignature(), "Fetch from " + remote)
     .then(function() {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -599,7 +599,7 @@ Repository.prototype.getRemote = function(remote, callback) {
  *
  * @param {String|Remote} remote
  * @param {Object|RemoteCallback} remoteCallbacks Any custom callbacks needed
- * @param {Number|autoTagOption} set the AUTO_TAG option for remote
+ * @param {Number|autoTag} set the AUTO_TAG option for remote
  * @param {Bool} pruneAfter will perform a prune after the fetch if true
  */
 Repository.prototype.fetch = function(


### PR DESCRIPTION
Added the autoTag option to allow for automatic downloading of tags when executing Repository.fetch.

Fixes: #608