### PR TITLE
Added missing arguments to compare

### DIFF
--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -262,7 +262,9 @@ var Helpers = {
       // itself and determine if this function goes on the prototype
       // or is a constructor method.
       arg.isReturn = arg.name === "out" || (utils.isDoublePointer(arg.type) && normalizedType == typeDef.cType);
-      arg.isSelf = utils.isPointer(arg.type) && normalizedType == typeDef.cType;
+      arg.isSelf = utils.isPointer(arg.type) &&
+        normalizedType == typeDef.cType &&
+        _.every(allArgs, function(_arg) { return !_arg.isSelf; });
 
       if (arg.isReturn && fnDef.return && fnDef.return.type === "int") {
         fnDef.return.isErrorCode = true;

--- a/test/tests/oid.js
+++ b/test/tests/oid.js
@@ -43,4 +43,31 @@ describe("Oid", function() {
         assert.equal(commits[0].toString(), oid);
       });
   });
+
+  it("can compare two identical oids", function() {
+    assert.equal(this.oid.cmp(this.oid), 0);
+  });
+
+  it("can compare two different oids", function() {
+    var oid2 = Oid.fromString("13c633665257696a3800b0a39ff636b4593f918f");
+    assert.notEqual(this.oid.cmp(oid2), 0);
+  });
+
+  it("can compare the first chunk of two identical oids", function() {
+    assert.equal(this.oid.ncmp(this.oid, 5), 0);
+  });
+
+  it("can compare the first chunk of two different oids", function() {
+    var oid2 = Oid.fromString("13c633665257696a3800b0a39ff636b4593f918f");
+    assert.notEqual(this.oid.ncmp(oid2, 5), 0);
+  });
+
+  it("can check the equality of two identical oids", function() {
+    assert(this.oid.equal(this.oid));
+  });
+
+  it("can check the equality of two different oids", function() {
+    var oid2 = Oid.fromString("13c633665257696a3800b0a39ff636b4593f918f");
+    assert(!this.oid.equal(oid2));
+  });
 });

--- a/test/tests/refs.js
+++ b/test/tests/refs.js
@@ -53,6 +53,19 @@ describe("Reference", function() {
     assert.equal(this.reference.toString(), refName);
   });
 
+  it("can compare two identical references", function() {
+    assert.equal(this.reference.cmp(this.reference), 0);
+  });
+
+  it("can compare two different references", function() {
+    var ref = this.reference;
+
+    return this.repository.getReference("checkout-test")
+      .then(function(otherRef) {
+        assert.notEqual(ref.cmp(otherRef), 0);
+      });
+  });
+
   it("will return undefined looking up the symbolic target if not symbolic",
     function() {
       assert(this.reference.symbolicTarget() === undefined);


### PR DESCRIPTION
This should fix #800. The issue was that the second argument was marked as `isSelf`in the following methods. So comparing two objects really just compared an object to itself.

From what I could tell this will only change the following:
- `Hashsig#compare`
- `Oid#cmp`
- `Oid#equal`
- `Oid#ncmp`
- `Reference#cmp`
- `Strarray#copy`