### PR TITLE
Clean up AppVeyor environment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ init:
 
 # what combinations to test
 environment:
+  JOBS: 4
+  BUILD_ONLY: true
+  GIT_SSH: c:\projects\nodegit\vendor\plink.exe
+  GYP_MSVS_VERSION: 2013
   matrix:
     # Node.js
     - nodejs_version: "0.12"
@@ -33,14 +37,9 @@ matrix:
 # Get the latest stable version of Node 0.STABLE.latest
 install:
   - ps: Install-Product node $env:nodejs_version
-  - cmd: SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
-  - cmd: SET PATH=c:\python27;%PATH%
-  - cmd: SET JOBS=4
-  - cmd: SET BUILD_ONLY=true
-  - cmd: SET GIT_SSH=c:\projects\nodegit\vendor\plink.exe
   - ps: Start-Process c:\projects\nodegit\vendor\pageant.exe c:\projects\nodegit\vendor\private.ppk
   - cmd: npm install -g node-gyp
-  - npm install --msvs_version=2013
+  - npm install
 
 test_script:
   - node --version


### PR DESCRIPTION
Use Gyp environment variable to
set up the compiler (as we don't pass
npm parameter to node-gyp).