### PR TITLE
remove non-isolate FatalException

### DIFF
--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -103,8 +103,6 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
 }
 
 void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
-  TryCatch try_catch;
-
   if (baton->error_code == GIT_OK) {
     {%if not .|returnsCount %}
     Handle<v8::Value> result = NanUndefined();
@@ -160,10 +158,6 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         {%endif%}
       {%endif%}
     {%endeach%}
-  }
-
-  if (try_catch.HasCaught()) {
-    node::FatalException(try_catch);
   }
 
   {%each args|argsInfo as arg %}


### PR DESCRIPTION
```
The non-isolate version of node::FatalException() has been deprecated
in io.js; more precisely, it's deprecated in node.js v0.12 as well but
a bug in joyent/node prevents the deprecation warning from printing.

We don't have to catch exceptions ourselves.  Exceptions simply unwind
the stack until they encounter a try/catch block is encountered or the
fatal exception handler in the io.js or node.js run-time.
```
commit message modified from https://github.com/bnoordhuis/node-unix-dgram/commit/314858e9bab97d24e3a80c1dc67ffa5242c38e83

no tests fail. works the same for me.
though, I'm not sure how node-0.10 would work.
I think it'd be the same though - a fatal exception is a fatal exception.