### PR TITLE
bluebird promises + thenify

### DIFF
--- a/examples/add-and-commit.js
+++ b/examples/add-and-commit.js
@@ -1,15 +1,10 @@
 var nodegit = require("../");
 var path = require("path");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["ensureDir", "writeFile"]);
 var fileName = "newfile.txt";
 var fileContent = "hello world";
 var directoryName = "salad/toast/strangerinastrangeland/theresnowaythisexists";
-// ensureDir is an alias to mkdirp, which has the callback with a weird name
-// and in the 3rd position of 4 (the 4th being used for recursion). We have to
-// force promisify it, because promisify-node won't detect it on its
-// own and assumes sync
-fse.ensureDir = promisify(fse.ensureDir);
 
 /**
  * This example creates a certain file `newfile.txt`, adds it to the git
@@ -71,6 +66,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
 
   return repo.createCommit("HEAD", author, committer, "message", oid, [parent]);
 })
-.done(function(commitId) {
+.then(function(commitId) {
   console.log("New Commit: ", commitId);
 });

--- a/examples/clone.js
+++ b/examples/clone.js
@@ -1,6 +1,6 @@
 var nodegit = require("../");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove"]);
 var path = "/tmp/nodegit-clone-demo";
 
 fse.remove(path).then(function() {
@@ -28,7 +28,7 @@ fse.remove(path).then(function() {
     entry = entryResult;
     return entry.getBlob();
   })
-  .done(function(blob) {
+  .then(function(blob) {
     console.log(entry.filename(), entry.sha(), blob.rawsize() + "b");
     console.log("========================================================\n\n");
     var firstTenLines = blob.toString().split("\n").slice(0, 10).join("\n");

--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -1,6 +1,6 @@
 var nodegit = require("../");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove"]);
 var path = "/tmp/nodegit-github-2factor-demo";
 
 var token = "{Your GitHub user token}";
@@ -35,7 +35,7 @@ var opts = {
 
 fse.remove(path).then(function() {
   nodegit.Clone(repoUrl, path, opts)
-    .done(function(repo) {
+    .then(function(repo) {
       if (repo instanceof nodegit.Repository) {
         console.info("We cloned the repo!");
       }

--- a/examples/create-branch.js
+++ b/examples/create-branch.js
@@ -13,6 +13,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
         repo.defaultSignature(),
         "Created new-branch on HEAD");
     });
-  }).done(function() {
+  }).then(function() {
     console.log("All done!");
   });

--- a/examples/create-new-repo.js
+++ b/examples/create-new-repo.js
@@ -1,12 +1,10 @@
 var nodegit = require("../");
 var path = require("path");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["ensureDir", "writeFile"]);
 var fileName = "newfile.txt";
 var fileContent = "hello world";
 var repoDir = "../../newRepo";
-
-fse.ensureDir = promisify(fse.ensureDir);
 
 var repository;
 var index;
@@ -45,6 +43,6 @@ fse.ensureDir(path.resolve(__dirname, repoDir))
   // normal we don't get the head either, because there isn't one yet.
   return repository.createCommit("HEAD", author, committer, "message", oid, []);
 })
-.done(function(commitId) {
+.then(function(commitId) {
   console.log("New Commit: ", commitId);
 });

--- a/examples/details-for-tree-entry.js
+++ b/examples/details-for-tree-entry.js
@@ -24,6 +24,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
       });
     });
   })
-  .done(function() {
+  .then(function() {
     console.log("Done!");
   });

--- a/examples/diff-commits.js
+++ b/examples/diff-commits.js
@@ -18,7 +18,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
 
   return commit.getDiff();
 })
-.done(function(diffList) {
+.then(function(diffList) {
   diffList.forEach(function(diff) {
     diff.patches().forEach(function(patch) {
       console.log("diff", patch.oldFile().path(), patch.newFile().path());

--- a/examples/fetch.js
+++ b/examples/fetch.js
@@ -8,6 +8,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
         return nodegit.Cred.sshKeyFromAgent(userName);
       }
     });
-  }).done(function() {
+  }).then(function() {
     console.log("It worked!");
   });

--- a/examples/general.js
+++ b/examples/general.js
@@ -1,6 +1,6 @@
 var nodegit = require("../");
 var path = require("path");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var oid;
 var odb;
 var repo;
@@ -362,6 +362,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     return Promise.all(promises);
   })
 
-  .done(function() {
+  .then(function() {
     console.log("Done!");
   });

--- a/examples/index-add-and-remove.js
+++ b/examples/index-add-and-remove.js
@@ -1,8 +1,8 @@
 var nodegit = require("../");
 var path = require("path");
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["writeFile"]);
 
 nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   .then(function(repo) {
@@ -129,6 +129,6 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
         console.log("New files in index: " + newFiles.length);
       });
     });
-  }).done(function() {
+  }).then(function() {
     console.log("All done!");
   });

--- a/examples/merge-cleanly.js
+++ b/examples/merge-cleanly.js
@@ -1,8 +1,7 @@
 var nodegit = require("../");
 var path = require("path");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
-fse.ensureDir = promisify(fse.ensureDir);
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove", "ensureDir", "writeFile"]);
 
 var ourFileName = "ourNewFile.txt";
 var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
@@ -123,7 +122,7 @@ fse.remove(path.resolve(__dirname, repoDir))
   return repository.createCommit(ourBranch.name(), ourSignature,
     ourSignature, "we merged their commit", oid, [ourCommit, theirCommit]);
 })
-.done(function(commitId) {
+.then(function(commitId) {
   // We never changed the HEAD after the initial commit;
   // it should still be the same as master.
   console.log("New Commit: ", commitId);

--- a/examples/merge-with-conflicts.js
+++ b/examples/merge-with-conflicts.js
@@ -1,8 +1,8 @@
 var nodegit = require("../");
 var path = require("path");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
-fse.ensureDir = promisify(fse.ensureDir);
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove", "ensureDir", "writeFile"]);
+var fs = require("fs");
 
 var repoDir = "../../newRepo";
 var fileName = "newFile.txt";
@@ -163,7 +163,7 @@ fse.remove(path.resolve(__dirname, repoDir))
 
     // if the merge had comflicts, solve them
     // (in this case, we simply overwrite the file)
-    fse.writeFileSync(
+    fs.writeFileSync(
       path.join(repository.workdir(), fileName),
       finalFileContent
     );
@@ -187,6 +187,6 @@ fse.remove(path.resolve(__dirname, repoDir))
   return repository.createCommit(ourBranch.name(), baseSignature,
     baseSignature, "Stop this bob sized fued", oid, [ourCommit, theirCommit]);
 })
-.done(function(commitId) {
+.then(function(commitId) {
   console.log("New Commit: ", commitId);
 });

--- a/examples/pull.js
+++ b/examples/pull.js
@@ -24,6 +24,6 @@ nodegit.Repository.open(path.resolve(__dirname, repoDir))
   .then(function() {
     return repository.mergeBranches("master", "origin/master");
   })
-  .done(function() {
+  .then(function() {
     console.log("Done!");
   });

--- a/examples/push.js
+++ b/examples/push.js
@@ -1,8 +1,7 @@
 var nodegit = require("../");
 var path = require("path");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
-fse.ensureDir = promisify(fse.ensureDir);
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove", "ensureDir", "writeFile"]);
 
 var fileName = "newFile.txt";
 var fileContent = "hello world";
@@ -64,6 +63,6 @@ fse.remove(path.resolve(__dirname, repoDir))
       repository.defaultSignature(),
       "Push to master");
   });
-}).done(function() {
+}).then(function() {
   console.log("Done!");
 });

--- a/examples/read-file.js
+++ b/examples/read-file.js
@@ -22,4 +22,4 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     console.log(firstTenLines);
     console.log("...");
   })
-  .done();
+  .then();

--- a/examples/remove-and-commit.js
+++ b/examples/remove-and-commit.js
@@ -52,4 +52,4 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // from the filesystem.
     console.log("New Commit:", commitId.allocfmt());
   })
-  .done();
+  .then();

--- a/examples/walk-history-for-file.js
+++ b/examples/walk-history-for-file.js
@@ -52,4 +52,4 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // Don't forget to call `start()`!
     history.start();
   })
-  .done();
+  .then();

--- a/examples/walk-history.js
+++ b/examples/walk-history.js
@@ -24,4 +24,4 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // Don't forget to call `start()`!
     history.start();
   })
-  .done();
+  .then();

--- a/examples/walk-tree.js
+++ b/examples/walk-tree.js
@@ -22,4 +22,4 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     // Don't forget to call `start()`!
     walker.start();
   })
-  .done();
+  .then();

--- a/generate/scripts/generateMissingTests.js
+++ b/generate/scripts/generateMissingTests.js
@@ -1,7 +1,5 @@
 const path = require("path");
-const Promise = require("nodegit-promise");
-const promisify = require("promisify-node");
-const fse = promisify(require("fs-extra"));
+const Promise = require("bluebird");
 const utils = require("./utils");
 
 const testFilesPath = "../test/tests";

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -1,10 +1,7 @@
 const path = require("path");
-const promisify = require("promisify-node");
-const fse = promisify(require("fs-extra"));
-const exec = promisify(function(command, opts, callback) {
-  return require("child_process").exec(command, opts, callback);
-});
-
+const promisify = require("thenify-all");
+const fse = promisify(require("fs-extra"), ["remove", 'copy']);
+const exec = promisify(require("child_process").exec);
 const utils = require("./utils");
 
 module.exports = function generateNativeCode() {

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -1,5 +1,5 @@
-const promisify = require("promisify-node");
-const fse = require("fs-extra");
+const promisify = require("thenify-all");
+const fse = require("fs-extra", []);
 
 const fs = require("fs");
 const path = require("path");

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -1,5 +1,5 @@
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
 var rawApi;
 
 // Attempt to load the production release first, if it fails fall back to the

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -1,6 +1,69 @@
 var Promise = require("bluebird");
-var promisify = require("thenify-all");
 var rawApi;
+
+function promisify(source) {
+  var destination = {};
+  if (typeof source === "function") {
+    return thenify(source);
+  } else {
+    Object.keys(source).forEach(function (name) {
+      if (typeof source[name] === "function") {
+        destination[name] = thenify(source[name]);
+      }
+    });
+  }
+}
+
+function thenify ($$__fn__$$) {
+  return eval(createWrapper($$__fn__$$.name));
+}
+
+function createWrapper (name) {
+  name = name ? ~[
+    // js reserved words
+    // "abstract", "arguments", "boolean", "break", "byte", "case", "catch",
+    // "char", "class", "const", "continue", "debugger", "while", "with",
+    // "yield", "do", "double", "else", "enum", "eval", "export", "extends",
+    // "false", "final", "finally", "float", "for", "function", "goto", "if",
+    // "implements", "import", "in", "instanceof", "int", "interface", "let",
+    // "long", "native", "new", "null", "package", "private", "protected",
+    // "public", "return", "short", "static", "super", "switch", "synchronized",
+    // "this", "throw", "throws", "transient", "true", "try", "typeof", "var",
+    // "void", "volatile",
+
+    "default", "delete"
+  ].indexOf(name) ? "$$" + name : name : "";
+
+  /* jshint ignore:start */
+  return "(function " + name + "() {\n"
+    + "var self = this\n"
+    + "var len = arguments.length\n"
+    + "var args = new Array(len + 1)\n"
+    + "for (var i = 0; i < len; ++i) args[i] = arguments[i]\n"
+    + "var lastIndex = i\n"
+    + "return new Promise(function (resolve, reject) {\n"
+      + "args[lastIndex] = createCallback(resolve, reject)\n"
+      + "$$__fn__$$.apply(self, args)\n"
+    + "})\n"
+  + "})"
+  /* jshint ignore:end */
+}
+
+/* jshint ignore:start */
+function createCallback(resolve, reject) {
+  return function(err, value) {
+    if (err) return reject(err)
+    var length = arguments.length
+    if (length <= 2) return resolve(value)
+    var values = new Array(length - 1)
+    for (var i = 1; i < length; ++i) values[i - 1] = arguments[i]
+    resolve(values)
+  }
+}
+/* jshint ignore:end */
+
+
+
 
 // Attempt to load the production release first, if it fails fall back to the
 // debug release.

