### PR TITLE
Make submodule init / setup functions async

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1967,6 +1967,24 @@
     },
     "submodule": {
       "functions": {
+        "git_submodule_add_to_index": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_submodule_add_finalize": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_submodule_init": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_submodule_foreach": {
           "isAsync": true,
           "args": {
@@ -1984,8 +2002,39 @@
         "git_submodule_location": {
           "ignore": true
         },
+        "git_submodule_open": {
+          "isAsync": true,
+          "args": {
+            "repo": {
+              "isReturn": true
+            },
+            "submodule": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_submodule_update": {
+          "isAsync": true,
+          "args": {
+            "options": {
+              "isOptional": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_submodule_status": {
           "ignore": true
+        },
+        "git_submodule_sync": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },

--- a/test/tests/submodule.js
+++ b/test/tests/submodule.js
@@ -5,23 +5,29 @@ var local = path.join.bind(path, __dirname);
 describe("Submodule", function() {
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
+  var RepoUtils = require("../utils/repository_setup");
   var Submodule = NodeGit.Submodule;
 
-  var repoPath = local("../repos/workdir");
+  var repoPath = local("../repos/submodule");
 
   beforeEach(function() {
     var test = this;
 
-    return Repository.open(repoPath)
+    return RepoUtils.createRepository(repoPath)
       .then(function(repo) {
         test.repository = repo;
       });
   });
 
   it("can walk over the submodules", function() {
-    var repo = this.repository;
+    var repo;
     var submoduleName = "vendor/libgit2";
-    return repo.getSubmoduleNames()
+
+    return Repository.open(local("../repos/workdir"))
+      .then(function(_repo) {
+        repo = _repo;
+        return repo.getSubmoduleNames();
+      })
       .then(function(submodules) {
         assert.equal(submodules.length, 1);
 
@@ -34,6 +40,56 @@ describe("Submodule", function() {
       })
       .then(function(submodule) {
         assert.equal(submodule.name(), submoduleName);
+      });
+  });
+
+  it("can setup and finalize submodule add", function() {
+    var repo = this.repository;
+    var submodulePath = "hellogitworld";
+    var submoduleUrl = "https://github.com/githubtraining/hellogitworld.git";
+
+    var submodule;
+    var submoduleRepo;
+
+    return NodeGit.Submodule.addSetup(repo, submoduleUrl, submodulePath, 0)
+      .then(function(_submodule) {
+        submodule = _submodule;
+
+        return submodule.init(0);
+      })
+      .then(function() {
+        return submodule.open();
+      })
+      .then(function(_submoduleRepo) {
+        submoduleRepo = _submoduleRepo;
+        return submoduleRepo.fetch("origin", null, null);
+      })
+      .then(function() {
+        return submoduleRepo.getReference("origin/master");
+      })
+      .then(function(reference) {
+        return reference.peel(NodeGit.Object.TYPE.COMMIT);
+      })
+      .then(function(commit) {
+        return submoduleRepo.createBranch("master", commit);
+      })
+      .then(function() {
+        return submodule.addFinalize();
+      })
+      .then(function() {
+        // check whether the submodule exists
+        return Submodule.lookup(repo, submodulePath);
+      })
+      .then(function(submodule) {
+        assert.equal(submodule.name(), submodulePath);
+        // check whether .gitmodules and the submodule are in the index
+        return repo.openIndex();
+      })
+      .then(function(index) {
+        var entries = index.entries();
+        assert.equal(entries.length, 2);
+        assert.equal(entries[0].path, ".gitmodules");
+        assert.equal(entries[1].path, submodulePath);
       });
   });
 });


### PR DESCRIPTION
This makes a number of NodeGit functions related to adding / opening / initializing a submodule async.  This is to better process the return value (getting a promise rejection with an error message instead of a numeric error code), and to reflect that the methods are affecting the repo in the file system.

Also added a test which exercises most of the affected functions (except for `update` - I am getting crashes on `update` that I still need to dig into, but the new NodeGit signature of the function should be correct).