### PR TITLE
Fixed fetch call.

### DIFF
--- a/examples/fetch.js
+++ b/examples/fetch.js
@@ -4,8 +4,10 @@ var path = require("path");
 nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   .then(function(repo) {
     return repo.fetch("origin", {
-      credentials: function(url, userName) {
-        return nodegit.Cred.sshKeyFromAgent(userName);
+      callbacks: {
+        credentials: function(url, userName) {
+          return nodegit.Cred.sshKeyFromAgent(userName);
+        }
       }
     });
   }).done(function() {


### PR DESCRIPTION
Fetch requires the credentials function to be wrapped in the callbacks object (otherwise the promise succeeds even though it has failed silently).