### PR TITLE
Extend stageFilemode to accept array of paths

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1171,7 +1171,7 @@ Repository.prototype.fetchheadForeach = function(callback) {
 /**
  * Stages or unstages line selection of a specified file
  * @async
- * @param {String} filePath The relative path of this file in the repo
+ * @param {String, Array} filePath The relative path of this file in the repo
  * @param {Boolean} stageNew Set to stage new filemode. Unset to unstage.
  * @return {Number} 0 or an error code
  */
@@ -1192,6 +1192,7 @@ Repository.prototype.stageFilemode = function(filePath, stageNew) {
       .then(function getDiffFromTree(tree) {
         return NodeGit.Diff.treeToIndex(repo, tree, index);
       });
+  var filePaths = (filePath instanceof Array) ? filePath : [filePath];
 
   var indexLock = repo.path().replace(".git/", "") + ".git/index.lock";
 
@@ -1207,29 +1208,36 @@ Repository.prototype.stageFilemode = function(filePath, stageNew) {
       return diffPromise;
     })
     .then(function(diff) {
-      if (!(NodeGit.Status.file(repo, filePath) &
-          NodeGit.Status.STATUS.WT_MODIFIED) &&
-          !(NodeGit.Status.file(repo, filePath) &
-          NodeGit.Status.STATUS.INDEX_MODIFIED)) {
+      var origLength = filePaths.length;
+      filePaths = filePaths.filter(function(p) {
+        return (
+          (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.WT_MODIFIED) ||
+          (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.INDEX_MODIFIED)
+        );
+      });
+      if (filePaths.length === 0 && origLength > 0) {
         return Promise.reject
             ("Selected staging is only available on modified files.");
       }
       return diff.patches();
     })
     .then(function(patches) {
-      var pathPatch = patches.filter(function(patch) {
-        return patch.newFile().path() === filePath;
+      var pathPatches = patches.filter(function(patch) {
+        return ~filePaths.indexOf(patch.newFile().path());
       });
-      if (pathPatch.length !== 1) {
+      if (pathPatches.length === 0) {
         return Promise.reject("No differences found for this file.");
       }
 
-      var entry = index.getByPath(filePath, 0);
+      pathPatches.forEach(function(pathPatch) {
+        var entry = index.getByPath(pathPatch.newFile().path(), 0);
 
-      entry.mode = stageNew ?
-        pathPatch[0].newFile().mode() : pathPatch[0].oldFile().mode();
+        entry.mode = stageNew ?
+          pathPatch.newFile().mode() : pathPatch.oldFile().mode();
 
-      index.add(entry);
+        index.add(entry);
+      });
+
       return index.write();
     });
 };


### PR DESCRIPTION
...as well as just a string.

There is a case in GK where `Repository.prototype.stageFilemode` gets called a bunch of times (once for every file in working directory, for instance). This wastes resources. `stageFilemode` should be able to accept a single path as string or multiple paths as array, then stage/unstage filemode changes for files specified as usual.