### PR TITLE
Fix clone options in two factor authorization

### DIFF
--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -11,24 +11,18 @@ var repoName = "{The name of the repo}";
 // over https, it can't be done with actual 2 factor.
 // https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth
 
-// The token has to be included in the URL if the repo is private.
-// Otherwise, github just wont respond, so a normal credential callback
-// wont work.
-var repoUrl = "https://" + token +
-  ":x-oauth-basic@github.com/" +
-  repoOwner + "/" +
-  repoName + ".git";
-
 // If the repo is public, you can use a callback instead
 var repoUrl = "https://github.com/" + repoOwner + "/" + repoName + ".git";
 
 var opts = {
-  remoteCallbacks: {
-    credentials: function() {
-      return nodegit.Cred.userpassPlaintextNew (token, "x-oauth-basic");
-    },
-    certificateCheck: function() {
-      return 1;
+  fetchOpts: {
+    callbacks: {
+      credentials: function() {
+        return nodegit.Cred.userpassPlaintextNew(token, "x-oauth-basic");
+      },
+      certificateCheck: function() {
+        return 1;
+      }
     }
   }
 };

--- a/guides/cloning/README.md
+++ b/guides/cloning/README.md
@@ -83,8 +83,10 @@ to passthrough the certificate check.
 *Note: this is not a problem with Windows or Linux*
 
 ``` javascript
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; }
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; }
+  }
 };
 ```
 

--- a/guides/cloning/gh-two-factor/README.md
+++ b/guides/cloning/gh-two-factor/README.md
@@ -99,8 +99,10 @@ to passthrough the certificate check.
 *Note: this is not a problem with Windows or Linux*
 
 ``` javascript
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; }
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; }
+  }
 };
 ```
 
@@ -112,13 +114,15 @@ callback that expects credentials to be passed.
 This function will be attached below the above `certificateCheck`, and will
 respond back with the OAuth token.
 
-The `remoteCallbacks` object now looks like this:
+The `fetchOpts` object now looks like this:
 
 ``` javascript
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; },
-  credentials: function() {
-    return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; },
+    credentials: function() {
+      return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
+    }
   }
 };
 ```

--- a/guides/cloning/gh-two-factor/index.js
+++ b/guides/cloning/gh-two-factor/index.js
@@ -20,10 +20,12 @@ var cloneOptions = {};
 
 // This is a required callback for OS X machines.  There is a known issue
 // with libgit2 being able to verify certificates from GitHub.
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; },
-  credentials: function() {
-    return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; },
+    credentials: function() {
+      return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
+    }
   }
 };
 

--- a/guides/cloning/index.js
+++ b/guides/cloning/index.js
@@ -16,8 +16,10 @@ var cloneOptions = {};
 
 // This is a required callback for OS X machines.  There is a known issue
 // with libgit2 being able to verify certificates from GitHub.
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; }
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; }
+  }
 };
 
 // Invoke the clone operation and store the returned Promise.

--- a/guides/cloning/ssh-with-agent/README.md
+++ b/guides/cloning/ssh-with-agent/README.md
@@ -81,8 +81,10 @@ to passthrough the certificate check.
 *Note: this is not a problem with Windows or Linux*
 
 ``` javascript
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; }
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; }
+  }
 };
 ```
 
@@ -95,13 +97,15 @@ This function will be attached below the above `certificateCheck`, and will
 respond back with the credentials from the agent.  You'll notice we handle
 the second argument passed to credentials, `userName`.
 
-The `remoteCallbacks` object now looks like this:
+The `fetchOpts` object now looks like this:
 
 ``` javascript
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; },
-  credentials: function(url, userName) {
-    return NodeGit.Cred.sshKeyFromAgent(userName);
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; },
+    credentials: function(url, userName) {
+      return NodeGit.Cred.sshKeyFromAgent(userName);
+    }
   }
 };
 ```

--- a/guides/cloning/ssh-with-agent/index.js
+++ b/guides/cloning/ssh-with-agent/index.js
@@ -15,14 +15,16 @@ var cloneOptions = {};
 
 // This is a required callback for OS X machines.  There is a known issue
 // with libgit2 being able to verify certificates from GitHub.
-cloneOptions.remoteCallbacks = {
-  certificateCheck: function() { return 1; },
+cloneOptions.fetchOpts = {
+  callbacks: {
+    certificateCheck: function() { return 1; },
 
-  // Credentials are passed two arguments, url and username. We forward the
-  // `userName` argument to the `sshKeyFromAgent` function to validate
-  // authentication.
-  credentials: function(url, userName) {
-    return NodeGit.Cred.sshKeyFromAgent(userName);
+    // Credentials are passed two arguments, url and username. We forward the
+    // `userName` argument to the `sshKeyFromAgent` function to validate
+    // authentication.
+    credentials: function(url, userName) {
+      return NodeGit.Cred.sshKeyFromAgent(userName);
+    }
   }
 };
 


### PR DESCRIPTION
Related to https://github.com/nodegit/nodegit/pull/647#issuecomment-142915106 and #848

The fixes similar to #848 is applied to cloning with two factor authorization as well.
And if you use `fetchOpts` you don't need a URL with a token any more.
