### PR TITLE
fixed string concatenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ open("tmp")
       var author = commit.author();
 
       // Display author information.
-      console.log("Author:\t" + author.name() + " <", author.email() + ">");
+      console.log("Author:\t" + author.name() + " <" + author.email() + ">");
 
       // Show the commit date.
       console.log("Date:\t" + commit.date());


### PR DESCRIPTION
i guess this was a typo, which results in unexpected output like `Foo Bar < foo.bar@example.com>` instead of `Foo Bar <foo.bar@example.com>`.