### PR TITLE
Fix missing Revwalk#repo property

### DIFF
--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -4,6 +4,10 @@ var Promise = require("nodegit-promise");
 
 var oldSorting = Revwalk.prototype.sorting;
 
+Object.defineProperty(Revwalk.prototype, 'repo', {
+  get: function () { return this.repository(); }
+});
+
 /**
  * Set the sort order for the revwalk. This function takes variable arguments
  * like `revwalk.sorting(NodeGit.RevWalk.Topological, NodeGit.RevWalk.Reverse).`


### PR DESCRIPTION
Most of the walk callbacks fail due to a missing `repo` property.