### PR TITLE
Fix `getHeadCommit` dying on empty repo

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -431,9 +431,13 @@ Repository.prototype.getMasterCommit = function(callback) {
 Repository.prototype.getHeadCommit = function(callback) {
   var repo = this;
 
-  return Reference.nameToId(repo, "HEAD").then(function(head) {
-    return repo.getCommit(head, callback);
-  });
+  return Reference.nameToId(repo, "HEAD")
+    .then(function(head) {
+      return repo.getCommit(head, callback);
+    })
+    .catch(function() {
+      return null;
+    });
 };
 
 /**

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -12,7 +12,8 @@ describe("Repository", function() {
   var Signature = NodeGit.Signature;
 
   var reposPath = local("../repos/workdir");
-  var newRepo = local("../repos/newrepo");
+  var newRepoPath = local("../repos/newrepo");
+  var emptyRepoPath = local("../repos/empty");
 
   beforeEach(function() {
     var test = this;
@@ -20,6 +21,12 @@ describe("Repository", function() {
     return Repository.open(reposPath)
       .then(function(repository) {
         test.repository = repository;
+      })
+      .then(function() {
+        return Repository.open(emptyRepoPath);
+      })
+      .then(function(emptyRepo) {
+        test.emptyRepo = emptyRepo;
       });
   });
 
@@ -44,16 +51,16 @@ describe("Repository", function() {
   });
 
   it("can initialize a repository into a folder", function() {
-    return Repository.init(newRepo, 1)
+    return Repository.init(newRepoPath, 1)
       .then(function(path, isBare) {
-        return Repository.open(newRepo);
+        return Repository.open(newRepoPath);
       });
   });
 
   it("can utilize repository init options", function() {
-    return fse.remove(newRepo)
+    return fse.remove(newRepoPath)
       .then(function() {
-        return Repository.initExt(newRepo, {
+        return Repository.initExt(newRepoPath, {
           flags: Repository.INIT_FLAG.MKPATH
         });
       });
@@ -183,12 +190,29 @@ describe("Repository", function() {
     var initFlags = NodeGit.Repository.INIT_FLAG.NO_REINIT |
       NodeGit.Repository.INIT_FLAG.MKPATH |
       NodeGit.Repository.INIT_FLAG.MKDIR;
-    return fse.remove(newRepo)
+    return fse.remove(newRepoPath)
       .then(function() {
-        return NodeGit.Repository.initExt(newRepo, { flags: initFlags });
+        return NodeGit.Repository.initExt(newRepoPath, { flags: initFlags });
       })
       .then(function() {
-        return NodeGit.Repository.open(newRepo);
+        return NodeGit.Repository.open(newRepoPath);
+      });
+  });
+
+  it("can get the head commit", function() {
+    return this.repository.getHeadCommit()
+      .then(function(commit) {
+        assert.equal(
+          commit.toString(),
+          "32789a79e71fbc9e04d3eff7425e1771eb595150"
+        );
+      });
+  });
+
+  it("returns null if there is no head commit", function() {
+    return this.emptyRepo.getHeadCommit()
+      .then(function(commit) {
+        assert(!commit);
       });
   });
 });


### PR DESCRIPTION
If you open a repo in NodeGit that's empty (i.e. has no commits yet)
doing `Repository.prototype.getHeadCommit` will error in the promise
chain. I think that really should just return null instead of killing
the promise chain.

There are also probably more of these in the library and we'll have
to add them as we find them.