### PR TITLE
Wrap toolPath in quotes instead of escaping spaces

### DIFF
--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -52,7 +52,7 @@ function installPrebuilt() {
 
 function pathForTool(name) {
   var toolPath = path.resolve(".", "node_modules", ".bin", name);
-  toolPath = toolPath.replace(/\s/g, "\\$&");
+  toolPath = '"' + toolPath + '"';
   return toolPath;
 }
 

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -52,7 +52,7 @@ function installPrebuilt() {
 
 function pathForTool(name) {
   var toolPath = path.resolve(".", "node_modules", ".bin", name);
-  toolPath = '"' + toolPath + '"';
+  toolPath = "\"" + toolPath + "\"";
   return toolPath;
 }
 


### PR DESCRIPTION
For better Windows support.
Fixes #850