### PR TITLE
Fix manual install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,11 @@ script:
 
 after_success:
   - if [ -n "$TRAVIS_TAG" ]; then
-      npm install -g node-pre-gyp
-      npm install -g aws-sdk
-      node lifecycleScripts/clean
-      node-pre-gyp package
-      node-pre-gyp publish
+      npm install -g node-pre-gyp;
+      npm install -g aws-sdk;
+      node lifecycleScripts/clean;
+      node-pre-gyp package;
+      node-pre-gyp publish;
     fi
 
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ] && [ $TRAVIS_OS_NAME == "linux" ] && [ $NODE_VERSION == "4.1" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Change Log
 
+## [0.6.3](https://github.com/nodegit/nodegit/releases/tag/v0.6.3) (2015-12-16)
+
+[Full Changelog](https://github.com/nodegit/nodegit/compare/v0.6.2...0.6.3)
+
+ - Fixed a bug where manually building for vanilla node would fail without explicitly
+   setting the target
+
+## [0.6.2](https://github.com/nodegit/nodegit/releases/tag/v0.6.2) (2015-12-16)
+
+[Full Changelog](https://github.com/nodegit/nodegit/compare/v0.6.1...0.6.2)
+
+ - Fixed a bug where manually building on windows would fail (if unable to download a prebuilt binary)
+
+## [0.6.1](https://github.com/nodegit/nodegit/releases/tag/v0.6.1) (2015-12-14)
+
+[Full Changelog](https://github.com/nodegit/nodegit/compare/v0.6.0...0.6.1)
+
+ - Fixed Treebuilder.create to have an optional source
+ - Added Repository.getSubmoduleNames
+ - Added Submodule.Foreach
+
+## [0.6.0](https://github.com/nodegit/nodegit/releases/tag/v0.6.0) (2015-12-08)
+
+ - Added file mode staging
+ - Added a fast rev walk to do the rev walk in C++ and bubble the result up to JS
+ - Updated to latest libgit2
+ - Updated to latest openssl
+ - Updated to latest nodegit-promise
+ - Removed c++11 dependency
+ - Fixed weirdness in lifecycle scripts
+ - Added downloading prebuilt binaries for electron
+
 ## [0.4.1](https://github.com/nodegit/nodegit/tree/0.4.1) (2015-06-02)
 
 [Full Changelog](https://github.com/nodegit/nodegit/compare/v0.4.0...0.4.1)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ NodeGit
   </tbody>
 </table>
 
-**Stable: 0.6.0**
+**Stable: 0.6.3**
 
 ## Have a problem? Come chat with us! ##
 

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -77,7 +77,7 @@ function build() {
 
   var builder = "node-gyp";
   var debug = (process.env.BUILD_DEBUG ? " --debug" : "");
-  var target;
+  var target = "";
   var distUrl;
 
   process.argv.forEach(function(arg) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nodegit",
   "description": "Node.js libgit2 asynchronous native bindings",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "homepage": "http://nodegit.org",
   "keywords": [
     "libgit2",


### PR DESCRIPTION
Fixes an issue where when manuallybuilding after a failed download, `"undefined"` would sneak in to the arguments for node-gyp. Also updates missing changelog entries (not including 0.5.x) and bumps to 0.6.3