### PR TITLE
Stage line eof bug part 2

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1197,10 +1197,6 @@ Repository.prototype.stageLines =
         var hunkStart = isStaged ? pathHunks[index].hunk.newStart()
                         : pathHunks[index].hunk.oldStart();
         var lines = results[index];
-        if (lines[lines.length - 1].raw.content()
-          .indexOf("\\ No newline at end of file") != -1) {
-          lines.splice(lines.length - 1, 1);  //Delete last line
-        }
         if (lines.filter(lineEqualsFirstNewLine).length > 0) {
           //add content that is before the hunk
           while (hunkStart > (oldIndex + 1)) {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1186,7 +1186,10 @@ Repository.prototype.stageLines =
             }
             break;
           default:
-            newContent += oldLines[oldIndex++] + "\n";
+            newContent += oldLines[oldIndex++];
+            if (oldIndex < oldLines.length) {
+              newContent += "\n";
+            }
             break;
         }
       }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1150,6 +1150,11 @@ Repository.prototype.stageLines =
                 (hunkLine.newLineno() === nLine.newLineno()));
       });
 
+      if (hunkLine.raw.content()
+        .indexOf("\\ No newline at end of file") != -1) {
+        return false;
+      }
+
       //determine what to add to the new content
       if ((isStaged && newLine && newLine.length > 0) ||
             (!isStaged && (!newLine || newLine.length === 0))) {

--- a/test/tests/stage.js
+++ b/test/tests/stage.js
@@ -28,8 +28,9 @@ describe("Stage", function() {
 		return fse.remove(test.repository.workdir());
   });
 
-function stagingTest(staging) {
-    var fileContent = "One line of text\n" +
+function stagingTest(staging, newFileContent) {
+    var fileContent = newFileContent ||
+                      "One line of text\n" +
                       "Two lines of text\n"+
                       "Three lines of text\n"+
                       "Four lines of text\n"+
@@ -137,7 +138,7 @@ function stagingTest(staging) {
       return test.repository.getBlob(pathOid);
     })
     .then(function(resultFileContents) {
-      assert.equal(resultFileContents, stagedFile);
+      assert.equal(resultFileContents.toString(), stagedFile);
     });
   }
 
@@ -146,5 +147,39 @@ function stagingTest(staging) {
   });
   it("can unstage selected lines", function() {
     return stagingTest(false);
+  });
+
+  //This is used to test cases where there are no newline at EOF
+  var newlineEofTestFileContent =
+                  "One line of text\n" +
+                  "Two lines of text\n"+
+                  "Three lines of text\n"+
+                  "Four lines of text\n"+
+                  "Five lines of text\n"+
+                  "Six lines of text\n"+
+                  "Seven lines of text\n"+
+                  "Eight lines of text\n"+
+                  "Nine lines of text\n"+
+                  "Ten lines of text\n"+
+                  "Eleven lines of text\n"+
+                  "Twelve lines of text\n"+
+                  "Thirteen lines of text\n"+
+                  "Fourteen lines of text\n"+
+                  "Fifteen lines of text";
+  it("can stage last line with no newline at EOF", function() {
+    return stagingTest(true, newlineEofTestFileContent);
+  });
+  it("can unstage last line with no newline at EOF", function() {
+    return stagingTest(false, newlineEofTestFileContent);
+  });
+  it("can stage second to last line with no newline at EOF", function() {
+    var newlineEofTestFileContent2 = newlineEofTestFileContent +
+     "\nSixteen lines of text\nSeventeen lines of text\nEighteen lines of text";
+    return stagingTest(true, newlineEofTestFileContent2);
+  });
+  it("can unstage second to last line with no newline at EOF", function() {
+    var newlineEofTestFileContent2 = newlineEofTestFileContent +
+     "\nSixteen lines of text\nSeventeen lines of text\nEighteen lines of text";
+    return stagingTest(false, newlineEofTestFileContent2);
   });
 });


### PR DESCRIPTION
This one's better. Accounts for a case I haven't considered previously.
Basically added
```
      if (hunkLine.raw.content().indexOf("\\ No newline at end of file") != -1) {
        return false;
      }
```
in `Repo.prototype.stageLines`'s `processSelectedLine`. This replaces a similar check for `\\ No newline at end of file` I originally had in `Repo.prototype.stageLines`.
