### PR TITLE
Let node-pre-gyp handle Electron/nwjs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,7 +15,6 @@
 .jshintrc
 .travis.yml
 appveyor.yml
-.didntcomefromthenpmregistry
 
 *.vcxproj
 *.filters

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -26,7 +26,8 @@ return installPrebuilt();
 
 function installPrebuilt() {
   console.info("[nodegit] Fetching binary from S3.");
-  return exec("node-pre-gyp install --fallback-to-build=false")
+  var npg = pathForTool("node-pre-gyp");
+  return exec(npg + " install --fallback-to-build=false")
     .then(
       function() {
         console.info("[nodegit] Completed installation successfully.");
@@ -38,6 +39,13 @@ function installPrebuilt() {
         return prepareAndBuild();
       }
     );
+}
+
+
+function pathForTool(name) {
+  var toolPath = path.resolve(".", "node_modules", ".bin", name);
+  toolPath = toolPath.replace(/\s/g, "\\$&");
+  return toolPath;
 }
 
 
@@ -59,15 +67,13 @@ function build() {
   };
 
   var debug = (process.env.BUILD_DEBUG ? " --debug" : "");
-  var builder = "node-gyp";
 
   var home = process.platform == "win32" ?
               process.env.USERPROFILE : process.env.HOME;
 
   opts.env.HOME = path.join(home, ".nodegit-gyp");
 
-  builder = path.resolve(".", "node_modules", ".bin", builder);
-  builder = builder.replace(/\s/g, "\\$&");
+  var builder = pathForTool("node-gyp");
   var cmd = [builder, "rebuild", debug].join(" ").trim();
 
   return exec(cmd, opts)

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -8,9 +8,18 @@ var exec = promisify(function(command, opts, callback) {
   return require("child_process").exec(command, opts, callback);
 });
 
-var local = path.join.bind(path, __dirname);
+var fromRegistry;
+try {
+  fs.statSync(path.join(__dirname, "..", "include"));
+  fs.statSync(path.join(__dirname, "..", "src"));
+  fromRegistry = true;
+}
+catch(e) {
+  fromRegistry = false;
+}
 
-if (fs.existsSync(local("../.didntcomefromthenpmregistry"))) {
+if (fromRegistry) {
+  console.info("[nodegit] Local install, no fetching allowed.");
   return prepareAndBuild();
 }
 if (process.env.BUILD_DEBUG) {
@@ -41,13 +50,11 @@ function installPrebuilt() {
     );
 }
 
-
 function pathForTool(name) {
   var toolPath = path.resolve(".", "node_modules", ".bin", name);
   toolPath = toolPath.replace(/\s/g, "\\$&");
   return toolPath;
 }
-
 
 function prepareAndBuild() {
   console.info("[nodegit] Regenerating and configuring code");
@@ -73,8 +80,7 @@ function build() {
 
   opts.env.HOME = path.join(home, ".nodegit-gyp");
 
-  var builder = pathForTool("node-gyp");
-  var cmd = [builder, "rebuild", debug].join(" ").trim();
+  var cmd = [pathForTool("node-gyp"), "rebuild", debug].join(" ").trim();
 
   return exec(cmd, opts)
     .then(function() {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -18,7 +18,7 @@ catch(e) {
   fromRegistry = false;
 }
 
-if (fromRegistry) {
+if (!fromRegistry) {
   console.info("[nodegit] Local install, no fetching allowed.");
   return prepareAndBuild();
 }

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -32,9 +32,9 @@ function installPrebuilt() {
         console.info("[nodegit] Completed installation successfully.");
       },
       function(err) {
-        console.info("[nodegit] Failed to install prebuilt binary, " +
-          "building manually.");
+        console.info("[nodegit] Failed to install prebuilt binary:");
         console.error(err);
+        console.info("[nodegit] Building manually. (You'll be here a while.)");
         return prepareAndBuild();
       }
     );

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "fs-extra": "~0.26.2",
     "node-pre-gyp": "~0.6.15",
     "nodegit-promise": "~4.0.0",
-    "promisify-node": "~0.3.0",
-    "which-native-nodish": "~1.1.3"
+    "promisify-node": "~0.3.0"
   },
   "devDependencies": {
     "clean-for-publish": "~1.0.2",


### PR DESCRIPTION
`node_pre_gyp` [will parse `npm_config_` environment variables](https://github.com/mapbox/node-pre-gyp/blob/cfefa6f6197748d50980c5e49dc57c44ef3efc70/lib/node-pre-gyp.js#L130) to determine if the runtime is node/electron/nwjs. So nodegit doesn't need to do any special detection itself.

This supersedes #804.