### PR TITLE
In repository.fetch don't swallow errors thrown by remote.fetch .

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -640,9 +640,9 @@ Repository.prototype.fetch = function(
 {
   var repo = this;
 
-  function finallyFn() {
+  function finallyFn(error) {
     if (typeof callback === "function") {
-      callback();
+      callback(error);
     }
   }
 
@@ -653,7 +653,11 @@ Repository.prototype.fetch = function(
         return remote.disconnect();
       });
     })
-    .then(finallyFn, finallyFn);
+    .then(finallyFn)
+    .catch(function(error) {
+      finallyFn(error);
+      throw error;
+    });
 };
 
 /**


### PR DESCRIPTION
In repository.fetch don't swallow errors thrown by remote.fetch, catch them, pass them to the callback and then rethrow them.

There is a failing test "can reject fetching from private repository without valid credentials" for remote.js but that is not caused by this work.

Helps with https://github.com/nodegit/nodegit/issues/742 