### PR TITLE
Use relative paths for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,6 @@
 /lib/nodegit.js
 /coverage/
 
-
-/vendor/Release
-/vendor/Debug
-/vendor/*.vcxproj
-/vendor/*.filters
-/vendor/*.sln
-
 /generate/output
 /generate/**/*.json
 !/generate/input/*.json

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -6,7 +6,7 @@
       "target_name": "nodegit",
 
       "dependencies": [
-        "<(module_root_dir)/vendor/libgit2.gyp:libgit2"
+        "vendor/libgit2.gyp:libgit2"
       ],
 
       "variables": {

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -22,7 +22,7 @@
       ],
       "dependencies": [
         "zlib",
-        "<(module_root_dir)/vendor/http_parser/http_parser.gyp:http_parser",
+        "http_parser/http_parser.gyp:http_parser",
         "libssh2",
         "openssl"
       ],
@@ -302,9 +302,6 @@
               "AdditionalDependencies": [
                 "ws2_32.lib"
               ],
-            },
-            "VCCLCompilerTool": {
-                "ObjectFile": "$(IntDir)/%(RelativeDir)/"
             },
             # Workaround of a strange bug:
             # TargetMachine + static_library + x64 = nothing.


### PR DESCRIPTION
- gyp generates full paths where necessary
- keep generated .vcxproj files in the build directory
- don't set ObjectFile path to "$(IntDir)/%(RelativeDir)/",
  because win_delay_hook has an absolute path in %(RelativeDir)%
  which causes

     MSB3191 Unable to create directory: The given path's format is not supported

  (https://github.com/nodejs/node-gyp/issues/732)