### PR TITLE
TreeBuilder.create has source as optional param, plus associated tests

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2099,6 +2099,13 @@
               "isReturn": true
             }
           }
+        },
+        "git_treebuilder_new": {
+          "args": {
+            "source": {
+              "isOptional": true
+            }
+          }
         }
       }
     },

--- a/test/tests/treebuilder.js
+++ b/test/tests/treebuilder.js
@@ -47,4 +47,33 @@ describe("TreeBuilder", function(){
         });
       });
     });
+    //adding a tree is adding a folder
+    it("Can add a new tree to an existing tree", function(){
+
+      var test = this;
+      //get latest commit
+      return test.repo.getHeadCommit()
+      //get tree of commit
+      .then(function(commit){ return commit.getTree(); })
+      //make treebuilder from tree
+      .then(function(tree){ return Git.Treebuilder.create(test.repo, tree); })
+      //verify treebuilder can do stuff
+      .then(function(rootTreeBuilder){
+        //new dir builder
+        return Git.Treebuilder.create(test.repo, null)
+        .then(function(newTreeBuilder){
+          //insert new dir
+          return rootTreeBuilder.insert(
+            "mynewfolder",
+            newTreeBuilder.write(),
+            Git.TreeEntry.FILEMODE.TREE
+          );
+        });
+      })
+      .then(function(newTreeEntry){
+        assert(newTreeEntry.isTree(),
+          "Created a tree (new folder) that is a tree");
+        return Git.Tree.lookup(test.repo, newTreeEntry.oid());
+      });
+    });
 });

--- a/test/tests/treebuilder.js
+++ b/test/tests/treebuilder.js
@@ -1,13 +1,12 @@
 var assert = require("assert");
 var path = require("path");
-var fs = require('fs');
+var fs = require("fs");
 var promisify = require("promisify-node");
 var readDir = promisify(fs.readdir);
 var local = path.join.bind(path, __dirname);
 
 describe("TreeBuilder", function(){
 
-    var RepoUtils = require("../utils/repository_setup");
     var Git = require("../../");
     var reposPath = local("../repos/workdir");
     //setup test repo each test
@@ -19,7 +18,9 @@ describe("TreeBuilder", function(){
           test.repo = repo;
         });
     });
-    //treebuilder created with no source when creating a new folder (each folder in git is a tree), or the root folder for a root commit
+    //treebuilder created with no source when creating a new folder
+    //  (each folder in git is a tree)
+    //  or the root folder for a root commit
     it("Can create a new treebuilder with no source", function(){
 
         return Git.Treebuilder.create(this.repo, null);
@@ -31,16 +32,19 @@ describe("TreeBuilder", function(){
       //get latest commit
       return test.repo.getHeadCommit()
       //get tree of commit
-      .then(function(commit){ return commit.getTree() })
+      .then(function(commit){ return commit.getTree(); })
       //make treebuilder from tree
-      .then(function(tree){ return Git.Treebuilder.create(test.repo, tree)})
+      .then(function(tree){ return Git.Treebuilder.create(test.repo, tree); })
       //verify treebuilder can do stuff
       .then(function(treeBuilder){
         //check
         //count how many entries we should have
         return readDir(reposPath)
-        //treebuilder should have all entries in the clean working dir (minus .git folder)
-        .then(function(dirEntries){ return assert.equal(dirEntries.length-1, treeBuilder.entrycount()) });
+        //treebuilder should have all entries in the clean working dir
+        //(minus .git folder)
+        .then(function(dirEntries) {
+          return assert.equal(dirEntries.length-1, treeBuilder.entrycount());
+        });
       });
     });
-})
+});

--- a/test/tests/treebuilder.js
+++ b/test/tests/treebuilder.js
@@ -40,7 +40,7 @@ describe("TreeBuilder", function(){
         //count how many entries we should have
         return readDir(reposPath)
         //treebuilder should have all entries in the clean working dir (minus .git folder)
-        .then(dirEntries => assert.equal(dirEntries.length-1, treeBuilder.entrycount()));
+        .then(function(dirEntries){ return assert.equal(dirEntries.length-1, treeBuilder.entrycount()) });
       });
     });
 })

--- a/test/tests/treebuilder.js
+++ b/test/tests/treebuilder.js
@@ -1,0 +1,46 @@
+var assert = require("assert");
+var path = require("path");
+var fs = require('fs');
+var promisify = require("promisify-node");
+var readDir = promisify(fs.readdir);
+var local = path.join.bind(path, __dirname);
+
+describe("TreeBuilder", function(){
+
+    var RepoUtils = require("../utils/repository_setup");
+    var Git = require("../../");
+    var reposPath = local("../repos/workdir");
+    //setup test repo each test
+    beforeEach(function() {
+      var test = this;
+
+      return Git.Repository.open(reposPath)
+        .then(function(repo) {
+          test.repo = repo;
+        });
+    });
+    //treebuilder created with no source when creating a new folder (each folder in git is a tree), or the root folder for a root commit
+    it("Can create a new treebuilder with no source", function(){
+
+        return Git.Treebuilder.create(this.repo, null);
+    });
+    //treebuilder created with a source tree can add / read from tree
+    it("Can create a treebuilder from the latest commit tree", function(){
+
+      var test = this;
+      //get latest commit
+      return test.repo.getHeadCommit()
+      //get tree of commit
+      .then(function(commit){ return commit.getTree() })
+      //make treebuilder from tree
+      .then(function(tree){ return Git.Treebuilder.create(test.repo, tree)})
+      //verify treebuilder can do stuff
+      .then(function(treeBuilder){
+        //check
+        //count how many entries we should have
+        return readDir(reposPath)
+        //treebuilder should have all entries in the clean working dir (minus .git folder)
+        .then(dirEntries => assert.equal(dirEntries.length-1, treeBuilder.entrycount()));
+      });
+    });
+})


### PR DESCRIPTION
TreeBuilder.create(repo, null) should be allowed, since this is the method required to create new directories in any tree, or the initial tree for the initial commit of a repo.

In this branch I've specified that `source` is optional (though you still need to send `null` or it will throw `Error: Callback is required and must be a Function` - @maxkorp stated that this is a semi-known issue with the promisifier).

The tests are an initial set for Treebuilder: check it can create a new Tree, and check it can be created from an existing tree and verify it has the correct number of entries. I plan to add more tests verifying it can add and read specific types of entries, but that's unrelated to this fix.

