### PR TITLE
update/tighten modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,28 +37,25 @@
     "node-pre-gyp"
   ],
   "dependencies": {
-    "fs-extra": "^0.24.0",
-    "node-pre-gyp": "^0.6.15",
-    "nodegit-promise": "^4.0.0",
-    "npm": "^3.3.3",
-    "promisify-node": "^0.3.0",
-    "which-native-nodish": "^1.1.3"
+    "fs-extra": "~0.26.2",
+    "node-pre-gyp": "~0.6.15",
+    "nodegit-promise": "~4.0.0",
+    "promisify-node": "~0.3.0",
+    "which-native-nodish": "~1.1.3"
   },
   "devDependencies": {
-    "clean-for-publish": "^1.0.2",
-    "combyne": "^0.8.1",
-    "coveralls": "^2.11.4",
-    "istanbul": "^0.3.20",
-    "js-beautify": "^1.5.10",
-    "jshint": "^2.8.0",
-    "lcov-result-merger": "^1.0.2",
-    "lodash": "^3.10.1",
-    "mocha": "^2.3.3",
-    "nan": "^2.0.9",
-    "node-gyp": "^3.0.3",
-    "nw-gyp": "^0.12.4",
-    "request": "^2.63.0",
-    "tar": "^2.2.1"
+    "clean-for-publish": "~1.0.2",
+    "combyne": "~0.8.1",
+    "coveralls": "~2.11.4",
+    "istanbul": "~0.3.20",
+    "js-beautify": "~1.5.10",
+    "jshint": "~2.8.0",
+    "lcov-result-merger": "~1.0.2",
+    "lodash": "~3.10.1",
+    "mocha": "~2.3.4",
+    "nan": "~2.0.9",
+    "node-gyp": "~3.0.3",
+    "nw-gyp": "~0.12.4"
   },
   "vendorDependencies": {
     "libgit2": {


### PR DESCRIPTION
remove unneeded modules
 - npm
 - request
 - tar
Tighten all modules from `^` to `~`
Update modules
 - fs-extra 0.24.0 -> 0.26.2
 - nodegit-promise 3.0.3 -> 4.0.0
 - promisify-node 0.2.1 -> 0.3.0
 - jshint 2.8.0 -> 2.9.0
 - mocha 2.3.3 -> 2.4.4