### PR TITLE
docs: Marking Repository#checkoutBranch async

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1000,6 +1000,8 @@ Repository.prototype.getStatusExt = function(opts) {
  * This will set the HEAD to point to the local branch and then attempt
  * to update the index and working tree to match the content of the
  * latest commit on that branch
+ * 
+ * @async
  * @param {String|Reference} branch the branch to checkout
  * @param {Object|CheckoutOptions} opts the options to use for the checkout
  */


### PR DESCRIPTION
Hi guys,

The [Repository#checkoutBranch](http://www.nodegit.org/api/repository/#checkoutBranch) is marked `sync` in the docs, but it [returns a promise](https://github.com/nodegit/nodegit/blob/master/lib/repository.js#L1012).

I was hoping that this could fix that.

Thanks!