### PR TITLE
Tests for Revert.revert

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1792,6 +1792,20 @@
     },
     "revert": {
       "functions": {
+        "git_revert": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_revert_commit": {
+          "isAsync": true,
+          "args": {
+            "merge_options": {
+              "isOptional": true
+            }
+          }
+        },
         "git_revert_init_options": {
           "ignore": true
         }

--- a/lib/revert.js
+++ b/lib/revert.js
@@ -1,0 +1,47 @@
+var NodeGit = require("../");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+
+var Revert = NodeGit.Revert;
+
+/**
+ * Reverts the given commit against the given "our" commit, producing an index
+ * that reflects the result of the revert.
+ *
+ * @async
+ * @param {Repository} repo the repository that contains the given commits.
+ * @param {Commit} revert_commit the commit to revert
+ * @param {Commit} our_commit the commit to revert against (e.g. HEAD)
+ * @param {Number} mainline the parent of the revert commit, if it is a merge
+ * @param {MergeOptions} merge_options the merge options (or null for defaults)
+ *
+ * @return {Index} the index result
+ */
+var commit = Revert.commit;
+Revert.commit = function(
+  repo,
+  revert_commit,
+  our_commit,
+  mainline,
+  merge_options,
+  callback
+) {
+  merge_options = normalizeOptions(merge_options, NodeGit.MergeOptions);
+
+  return commit.call(
+    this,
+    repo,
+    revert_commit,
+    our_commit,
+    mainline,
+    merge_options
+  )
+    .then(function(result) {
+      if (typeof callback === "function") {
+        callback(null, result);
+      }
+
+      return result;
+    }, callback);
+};
+
+module.exports = Revert;

--- a/test/tests/revert.js
+++ b/test/tests/revert.js
@@ -1,0 +1,63 @@
+var _ = require("lodash");
+var assert = require("assert");
+var RepoUtils = require("../utils/repository_setup");
+var path = require("path");
+var fs = require("fs");
+var local = path.join.bind(path, __dirname);
+
+describe("Revert", function() {
+  var NodeGit = require("../../");
+
+  var Revert = NodeGit.Revert;
+  var RevertOptions = NodeGit.RevertOptions;
+
+  var test;
+  var fileName = "foobar.js";
+  var repoPath = local("../repos/revertRepo");
+
+  beforeEach(function() {
+    test = this;
+
+    return RepoUtils.createRepository(repoPath)
+      .then(function(repository) {
+        test.repository = repository;
+
+        return RepoUtils.commitFileToRepo(
+          repository,
+          fileName,
+          "line1\nline2\nline3"
+        );
+      })
+      .then(function(firstCommit) {
+        test.firstCommit = firstCommit;
+      });
+  });
+
+  it("revert modifies the working directoy", function() {
+    var fileStats = fs.statSync(path.join(repoPath, fileName));
+    assert.ok(fileStats.isFile());
+
+    Revert.revert(test.repository, test.firstCommit, new RevertOptions())
+      .then(function() {
+        try {
+          fs.statSync(path.join(repoPath, fileName));
+          assert.fail("Working directory was not reverted");
+        }
+        catch (error) {
+          // pass
+        }
+      });
+  });
+
+  it("revert modifies the index", function() {
+    Revert.revert(test.repository, test.firstCommit, new RevertOptions())
+    .then(function() {
+      return test.repository.index();
+    })
+    .then(function(index) {
+      var entries = index.entries;
+      assert.equal(1, entries.length);
+      assert.ok(_.endsWith(fileName, entries[0].path));
+    });
+  });
+});


### PR DESCRIPTION
Updated Revert.revert and Revert.commit to both be async. Set merge_options to be optional.

Testing that Revert.revert properly updates the working directory and stages files in the index.