### PR TITLE
Add submodule foreach

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -611,6 +611,28 @@
       "error": -1
     }
   },
+  "git_submodule_cb": {
+    "args": [
+      {
+        "name": "sm",
+        "cType": "git_submodule *"
+      },
+      {
+        "name": "name",
+        "cType": "const char *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 0,
+      "success": 0,
+      "error": -1
+    }
+  },
   "git_tag_foreach_cb": {
     "args": [
       {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -392,7 +392,8 @@
               "cType": "const git_commit **",
               "cppClassName": "Array",
               "jsClassName": "Array",
-              "arrayElementCppClassName": "GitCommit"
+              "arrayElementCppClassName": "GitCommit",
+              "isSelf": false
             },
             "update_ref": {
               "isOptional": true

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1962,7 +1962,18 @@
     "submodule": {
       "functions": {
         "git_submodule_foreach": {
-          "ignore": true
+          "isAsync": true,
+          "args": {
+            "callback": {
+              "type": "git_submodule_cb",
+              "cType": "git_submodule_cb",
+              "cppClassName": "git_submodule_cb"
+            }
+          },
+          "return": {
+            "isErrorCode": true,
+            "type": "int"
+          }
         },
         "git_submodule_location": {
           "ignore": true

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -392,8 +392,7 @@
               "cType": "const git_commit **",
               "cppClassName": "Array",
               "jsClassName": "Array",
-              "arrayElementCppClassName": "GitCommit",
-              "isSelf": false
+              "arrayElementCppClassName": "GitCommit"
             },
             "update_ref": {
               "isOptional": true

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -109,8 +109,9 @@ var Helpers = {
   processCallback: function(field) {
     field.isCallbackFunction = true;
 
-    if (callbackDefs[field.type]) {
-      _.merge(field, callbackDefs[field.type]);
+    var callbackDef = callbackDefs[field.type] || callbackDefs[field.cType];
+    if (callbackDef) {
+      _.merge(field, callbackDef);
     }
     else {
       if (process.env.BUILD_ONLY) {
@@ -234,6 +235,10 @@ var Helpers = {
 
   decorateArg: function(arg, allArgs, typeDef, fnDef, argOverrides, enums) {
     var type = arg.cType || arg.type;
+    if (argOverrides) {
+      type = argOverrides.cType || argOverrides.type || type;
+    }
+
     var normalizedType = Helpers.normalizeCtype(type);
 
     arg.cType = type;

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -234,11 +234,7 @@ var Helpers = {
   },
 
   decorateArg: function(arg, allArgs, typeDef, fnDef, argOverrides, enums) {
-    var type = arg.cType || arg.type;
-    if (argOverrides) {
-      type = argOverrides.cType || argOverrides.type || type;
-    }
-
+    var type = argOverrides.cType || argOverrides.type || arg.cType || arg.type;
     var normalizedType = Helpers.normalizeCtype(type);
 
     arg.cType = type;
@@ -270,6 +266,8 @@ var Helpers = {
       if (typeof arg.isSelf == 'undefined') {
         arg.isSelf = utils.isPointer(arg.type) &&
           normalizedType == typeDef.cType &&
+          arg.cppClassName !== "Array" &&
+          argOverrides.cppClassName !== "Array" &&
           _.every(allArgs, function(_arg) { return !_arg.isSelf; });
       }
 

--- a/generate/templates/manual/include/typedefs.h
+++ b/generate/templates/manual/include/typedefs.h
@@ -1,0 +1,8 @@
+#ifndef TYPEDEFS_H
+#define TYPEDEFS_H
+
+#include "git2/submodule.h"
+
+typedef int (*git_submodule_cb)(git_submodule *sm, const char *name, void *payload);
+
+#endif

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -12,6 +12,8 @@ extern "C" {
 {%endeach%}
 }
 
+#include "../include/typedefs.h"
+
 {%each dependencies as dependency%}
 #include "{{ dependency }}"
 {%endeach%}

--- a/lib/submodule.js
+++ b/lib/submodule.js
@@ -1,0 +1,9 @@
+var NodeGit = require("../");
+
+var Submodule = NodeGit.Submodule;
+
+// Override Submodule.foreach to eliminate the need to pass null payload
+var foreach = Submodule.foreach;
+Submodule.foreach = function(repo, callback) {
+  return foreach(repo, callback, null);
+};

--- a/test/tests/submodule.js
+++ b/test/tests/submodule.js
@@ -1,0 +1,27 @@
+var assert = require("assert");
+var path = require("path");
+var local = path.join.bind(path, __dirname);
+
+describe("Submodule", function() {
+  var NodeGit = require("../../");
+  var Repository = NodeGit.Repository;
+  var Submodule = NodeGit.Submodule;
+  var repoPath = local("../repos/workdir");
+
+  beforeEach(function() {
+    var test = this;
+
+    return Repository.open(repoPath)
+      .then(function(repo) {
+        test.repository = repo;
+      });
+  });
+
+  it("can walk over the submodules", function() {
+    return Submodule.foreach(this.repository, function(submodule,
+                                                       name, context) {
+      assert.equal(name, "vendor/libgit2");
+      assert.notEqual(submodule, null);
+    });
+  });
+});


### PR DESCRIPTION
A lot of this is to work around the fact that `git_submodule_foreach`’s callback isn’t `typedef`’d. That’s fixed in https://github.com/libgit2/libgit2/pull/3539, but there hasn’t been a release including it yet. So in the mean time, we need to do a little extra futzing.