### PR TITLE
Node 4: Use embedded OpenSSL headers first

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -512,7 +512,7 @@
         "_REENTRANT",
         "NO_WINDOWS_BRAINDEATH",
       ],
-      "include_dirs": [
+      "include_dirs+": [
         ".",
         "openssl/openssl",
         "openssl/openssl/crypto",


### PR DESCRIPTION
This a workaround for the compilation
error with Node 4:

../vendor/openssl/openssl/ssl/s3_clnt.c:3262:60: error: use of undeclared identifier 'EVP_PKT_EXP'

Node 4.0.0 includes openssl 1.0.2d, which
no longer defines EVP_PKT_EXP and friends.

node-gyp puts header directories supplied
by node first, therefore OpenSSL include
files shipped by node are used, and
not the ones from the embedded OpenSSL
source.