### PR TITLE
Fix pull and clone example fetchOptions structure

### DIFF
--- a/examples/clone.js
+++ b/examples/clone.js
@@ -10,11 +10,13 @@ fse.remove(path).then(function() {
     "https://github.com/nodegit/nodegit.git",
     path,
     {
-      remoteCallbacks: {
-        certificateCheck: function() {
-          // github will fail cert check on some OSX machines
-          // this overrides that check
-          return 1;
+      fetchOpts: {
+        callbacks: {
+          certificateCheck: function() {
+            // github will fail cert check on some OSX machines
+            // this overrides that check
+            return 1;
+          }
         }
       }
     })

--- a/examples/pull.js
+++ b/examples/pull.js
@@ -11,11 +11,13 @@ nodegit.Repository.open(path.resolve(__dirname, repoDir))
     repository = repo;
 
     return repository.fetchAll({
-      credentials: function(url, userName) {
-        return nodegit.Cred.sshKeyFromAgent(userName);
-      },
-      certificateCheck: function() {
-        return 1;
+      callbacks: {
+        credentials: function(url, userName) {
+          return nodegit.Cred.sshKeyFromAgent(userName);
+        },
+        certificateCheck: function() {
+          return 1;
+        }
       }
     });
   })


### PR DESCRIPTION
[This line] (https://github.com/nodegit/nodegit/blob/232dbb19116c58d22cd7afd7435ee0bbe063f85b/lib/repository.js#L688) and my own trial and error with a project leads me to believe the auth callbacks need to be nested under the `callbacks` key in fetch options.

This also [applies](https://github.com/nodegit/nodegit/blob/44779afd0d460011e13a5cba9a47a48119aa472e/lib/clone.js#L31) to the clone example I think, though it requires a structure of fetchOpts.callbacks.<authCallback>.