### PR TITLE
Force read index when performing rebase

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -880,6 +880,7 @@ function performRebase(repository, rebase, signature) {
     .then(function(rebaseOperation, lel) {
       return repository.openIndex()
         .then(function(index) {
+          index.read(1);
           if (index.hasConflicts()) {
             throw index;
           }


### PR DESCRIPTION
The index is read to make sure the conflict check is performed on the true current state of the index.

Without this, I've seen problems where `hasConflicts` would report conflicts that were not really there.