### PR TITLE
Fix ci

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ matrix:
 
 # Get the latest stable version of Node 0.STABLE.latest
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Install-Product node $env:nodejs_version $env:platform
   - ps: Start-Process c:\projects\nodegit\vendor\pageant.exe c:\projects\nodegit\vendor\private.ppk
   - cmd: npm install -g node-gyp
   - npm install

--- a/test/tests/note.js
+++ b/test/tests/note.js
@@ -6,7 +6,7 @@ describe("Note", function() {
   var NodeGit = require("../../");
   var Note = NodeGit.Note;
   var Signature = NodeGit.Signature;
-  var reposPath = local("../../");
+  var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
     var test = this;
@@ -15,7 +15,7 @@ describe("Note", function() {
       test.repository = repository;
 
       return repository.getMasterCommit().then(function(commit) {
-        test.commit = commit; 
+        test.commit = commit;
       });
     });
   });


### PR DESCRIPTION
This fixes AppVeyor using x86 node when the platform is set to x64. It also fixes an error on Travis when building from a tag.