### PR TITLE
make checkoutBranch works with branches that lives outside of refs/heads

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1146,9 +1146,6 @@ Repository.prototype.checkoutBranch = function(branch, opts) {
       NodeGit.Checkout.STRATEGY.RECREATE_MISSING);
   return repo.getReference(branch)
   .then(function(ref) {
-    if (!ref.isBranch()) {
-      return false;
-    }
     reference = ref;
     return repo.getBranchCommit(ref.name());
   })

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1128,6 +1128,35 @@ Repository.prototype.getSubmoduleNames = function(callback) {
 };
 
 /**
+ * This will set the HEAD to point to the reference and then attempt
+ * to update the index and working tree to match the content of the
+ * latest commit on that reference
+ *
+ * @async
+ * @param {Reference} reference the reference to checkout
+ * @param {Object|CheckoutOptions} opts the options to use for the checkout
+ */
+Repository.prototype.checkoutRef = function(reference, opts) {
+  var repo = this;
+  opts = opts || {};
+
+  opts.checkoutStrategy = opts.checkoutStrategy ||
+    (NodeGit.Checkout.STRATEGY.SAFE |
+      NodeGit.Checkout.STRATEGY.RECREATE_MISSING);
+  return repo.getReferenceCommit(reference.name());
+  .then(function(commit) {
+    return commit.getTree();
+  })
+  .then(function(tree) {
+    return Checkout.tree(repo, tree, opts);
+  })
+  .then(function() {
+    var name = reference.name();
+    return repo.setHead(name);
+  });
+};
+
+/**
  * This will set the HEAD to point to the local branch and then attempt
  * to update the index and working tree to match the content of the
  * latest commit on that branch
@@ -1138,26 +1167,13 @@ Repository.prototype.getSubmoduleNames = function(callback) {
  */
 Repository.prototype.checkoutBranch = function(branch, opts) {
   var repo = this;
-  var reference;
-  opts = opts || {};
 
-  opts.checkoutStrategy = opts.checkoutStrategy ||
-    (NodeGit.Checkout.STRATEGY.SAFE |
-      NodeGit.Checkout.STRATEGY.RECREATE_MISSING);
   return repo.getReference(branch)
   .then(function(ref) {
-    reference = ref;
-    return repo.getBranchCommit(ref.name());
-  })
-  .then(function(commit) {
-    return commit.getTree();
-  })
-  .then(function(tree) {
-    return Checkout.tree(repo, tree, opts);
-  })
-  .then(function() {
-    var name = reference.name();
-    return repo.setHead(name);
+    if (!ref.isBranch()) {
+      return false;
+    }
+    return repo.checkoutRef(ref, opts);
   });
 };
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1143,7 +1143,7 @@ Repository.prototype.checkoutRef = function(reference, opts) {
   opts.checkoutStrategy = opts.checkoutStrategy ||
     (NodeGit.Checkout.STRATEGY.SAFE |
       NodeGit.Checkout.STRATEGY.RECREATE_MISSING);
-  return repo.getReferenceCommit(reference.name());
+  return repo.getReferenceCommit(reference.name())
   .then(function(commit) {
     return commit.getTree();
   })


### PR DESCRIPTION
And avoid trying to call a method on a boolean when isBranch() is false.