### PR TITLE
Ignore undefined options in normalizeOptions.

### DIFF
--- a/lib/utils/normalize_options.js
+++ b/lib/utils/normalize_options.js
@@ -18,7 +18,9 @@ function normalizeOptions(options, Ctor) {
   var instance = new Ctor();
 
   Object.keys(options).forEach(function(key) {
-    instance[key] = options[key];
+    if (typeof options[key] !== "undefined") {
+      instance[key] = options[key];
+    }
   });
 
   return instance;

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -274,6 +274,31 @@ describe("Diff", function() {
       });
   });
 
+  it("can pass undefined pathspec as option to indexToWorkdir", function() {
+    var test = this;
+
+    return Repository.open(reposPath).then(function(repository) {
+      test.repository = repository;
+
+      return repository.openIndex();
+    })
+    .then(function(index) {
+      test.index = index;
+
+      return test.repository.getBranchCommit("master");
+    })
+    .then(function() {
+      var opts = {
+        flags: Diff.OPTION.INCLUDE_UNTRACKED |
+               Diff.OPTION.RECURSE_UNTRACKED_DIRS,
+        pathspec: undefined
+      };
+
+      // should not segfault
+      return Diff.indexToWorkdir(test.repository, test.index, opts);
+    });
+  });
+
   // This wasn't working before. It was only passing because the promise chain
   // was broken
   it.skip("can find similar files in a diff", function() {


### PR DESCRIPTION
It's possible to have some options (DiffOptions, for example) where `options[key]` is undefined. There's no reason why undefined options should be passed to any of nodegit's class methods. Let's check for them in `normalizeOptions`, and prevent these undefined options from being copied.

I didn't check for `null`, since for some options, `null` is ok.