### PR TITLE
Node v5.0 (modules v47) to allow prebuilt binaries in S3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   matrix:
     - export NODE_VERSION="0.12"
     - export NODE_VERSION="4.1"
+    - export NODE_VERSION="5.0"
 matrix:
   fast_finish: true
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,9 @@ environment:
   matrix:
     # Node.js
     - nodejs_version: "0.12"
-    # io.js
+    # Node.js
     - nodejs_version: "4.1"
+    - nodejs_version: "5.0"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Building nodegit locally in the absence of a prebuilt binary is still a complicated task 😰. By adding Node v5 support to the CI builds now we can get the prebuilt up on S3 quickly.