### PR TITLE
Eliminate promise polling

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,7 @@
   "maxlen": 80,
   "node": true,
   "predef": [
-    "-Promise"
+    "Promise"
   ],
   "proto": true,
   "quotmark": "double",

--- a/examples/general.js
+++ b/examples/general.js
@@ -1,6 +1,5 @@
 var nodegit = require("../");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var oid;
 var odb;
 var repo;

--- a/examples/index-add-and-remove.js
+++ b/examples/index-add-and-remove.js
@@ -1,6 +1,5 @@
 var nodegit = require("../");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 

--- a/generate/index.js
+++ b/generate/index.js
@@ -1,4 +1,3 @@
-var Promise = require('nodegit-promise');
 var generateJson = require("./scripts/generateJson");
 var generateNativeCode = require("./scripts/generateNativeCode");
 var generateMissingTests = require("./scripts/generateMissingTests");

--- a/generate/scripts/generateMissingTests.js
+++ b/generate/scripts/generateMissingTests.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const Promise = require("nodegit-promise");
 const promisify = require("promisify-node");
 const fse = promisify(require("fs-extra"));
 const utils = require("./utils");

--- a/generate/templates/manual/include/async_baton.h
+++ b/generate/templates/manual/include/async_baton.h
@@ -10,7 +10,6 @@
 struct AsyncBaton {
   uv_async_t req;
 
-  Nan::Persistent<v8::Object> promise;
   bool done;
 };
 

--- a/generate/templates/manual/include/async_baton.h
+++ b/generate/templates/manual/include/async_baton.h
@@ -1,0 +1,17 @@
+#ifndef ASYNC_BATON
+#define ASYNC_BATON
+
+#include <uv.h>
+#include <nan.h>
+
+// Base class for Batons used for callbacks (for example,
+// JS functions passed as callback parameters,
+// or field properties of configuration objects whose values are callbacks)
+struct AsyncBaton {
+  uv_async_t req;
+
+  Nan::Persistent<v8::Object> promise;
+  bool done;
+};
+
+#endif

--- a/generate/templates/manual/include/promise_completion.h
+++ b/generate/templates/manual/include/promise_completion.h
@@ -1,0 +1,46 @@
+#ifndef PROMISE_COMPLETION
+#define PROMISE_COMPLETION
+
+#include <nan.h>
+
+#include "async_baton.h"
+
+// PromiseCompletion forwards either the resolved result or the rejection reason
+// to the native layer, once the promise completes
+//
+// inherits ObjectWrap so it can be used in v8 and managed by the garbage collector
+// it isn't wired up to be instantiated or accessed from the JS layer other than
+// for the purpose of promise result forwarding
+class PromiseCompletion : public Nan::ObjectWrap
+{
+  // callback type called when a promise completes
+  typedef void (*Callback) (bool isFulfilled, AsyncBaton *baton, v8::Local<v8::Value> resultOfPromise);
+
+  static NAN_METHOD(New);
+  static NAN_METHOD(PromiseFulfilled);
+  static NAN_METHOD(PromiseRejected);
+
+  // persistent handles for NAN_METHODs
+  static Nan::Persistent<v8::Function> newFn;
+  static Nan::Persistent<v8::Function> promiseFulfilled;
+  static Nan::Persistent<v8::Function> promiseRejected;
+
+  static v8::Local<v8::Value> Bind(Nan::Persistent<v8::Function> &method, v8::Local<v8::Object> object);
+  static void CallCallback(bool isFulfilled, const Nan::FunctionCallbackInfo<v8::Value> &info);
+
+  // callback and baton stored for the promise that this PromiseCompletion is
+  // attached to.  when the promise completes, the callback will be called with
+  // the result, and the stored baton.
+  Callback callback;
+  AsyncBaton *baton;
+
+  void Setup(v8::Local<v8::Function> thenFn, v8::Local<v8::Value> result, AsyncBaton *baton, Callback callback);
+public:
+  // If result is a promise, this will instantiate a new PromiseCompletion
+  // and have it forward the promise result / reason via the baton and callback
+  static bool ForwardIfPromise(v8::Local<v8::Value> result, AsyncBaton *baton, Callback callback);
+
+  static void InitializeComponent();
+};
+
+#endif

