### PR TITLE
Bump nodegit-promise to 4.0.0 and Promisify to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   "dependencies": {
     "fs-extra": "^0.24.0",
     "node-pre-gyp": "^0.6.15",
-    "nodegit-promise": "^3.0.3",
+    "nodegit-promise": "^4.0.0",
     "npm": "^3.3.3",
-    "promisify-node": "^0.2.1",
+    "promisify-node": "^0.3.0",
     "which-native-nodish": "^1.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes issues where promises that resolve to promise chains could end up in an invalid state where they were neither pending, fulfilled, nor rejected.