### PR TITLE
Fix error: invalid operands to binary expression ('size_t' (aka 'unsigned long') and 'nullptr_t')

### DIFF
--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -133,13 +133,11 @@
           {% if arg.name == "payload" %}
             {%-- Do nothing --%}
           {% elsif arg.isJsArg %}
-          if (baton->{{ arg.name }} == NULL) {
             {% if arg.cType == "const char *" %}
+          if (baton->{{ arg.name }} == NULL) {
               baton->{{ arg.name }} = "";
-            {% elsif arg.cType == "unsigned int" %}
-              baton->{{ arg.name }} = 0;
-            {% endif %}
           }
+            {% endif %}
           {% endif %}
         {% endeach %}
 


### PR DESCRIPTION
When compiling with clang we are getting:

    ../src/checkout_options.cc:536:39:
       error: invalid operands to binary expression
       ('size_t' (aka 'unsigned long') and 'nullptr_t')

This commit improves the generated code.