--- a/guides/repositories/README.md
+++ b/guides/repositories/README.md
@@ -119,7 +119,7 @@ NodeGit.Repository.open(pathToRepo).then(function (sucessfulResult) {
   // This is the first function of the then which contains the successfully
   // calculated result of the promise
 })
-.done(function () {
+.then(function () {
   // If we have a .done then the error will be thrown if there was an error that
   // wasn't caught by either providing a 2nd function to the `.then` or a
   // `.catch` function

--- a/guides/repositories/index.js
+++ b/guides/repositories/index.js
@@ -32,7 +32,7 @@ NodeGit.Repository.open(pathToRepo).then(function (repo) {
   // You can also provide a catch function which will contain the reason why
   // any above promises that weren't handled have failed
 })
-.done(function() {
+.then(function() {
   // If we have a .done then the error will be thrown if there was an error that
   // wasn't caught by either providing a 2nd function to the `.then` or a
   // `.catch` function

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -1,5 +1,5 @@
 var events = require("events");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var NodeGit = require("../");
 var Commit = NodeGit.Commit;
 var LookupWrapper = NodeGit.Utils.lookupWrapper;

--- a/lib/convenient_hunk.js
+++ b/lib/convenient_hunk.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var ConvenientLine = NodeGit.ConvenientLine;
 
 function ConvenientHunk(hunk, linesInHunk, patch, i) {

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var Diff = NodeGit.Diff;
 var ConvenientHunk = NodeGit.ConvenientHunk;
 

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,5 +1,5 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var Diff = NodeGit.Diff;
 var ConvenientPatch = NodeGit.ConvenientPatch;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,6 @@
 var NodeGit = require("../");
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 
 var Merge = NodeGit.Merge;
 var mergeCommits = Merge.commits;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1,4 +1,4 @@
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var NodeGit = require("../");
 var Blob = NodeGit.Blob;
 var Checkout = NodeGit.Checkout;

--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -1,6 +1,6 @@
 var NodeGit = require("../");
 var Revwalk = NodeGit.Revwalk;
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 
 var oldSorting = Revwalk.prototype.sorting;
 

--- a/lib/utils/lookup_wrapper.js
+++ b/lib/utils/lookup_wrapper.js
@@ -1,4 +1,4 @@
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var NodeGit = require("../../");
 
 /**

--- a/lifecycleScripts/checkPrepared.js
+++ b/lifecycleScripts/checkPrepared.js
@@ -1,4 +1,4 @@
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var path = require("path");
 var fs = require("fs");
 var rooted = path.join.bind(path, __dirname, "..");

--- a/lifecycleScripts/clean.js
+++ b/lifecycleScripts/clean.js
@@ -1,7 +1,7 @@
 var fse = require("fs-extra");
 var path = require("path");
 var npm = require("npm");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 
 var rooted = path.join.bind(path, __dirname, "..");
 if (fse.existsSync(rooted(".didntcomefromthenpmregistry"))) {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -1,5 +1,5 @@
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
 var path = require("path");
 var fs = require("fs");
 

--- a/lifecycleScripts/prepareForBuild.js
+++ b/lifecycleScripts/prepareForBuild.js
@@ -1,4 +1,4 @@
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var cp = require("child_process");
 var path = require("path");
 

--- a/lifecycleScripts/retrieveExternalDependencies.js
+++ b/lifecycleScripts/retrieveExternalDependencies.js
@@ -1,6 +1,6 @@
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify("fs-extra");
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove", "writeFile"]);
 var zlib = require("zlib");
 var cp = require("child_process");
 var path = require("path");

--- a/package.json
+++ b/package.json
@@ -54,11 +54,12 @@
     "node-pre-gyp"
   ],
   "dependencies": {
+    "bluebird": "^2.9.30",
     "fs-extra": "^0.18.2",
     "node-pre-gyp": "^0.6.5",
-    "nodegit-promise": "^2.0.1",
     "npm": "^2.9.0",
-    "promisify-node": "^0.1.5",
+    "thenify": "heavyk/thenify",
+    "thenify-all": "^1.6.0",
     "which-native-nodish": "^1.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "fs-extra": "^0.18.2",
     "node-pre-gyp": "^0.6.5",
     "npm": "^2.9.0",
-    "thenify": "heavyk/thenify",
     "thenify-all": "^1.6.0",
     "which-native-nodish": "^1.1.1"
   },

--- a/test/runner.js
+++ b/test/runner.js
@@ -1,12 +1,8 @@
-var promisify = require("promisify-node");
-var fse = promisify("fs-extra");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ['mkdir', "remove", "writeFile"]);
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-
-// Have to wrap exec, since it has a weird callback signature.
-var exec = promisify(function(command, opts, callback) {
-  return require("child_process").exec(command, opts, callback);
-});
+var exec = promisify(require("child_process").exec);
 
 var workdirPath = local("repos/workdir");
 

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var local = path.join.bind(path, __dirname);
 
 describe("Branch", function() {
@@ -45,7 +45,11 @@ describe("Branch", function() {
 
     return repo.getBranch(branchName)
       // Reverse the results, since if we found it it wasn't deleted
-      .then(Promise.reject, Promise.resolve);
+      .then(function() {
+        return Promise.reject();
+      }, function() {
+        return Promise.resolve();
+      });
   });
 
   it("can see if the branch is pointed to by head", function() {

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
-var fse = require("fs-extra");
+var Promise = require("bluebird");
+var fse = require("fs-extra", []);
 var local = path.join.bind(path, __dirname);
 
 describe("Checkout", function() {

--- a/test/tests/cherrypick.js
+++ b/test/tests/cherrypick.js
@@ -1,9 +1,10 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"),
+  ["remove", "ensureDir", "writeFile", "readFile"]);
 
 describe("Cherrypick", function() {
   var NodeGit = require("../../");

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -1,7 +1,7 @@
 var path = require("path");
 var assert = require("assert");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove"]);
 var local = path.join.bind(path, __dirname);
 
 describe("Clone", function() {

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["writeFile"]);
 var local = path.join.bind(path, __dirname);
 
 describe("Commit", function() {

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var promisify = require("promisify-node");
+var promisify = require("thenify-all");
 
 // Have to wrap exec, since it has a weird callback signature.
 var exec = promisify(function(command, opts, callback) {

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -1,8 +1,9 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
+var fse = promisify(require("fs-extra"),
+  ["remove", "move", "writeFile"]);
 var local = path.join.bind(path, __dirname);
 
 describe("Diff", function() {

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -1,9 +1,9 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["remove", "writeFile"]);
 
 var writeFile = promisify(function(filename, data, callback) {
   return require("fs").writeFile(filename, data, {}, callback);

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -1,11 +1,10 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"),
+  ["ensureDir", "remove", "writeFile", "readFile"]);
 var local = path.join.bind(path, __dirname);
-
-fse.ensureDir = promisify(fse.ensureDir);
 
 describe("Merge", function() {
   var NodeGit = require("../../");

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -1,9 +1,10 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var Promise = require("bluebird");
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"),
+  ["remove", "ensureDir", "writeFile", "readFile"]);
 
 describe("Rebase", function() {
   var NodeGit = require("../../");

--- a/test/tests/refs.js
+++ b/test/tests/refs.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
+var promisify = require("thenify-all");
 var local = path.join.bind(path, __dirname);
 
 // Have to wrap exec, since it has a weird callback signature.

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var local = path.join.bind(path, __dirname);
 
 describe("Remote", function() {
@@ -88,7 +88,11 @@ describe("Remote", function() {
       .then(function() {
         return Remote.lookup(repository, "origin3");
       })
-      .then(Promise.reject, Promise.resolve);
+      .then(function() {
+        return Promise.reject();
+      }, function() {
+        return Promise.resolve();
+      });
   });
 
   it("can download from a remote", function() {

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
+var fse = promisify(require("fs-extra"), ["remove", "writeFile"]);
 var local = path.join.bind(path, __dirname);
 
 describe("Repository", function() {

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var promisify = require("promisify-node");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var fse = promisify(require("fs-extra"), ["readFile"]);
 
 describe("Reset", function() {
   var NodeGit = require("../../");

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
 
 // Have to wrap exec, since it has a weird callback signature.
 var exec = promisify(function(command, opts, callback) {
@@ -57,13 +57,13 @@ describe("Signature", function() {
     };
 
     return exec("git config --global user.name")
-    .then(function(userName) {
-      savedUserName = userName.trim();
+    .then(function(std) {
+      savedUserName = std[0].trim();
 
       return exec("git config --global user.email");
     })
-    .then(function(userEmail) {
-      savedUserEmail = userEmail.trim();
+    .then(function(std) {
+      savedUserEmail = std[0].trim();
 
       return exec("git config --global --unset user.name");
     })

--- a/test/tests/stash.js
+++ b/test/tests/stash.js
@@ -1,8 +1,8 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
+var fse = promisify(require("fs-extra"), ["writeFile", "readFile"]);
 var local = path.join.bind(path, __dirname);
 
 describe("Stash", function() {

--- a/test/tests/status.js
+++ b/test/tests/status.js
@@ -1,12 +1,10 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
+var fse = promisify(require("fs-extra"), ["remove", "writeFile", "readFile"]);
 var local = path.join.bind(path, __dirname);
-var exec = promisify(function(command, opts, callback) {
-  return require("child_process").exec(command, opts, callback);
-});
+var exec = promisify(require("child_process").exec);
 
 describe("Status", function() {
   var NodeGit = require("../../");

--- a/test/tests/status_list.js
+++ b/test/tests/status_list.js
@@ -1,12 +1,10 @@
 var assert = require("assert");
 var path = require("path");
-var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
-var fse = promisify(require("fs-extra"));
+var promisify = require("thenify-all");
+var Promise = require("bluebird");
+var fse = promisify(require("fs-extra"), ["remove", "writeFile"]);
 var local = path.join.bind(path, __dirname);
-var exec = promisify(function(command, opts, callback) {
-  return require("child_process").exec(command, opts, callback);
-});
+var exec = promisify(require("child_process").exec);
 
 describe("StatusList", function() {
   var NodeGit = require("../../");

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 
 describe("Tag", function() {
   var NodeGit = require("../../");

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -1,5 +1,5 @@
 var assert = require("assert");
-var Promise = require("nodegit-promise");
+var Promise = require("bluebird");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 
@@ -75,7 +75,7 @@ describe("TreeEntry", function() {
 
     return this.commit.getTree()
       .then(testTree)
-      .done(function() {
+      .then(function() {
         done();
       });
   });


### PR DESCRIPTION
this change does the following:
 - uses bluebird promises
 - only promisify's necessary functions, and promisified functions are guaranteed to be fast and not deoptimized. (also some hacks eg. `fse.ensureDir` were removed. further cleaning can be done.)

some notes:
 - bluebird is really really fast. it's even faster than native promises.
 - promisfiy-node could have been left as is. tbh, I didn't benchmark this change to justify it.
 - in general, the net gain, is virtually unnoticeable. a bit of memory and a bit of speed. the primary motivation behind this change, was to use bluebird instead of having multiple promise libraries

ref: https://github.com/petkaantonov/bluebird/pull/667