### PR TITLE
Add amend commit convenience function 

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -325,6 +325,26 @@
     },
     "commit": {
       "functions": {
+        "git_commit_ammend": {
+          "args": {
+            "id": {
+              "isReturn": true
+            },
+            "message_encoding": {
+              "isOptional": true
+            },
+            "parents": {
+              "cType": "const git_commit **",
+              "cppClassName": "Array",
+              "jsClassName": "Array",
+              "arrayElementCppClassName": "GitCommit"
+            },
+            "update_ref": {
+              "isOptional": true
+            }
+          },
+          "isAsync": true
+        },
         "git_commit_create": {
           "args": {
             "id": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -325,25 +325,27 @@
     },
     "commit": {
       "functions": {
-        "git_commit_ammend": {
+        "git_commit_amend": {
           "args": {
+            "author": {
+              "isOptional": true
+            },
+            "committer": {
+              "isOptional": true
+            },
             "id": {
               "isReturn": true
             },
             "message_encoding": {
               "isOptional": true
             },
-            "parents": {
-              "cType": "const git_commit **",
-              "cppClassName": "Array",
-              "jsClassName": "Array",
-              "arrayElementCppClassName": "GitCommit"
+            "message": {
+              "isOptional": true
             },
-            "update_ref": {
+            "tree": {
               "isOptional": true
             }
-          },
-          "isAsync": true
+          }
         },
         "git_commit_create": {
           "args": {

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -200,6 +200,48 @@ Commit.prototype.getDiff = function(callback) {
 };
 
 /**
+ * Amend a commit
+ * @async
+ * @param {String} update_ref
+ * @param {Signature} author
+ * @param {Signature} committer
+ * @param {String} message_encoding
+ * @param {String} message
+ * @param {Tree|Oid} tree
+ * @param {Oid} callback
+ */
+ var amend = Commit.prototype.amend;
+ Commit.prototype.amend = function (
+   updateRef, author, committer, message_encoding, message, tree, callback) {
+     var repo = this.repo;
+     var treeObject = tree;
+     var _this = this;
+
+     if (tree instanceof NodeGit.Oid){
+       return repo.getTree(tree).then(function(result){
+         treeObject = result;
+         return amend.call(_this,
+           updateRef,
+           author,
+           committer,
+           message_encoding,
+           message,
+           treeObject
+         );
+       });
+     } else {
+       return new Promise(amend.call(_this,
+         updateRef,
+         author,
+         committer,
+         message_encoding,
+         message,
+         treeObject
+       ));
+     }
+ };
+
+/**
  * The sha of this commit
  * @return {String}
  */

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -210,35 +210,30 @@ Commit.prototype.getDiff = function(callback) {
  * @param {Tree|Oid} tree
  * @param {Oid} callback
  */
- var amend = Commit.prototype.amend;
- Commit.prototype.amend = function (
-   updateRef, author, committer, message_encoding, message, tree, callback) {
-     var repo = this.repo;
-     var treeObject = tree;
-     var _this = this;
+var amend = Commit.prototype.amend;
+Commit.prototype.amend = function (
+  updateRef, author, committer, message_encoding, message, tree, callback) {
+    var repo = this.repo;
+    var _this = this;
+    var treePromise;
 
-     if (tree instanceof NodeGit.Oid){
-       return repo.getTree(tree).then(function(result){
-         treeObject = result;
-         return amend.call(_this,
-           updateRef,
-           author,
-           committer,
-           message_encoding,
-           message,
-           treeObject
-         );
-       });
-     } else {
-       return new Promise(amend.call(_this,
-         updateRef,
-         author,
-         committer,
-         message_encoding,
-         message,
-         treeObject
-       ));
-     }
+    if (tree instanceof NodeGit.Oid){
+      treePromise = repo.getTree(tree);
+    } else {
+      treePromise = Promise.resolve(tree);
+    }
+
+    return treePromise
+      .then(function(treeObject){
+        return amend.call(_this,
+          updateRef,
+          author,
+          committer,
+          message_encoding,
+          message,
+          treeObject
+        );
+      });
  };
 
 /**

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -413,7 +413,22 @@ Repository.prototype.getHeadCommit = function(callback) {
     return repo.getCommit(head, callback);
   });
 };
-
+/**
+ * Create a commit
+ *
+ * @async
+ * @param {Commit} commit
+ * @param {String} updateRef
+ * @param {Signature} author
+ * @param {Signature} committer
+ * @param {String} message
+ * @param {Tree|Oid|String} Tree
+ * @return {Oid} The oid of the commit
+ */
+ Repository.prototype.amendCommit = function (
+   commit, updateRef, author, committer, message, tree, callback) {
+     
+ };
 /**
  * Create a commit
  *

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -417,22 +417,6 @@ Repository.prototype.getHeadCommit = function(callback) {
  * Create a commit
  *
  * @async
- * @param {Commit} commit
- * @param {String} updateRef
- * @param {Signature} author
- * @param {Signature} committer
- * @param {String} message
- * @param {Tree|Oid|String} Tree
- * @return {Oid} The oid of the commit
- */
- Repository.prototype.amendCommit = function (
-   commit, updateRef, author, committer, message, tree, callback) {
-     
- };
-/**
- * Create a commit
- *
- * @async
  * @param {String} updateRef
  * @param {Signature} author
  * @param {Signature} committer

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -413,6 +413,7 @@ Repository.prototype.getHeadCommit = function(callback) {
     return repo.getCommit(head, callback);
   });
 };
+
 /**
  * Create a commit
  *

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -137,9 +137,9 @@ describe("Commit", function() {
   });
 
 
-  it("can amend commit", function(){
+  it.only("can amend commit", function(){
     var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
-    var amendedCommitId = "98835fb6903436c298a603f263ed698b03106c05";
+    var amendedCommitId = "7afb945e108e10d98732963c15682072db99bc28";
     var fileName = "newfile.txt";
     var fileContent = "hello world";
     var newFileName = "newerfile.txt";

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -137,7 +137,7 @@ describe("Commit", function() {
   });
 
 
-  it.only("can amend commit", function(){
+  it("can amend commit", function(){
     var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
     var amendedCommitId = "98835fb6903436c298a603f263ed698b03106c05";
     var fileName = "newfile.txt";
@@ -145,7 +145,7 @@ describe("Commit", function() {
     var newFileName = "newerfile.txt";
     var newFileContent = "goodbye world";
     var messageEncoding = "US-ASCII";
-    var message = "KYLE + KEN = BFF INDEFINITELY";
+    var message = "First commit";
 
     var repo;
     var index;

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -151,7 +151,7 @@ describe("Commit", function() {
 
   it("can amend commit", function(){
     var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
-    var amendedCommitId = "7afb945e108e10d98732963c15682072db99bc28";
+    var expectedAmendedCommitId = "7afb945e108e10d98732963c15682072db99bc28";
     var fileName = "newfile.txt";
     var fileContent = "hello world";
     var newFileName = "newerfile.txt";
@@ -165,6 +165,7 @@ describe("Commit", function() {
     var parent;
     var author;
     var committer;
+    var amendedCommitId;
 
     return NodeGit.Repository.open(reposPath)
     .then(function(repoResult) {
@@ -268,8 +269,12 @@ describe("Commit", function() {
         treeOid
       );
     })
-    .then(function(newCommitId){
-      assert.equal(newCommitId, amendedCommitId);
+    .then(function(commitId){
+      amendedCommitId = commitId;
+      return undoCommit();
+    })
+    .then(function(){
+      assert.equal(amendedCommitId, expectedAmendedCommitId);
     });
   });
 

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -151,7 +151,7 @@ describe("Commit", function() {
 
   it("can amend commit", function(){
     var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
-    var expectedAmendedCommitId = "7afb945e108e10d98732963c15682072db99bc28";
+    var expectedAmendedCommitId = "57836e96555243666ea74ea888310cc7c41d4613";
     var fileName = "newfile.txt";
     var fileContent = "hello world";
     var newFileName = "newerfile.txt";
@@ -242,24 +242,23 @@ describe("Commit", function() {
          repo.getCommit(commitToAmendId),
          NodeGit.Signature.create(
            "New Foo Bar",
-           "fizz@buzz.com",
+           "newfoo@bar.com",
            246802468,
            12
          ),
          NodeGit.Signature.create(
            "New Foo A Bar",
-           "fizz@buzz.com",
+           "newfoo@bar.com",
            4807891730,
            32
-         ),
-         repo.getTree(resultOid)
+         )
        ]);
+
     })
     .then(function(amendInfo){
       var commit = amendInfo[0];
       author = amendInfo[1];
       committer = amendInfo[2];
-
       return commit.amend(
         "HEAD",
         author,

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -137,6 +137,132 @@ describe("Commit", function() {
   });
 
 
+  it.only("can amend commit", function(){
+    var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
+    var amendedCommitId = "98835fb6903436c298a603f263ed698b03106c05";
+    var fileName = "newfile.txt";
+    var fileContent = "hello world";
+    var newFileName = "newerfile.txt";
+    var newFileContent = "goodbye world";
+    var messageEncoding = "US-ASCII";
+    var message = "KYLE + KEN = BFF INDEFINITELY";
+
+    var repo;
+    var index;
+    var treeOid;
+    var parent;
+    var author;
+    var committer;
+
+    return NodeGit.Repository.open(reposPath)
+    .then(function(repoResult) {
+      repo = repoResult;
+      return fse.writeFile(path.join(repo.workdir(), fileName), fileContent);
+    })
+    .then(function() {
+      return repo.openIndex();
+    })
+    .then(function(indexResult) {
+      index = indexResult;
+      return index.read(1);
+    })
+    .then(function() {
+      return index.addByPath(fileName);
+    })
+    .then(function() {
+      return index.write();
+    })
+    .then(function() {
+      return index.writeTree();
+    })
+    .then(function(oidResult) {
+      console.log("Commit to amend tree id: " + oidResult);
+      treeOid = oidResult;
+      return NodeGit.Reference.nameToId(repo, "HEAD");
+    })
+    .then(function(head) {
+      return repo.getCommit(head);
+    })
+    .then(function(parentResult) {
+      parent = parentResult;
+      return Promise.all([
+        NodeGit.Signature.create("Foo Bar", "foo@bar.com", 123456789, 60),
+        NodeGit.Signature.create("Foo A Bar", "foo@bar.com", 987654321, 90)
+      ]);
+    })
+    .then(function(signatures) {
+      var author = signatures[0];
+      var committer = signatures[1];
+
+      return repo.createCommit(
+        "HEAD",
+        author,
+        committer,
+        "message",
+        treeOid,
+        [parent]);
+    })
+    .then(function() {
+      return fse.writeFile(
+        path.join(repo.workdir(), newFileName),
+        newFileContent
+      );
+    })
+    .then(function() {
+      return repo.openIndex();
+    })
+    .then(function(indexResult) {
+      index = indexResult;
+      return index.read(1);
+    })
+    .then(function() {
+      return index.addByPath(newFileName);
+    })
+    .then(function() {
+      return index.write();
+    })
+    .then(function() {
+      return index.writeTree();
+    })
+    .then(function(resultOid){
+      treeOid = resultOid;
+      console.log("New Tree oid before amend: " + treeOid);
+       return Promise.all([
+         repo.getCommit(commitToAmendId),
+         NodeGit.Signature.create(
+           "New Foo Bar",
+           "fizz@buzz.com",
+           246802468,
+           12
+         ),
+         NodeGit.Signature.create(
+           "New Foo A Bar",
+           "fizz@buzz.com",
+           4807891730,
+           32
+         ),
+         repo.getTree(resultOid)
+       ]);
+    })
+    .then(function(amendInfo){
+      var commit = amendInfo[0];
+      author = amendInfo[1];
+      committer = amendInfo[2];
+      //var tree = amendInfo[3];
+
+      return commit.amend(
+        "HEAD",
+        author,
+        committer,
+        messageEncoding,
+        message,
+        treeOid
+      );
+    })
+    .then(function(newCommitId){
+      assert.equal(newCommitId, amendedCommitId);
+    });
+  });
 
   it("has an owner", function() {
     var owner = this.commit.owner();

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -137,7 +137,7 @@ describe("Commit", function() {
   });
 
 
-  it.only("can amend commit", function(){
+  it("can amend commit", function(){
     var commitToAmendId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";
     var amendedCommitId = "7afb945e108e10d98732963c15682072db99bc28";
     var fileName = "newfile.txt";

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -176,7 +176,6 @@ describe("Commit", function() {
       return index.writeTree();
     })
     .then(function(oidResult) {
-      console.log("Commit to amend tree id: " + oidResult);
       treeOid = oidResult;
       return NodeGit.Reference.nameToId(repo, "HEAD");
     })
@@ -226,7 +225,6 @@ describe("Commit", function() {
     })
     .then(function(resultOid){
       treeOid = resultOid;
-      console.log("New Tree oid before amend: " + treeOid);
        return Promise.all([
          repo.getCommit(commitToAmendId),
          NodeGit.Signature.create(
@@ -248,7 +246,6 @@ describe("Commit", function() {
       var commit = amendInfo[0];
       author = amendInfo[1];
       committer = amendInfo[2];
-      //var tree = amendInfo[3];
 
       return commit.amend(
         "HEAD",

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -229,7 +229,7 @@ describe("Diff", function() {
         return diff.patches();
       })
       .then(function(patches) {
-        assert.equal(patches.length, 85);
+        assert.equal(patches.length, 84);
       });
   });
 


### PR DESCRIPTION
The convenience function extends the original commit amend to accepts a tree object or a treeOid.
Also included is a test for the new commit amend function.

When testing the new function we noticed that the add commit test did not reset the head to the previous commit upon completion of the test. We modified that test to do so. This caused the "can diff with a null tree" test to fail since it was expecting 85 patches and resetting the commit test brought the number of patches to 84. We modified the test to expect the correct number of patches.