### PR TITLE
add statusFile.isConflicted

### DIFF
--- a/lib/status_file.js
+++ b/lib/status_file.js
@@ -81,7 +81,10 @@ var StatusFile = function(args) {
              status & codes.INDEX_RENAMED;
     },
     isIgnored: function() {
-      return data.statusBit & codes.IGNORED;
+      return status & codes.IGNORED;
+    },
+    isConflicted: function() {
+      return status & codes.CONFLICTED;
     },
     inWorkingTree: function() {
       return status & codes.WT_NEW ||


### PR DESCRIPTION
`CONFLICTED` is the only Status that StatusFile didn't have a helper method for. Before, it could only be determined by doing `statusFile.status()` and looking for `CONFLICTED` in the result