### PR TITLE
Omit baton->error on GIT_ITEROVER

### DIFF
--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -30,6 +30,7 @@ void GitRevwalk::FastWalkWorker::Execute()
   for (int i = 0; i < baton->max_count; i++)
   {
     git_oid *nextCommit = (git_oid *)malloc(sizeof(git_oid));
+    giterr_clear();
     baton->error_code = git_revwalk_next(nextCommit, baton->walk);
 
     if (baton->error_code != GIT_OK)

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -79,6 +79,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 }
 
 void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
+  giterr_clear();
   {%if .|hasReturnType %}
   {{ return.cType }} result = {{ cFunctionName }}(
   {%else%}

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -34,6 +34,8 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL) {
 {% endif %}
 
+giterr_clear();
+
 {%if .|hasReturnValue %}
   {{ return.cType }} result = {%endif%}{{ cFunctionName }}(
   {%each args|argsInfo as arg %}

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -12,6 +12,9 @@
 {% endeach %}
 
 extern "C" void init(Local<v8::Object> target) {
+  // Initialize libgit2.
+  git_libgit2_init();
+
   Nan::HandleScope scope;
 
   Wrapper::InitializeComponent(target);

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -118,6 +118,3 @@ exports.version = require("../package").version;
 
 // Expose Promise implementation.
 exports.Promise = Promise;
-
-// Initialize libgit2.
-exports.Libgit2.init();


### PR DESCRIPTION
This addresses a bug that would happen occasionally during rebase - because `Rebase.next` doesn't set or clear `giterr_last` when it returns `GIT_ITEROVER`, we would pick up a stale error if one was previously left in that thread.  `performRebase` would then get the stale error instead of `GIT_ITEROVER` and not finish correctly (https://github.com/nodegit/nodegit/blob/d1201998a6fe64e35cf8c357b3dd94d2f6982bc0/lib/repository.js#L904-L908).

I am not sure whether this is the best way to fix this, and if it is, whether similar adjustments need to be made in other places in code.  For example, https://github.com/nodegit/nodegit/blob/d1201998a6fe64e35cf8c357b3dd94d2f6982bc0/generate/templates/partials/sync_function.cc#L66-L70 accesses `giterr_last` where `result` could be `GIT_ITEROVER`.

An alternative to this fix might be to do a `giterr_clear` before we call into `libgit2`, for example these places: https://github.com/nodegit/nodegit/blob/d1201998a6fe64e35cf8c357b3dd94d2f6982bc0/generate/templates/partials/sync_function.cc#L38 https://github.com/nodegit/nodegit/blob/d1201998a6fe64e35cf8c357b3dd94d2f6982bc0/generate/templates/partials/async_function.cc#L82-L86.  That way `giterr_last` won't be stale to begin with, and we might not even need to have special handling for `GIT_ITEROVER`.