### PR TITLE
Add rudimentary diagnostics and testing for thread safety code

### DIFF
--- a/generate/templates/manual/include/lock_master.h
+++ b/generate/templates/manual/include/lock_master.h
@@ -86,6 +86,19 @@ public:
   static void Disable() {
     enabled = false;
   }
+
+  static bool IsEnabled() {
+    return enabled;
+  }
+
+  // Diagnostic information that can be provided to the JavaScript layer
+  // for a minimal level of testing
+  struct Diagnostics {
+    // this counts all stored mutexes - even if they are unlocked:
+    int storedMutexesCount;
+  };
+
+  static Diagnostics GetDiagnostics();
 };
 
 

--- a/generate/templates/manual/src/lock_master.cc
+++ b/generate/templates/manual/src/lock_master.cc
@@ -55,6 +55,7 @@ public:
   static LockMasterImpl *CurrentLockMasterImpl() {
     return (LockMasterImpl *)uv_key_get(&currentLockMasterKey);
   }
+  static LockMaster::Diagnostics GetDiagnostics();
 
   LockMasterImpl() {
     Register();
@@ -198,6 +199,13 @@ void LockMasterImpl::CleanupMutexes() {
   uv_async_send(&cleanupMutexesHandle);
 }
 
+LockMaster::Diagnostics LockMasterImpl::GetDiagnostics() {
+  LockMaster::Diagnostics diagnostics;
+  uv_mutex_lock(&LockMasterImpl::mapMutex);
+  diagnostics.storedMutexesCount = mutexes.size();
+  uv_mutex_unlock(&LockMasterImpl::mapMutex);
+  return diagnostics;
+}
 
 // LockMaster
 
@@ -215,6 +223,10 @@ void LockMaster::ObjectToLock(const void *objectToLock) {
 
 void LockMaster::ObjectsToLockAdded() {
   impl->Lock(true);
+}
+
+LockMaster::Diagnostics LockMaster::GetDiagnostics() {
+  return LockMasterImpl::GetDiagnostics();
 }
 
 // LockMaster::TemporaryUnlock

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -15,12 +15,25 @@
   {% endif %}
 {% endeach %}
 
-void LockMasterEnable(const FunctionCallbackInfo<Value>& args) {
+void LockMasterEnable(const FunctionCallbackInfo<Value>& info) {
   LockMaster::Enable();
 }
 
-void LockMasterDisable(const FunctionCallbackInfo<Value>& args) {
+void LockMasterDisable(const FunctionCallbackInfo<Value>& info) {
   LockMaster::Disable();
+}
+
+void LockMasterIsEnabled(const FunctionCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(Nan::New(LockMaster::IsEnabled()));
+}
+
+void LockMasterGetDiagnostics(const FunctionCallbackInfo<Value>& info) {
+  LockMaster::Diagnostics diagnostics(LockMaster::GetDiagnostics());
+
+  // return a plain JS object with properties
+  v8::Local<v8::Object> result = Nan::New<v8::Object>();
+  result->Set(Nan::New("storedMutexesCount").ToLocalChecked(), Nan::New(diagnostics.storedMutexesCount));
+  info.GetReturnValue().Set(result);
 }
 
 extern "C" void init(Local<v8::Object> target) {
@@ -38,6 +51,8 @@ extern "C" void init(Local<v8::Object> target) {
 
   NODE_SET_METHOD(target, "enableThreadSafety", LockMasterEnable);
   NODE_SET_METHOD(target, "disableThreadSafety", LockMasterDisable);
+  NODE_SET_METHOD(target, "isThreadSafetyEnabled", LockMasterIsEnabled);
+  NODE_SET_METHOD(target, "getThreadSafetyDiagnostics", LockMasterGetDiagnostics);
 
   LockMaster::Initialize();
 }

--- a/test/runner.js
+++ b/test/runner.js
@@ -3,6 +3,12 @@ var fse = promisify("fs-extra");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 
+var NodeGit = require('..');
+
+if(process.env.NODEGIT_TEST_THREADSAFETY) {
+  NodeGit.enableThreadSafety();
+}
+
 // Have to wrap exec, since it has a weird callback signature.
 var exec = promisify(function(command, opts, callback) {
   return require("child_process").exec(command, opts, callback);

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -17,9 +17,6 @@ describe("Index", function() {
   var reposPath = local("../repos/workdir");
 
   beforeEach(function() {
-    // enable thread safety for this test suite to test the deadlock scenario
-    NodeGit.enableThreadSafety();
-
     var test = this;
 
     return Repository.open(reposPath)

--- a/test/tests/thread_safety.js
+++ b/test/tests/thread_safety.js
@@ -1,0 +1,61 @@
+var assert = require("assert");
+var path = require("path");
+var local = path.join.bind(path, __dirname);
+
+describe("ThreadSafety", function() {
+  var NodeGit = require("../../");
+  var Repository = NodeGit.Repository;
+
+  var reposPath = local("../repos/workdir");
+
+  beforeEach(function() {
+    var test = this;
+
+    return Repository.open(reposPath)
+      .then(function(repo) {
+        test.repository = repo;
+        return repo.openIndex();
+      })
+      .then(function(index) {
+        test.index = index;
+      });
+  });
+
+  it("can enable and disable thread safety", function() {
+    var originalValue = NodeGit.isThreadSafetyEnabled();
+
+    NodeGit.enableThreadSafety();
+    assert.equal(true, NodeGit.isThreadSafetyEnabled());
+
+    NodeGit.disableThreadSafety();
+    assert.equal(false, NodeGit.isThreadSafetyEnabled());
+
+    // flip the switch again, to make sure we test all transitions
+    // (we could have started with thread safety enabled)
+    NodeGit.enableThreadSafety();
+    assert.equal(true, NodeGit.isThreadSafetyEnabled());
+
+    if (originalValue) {
+      NodeGit.enableThreadSafety();
+    } else {
+      NodeGit.disableThreadSafety();
+    }
+  });
+
+  it("can lock something", function() {
+    // call a sync method to guarantee that it stores a mutex,
+    // and that it will not clean up the mutex (since the cleanup is
+    // scheduled on the main node thread)
+    this.repository.headDetached();
+
+    var diagnostics = NodeGit.getThreadSafetyDiagnostics();
+    if (diagnostics.isEnabled) {
+      // this is a fairly vague test - it just tests that something
+      // had a mutex created for it at some point (i.e., the thread safety
+      // code is not completely dead)
+      assert.ok(diagnostics.storedMutexesCount > 0);
+    } else {
+      assert.equal(0, diagnostics.storedMutexesCount);
+    }
+  });
+});


### PR DESCRIPTION
Exposes a few thread safety internals so they can be at least somewhat tested.

Also adds support for an environment variable `NODEGIT_TEST_THREADSAFETY`, which when set will enable thread safety for the run of the test suite.