### PR TITLE
Use libgit2 fork to fix ssh url detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "vendorDependencies": {
     "libgit2": {
-      "sha": "e8feafe32007ebd16a61820c70abd221655d053c",
+      "sha": "c2786d822cfafe40c0b27392d0b29ece0c426e36",
       "version": "0.23.4"
     },
     "libssh2": "1.6.0",

--- a/vendor/libgit2/deps/http-parser/http_parser.c
+++ b/vendor/libgit2/deps/http-parser/http_parser.c
@@ -451,7 +451,7 @@ parse_url_char(enum state s, const char ch)
       break;
 
     case s_req_schema:
-      if (IS_ALPHA(ch)) {
+      if (IS_ALPHA(ch) || ch == '+') {
         return s;
       }
 

--- a/vendor/libgit2/src/transport.c
+++ b/vendor/libgit2/src/transport.c
@@ -35,6 +35,8 @@ static transport_definition transports[] = {
 	{ "file://",  git_transport_local, NULL },
 #ifdef GIT_SSH
 	{ "ssh://",   git_transport_smart, &ssh_subtransport_definition },
+  { "ssh+git://",   git_transport_smart, &ssh_subtransport_definition },
+  { "git+ssh://",   git_transport_smart, &ssh_subtransport_definition },
 #endif
 	{ NULL, 0, 0 }
 };

--- a/vendor/libgit2/tests/transport/register.c
+++ b/vendor/libgit2/tests/transport/register.c
@@ -44,6 +44,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));
@@ -60,6 +62,8 @@ void test_transport_register__custom_transport_ssh(void)
 
 #ifndef GIT_SSH
 	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "ssh+git://somehost:somepath"), -1);
+	cl_git_fail_with(git_transport_new(&transport, NULL, "git+ssh://somehost:somepath"), -1);
 	cl_git_fail_with(git_transport_new(&transport, NULL, "git@somehost:somepath"), -1);
 #else
 	cl_git_pass(git_transport_new(&transport, NULL, "git@somehost:somepath"));


### PR DESCRIPTION
This should add support for the ssh+git:// and git+ssh:// protocol schemes.