### PR TITLE
Stage line eof bug

### DIFF
--- a/lib/convenient_line.js
+++ b/lib/convenient_line.js
@@ -67,7 +67,7 @@ ConvenientLine.prototype.rawContent = function() {
 * @return {String}
 */
 ConvenientLine.prototype.content = function() {
-  return this.raw.content().substring(0, this.raw.contentLen() - 1);
+  return this.raw.content().substring(0, this.raw.contentLen()).replace('\n', '');
 };
 
 NodeGit.ConvenientLine = ConvenientLine;

--- a/lib/convenient_line.js
+++ b/lib/convenient_line.js
@@ -67,7 +67,8 @@ ConvenientLine.prototype.rawContent = function() {
 * @return {String}
 */
 ConvenientLine.prototype.content = function() {
-  return this.raw.content().substring(0, this.raw.contentLen()).replace('\n', '');
+  return this.raw.content()
+    .substring(0, this.raw.contentLen()).replace("\n", "");
 };
 
 NodeGit.ConvenientLine = ConvenientLine;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1154,7 +1154,10 @@ Repository.prototype.stageLines =
       if ((isStaged && newLine && newLine.length > 0) ||
             (!isStaged && (!newLine || newLine.length === 0))) {
         if (hunkLine.origin() !== lineTypes.ADDED) {
-          newContent += hunkLine.content() + "\n";
+          newContent += hunkLine.content();
+          if (hunkLine.raw.numLines() != 0) {
+            newContent += "\n";
+          }
         }
         if ((isStaged && hunkLine.origin() !== lineTypes.DELETED) ||
             (!isStaged && hunkLine.origin() !== lineTypes.ADDED)) {
@@ -1164,7 +1167,10 @@ Repository.prototype.stageLines =
       else {
         switch (hunkLine.origin()) {
           case lineTypes.ADDED:
-            newContent += hunkLine.content() + "\n";
+            newContent += hunkLine.content();
+            if (hunkLine.raw.numLines() != 0) {
+              newContent += "\n";
+            }
             if (isStaged) {
               oldIndex++;
             }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1155,7 +1155,7 @@ Repository.prototype.stageLines =
             (!isStaged && (!newLine || newLine.length === 0))) {
         if (hunkLine.origin() !== lineTypes.ADDED) {
           newContent += hunkLine.content();
-          if (hunkLine.raw.numLines() != 0) {
+          if (hunkLine.raw.numLines() !== 0) {
             newContent += "\n";
           }
         }
@@ -1168,7 +1168,7 @@ Repository.prototype.stageLines =
         switch (hunkLine.origin()) {
           case lineTypes.ADDED:
             newContent += hunkLine.content();
-            if (hunkLine.raw.numLines() != 0) {
+            if (hunkLine.raw.numLines() !== 0) {
               newContent += "\n";
             }
             if (isStaged) {


### PR DESCRIPTION
Fixes bug that involves staging lines:
- User can stage '\ no newline at end of file'. Shouldn't happen!
- Last character in a diff gets cut off if it's the last line in file.
- Staging the last line with no \n will magically add a newline. Shouldn't happen.