### PR TITLE
Add beforeNextFn callback for rebase

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -868,42 +868,64 @@ Repository.prototype.mergeBranches =
  * Goes through a rebase's rebase operations and commits them if there are
  * no merge conflicts
  *
- * @param {Repository}  repository  The repository that the rebase is being
- *                                  performed in
- * @param {Rebase}      rebase      The current rebase being performed
- * @param {Signature}   signature   Identity of the one performing the rebase
- * @return  {Int|Index} An error code for an unsuccesful rebase or an index for
- *                      a rebase with conflicts
+ * @param {Repository}  repository    The repository that the rebase is being
+ *                                    performed in
+ * @param {Rebase}      rebase        The current rebase being performed
+ * @param {Signature}   signature     Identity of the one performing the rebase
+ * @param {Function}    beforeNextFn  Callback to be called before each
+ *                                    invocation of next(). If the callback
+ *                                    returns a promise, the next() will be
+ *                                    called when the promise resolves.
+ * @return {Int|Index} An error code for an unsuccesful rebase or an index for
+ *                     a rebase with conflicts
  */
-function performRebase(repository, rebase, signature) {
-  return rebase.next()
-    .then(function(rebaseOperation, lel) {
-      return repository.openIndex()
-        .then(function(index) {
-          if (index.hasConflicts()) {
-            throw index;
-          }
+function performRebase(repository, rebase, signature, beforeNextFn) {
+  var beforeNextFnResult;
 
-          rebase.commit(null, signature);
+  function getPromise() {
+    return rebase.next()
+      .then(function() {
+        return repository.openIndex()
+          .then(function(index) {
+            if (index.hasConflicts()) {
+              throw index;
+            }
 
-          return performRebase(repository, rebase, signature);
-        });
-    }, function(error) {
-      if (error && error.errno === NodeGit.Error.CODE.ITEROVER) {
-        return rebase.finish(signature);
-      } else {
-        throw error;
-      }
-    });
+            rebase.commit(null, signature);
+
+            return performRebase(repository, rebase, signature, beforeNextFn);
+          });
+      }, function(error) {
+        if (error && error.errno === NodeGit.Error.CODE.ITEROVER) {
+          return rebase.finish(signature);
+        } else {
+          throw error;
+        }
+      });
+  }
+
+  if(beforeNextFn) {
+    beforeNextFnResult = beforeNextFn(rebase);
+    // if beforeNextFn returns a promise, chain the promise
+    return Promise.resolve(beforeNextFnResult)
+      .then(getPromise);
+  }
+
+  return getPromise();
 }
 
 /**
  * Rebases a branch onto another branch
  *
- * @param {String}    branch
- * @param {String}    upstream
- * @param {String}    onto
- * @param {Signature} signature Identity of the one performing the rebase
+ * @param {String}     branch
+ * @param {String}     upstream
+ * @param {String}     onto
+ * @param {Signature}  signature     Identity of the one performing the rebase
+ * @param {Function}   beforeNextFn  Callback to be called before each step
+ *                                   of the rebase.  If the callback returns a
+ *                                   promise, the rebase will resume when the
+ *                                   promise resolves.  The rebase object is
+ *                                   is passed to the callback.
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      rebase with conflicts
  */
@@ -911,7 +933,9 @@ Repository.prototype.rebaseBranches = function(
   branch,
   upstream,
   onto,
-  signature)
+  signature,
+  beforeNextFn
+)
 {
   var repo = this;
   var branchCommit;
@@ -955,7 +979,7 @@ Repository.prototype.rebaseBranches = function(
 
     return NodeGit.Rebase.init(repo, branchCommit, upstreamCommit, ontoCommit)
       .then(function(rebase) {
-        return performRebase(repo, rebase, signature);
+        return performRebase(repo, rebase, signature, beforeNextFn);
       })
       .then(function(error) {
         if (error) {
@@ -971,11 +995,16 @@ Repository.prototype.rebaseBranches = function(
 /**
  * Continues an existing rebase
  *
- * @param {Signature} signature Identity of the one performing the rebase
+ * @param {Signature}  signature     Identity of the one performing the rebase
+ * @param {Function}   beforeNextFn  Callback to be called before each step
+ *                                   of the rebase. If the callback returns a
+ *                                   promise, the rebase will resume when the
+ *                                   promise resolves. The rebase object is
+ *                                   is passed to the callback.
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      rebase with conflicts
  */
-Repository.prototype.continueRebase = function(signature) {
+Repository.prototype.continueRebase = function(signature, beforeNextFn) {
   var repo = this;
 
   signature = signature || repo.defaultSignature();
@@ -991,7 +1020,7 @@ Repository.prototype.continueRebase = function(signature) {
     .then(function(rebase) {
       rebase.commit(null, signature);
 
-      return performRebase(repo, rebase, signature);
+      return performRebase(repo, rebase, signature, beforeNextFn);
     })
     .then(function(error) {
       if (error) {


### PR DESCRIPTION
This adds support for a callback parameter that can be passed to `rebaseBranches` and `performRebase`.  The callback allows the caller to perform actions between steps of the rebase (between calls to `next`).