### PR TITLE
Allow update_ref to be null in Commit.amend

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -360,6 +360,9 @@
             },
             "tree": {
               "isOptional": true
+            },
+            "update_ref": {
+              "isOptional": true
             }
           }
         },


### PR DESCRIPTION
NodeGit's http://www.nodegit.org/api/commit/#amend chokes if you give it a null update_ref value, but according to https://libgit2.github.com/libgit2/#HEAD/group/commit/git_commit_amend NULL is acceptable.

This PR changes update_ref to an optional parameter and adds a test.