### PR TITLE
make signature optional for repository.continueRebase

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -970,6 +970,8 @@ Repository.prototype.rebaseBranches = function(
 Repository.prototype.continueRebase = function(signature) {
   var repo = this;
 
+  signature = signature || repo.defaultSignature();
+
   return repo.openIndex()
     .then(function(index) {
       if (index.hasConflicts()) {


### PR DESCRIPTION
`repository.rebaseBranches` will use the default signature if one isn't passed in, but `repository.continueRebase` didn't do that, and would fail if one wasn't provided.

continueRebase will now use the default signature if a signature isn't passed in.