### PR TITLE
Bump `promisify-node` to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "node-pre-gyp": "^0.6.5",
     "nodegit-promise": "^3.0.1",
     "npm": "^2.9.0",
-    "promisify-node": "^0.1.5",
+    "promisify-node": "^0.2.1",
     "which-native-nodish": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This makes our promisified functions use the latest `nodegit-promise` library (3.0.2)