### PR TITLE
Adding convenience methods for setUrl and setPushurl methods on the Remote object

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -124,4 +124,24 @@ Remote.prototype.push = function(refSpecs, opts) {
   return push.call(this, refSpecs, opts);
 };
 
+/**
+ * Set the remote's url in the configuration
+ *
+ * @param {String} url The url to set
+ * @return {Number} error code
+ */
+Remote.prototype.setUrl = function(url) {
+  return NodeGit.Remote.setUrl(this.repo, this.name(), url);
+};
+
+/**
+ * Set the remote's url for pushing in the configuration
+ *
+ * @param {String} url The url to set
+ * @return {Number} error code
+ */
+Remote.prototype.setPushurl = function(url) {
+  return NodeGit.Remote.setPushurl(this.repo, this.name(), url);
+};
+
 module.exports = Remote;


### PR DESCRIPTION
After talking to Jose and Tyler, likely what happened is libgit2 changed the signature of git_remote_set_url to take in remote as a `char *` instead of a `git_remote *`. This caused the generator to not recognize setUrl as an instance method. They're in the NodeGit documentation and they're useful methods so adding them to the Remote prototype as convenience methods seems reasonable.