### PR TITLE
Stage last hunk? No empty diffs!

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1242,6 +1242,39 @@ Repository.prototype.stageLines =
           NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
       });
 
+    //The following chain checks if there is a patch with no hunks left for the
+    //file, and no filemode changes were done on the file. It is then safe to
+    //stage the entire file so the file doesn't show as having unstaged changes
+    //in `git status`. Also, check if there are no type changes.
+    var lastHunkStagedPromise = function lastHunkStagedPromise(result) {
+      return NodeGit.Diff.indexToWorkdir(repo, index, {
+          flags:
+            NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
+            NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
+        })
+      .then(function (diff) {
+        return diff.patches();
+      })
+      .then(function(patches) {
+        var pathPatch = patches.filter(function(patch) {
+          return patch.newFile().path() === filePath;
+        });
+        var emptyPatch = false;
+        if (pathPatch.length > 0) {
+          //No hunks, unchanged file mode, and no type changes.
+          emptyPatch = pathPatch[0].patch.numHunks() === 0 &&
+            pathPatch[0].oldFile().mode() == pathPatch[0].newFile().mode() &&
+            !pathPatch[0].isTypeChange();
+        }
+        if (emptyPatch) {
+          index.addByPath(filePath);
+          return index.write();
+        } else {
+          return result;
+        }
+      });
+    };
+
   var indexLock = repo.path().replace(".git/", "") + ".git/index.lock";
 
   return fse.remove(indexLock)
@@ -1296,6 +1329,13 @@ Repository.prototype.stageLines =
 
       index.add(entry);
       return index.write();
+    })
+    .then(function(result) {
+      if (isSelectionStaged) {
+        return result;
+      } else {
+        return lastHunkStagedPromise(result);
+      }
     });
 };
 

--- a/test/tests/stage.js
+++ b/test/tests/stage.js
@@ -182,4 +182,35 @@ function stagingTest(staging, newFileContent) {
      "\nSixteen lines of text\nSeventeen lines of text\nEighteen lines of text";
     return stagingTest(false, newlineEofTestFileContent2);
   });
+
+  //This is used to test case where the last hunk is staged.
+  var lastHunkStagedFileContent =
+                "Thirteen lines of text\n"+
+                "Fourteen lines of text\n"+
+                "Fifteen lines of text\n"+
+                "Sixteen lines of text\n"+
+                "Shforteenteen lines of text\n";
+
+  it("staging last hunk stagse whole file if no filemode changes", function() {
+    return stagingTest(true, lastHunkStagedFileContent)
+      .then(function() {
+        return test.repository.openIndex();
+      })
+      .then(function(index) {
+        return NodeGit.Diff.indexToWorkdir(test.repository, index, {
+            flags:
+              NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
+              NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
+          });
+      })
+      .then(function(diff) {
+        assert.equal(Object.keys(diff).length, 0);  //Empty diff
+        return diff.patches();
+      })
+      .then(function(patches) {
+        //patches will have at least one item if there is something unstaged
+        assert.equal(patches.length, 0);
+      });
+
+  });
 });


### PR DESCRIPTION
Upon staging a hunk/line, stage the whole file if:
* It is the last hunk/line, ie the result of 
```Diff.indexToWorkdir(repo, index, {
          flags:
            NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
            NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
        })```
  will be a diff containing a single patch with _no hunks_.
* The file does not have filemode (permission, type) changes.