### PR TITLE
Set the npm_config_ runtime and target too.

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -18,6 +18,24 @@ catch(e) {
   fromRegistry = false;
 }
 
+var electronVersion = process.env.ELECTRON_VERSION;
+var nwjsVersion = process.env.NWJS_VERSION;
+
+process.argv.forEach(function(arg) {
+  if (~arg.indexOf("electronVersion")) {
+    process.env.npm_config_runtime = "electron";
+
+    electronVersion = arg.split("=")[1].trim();
+    process.env.npm_config_target = electronVersion;
+  }
+  else if (~arg.indexOf("nwjsVersion")) {
+    process.env.npm_config_runtime = "node-webkit";
+
+    nwjsVersion = arg.split("=")[1].trim();
+    process.env.npm_config_target = nwjsVersion;
+  }
+});
+
 if (!fromRegistry) {
   console.info("[nodegit] Local install, no fetching allowed.");
   return prepareAndBuild();
@@ -67,8 +85,6 @@ function prepareAndBuild() {
 function build() {
   console.info("[nodegit] Everything is ready to go, attempting compilation");
 
-  var electronVersion = process.env.ELECTRON_VERSION;
-  var nwjsVersion = process.env.NWJS_VERSION;
   var opts = {
     cwd: ".",
     maxBuffer: Number.MAX_VALUE,
@@ -79,15 +95,6 @@ function build() {
   var debug = (process.env.BUILD_DEBUG ? " --debug" : "");
   var target;
   var distUrl;
-
-  process.argv.forEach(function(arg) {
-    if (~arg.indexOf("electronVersion")) {
-      electronVersion = arg.split("=")[1].trim();
-    }
-    else if (~arg.indexOf("nsjwVersion")) {
-      nwjsVersion = arg.split("=")[1].trim();
-    }
-  });
 
   if (electronVersion) {
     target = "--target=" + electronVersion;


### PR DESCRIPTION
I *believe* this is at least One Of The Problems with the Windows builds. We’re a little too eager to download a binary instead of building.

1. Our [install script](https://github.com/nodegit/nodegit/blob/1a07da394b646e6c382c78998e65a0b4cfcf0f54/lifecycleScripts/install.js#L13) sees `include` and `src` since we downloaded a tarball of the repository.
2. We mark `fromRegistry` as `true`.
3. So we try to install a prebuilt.
4. Good news everyone! There’s already a binary up for `nodegit-v0.6.0-node-v14`!
5. We download the binary and think our job is done, instead of building.

It’s debatable whether this is the bug, or the bug is that we think we’re from the registry when we downloaded a tarball. :shrug: