### PR TITLE
Build both x86 and x64 on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@
 # Try out "interactive-mode"
 os: Windows Server 2012 R2
 
+platform:
+  - x86
+  - x64
+
 # build version format
 version: "{build}"
 


### PR DESCRIPTION
What it says above. Needed so we can get all the binaries out there. 