### PR TITLE
Log error when downloading from aws

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -44,9 +44,10 @@ return whichNativeNodish("..")
         function() {
           console.info("[nodegit] Completed installation successfully.");
         },
-        function() {
+        function(err) {
           console.info("[nodegit] Failed to install prebuilt binary, " +
             "building manually.");
+          console.error(err);
           return prepareAndBuild();
         }
       );


### PR DESCRIPTION
When downloading from aws via node-pre-gyp fails, we should log the reason for the failure. #758 