### PR TITLE
Remove `Index#addAll` hack

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 var NodeGit = require("../");
 
 var Index = NodeGit.Index;
-var Pathspec = NodeGit.Pathspec;
 
 /**
  * Return an array of the entries in this index.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 var NodeGit = require("../");
 
 var Index = NodeGit.Index;
-var Status = NodeGit.Status;
 var Pathspec = NodeGit.Pathspec;
 
 /**
@@ -21,28 +20,7 @@ Index.prototype.entries = function() {
 
 var addAll = Index.prototype.addAll;
 Index.prototype.addAll = function(pathspec, flags, matchedCallback) {
-  // This status path code is here to speedup addall, which currently is
-  // excessively slow due to adding every single unignored file to the index
-  // even if it has no changes. Remove this when it's fixed in libgit2
-  // https://github.com/libgit2/libgit2/issues/2687
-  var paths = [];
-  var repo = this.owner();
-  var statusCB = function(path) {
-    paths.push(path);
-  };
-  var idx = this;
-  var ps = Pathspec.create(pathspec || "*");
-
-  return Status.foreach(repo, statusCB)
-    .then(function() {
-      return paths;
-    })
-    .then(function(paths) {
-      paths = paths.filter(function(path) {
-        return !!(ps.matchesPath(0, path));
-      });
-      return addAll.call(idx, paths, flags, matchedCallback, null);
-    });
+  return addAll.call(this, pathspec || "*", flags, matchedCallback, null);
 };
 
 var removeAll = Index.prototype.removeAll;


### PR DESCRIPTION
Now that https://github.com/libgit2/libgit2/issues/2687 has landed we don't need our hack to speed up `Index#addAll` anymore.

This fixes #751