### PR TITLE
Printing patch and hunk info at correct place.

### DIFF
--- a/examples/diff-commits.js
+++ b/examples/diff-commits.js
@@ -25,7 +25,8 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
         patch.hunks().then(function(hunks) {
           hunks.forEach(function(hunk) {
             hunk.lines().then(function(lines) {
-              console.log("diff", patch.oldFile().path(), patch.newFile().path());
+              console.log("diff", patch.oldFile().path(),
+                patch.newFile().path());
               console.log(hunk.header().trim());
               lines.forEach(function(line) {
                 console.log(String.fromCharCode(line.origin()) +

--- a/examples/diff-commits.js
+++ b/examples/diff-commits.js
@@ -22,11 +22,11 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   diffList.forEach(function(diff) {
     diff.patches().then(function(patches) {
       patches.forEach(function(patch) {
-        console.log("diff", patch.oldFile().path(), patch.newFile().path());
         patch.hunks().then(function(hunks) {
           hunks.forEach(function(hunk) {
-            console.log(hunk.header().trim());
             hunk.lines().then(function(lines) {
+              console.log("diff", patch.oldFile().path(), patch.newFile().path());
+              console.log(hunk.header().trim());
               lines.forEach(function(line) {
                 console.log(String.fromCharCode(line.origin()) +
                   line.content().trim());


### PR DESCRIPTION
Previously, the patch and hunk info got printed before the lines that got changed; the output on master was
```
commit 59b20b8d5c6ff8d09518454d4dd8b7b30f095ab5
Author: tbranyen <tim@tabdeveloper.com>
Date: Sat Apr 09 2011 01:48:49 GMT+0100 (BST)

    Updated gitignore and raw-commit test

diff .gitignore .gitignore
diff test/raw-commit.js test/raw-commit.js
@@ -1,4 +1,5 @@
@@ -2,7 +2,6 @@ var git = require( '../' ).raw,
 .lock-wscript
-./build/
-./doc
-!./doc/Theme.css
+build
+doc
+!doc/Theme.css
+example/stress/test
 rimraf = require( '../vendor/rimraf' ) || require( 'rimraf' ),
 path = require( 'path' );
 
-console.log(git);
 var testRepo = new git.Repo();
 
 // Helper functions
```

The output is now as expected (ignoring the first lines):
```
diff .gitignore .gitignore
@@ -1,4 +1,5 @@
 .lock-wscript
-./build/
-./doc
-!./doc/Theme.css
+build
+doc
+!doc/Theme.css
+example/stress/test
diff test/raw-commit.js test/raw-commit.js
@@ -2,7 +2,6 @@ var git = require( '../' ).raw,
 rimraf = require( '../vendor/rimraf' ) || require( 'rimraf' ),
 path = require( 'path' );
 
-console.log(git);
 var testRepo = new git.Repo();
 
 // Helper functions
```

Please note that I have a different version of this example at https://github.com/asgeirbirkis/nodegit/blob/cf3687a1eb154c291645a2916742c5b705c99425/examples/diff-commits.js , which uses arrays of promises, rather than the current nested forEach loops, however, that still has the issue that the patch and hunk infos all get printed before the lines changed.