### PR TITLE
Merge branches options

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -667,10 +667,13 @@ Repository.prototype.fetchAll = function(
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      merge with conflicts
  */
-Repository.prototype.mergeBranches = function(to, from, signature) {
+Repository.prototype.mergeBranches =
+  function(to, from, signature, noFF, ffOnly) {
   var repo = this;
   var fromBranch;
   var toBranch;
+  noFF = noFF || false;
+  ffOnly = ffOnly || false;
 
   signature = signature || repo.defaultSignature();
 
@@ -697,7 +700,7 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
         // nothing to do so just return the commit the branch is on
         return toCommitOid;
       }
-      else if (baseCommit.toString() == toCommitOid) {
+      else if (baseCommit.toString() == toCommitOid && !noFF) {
         // fast forward
         var message =
           "Fast forward branch " +
@@ -725,9 +728,17 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
           });
         });
       }
-      else {
+      else if (!ffOnly) {
+        var updateHead;
         // We have to merge. Lets do it!
-        return NodeGit.Merge.commits(repo, toCommitOid, fromCommitOid)
+        return NodeGit.Reference.lookup(repo, "HEAD")
+        .then(function(headRef) {
+          return headRef.resolve();
+        })
+        .then(function(headRef) {
+          updateHead = !!headRef && (headRef.name() === toBranch.name());
+          return NodeGit.Merge.commits(repo, toCommitOid, fromCommitOid);
+        })
         .then(function(index) {
           // if we have conflicts then throw the index
           if (index.hasConflicts()) {
@@ -737,7 +748,8 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
           // No conflicts so just go ahead with the merge
           index.write();
           return index.writeTreeTo(repo);
-        }).then(function(oid) {
+        })
+        .then(function(oid) {
           var message =
             "Merged " +
             fromBranch.shorthand() +
@@ -751,7 +763,36 @@ Repository.prototype.mergeBranches = function(to, from, signature) {
             message,
             oid,
             [toCommitOid, fromCommitOid]);
+        })
+        .then(function(commit) {
+        //   // we've updated the checked out branch, so make sure we update
+        //   // head so that our index isn't messed up
+          if (updateHead) {
+            return repo.getBranch(to)
+            .then(function(branch) {
+              return repo.getBranchCommit(branch);
+            })
+            .then(function(branchCommit) {
+              return branchCommit.getTree();
+            })
+            .then(function(tree) {
+              var opts = {
+                checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE_CREATE
+              };
+              return NodeGit.Checkout.tree(repo, tree, opts);
+            })
+            .then(function() {
+              return commit;
+            });
+          }
+          else {
+            return commit;
+          }
         });
+      }
+      else {
+        // A non fast-forwardable merge with ff-only
+        return toCommitOid;
       }
     });
   });

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -701,7 +701,8 @@ Repository.prototype.mergeBranches =
         // nothing to do so just return the commit the branch is on
         return toCommitOid;
       }
