### PR TITLE
Fixed example walk-history-for-file.js

### DIFF
--- a/examples/walk-history-for-file.js
+++ b/examples/walk-history-for-file.js
@@ -17,25 +17,19 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
     history.on("commit", function(commit) {
       return commit.getDiff()
       .then(function(diffList) {
-        var addCommit = diffList.reduce(function(prevVal, diff) {
-          var result =
-            prevVal ||
-            diff.patches().reduce(function(prevValDiff, patch) {
+        diffList.map(function(diff) {
+          diff.patches().then(function(patches) {
+            patches.map(function(patch) {
+              var result =
+                !!~patch.oldFile().path().indexOf("descriptor.json") ||
+                !!~patch.newFile().path().indexOf("descriptor.json");
 
-            var result =
-              prevValDiff ||
-              !!~patch.oldFile().path().indexOf("descriptor.json") ||
-              !!~patch.newFile().path().indexOf("descriptor.json");
-
-            return result;
-          }, false);
-
-          return result;
-        }, false);
-
-        if (addCommit) {
-          commits.push(commit);
-        }
+              if(result && !~commits.indexOf(commit)) {
+                commits.push(commit);
+              }
+            });
+          });
+        });
       });
     });
 


### PR DESCRIPTION
The walk-history-for-file.js example was broken so I fixed it with some minor changes. The reason it broke is that ```diff.patches()``` returns a promise and not an array that can be reduced. I made the example a little bit less efficient (checking for an already present commit) but I think it is a little bit more readable. The screenshot shows a comparison of ```git log``` and the example. Note that it is not a 1-1 mapping because git log is a little bit more intelligent.

```output of git log descriptor.js```
![selection_005](https://cloud.githubusercontent.com/assets/3428649/12078756/833e5b20-b21f-11e5-9a9d-bf0b0b6d8dc5.png)
```output of walk-history-for-file.js```
![selection_006](https://cloud.githubusercontent.com/assets/3428649/12078757/833ea6f2-b21f-11e5-8f88-8890503c0e9d.png)
