### PR TITLE
Remove c++11 dependency

### DIFF
--- a/generate/templates/manual/include/functions/sleep_for_ms.h
+++ b/generate/templates/manual/include/functions/sleep_for_ms.h
@@ -1,0 +1,6 @@
+#ifndef SLEEP_FOR_MS_H
+#define SLEEP_FOR_MS_H
+
+void sleep_for_ms(int milliseconds);
+
+#endif

--- a/generate/templates/manual/src/functions/sleep_for_ms.cc
+++ b/generate/templates/manual/src/functions/sleep_for_ms.cc
@@ -1,0 +1,16 @@
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <time.h>
+#endif // win32
+
+void sleep_for_ms(int milliseconds) {
+  #ifdef WIN32
+  Sleep(milliseconds);
+  #else
+  struct timespec t;
+  t.tv_sec = 0;
+  t.tv_nsec = milliseconds * 1000000; // 1 milliseconds == 1,000,000 nanoseconds
+  nanosleep(&t, NULL);
+  #endif
+}

--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -20,7 +20,7 @@
   uv_async_send(&baton->req);
 
   while(!baton->done) {
-    this_thread::sleep_for(chrono::milliseconds(1));
+    sleep_for_ms(1);
   }
 
   {% each cbFunction|returnsInfo false true as _return %}

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -97,7 +97,7 @@
         uv_async_send(&baton->req);
 
         while(!baton->done) {
-          this_thread::sleep_for(chrono::milliseconds(1));
+          sleep_for_ms(1);
         }
 
         {% each field|returnsInfo false true as _return %}

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -17,6 +17,7 @@
         "src/nodegit.cc",
         "src/wrapper.cc",
         "src/functions/copy.cc",
+        "src/functions/sleep_for_ms.cc",
         "src/str_array_converter.cc",
         {% each %}
           {% if type != "enum" %}
@@ -31,8 +32,7 @@
       ],
 
       "cflags": [
-        "-Wall",
-        "-std=c++11"
+        "-Wall"
       ],
 
       "conditions": [

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -1,8 +1,6 @@
 // This is a generated file, modify: generate/templates/class_content.cc.
 #include <nan.h>
 #include <string.h>
-#include <chrono>
-#include <thread>
 
 extern "C" {
   #include <git2.h>
@@ -13,6 +11,7 @@ extern "C" {
 
 #include "../include/functions/copy.h"
 #include "../include/{{ filename }}.h"
+#include "../include/functions/sleep_for_ms.h"
 
 {% each dependencies as dependency %}
   #include "{{ dependency }}"

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -1,8 +1,11 @@
 // This is a generated file, modify: generate/templates/struct_content.cc.
 #include <nan.h>
 #include <string.h>
-#include <chrono>
-#include <thread>
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif // win32
 
 extern "C" {
   #include <git2.h>
@@ -14,6 +17,7 @@ extern "C" {
 #include <iostream>
 #include "../include/functions/copy.h"
 #include "../include/{{ filename }}.h"
+#include "../include/functions/sleep_for_ms.h"
 
 {% each dependencies as dependency %}
   #include "{{ dependency }}"


### PR DESCRIPTION
We're using our own thread sleep function which I think removes the need now for using c++11. Hopefully this will fix everybody's build errors and we'll have rainbows and lollipops and unicorns instead.