### PR TITLE
Drop support for  node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 env:
   matrix:
-    - export NODE_VERSION="0.10"
     - export NODE_VERSION="0.12"
     - export NODE_VERSION="iojs-v2.5.0"
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ init:
 environment:
   matrix:
     # Node.js
-    - nodejs_version: "0.10"
     - nodejs_version: "0.12"
     # io.js
     - nodejs_version: "2"

--- a/lifecycleScripts/checkPrepared.js
+++ b/lifecycleScripts/checkPrepared.js
@@ -4,8 +4,6 @@ var fs = require("fs");
 var rooted = path.join.bind(path, __dirname, "..");
 var pkg = require(rooted("package"));
 
-var NODE_VERSION = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
-
 module.exports.checkAll = function checkAll() {
   return Promise.all([
     checkVendor("libgit2"),
@@ -36,9 +34,6 @@ function checkVendor(name, skipVersion) {
   var version = "";
   if (!skipVersion) {
     var vendorPackage = pkg[name];
-    if (vendorPackage[NODE_VERSION]) {
-      vendorPackage = vendorPackage[NODE_VERSION];
-    }
     version = vendorPackage.sha || vendorPackage.version;
   }
 

--- a/lifecycleScripts/retrieveExternalDependencies.js
+++ b/lifecycleScripts/retrieveExternalDependencies.js
@@ -13,8 +13,6 @@ var pkg = require(rooted("package"));
 var tar;
 var request;
 
-var NODE_VERSION = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
-
 module.exports = function retrieveExternalDependencies() {
   tar = require("tar");
   request = require("request");
@@ -29,10 +27,6 @@ module.exports = function retrieveExternalDependencies() {
 function getVendorLib(name) {
   var vendorPath = "vendor/" + name + "/";
   var vendorPackage = pkg[name];
-  if (vendorPackage[NODE_VERSION]) {
-    vendorPackage = vendorPackage[NODE_VERSION];
-  }
-
   var version = vendorPackage.sha || vendorPackage.version;
 
   console.info("[nodegit] Detecting " + vendorPath + version + ".");

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "lib": "./lib"
   },
   "engines": {
-    "node": ">= 0.8"
+    "node": ">= 0.12"
   },
   "bundledDependencies": [
     "node-pre-gyp"

--- a/package.json
+++ b/package.json
@@ -13,11 +13,7 @@
   },
   "http_parser": {
     "url": "https://github.com/joyent/http-parser/archive/v2.5.0.tar.gz",
-    "version": "2.5.0",
-    "0.1": {
-      "url": "https://github.com/joyent/http-parser/archive/v2.0.tar.gz",
-      "version": "2.0.0"
-    }
+    "version": "2.5.0"
   },
   "homepage": "http://nodegit.org",
   "keywords": [


### PR DESCRIPTION
This makes it way easier to deal with the electron (really, node-pre-gyp) madness, and everyone is cool with it.

 - Updates the engines field in package.json
 - Removes all of the references to (and handling for) legacy http_parser
 - Removes 0.10 from test matrices