### PR TITLE
fix config.getString

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,6 @@ var NodeGit = require("../");
 var Config = NodeGit.Config;
 
 // Backwards compatibility.
-Config.getString = function() {
-  return Config.getStringBuf.apply(this, arguments);
+Config.prototype.getString = function() {
+  return this.getStringBuf.apply(this, arguments);
 };

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -36,7 +36,13 @@ describe("Config", function() {
       .then(function(userNameFromNodeGit) {
         assert.equal(savedUserName + "-test", userNameFromNodeGit);
       })
-      .then(finallyFn, finallyFn);
+      .then(finallyFn)
+      .catch(function(e) {
+        return finallyFn()
+          .then(function() {
+            throw e;
+          });
+      });
   });
 
   it("can get and set a repo config value", function() {
@@ -70,6 +76,12 @@ describe("Config", function() {
     .then(function(userNameFromNodeGit) {
       assert.equal(savedUserName + "-test", userNameFromNodeGit);
     })
-    .then(finallyFn, finallyFn);
+    .then(finallyFn)
+    .catch(function(e) {
+      return finallyFn()
+        .then(function() {
+          throw e;
+        });
+    });
   });
 });


### PR DESCRIPTION
- `getStringBuf` is a method on Config's `prototype`, so the `getString` convenience method did not work. Fixed it to be on the prototype.
- We were getting false positives on the config tests because we were catching all errors with the `finallyFn`. Updated the tests the rethrow errors after the `finallyFn` is done.