--- a/generate/templates/manual/src/promise_completion.cc
+++ b/generate/templates/manual/src/promise_completion.cc
@@ -1,0 +1,103 @@
+#include "../include/promise_completion.h"
+
+Nan::Persistent<v8::Function> PromiseCompletion::newFn;
+Nan::Persistent<v8::Function> PromiseCompletion::promiseFulfilled;
+Nan::Persistent<v8::Function> PromiseCompletion::promiseRejected;
+
+// initializes the persistent handles for NAN_METHODs
+void PromiseCompletion::InitializeComponent() {
+  v8::Local<v8::FunctionTemplate> newTemplate = Nan::New<v8::FunctionTemplate>(New);
+  newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+  newFn.Reset(newTemplate->GetFunction());
+
+  promiseFulfilled.Reset(Nan::New<v8::FunctionTemplate>(PromiseFulfilled)->GetFunction());
+  promiseRejected.Reset(Nan::New<v8::FunctionTemplate>(PromiseRejected)->GetFunction());
+}
+
+bool PromiseCompletion::ForwardIfPromise(v8::Local<v8::Value> result, AsyncBaton *baton, Callback callback)
+{
+  Nan::HandleScope scope;
+
+  // check if the result is a promise
+  if (result->IsObject()) {
+    Nan::MaybeLocal<v8::Value> maybeThenProp = Nan::Get(result->ToObject(), Nan::New("then").ToLocalChecked());
+    if (!maybeThenProp.IsEmpty()) {
+      v8::Local<v8::Value> thenProp = maybeThenProp.ToLocalChecked();
+      if(thenProp->IsFunction()) {
+        // we can be reasonably certain that the result is a promise
+
+        // create a new v8 instance of PromiseCompletion
+        v8::Local<v8::Object> object = Nan::NewInstance(Nan::New(newFn)).ToLocalChecked();
+
+        // set up the native PromiseCompletion object
+        PromiseCompletion *promiseCompletion = ObjectWrap::Unwrap<PromiseCompletion>(object);
+        promiseCompletion->Setup(thenProp.As<v8::Function>(), result, baton, callback);
+
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+// creates a new instance of PromiseCompletion, wrapped in a v8 object
+NAN_METHOD(PromiseCompletion::New) {
+  PromiseCompletion *promiseCompletion = new PromiseCompletion();
+  promiseCompletion->Wrap(info.This());
+  info.GetReturnValue().Set(info.This());
+}
+
+// sets up a Promise to forward the promise result via the baton and callback
+void PromiseCompletion::Setup(v8::Local<v8::Function> thenFn, v8::Local<v8::Value> result, AsyncBaton *baton, Callback callback) {
+  this->callback = callback;
+  this->baton = baton;
+
+  v8::Local<v8::Object> promise = result->ToObject();
+
+  v8::Local<v8::Object> thisHandle = handle();
+
+  v8::Local<v8::Value> argv[2] = {
+    Bind(promiseFulfilled, thisHandle),
+    Bind(promiseRejected, thisHandle)
+  };
+
+  // call the promise's .then method with resolve and reject callbacks
+  Nan::Callback(thenFn).Call(promise, 2, argv);
+}
+
+// binds an object to be the context of the function.
+// there might be a better way to do this than calling Function.bind...
+v8::Local<v8::Value> PromiseCompletion::Bind(Nan::Persistent<v8::Function> &function, v8::Local<v8::Object> object) {
+  Nan::EscapableHandleScope scope;
+
+  v8::Local<v8::Function> bind =
+    Nan::Get(Nan::New(function), Nan::New("bind").ToLocalChecked())
+      .ToLocalChecked().As<v8::Function>();
+
+  v8::Local<v8::Value> argv[1] = { object };
+
+  return scope.Escape(bind->Call(Nan::New(function), 1, argv));
+}
+
+// calls the callback stored in the PromiseCompletion, passing the baton that
+// was provided in construction
+void PromiseCompletion::CallCallback(bool isFulfilled, const Nan::FunctionCallbackInfo<v8::Value> &info) {
+  v8::Local<v8::Value> resultOfPromise;
+
+  if (info.Length() > 0) {
+    resultOfPromise = info[0];
+  }
+
+  PromiseCompletion *promiseCompletion = ObjectWrap::Unwrap<PromiseCompletion>(info.This()->ToObject());
+
+  (*promiseCompletion->callback)(isFulfilled, promiseCompletion->baton, resultOfPromise);
+}
+
+NAN_METHOD(PromiseCompletion::PromiseFulfilled) {
+  CallCallback(true, info);
+}
+
+NAN_METHOD(PromiseCompletion::PromiseRejected) {
+  CallCallback(false, info);
+}

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -171,18 +171,10 @@
         Nan::TryCatch tryCatch;
         Local<v8::Value> result = instance->{{ field.name }}->Call({{ field.args|jsArgsCount }}, argv);
 
-        if (result->IsObject() && Nan::Has(result->ToObject(), Nan::New("then").ToLocalChecked()).FromJust()) {
-          Local<v8::Value> thenProp = Nan::Get(result->ToObject(), Nan::New("then").ToLocalChecked()).ToLocalChecked();
+        uv_close((uv_handle_t*) &baton->req, NULL);
 
-          if (thenProp->IsFunction()) {
-            // we can be reasonbly certain that the result is a promise
-            Local<Object> promise = result->ToObject();
-
-            baton->promise.Reset(promise);
-
-            uv_close((uv_handle_t*) &baton->req, (uv_close_cb) {{ field.name }}_setupAsyncPromisePolling);
-            return;
-          }
+        if(PromiseCompletion::ForwardIfPromise(result, baton, {{ cppClassName }}::{{ field.name }}_promiseCompleted)) {
+          return;
         }
 
         {% each field|returnsInfo false true as _return %}
@@ -210,36 +202,14 @@
           }
         {% endeach %}
         baton->done = true;
-        uv_close((uv_handle_t*) &baton->req, NULL);
-      }
-      void {{ cppClassName }}::{{ field.name }}_setupAsyncPromisePolling(uv_async_t* req) {
-        {{ field.name|titleCase }}Baton* baton = static_cast<{{ field.name|titleCase }}Baton*>(req->data);
-        uv_async_init(uv_default_loop(), &baton->req, (uv_async_cb) {{ field.name }}_asyncPromisePolling);
-        uv_async_send(&baton->req);
       }
 
-      void {{ cppClassName }}::{{ field.name }}_asyncPromisePolling(uv_async_t* req, int status) {
+      void {{ cppClassName }}::{{ field.name }}_promiseCompleted(bool isFulfilled, AsyncBaton *_baton, v8::Local<v8::Value> result) {
         Nan::HandleScope scope;
 
-        {{ field.name|titleCase }}Baton* baton = static_cast<{{ field.name|titleCase }}Baton*>(req->data);
-        Local<Object> promise = Nan::New<Object>(baton->promise);
+        {{ field.name|titleCase }}Baton* baton = static_cast<{{ field.name|titleCase }}Baton*>(_baton);
 
-        Nan::Callback* isPendingFn = new Nan::Callback(Nan::Get(promise, Nan::New("isPending").ToLocalChecked()).ToLocalChecked().As<Function>());
-        Local<Value> argv[1]; // MSBUILD won't assign an array of length 0
-        Local<Boolean> isPending = isPendingFn->Call(promise, 0, argv)->ToBoolean();
-
-        if (isPending->Value()) {
-          uv_async_send(&baton->req);
-          return;
-        }
-
-        Nan::Callback* isFulfilledFn = new Nan::Callback(Nan::Get(promise, Nan::New("isFulfilled").ToLocalChecked()).ToLocalChecked().As<Function>());
-        Local<Boolean> isFulfilled = isFulfilledFn->Call(promise, 0, argv)->ToBoolean();
-
-        if (isFulfilled->Value()) {
-          Nan::Callback* resultFn = new Nan::Callback(Nan::Get(promise, Nan::New("value").ToLocalChecked()).ToLocalChecked().As<Function>());
-          Local<v8::Value> result = resultFn->Call(promise, 0, argv);
-
+        if (isFulfilled) {
           {% each field|returnsInfo false true as _return %}
             if (result.IsEmpty() || result->IsNativeError()) {
               baton->result = {{ field.return.error }};
@@ -264,7 +234,6 @@
               baton->result = {{ field.return.noResults }};
             }
           {% endeach %}
-          baton->done = true;
         }
         else {
           // promise was rejected
@@ -272,15 +241,11 @@
             {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
           {% endeach %});
           Local<v8::Object> parent = instance->handle();
-          Nan::Callback* reasonFn = new Nan::Callback(Nan::Get(promise, Nan::New("reason").ToLocalChecked()).ToLocalChecked().As<Function>());
-          Local<v8::Value> reason = reasonFn->Call(promise, 0, argv);
-          parent->SetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked(), reason);
+          parent->SetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
           baton->result = {{ field.return.error }};
-          baton->done = true;
         }
-
-        uv_close((uv_handle_t*) &baton->req, NULL);
+        baton->done = true;
       }
     {% endif %}
   {% endif %}

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -16,6 +16,7 @@
       "sources": [
         "src/lock_master.cc",
         "src/nodegit.cc",
+        "src/promise_completion.cc",
         "src/wrapper.cc",
         "src/functions/copy.cc",
         "src/functions/sleep_for_ms.cc",

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -6,6 +6,7 @@
 #include <queue>
 
 #include "async_baton.h"
+#include "promise_completion.h"
 
 extern "C" {
 #include <git2.h>
@@ -63,8 +64,7 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     );
 
     static void {{ function.cppFunctionName }}_{{ arg.name }}_async(uv_async_t* req, int status);
-    static void {{ function.cppFunctionName }}_{{ arg.name }}_setupAsyncPromisePolling(uv_async_t* req);
-    static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncPromisePolling(uv_async_t* req, int status);
+    static void {{ function.cppFunctionName }}_{{ arg.name }}_promiseCompleted(bool isFulfilled, AsyncBaton *_baton, v8::Local<v8::Value> result);
     struct {{ function.cppFunctionName }}_{{ arg.name|titleCase }}Baton : AsyncBaton {
       {% each arg.args|argsInfo as cbArg %}
       {{ cbArg.cType }} {{ cbArg.name }};

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <queue>
 
+#include "async_baton.h"
+
 extern "C" {
 #include <git2.h>
 {%each cDependencies as dependency %}
@@ -63,15 +65,12 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     static void {{ function.cppFunctionName }}_{{ arg.name }}_async(uv_async_t* req, int status);
     static void {{ function.cppFunctionName }}_{{ arg.name }}_setupAsyncPromisePolling(uv_async_t* req);
     static void {{ function.cppFunctionName }}_{{ arg.name }}_asyncPromisePolling(uv_async_t* req, int status);
-    struct {{ function.cppFunctionName }}_{{ arg.name|titleCase }}Baton {
+    struct {{ function.cppFunctionName }}_{{ arg.name|titleCase }}Baton : AsyncBaton {
       {% each arg.args|argsInfo as cbArg %}
       {{ cbArg.cType }} {{ cbArg.name }};
       {% endeach %}
 
-      uv_async_t req;
       {{ arg.return.type }} result;
-      Nan::Persistent<Object> promise;
-      bool done;
     };
           {% endif %}
         {% endeach %}

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -8,6 +8,7 @@
 
 #include "../include/lock_master.h"
 #include "../include/wrapper.h"
+#include "../include/promise_completion.h"
 #include "../include/functions/copy.h"
 {% each %}
   {% if type != "enum" %}
@@ -30,6 +31,7 @@ extern "C" void init(Local<v8::Object> target) {
   Nan::HandleScope scope;
 
   Wrapper::InitializeComponent(target);
+  PromiseCompletion::InitializeComponent();
   {% each %}
     {% if type != "enum" %}
       {{ cppClassName }}::InitializeComponent(target);

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -1,4 +1,3 @@
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var rawApi;
 

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -48,8 +48,7 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
           );
 
           static void {{ field.name }}_async(uv_async_t* req, int status);
-          static void {{ field.name }}_setupAsyncPromisePolling(uv_async_t* req);
-          static void {{ field.name }}_asyncPromisePolling(uv_async_t* req, int status);
+          static void {{ field.name }}_promiseCompleted(bool isFulfilled, AsyncBaton *_baton, v8::Local<v8::Value> result);
           struct {{ field.name|titleCase }}Baton : public AsyncBaton {
             {% each field.args|argsInfo as arg %}
               {{ arg.cType }} {{ arg.name}};

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -5,6 +5,8 @@
 #include <string>
 #include <queue>
 
+#include "async_baton.h"
+
 extern "C" {
   #include <git2.h>
   {% each cDependencies as dependency %}
@@ -48,15 +50,12 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
           static void {{ field.name }}_async(uv_async_t* req, int status);
           static void {{ field.name }}_setupAsyncPromisePolling(uv_async_t* req);
           static void {{ field.name }}_asyncPromisePolling(uv_async_t* req, int status);
-          struct {{ field.name|titleCase }}Baton {
+          struct {{ field.name|titleCase }}Baton : public AsyncBaton {
             {% each field.args|argsInfo as arg %}
               {{ arg.cType }} {{ arg.name}};
             {% endeach %}
 
-            uv_async_t req;
             {{ field.return.type }} result;
-            Nan::Persistent<Object> promise;
-            bool done;
           };
         {% endif %}
       {% endif %}

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -1,5 +1,4 @@
 var events = require("events");
-var Promise = require("nodegit-promise");
 var NodeGit = require("../");
 var Commit = NodeGit.Commit;
 var LookupWrapper = NodeGit.Utils.lookupWrapper;

--- a/lib/convenient_hunk.js
+++ b/lib/convenient_hunk.js
@@ -1,5 +1,4 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
 var ConvenientLine = NodeGit.ConvenientLine;
 
 function ConvenientHunk(hunk, linesInHunk, patch, i) {

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -1,5 +1,4 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
 var Diff = NodeGit.Diff;
 var ConvenientHunk = NodeGit.ConvenientHunk;
 

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,5 +1,4 @@
 var NodeGit = require("../");
-var Promise = require("nodegit-promise");
 var Diff = NodeGit.Diff;
 var ConvenientPatch = NodeGit.ConvenientPatch;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,5 @@
 var NodeGit = require("../");
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
-var Promise = require("nodegit-promise");
 
 var Merge = NodeGit.Merge;
 var mergeCommits = Merge.commits;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1,4 +1,3 @@
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var NodeGit = require("../");

--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -1,6 +1,5 @@
 var NodeGit = require("../");
 var Revwalk = NodeGit.Revwalk;
-var Promise = require("nodegit-promise");
 
 Object.defineProperty(Revwalk.prototype, "repo", {
   get: function () { return this.repository(); }

--- a/lib/utils/lookup_wrapper.js
+++ b/lib/utils/lookup_wrapper.js
@@ -1,4 +1,3 @@
-var Promise = require("nodegit-promise");
 var NodeGit = require("../../");
 
 /**

--- a/lifecycleScripts/configureLibssh2.js
+++ b/lifecycleScripts/configureLibssh2.js
@@ -1,4 +1,3 @@
-var Promise = require("nodegit-promise");
 var cp = require("child_process");
 var path = require("path");
 var rooted = path.join.bind(path, __dirname, "..");

--- a/lifecycleScripts/prepareForBuild.js
+++ b/lifecycleScripts/prepareForBuild.js
@@ -1,4 +1,3 @@
-var Promise = require("nodegit-promise");
 var cp = require("child_process");
 var path = require("path");
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "fs-extra": "~0.26.2",
     "node-pre-gyp": "~0.6.15",
-    "nodegit-promise": "~4.0.0",
     "promisify-node": "~0.3.0"
   },
   "devDependencies": {

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Branch", function() {
@@ -46,7 +45,7 @@ describe("Branch", function() {
 
     return repo.getBranch(branchName)
       // Reverse the results, since if we found it it wasn't deleted
-      .then(Promise.reject, Promise.resolve);
+      .then(Promise.reject.bind(Promise), Promise.resolve.bind(Promise));
   });
 
   it("can see if the branch is pointed to by head", function() {

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var fse = require("fs-extra");
 var local = path.join.bind(path, __dirname);
 

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -61,10 +61,9 @@ describe("Index", function() {
     }))
     .then(function() {
       return index.addAll(undefined, undefined, function() {
-        // ensure that the add callback is called,
-        // and that there is no deadlock if we call
-        // a sync libgit2 function from the callback
         addCallbacksCount++;
+        // ensure that there is no deadlock if we call
+        // a sync libgit2 function from the callback
         test.repository.path();
 
         return 0; // confirm add
@@ -98,6 +97,7 @@ describe("Index", function() {
       differentFileName: "this has a different name and shouldn't be deleted"
     };
     var fileNames = Object.keys(fileContent);
+    var removeCallbacksCount = 0;
 
     return Promise.all(fileNames.map(function(fileName) {
       return writeFile(
@@ -114,9 +114,15 @@ describe("Index", function() {
 
       assert.equal(newFiles.length, 3);
 
-      return index.removeAll("newFile*");
+      return index.removeAll("newFile*", function() {
+        removeCallbacksCount++;
+
+        return 0; // confirm remove
+      });
     })
     .then(function() {
+      assert.equal(removeCallbacksCount, 2);
+
       var newFiles = index.entries().filter(function(entry) {
         return ~fileNames.indexOf(entry.path);
       });
@@ -141,6 +147,7 @@ describe("Index", function() {
       newFile2: "and this will have more content"
     };
     var fileNames = Object.keys(fileContent);
+    var updateCallbacksCount = 0;
 
     return Promise.all(fileNames.map(function(fileName) {
       return writeFile(
@@ -160,9 +167,15 @@ describe("Index", function() {
       return fse.remove(path.join(repo.workdir(), fileNames[0]));
     })
     .then(function() {
-      return index.updateAll("newFile*");
+      return index.updateAll("newFile*", function() {
+        updateCallbacksCount++;
+
+        return 0; // confirm update
+      });
     })
     .then(function() {
+      assert.equal(updateCallbacksCount, 1);
+
       var newFiles = index.entries().filter(function(entry) {
         return ~fileNames.indexOf(entry.path);
       });

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Patch", function() {

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 
@@ -1046,7 +1045,7 @@ describe("Rebase", function() {
 
             return repository.continueRebase(ourSignature, function(rebase) {
               assert.ok(rebase instanceof NodeGit.Rebase);
-              
+
               nextCalls++;
 
               return Promise.resolve();

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var local = path.join.bind(path, __dirname);
 
 describe("Remote", function() {
@@ -92,7 +91,7 @@ describe("Remote", function() {
       .then(function() {
         return Remote.lookup(repository, "origin3");
       })
-      .then(Promise.reject, Promise.resolve);
+      .then(Promise.reject.bind(Promise), Promise.resolve.bind(Promise));
   });
 
   it("can download from a remote", function() {
@@ -293,10 +292,10 @@ describe("Remote", function() {
           callbacks: {
             credentials: function(url, userName) {
               var test = Promise.resolve()
-                .then(Promise.resolve)
-                .then(Promise.resolve)
-                .then(Promise.resolve)
-                .then(Promise.reject);
+                .then(Promise.resolve.bind(Promise))
+                .then(Promise.resolve.bind(Promise))
+                .then(Promise.resolve.bind(Promise))
+                .then(Promise.reject.bind(Promise));
               return test;
             },
             certificateCheck: function() {

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
 
 describe("Revwalk", function() {
   var NodeGit = require("../../");

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -2,7 +2,6 @@ var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 
 // Have to wrap exec, since it has a weird callback signature.
 var exec = promisify(function(command, opts, callback) {

--- a/test/tests/stage.js
+++ b/test/tests/stage.js
@@ -1,6 +1,5 @@
 var assert = require("assert");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 

--- a/test/tests/stash.js
+++ b/test/tests/stash.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 

--- a/test/tests/status.js
+++ b/test/tests/status.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 var exec = promisify(function(command, opts, callback) {

--- a/test/tests/status_list.js
+++ b/test/tests/status_list.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
-var Promise = require("nodegit-promise");
 var fse = promisify(require("fs-extra"));
 var local = path.join.bind(path, __dirname);
 var exec = promisify(function(command, opts, callback) {

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
-var Promise = require("nodegit-promise");
 
 describe("Tag", function() {
   var NodeGit = require("../../");

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -1,5 +1,4 @@
 var assert = require("assert");
-var Promise = require("nodegit-promise");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 
@@ -44,7 +43,7 @@ describe("TreeEntry", function() {
 	  .then(function(entry) {
               assert.equal(entry.filenameLen(), 9);
 	  });
-  });  
+  });
 
   it("provides the filename", function() {
     return this.commit.getEntry("test/raw-commit.js")

--- a/test/utils/repository_setup.js
+++ b/test/utils/repository_setup.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var NodeGit = require("../../");
 var path = require("path");
-var Promise = require("nodegit-promise");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
 


### PR DESCRIPTION
Eliminates the polling of promises when executing javascript callbacks from within async libgit2 calls. Replaces with a system that forwards the promise result / rejection reason to the native layer directly.

This should remove our dependency on the nodegit-promise library.