### PR TITLE
Add support for patch method git_patch_line_stats + test for it

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1360,7 +1360,20 @@
           }
         },
         "git_patch_line_stats": {
-          "ignore": true
+          "args": {
+            "total_context": {
+              "isReturn": true
+            },
+            "total_additions": {
+              "isReturn": true
+            },
+            "total_deletions": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_patch_print": {
           "ignore": true

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -73,6 +73,22 @@ ConvenientPatch.prototype.status = function() {
 };
 
 /**
+ * @typedef lineStats
+ * @type {Object}
+ * @property {number} total_context # of contexts in the patch
+ * @property {number} total_additions # of lines added in the patch
+ * @property {number} total_deletions # of lines deleted in the patch
+ */
+
+/**
+ * The line statistics of this patch (#contexts, #added, #deleted)
+ * @return {lineStats}
+ */
+ConvenientPatch.prototype.lineStats = function() {
+  return this.patch.lineStats();
+};
+
+/**
  * Is this an unmodified patch?
  * @return {Boolean}
  */

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -1,0 +1,67 @@
+var assert = require("assert");
+var path = require("path");
+var Promise = require("nodegit-promise");
+var local = path.join.bind(path, __dirname);
+
+describe("Patch", function() {
+  var NodeGit = require("../../");
+  var Repository = NodeGit.Repository;
+
+  var reposPath = local("../repos/workdir");
+  var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";
+
+  beforeEach(function() {
+    var test = this;
+
+    return Repository.open(reposPath).then(function(repository) {
+        test.repository = repository;
+
+        return repository.openIndex();
+      })
+      .then(function(index) {
+        test.index = index;
+
+        return test.repository.getBranchCommit("master");
+      })
+      .then(function(masterCommit) {
+        return masterCommit.getTree();
+      })
+      .then(function(tree) {
+        test.masterCommitTree = tree;
+
+        return test.repository.getCommit(oid);
+      })
+      .then(function(commit) {
+        test.commit = commit;
+
+        return commit.getDiff();
+      })
+      .then(function(diff) {
+        test.diff = diff;
+
+        return diff[0].patches();
+      })
+      .catch(function(e) {
+          return Promise.reject(e);
+      });
+  });
+
+  it("retrieve the line stats of a patch", function() {
+    return this.diff[0].patches()
+      .then(function(patches) {
+        var patch = patches[0];
+        var lineStats = patch.lineStats();
+
+        assert.equal(patch.oldFile().path(), "README.md");
+        assert.equal(patch.newFile().path(), "README.md");
+        assert.equal(patch.size(), 1);
+        assert.ok(patch.isModified());
+        assert.equal(lineStats.total_context, 3);
+        assert.equal(lineStats.total_additions, 1);
+        assert.equal(lineStats.total_deletions, 1);
+      });
+
+  });
+
+
+});


### PR DESCRIPTION
I've just added support for the git_patch_line_stats method.
The only caveat is that the returned values are size_t being cast to a js number.
This is convenient to quickly gather stats about the patches without having to go down to the line level.

Added a simple test for the function as well