### PR TITLE
Allow node-pre-gyp for Electron and node-webkit

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -23,10 +23,6 @@ return whichNativeNodish("..")
       console.info("[nodegit] Must build for node-webkit/nw.js");
       return prepareAndBuild();
     }
-    else if (asVersion) {
-      console.info("[nodegit] Must build for atom-shell");
-      return prepareAndBuild();
-    }
     if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
       return prepareAndBuild();
     }

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -19,10 +19,6 @@ return whichNativeNodish("..")
     asVersion = results.asVersion;
   })
   .then(function() {
-    if (nwVersion) {
-      console.info("[nodegit] Must build for node-webkit/nw.js");
-      return prepareAndBuild();
-    }
     if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
       return prepareAndBuild();
     }

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -23,10 +23,9 @@ return whichNativeNodish("..")
       console.info("[nodegit] Must build for node-webkit/nw.js");
       return prepareAndBuild();
     }
+    if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
+      return prepareAndBuild();
     }
-    // if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
-    //   return prepareAndBuild();
-    // }
     if (process.env.BUILD_DEBUG) {
       console.info("[nodegit] Doing a debug build, no fetching allowed.");
       return prepareAndBuild();

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -39,7 +39,7 @@ return whichNativeNodish("..")
       args.push("--runtime=electron");
       args.push("--target=" + asVersion);
     }
-    return installPrebuilt(args)
+    return installPrebuilt(args);
   });
 
 function installPrebuilt(args) {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -44,8 +44,8 @@ return whichNativeNodish("..")
 
 function installPrebuilt(args) {
   console.info("[nodegit] Fetching binary from S3.");
-  var arguments = args.join(' ');
-  return exec("node-pre-gyp install " + arguments)
+  var installArguments = args.join(" ");
+  return exec("node-pre-gyp install " + installArguments)
     .then(
       function() {
         console.info("[nodegit] Completed installation successfully.");

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -23,10 +23,6 @@ return whichNativeNodish("..")
       console.info("[nodegit] Must build for node-webkit/nw.js");
       return prepareAndBuild();
     }
-    var args = []
-    if (asVersion) {
-      args.push("--runtime=electron")
-      args.push("--target=" + asVersion)
     }
     // if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
     //   return prepareAndBuild();
@@ -39,12 +35,17 @@ return whichNativeNodish("..")
       console.info("[nodegit] BUILD_ONLY is set to true, no fetching allowed.");
       return prepareAndBuild();
     }
-    return installWithPreGyp(args)
+    var args = [];
+    if (asVersion) {
+      args.push("--runtime=electron");
+      args.push("--target=" + asVersion);
+    }
+    return installPrebuilt(args)
   });
 
-function installWithPreGyp(args) {
+function installPrebuilt(args) {
   console.info("[nodegit] Fetching binary from S3.");
-  var arguments = args.join(' ')
+  var arguments = args.join(' ');
   return exec("node-pre-gyp install " + arguments)
     .then(
       function() {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -23,9 +23,9 @@ return whichNativeNodish("..")
       console.info("[nodegit] Must build for node-webkit/nw.js");
       return prepareAndBuild();
     }
-    if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
-      return prepareAndBuild();
-    }
+    // if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
+    //   return prepareAndBuild();
+    // }
     if (process.env.BUILD_DEBUG) {
       console.info("[nodegit] Doing a debug build, no fetching allowed.");
       return prepareAndBuild();

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -26,7 +26,6 @@ return whichNativeNodish("..")
     var args = []
     if (asVersion) {
       args.push("--runtime=electron")
-      console.info("version: " + asVersion)
       args.push("--target=" + asVersion)
     }
     // if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -23,6 +23,12 @@ return whichNativeNodish("..")
       console.info("[nodegit] Must build for node-webkit/nw.js");
       return prepareAndBuild();
     }
+    var args = []
+    if (asVersion) {
+      args.push("--runtime=electron")
+      console.info("version: " + asVersion)
+      args.push("--target=" + asVersion)
+    }
     // if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
     //   return prepareAndBuild();
     // }
@@ -34,20 +40,25 @@ return whichNativeNodish("..")
       console.info("[nodegit] BUILD_ONLY is set to true, no fetching allowed.");
       return prepareAndBuild();
     }
-    console.info("[nodegit] Fetching binary from S3.");
-    return exec("node-pre-gyp install")
-      .then(
-        function() {
-          console.info("[nodegit] Completed installation successfully.");
-        },
-        function(err) {
-          console.info("[nodegit] Failed to install prebuilt binary, " +
-            "building manually.");
-          console.error(err);
-          return prepareAndBuild();
-        }
-      );
+    return installWithPreGyp(args)
   });
+
+function installWithPreGyp(args) {
+  console.info("[nodegit] Fetching binary from S3.");
+  var arguments = args.join(' ')
+  return exec("node-pre-gyp install " + arguments)
+    .then(
+      function() {
+        console.info("[nodegit] Completed installation successfully.");
+      },
+      function(err) {
+        console.info("[nodegit] Failed to install prebuilt binary, " +
+          "building manually.");
+        console.error(err);
+        return prepareAndBuild();
+      }
+    );
+}
 
 
 function prepareAndBuild() {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -34,6 +34,9 @@ return whichNativeNodish("..")
     if (asVersion) {
       args.push("--runtime=electron");
       args.push("--target=" + asVersion);
+    } else if (nwVersion) {
+      args.push("--runtime=node-webkit");
+      args.push("--target=" + nwVersion);
     }
     return installPrebuilt(args);
   });

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "fs-extra": "^0.24.0",
-    "node-pre-gyp": "https://github.com/joshaber/node-pre-gyp/tarball/master",
+    "node-pre-gyp": "^0.6.15",
     "nodegit-promise": "^3.0.3",
     "npm": "^3.3.3",
     "promisify-node": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "fs-extra": "^0.24.0",
-    "node-pre-gyp": "^0.6.15",
+    "node-pre-gyp": "https://github.com/joshaber/node-pre-gyp/tarball/master",
     "nodegit-promise": "^3.0.3",
     "npm": "^3.3.3",
     "promisify-node": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "fs-extra": "^0.24.0",
-    "node-pre-gyp": "^0.6.10",
+    "node-pre-gyp": "^0.6.15",
     "nodegit-promise": "^3.0.3",
     "npm": "^3.3.3",
     "promisify-node": "^0.2.1",


### PR DESCRIPTION
As of https://github.com/mapbox/node-pre-gyp/pull/175, node-pre-gyp now understands “electron” as a runtime.

This doesn’t actually create and publish Electron builds—I’ll work on that next—but it does mean that nodegit will try to use a prebuilt binary and then simply fallback to source.

(Context: we’re investigating bundling nodegit in Atom, but CI times explode without nodegit binary support: https://github.com/atom/atom/pull/9213.)