### PR TITLE
Asyncify graph descendant of

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -898,6 +898,12 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_graph_descendant_of": {
+          "isAsync": true,
+          "return": {
+            "isResultOrError": true
+          }
         }
       }
     },

--- a/test/tests/graph.js
+++ b/test/tests/graph.js
@@ -9,6 +9,9 @@ describe("Graph", function() {
 
   var reposPath = local("../repos/workdir");
 
+  var expectedError = "Object not found - no match for id " +
+    "(81b06facd90fe7a6e9bbd9cee59736a79105b7be)";
+
   beforeEach(function() {
     var test = this;
 
@@ -27,5 +30,38 @@ describe("Graph", function() {
       assert.equal(result.ahead, 1);
       assert.equal(result.behind, 1);
     });
+  });
+
+  it("can tell if a commit is a descendant of another", function() {
+    return Graph.descendantOf(
+      this.repository,
+      "32789a79e71fbc9e04d3eff7425e1771eb595150",
+      "e0aeedcff0584ebe00aed2c03c8ecd10839df908"
+    )
+      .then(function(result) {
+        assert.equal(result, 1);
+      });
+  });
+
+  it("can tell if a commit is not a descendant of another", function() {
+    return Graph.descendantOf(
+      this.repository,
+      "1528a019c504c9b5a68dc7d83bb2a887eb2473af",
+      "32789a79e71fbc9e04d3eff7425e1771eb595150"
+    )
+      .then(function(result) {
+        assert.equal(result, 0);
+      });
+  });
+
+  it("will error if provided bad commits", function() {
+    return Graph.descendantOf(
+      this.repository,
+      "81b06facd90fe7a6e9bbd9cee59736a79105b7be",
+      "26744fc697849d370246749b67ac43b792a4af0c"
+    )
+      .catch(function(result) {
+        assert.equal(result.message, expectedError);
+      });
   });
 });


### PR DESCRIPTION
1. Add a new template for mixed result/error code return values from libgit2 for async code.
2. Make git_graph_descendant_of use the new async template.