### PR TITLE
Handle ITEROVER properly in RevWalk

### DIFF
--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -74,14 +74,17 @@ Revwalk.prototype.getCommitsUntil = function(checkFn) {
 
   function walkCommitsCb() {
     return walker.next().then(function(oid) {
-      if (!oid) { return; }
-
       return walker.repo.getCommit(oid).then(function(commit) {
         commits.push(commit);
         if (checkFn(commit)) {
           return walkCommitsCb();
         }
       });
+    })
+    .catch(function(error) {
+      if (error.errno !== NodeGit.Error.CODE.ITEROVER) {
+        throw error;
+      }
     });
   }
 
@@ -105,10 +108,13 @@ Revwalk.prototype.getCommits = function(count) {
     if (count === 0) { return; }
 
     return walker.next().then(function(oid) {
-      if (!oid) { return; }
-
       promises.push(walker.repo.getCommit(oid));
       return walkCommitsCount(count - 1);
+    })
+    .catch(function(error) {
+      if (error.errno !== NodeGit.Error.CODE.ITEROVER) {
+        throw error;
+      }
     });
   }
 

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -83,7 +83,7 @@ describe("Revwalk", function() {
   it("can get a specified number of commits", function() {
     var test = this;
     var storedCommits;
-    return test.walker.getCommits()
+    return test.walker.getCommits(10)
       .then(function(commits) {
         assert.equal(commits.length, 10);
         storedCommits = commits;
@@ -97,6 +97,33 @@ describe("Revwalk", function() {
         for (var i = 0; i < 8; i++) {
           assert.equal(commits[i].toString(), storedCommits[i].toString());
         }
+      });
+  });
+
+  it("can get the largest number of commits within a specified range",
+    function() {
+      var test = this;
+      var storedCommits;
+      return test.walker.getCommits(991)
+        .then(function(commits) {
+          assert.equal(commits.length, 990);
+          storedCommits = commits;
+          test.walker = test.repository.createRevWalk();
+          test.walker.push(test.commit.id());
+        });
+    });
+
+  it("will return all commits from the revwalk if nothing matches", function() {
+    var test = this;
+    var magicSha = "notintherepoatallwhatsoeverisntthatcool";
+
+    function checkCommit(commit) {
+      return commit.toString() != magicSha;
+    }
+
+    return test.walker.getCommitsUntil(checkCommit)
+      .then(function(commits) {
+        assert.equal(commits.length, 990);
       });
   });
 


### PR DESCRIPTION
Libgit2 throws E_ITEROVER at the end of traversals, we need to catch that error and treat it as the end of a traversal from now on.