-      else if (baseCommit.toString() == toCommitOid && mergePreference !== NodeGit.Merge.PREFERENCE.NO_FASTFORWARD) {
+      else if (baseCommit.toString() == toCommitOid &&
+                mergePreference !== NodeGit.Merge.PREFERENCE.NO_FASTFORWARD) {
         // fast forward
         var message =
           "Fast forward branch " +

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -662,18 +662,19 @@ Repository.prototype.fetchAll = function(
 /**
  * Merge a branch onto another branch
  *
- * @param {String|Ref}  to
- * @param {String|Ref}  from
+ * @param {String|Ref}        to
+ * @param {String|Ref}        from
+ * @param {Signature}         signature
+ * @param {Merge.PREFERENCE}  mergePreference
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      merge with conflicts
  */
 Repository.prototype.mergeBranches =
-  function(to, from, signature, noFF, ffOnly) {
+  function(to, from, signature, mergePreference) {
   var repo = this;
   var fromBranch;
   var toBranch;
-  noFF = noFF || false;
-  ffOnly = ffOnly || false;
+  mergePreference = mergePreference || NodeGit.Merge.PREFERENCE.NONE;
 
   signature = signature || repo.defaultSignature();
 
@@ -700,7 +701,7 @@ Repository.prototype.mergeBranches =
         // nothing to do so just return the commit the branch is on
         return toCommitOid;
       }
-      else if (baseCommit.toString() == toCommitOid && !noFF) {
+      else if (baseCommit.toString() == toCommitOid && mergePreference !== NodeGit.Merge.PREFERENCE.NO_FASTFORWARD) {
         // fast forward
         var message =
           "Fast forward branch " +
@@ -728,7 +729,7 @@ Repository.prototype.mergeBranches =
           });
         });
       }
-      else if (!ffOnly) {
+      else if (mergePreference !== NodeGit.Merge.PREFERENCE.FASTFORWARD_ONLY) {
         var updateHead;
         // We have to merge. Lets do it!
         return NodeGit.Reference.lookup(repo, "HEAD")

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -243,6 +243,119 @@ describe("Merge", function() {
     });
   });
 
+  it("can merge --no-ff a fast-forward using the convenience method",
+    function() {
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+    ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+    ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var theirCommit;
+    var ourBranch;
+    var theirBranch;
+
+    return fse.writeFile(
+      path.join(repository.workdir(), ourFileName),
+      ourFileContent)
+    // Load up the repository index and make our initial commit to HEAD
+    .then(function() {
+      return repository.openIndex()
+      .then(function(index) {
+        index.read(1);
+        index.addByPath(ourFileName);
+        index.write();
+
+        return index.writeTree();
+      });
+    })
+    .then(function(oid) {
+      assert.equal(oid.toString(),
+      "11ead82b1135b8e240fb5d61e703312fb9cc3d6a");
+
+      return repository.createCommit("HEAD", ourSignature,
+      ourSignature, "we made a commit", oid, []);
+    })
+    .then(function(commitOid) {
+      assert.equal(commitOid.toString(),
+      "91a183f87842ebb7a9b08dad8bc2473985796844");
+
+      return repository.getCommit(commitOid).then(function(commit) {
+        ourCommit = commit;
+      }).then(function() {
+        return repository.createBranch(ourBranchName, commitOid)
+        .then(function(branch) {
+          ourBranch = branch;
+          return repository.createBranch(theirBranchName, commitOid);
+        });
+      });
+    })
+    .then(function(branch) {
+      theirBranch = branch;
+      return fse.writeFile(path.join(repository.workdir(), theirFileName),
+      theirFileContent);
+    })
+    .then(function() {
+      return repository.openIndex()
+      .then(function(index) {
+        index.read(1);
+        index.addByPath(theirFileName);
+        index.write();
+
+        return index.writeTree();
+      });
+    })
+    .then(function(oid) {
+      assert.equal(oid.toString(),
+      "76631cb5a290dafe2959152626bb90f2a6d8ec94");
+
+      return repository.createCommit(theirBranch.name(), theirSignature,
+      theirSignature, "they made a commit", oid, [ourCommit]);
+    })
+    .then(function(commitOid) {
+      assert.equal(commitOid.toString(),
+      "0e9231d489b3f4303635fc4b0397830da095e7e7");
+
+      return repository.getCommit(commitOid).then(function(commit) {
+        theirCommit = commit;
+      });
+    })
+    .then(function() {
+      var opts = {checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE};
+      return repository.checkoutBranch(ourBranchName, opts);
+    })
+    .then(function() {
+      return repository.mergeBranches(
+        ourBranchName,
+        theirBranchName,
+        ourSignature,
+        true);
+    })
+    .then(function(oid) {
+      assert.equal(oid.toString(),
+      "6806d22d2b6c0095b29dc5ec51829caeb67861f1");
+
+      return repository.getBranchCommit(ourBranchName)
+        .then(function(branchCommit) {
+          assert.equal(oid.toString(), branchCommit.toString());
+        });
+    })
+    .then(function() {
+      return repository.getStatus();
+    })
+    .then(function(statuses) {
+      // make sure we didn't change the index
+      assert.equal(statuses.length, 0);
+    });
+  });
+
   it("can merge cleanly using the convenience method", function() {
     var initialFileName = "initialFile.txt";
     var ourFileName = "ourNewFile.txt";

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -336,7 +336,7 @@ describe("Merge", function() {
         ourBranchName,
         theirBranchName,
         ourSignature,
-        true);
+        NodeGit.Merge.PREFERENCE.NO_FASTFORWARD);
     })
     .then(function(oid) {
       assert.equal(oid.toString(),
@@ -357,7 +357,7 @@ describe("Merge", function() {
   });
 
   it("can merge --no-ff a non-fast-forward using the convenience method",
-  function() {
+    function() {
     var initialFileName = "initialFile.txt";
     var ourFileName = "ourNewFile.txt";
     var theirFileName = "theirNewFile.txt";
@@ -483,7 +483,7 @@ describe("Merge", function() {
         ourBranchName,
         theirBranchName,
         ourSignature,
-        true);
+        NodeGit.Merge.PREFERENCE.NO_FASTFORWARD);
     })
     .then(function(commitId) {
       assert.equal(commitId.toString(),
@@ -591,8 +591,7 @@ describe("Merge", function() {
         ourBranchName,
         theirBranchName,
         ourSignature,
-        false,
-        true);
+        NodeGit.Merge.PREFERENCE.FASTFORWARD_ONLY);
     })
     .then(function(oid) {
       assert.equal(oid.toString(),
@@ -613,7 +612,7 @@ describe("Merge", function() {
   });
 
   it("doesn't merge --ff-only a non-fast-forward using the convenience method",
-  function() {
+    function() {
     var initialFileName = "initialFile.txt";
     var ourFileName = "ourNewFile.txt";
     var theirFileName = "theirNewFile.txt";
@@ -739,8 +738,7 @@ describe("Merge", function() {
         ourBranchName,
         theirBranchName,
         ourSignature,
-        false,
-        true);
+        NodeGit.Merge.PREFERENCE.FASTFORWARD_ONLY);
     })
     .then(function(commitId) {
       assert.equal(commitId.toString(),


### PR DESCRIPTION
Finishing up what @maxkorp started by adding tests.

Adds --no-ff and --ff-only options to `Repository.mergeBranches()`