### PR TITLE
Mark the output param of treebuilder.write. Its unusable otherwise be…

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2059,6 +2059,13 @@
       "functions": {
         "git_treebuilder_filter": {
           "ignore": true
+        },
+        "git_treebuilder_write": {
+          "args": {
+            "id": {
+              "isReturn": true
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
…cause one cannot instantiate an Oid to pass in.