### PR TITLE
Call Lock after objects to lock have been added

### DIFF
--- a/generate/templates/manual/include/lock_master.h
+++ b/generate/templates/manual/include/lock_master.h
@@ -30,6 +30,7 @@ class LockMaster {
   void ConstructorImpl();
   void DestructorImpl();
   void ObjectToLock(const void *);
+  void ObjectsToLockAdded();
 public:
 
   // we lock on construction
@@ -41,6 +42,7 @@ public:
 
     ConstructorImpl();
     AddParameters(types...);
+    ObjectsToLockAdded();
   }
 
   // and unlock on destruction

--- a/generate/templates/manual/src/lock_master.cc
+++ b/generate/templates/manual/src/lock_master.cc
@@ -58,7 +58,6 @@ public:
 
   LockMasterImpl() {
     Register();
-    Lock(true);
   }
 
   ~LockMasterImpl() {
@@ -214,6 +213,9 @@ void LockMaster::ObjectToLock(const void *objectToLock) {
   impl->ObjectToLock(objectToLock);
 }
 
+void LockMaster::ObjectsToLockAdded() {
+  impl->Lock(true);
+}
 
 // LockMaster::TemporaryUnlock
 


### PR DESCRIPTION
This fixes a small but serious bug in the new thread safety code, introduced in https://github.com/srajko/nodegit/commit/dbce34f9f6298c6df80f2e0771dcafef51a6c35f

The referenced commit moves the call to `ConstructorImpl` before `AddParameters`, because `AddParameters` relies of `impl` being initialized, and `ConstructorImpl` initializes `impl`.  Unfortunately, `ConstructorImpl` was also calling `Lock`, and after this change `Lock` was doing nothing because `ObjectsToLock` calls happen in `AddParameters`, which was now happening later.

This PR moves the `Lock` call into a new `ObjectsToLockAdded` method, which is called after `AddParameters`.

I will try to add some testing for the locking itself (in a separate PR, to not tie this up)... it might be hard to do detailed testing from JS, but even a basic "assert that something got locked at some point" test would have helped catch this.