### PR TITLE
Fix documentation issues

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -151,7 +151,7 @@ Commit.prototype.getParents = function(limit, callback) {
  * Retrieve the commit"s parent shas.
  *
  * @param {Function} callback
- * @return {Array<Oids>} array of oids
+ * @return {Array<Oid>} array of oids
  */
 Commit.prototype.parents = function() {
   var result = [];

--- a/lib/convenient_hunks.js
+++ b/lib/convenient_hunks.js
@@ -60,4 +60,4 @@ var oldStart = ConvenientHunk.prototype.oldStart;
  */
 ConvenientHunk.prototype.oldStart = oldStart;
 
- exports.module = ConvenientHunk;
+module.exports = ConvenientHunk;

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -129,6 +129,6 @@ var isConflicted = ConvenientPatch.prototype.isConflicted;
  * Is this a conflicted patch?
  * @return {Boolean}
  */
- ConvenientPatch.prototype.isConflicted = isConflicted;
+ConvenientPatch.prototype.isConflicted = isConflicted;
 
- exports.module = ConvenientPatch;
+module.exports = ConvenientPatch;

--- a/lib/convenient_patch.js
+++ b/lib/convenient_patch.js
@@ -4,15 +4,15 @@ var ConvenientPatch = NodeGit.ConvenientPatch;
 
 var oldFile = ConvenientPatch.prototype.oldFile;
 /**
- * Old name of the file
- * @return {String}
+ * Old attributes of the file
+ * @return {DiffFile}
  */
 ConvenientPatch.prototype.oldFile = oldFile;
 
 var newFile = ConvenientPatch.prototype.newFile;
 /**
- * New name of the file
- * @return {String}
+ * New attributes of the file
+ * @return {DiffFile}
  */
 ConvenientPatch.prototype.newFile = newFile;
 

--- a/lib/diff_file.js
+++ b/lib/diff_file.js
@@ -1,0 +1,38 @@
+var NodeGit = require("../");
+
+var DiffFile = NodeGit.DiffFile;
+
+var flags = DiffFile.prototype.flags;
+/**
+ * Returns the file's flags
+ * @return {Number}
+ */
+DiffFile.prototype.flags = flags;
+
+var id = DiffFile.prototype.id;
+/**
+ * Returns the file's Oid
+ * @return {Oid}
+ */
+DiffFile.prototype.id = id;
+
+var mode = DiffFile.prototype.mode;
+/**
+ * Returns the file's mode
+ * @return {Number}
+ */
+DiffFile.prototype.mode = mode;
+
+var path = DiffFile.prototype.path;
+/**
+ * Returns the file's path
+ * @return {String}
+ */
+DiffFile.prototype.path = path;
+
+var size = DiffFile.prototype.size;
+/**
+ * Returns the file's size
+ * @return {Number}
+ */
+DiffFile.prototype.size = size;

--- a/lib/diff_file.js
+++ b/lib/diff_file.js
@@ -37,4 +37,4 @@ var size = DiffFile.prototype.size;
  */
 DiffFile.prototype.size = size;
 
-exports.module = DiffFile;
+module.exports = DiffFile;

--- a/lib/diff_file.js
+++ b/lib/diff_file.js
@@ -36,3 +36,5 @@ var size = DiffFile.prototype.size;
  * @return {Number}
  */
 DiffFile.prototype.size = size;
+
+exports.module = DiffFile;

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -33,7 +33,7 @@ Object.defineProperty(Repository.prototype, "openIndex", {
  * @param {bool} force Overwrite branch if it exists
  * @param {Signature} signature Identity to use to populate reflog
  * @param {String} logMessage One line message to be appended to the reflog
- * @return {Ref}
+ * @return {Reference}
  */
 Repository.prototype.createBranch =
 function(name, commit, force) {
@@ -86,8 +86,8 @@ Repository.discover = function(startPath, acrossFs, ceilingDirs, callback) {
  * Look up a refs's commit.
  *
  * @async
- * @param {String|Ref} name Ref name, e.g. "master", "refs/heads/master"
- *                          or Branch Ref
+ * @param {String|Reference} name Ref name, e.g. "master", "refs/heads/master"
+ *                              or Branch Ref
  * @return {Commit}
  */
 Repository.prototype.getReferenceCommit = function(name, callback) {
@@ -108,9 +108,9 @@ Repository.prototype.getReferenceCommit = function(name, callback) {
 * Look up a branch. Alias for `getReference`
 *
 * @async
-* @param {String|Ref} name Ref name, e.g. "master", "refs/heads/master"
-*                          or Branch Ref
-* @return {Ref}
+* @param {String|Reference} name Ref name, e.g. "master", "refs/heads/master"
+*                              or Branch Ref
+* @return {Reference}
 */
 Repository.prototype.getBranch = function(name, callback) {
   return this.getReference(name, callback);
@@ -120,7 +120,7 @@ Repository.prototype.getBranch = function(name, callback) {
 * Look up a branch's most recent commit. Alias to `getReferenceCommit`
 *
 * @async
-* @param {String|Ref} name Ref name, e.g. "master", "refs/heads/master"
+* @param {String|Reference} name Ref name, e.g. "master", "refs/heads/master"
 *                          or Branch Ref
 * @return {Commit}
 */
@@ -142,8 +142,8 @@ Repository.prototype.getCurrentBranch = function() {
  * Lookup the reference with the given name.
  *
  * @async
- * @param {String|Ref} name Ref name, e.g. "master", "refs/heads/master"
- *                          or Branch Ref
+ * @param {String|Reference} name Ref name, e.g. "master", "refs/heads/master"
+ *                               or Branch Ref
  * @return {Reference}
  */
 Repository.prototype.getReference = function(name, callback) {
@@ -728,8 +728,8 @@ Repository.prototype.fetchAll = function(
 /**
  * Merge a branch onto another branch
  *
- * @param {String|Ref}        to
- * @param {String|Ref}        from
+ * @param {String|Reference}        to
+ * @param {String|Reference}        from
  * @param {Signature}         signature
  * @param {Merge.PREFERENCE}  mergePreference
  * @param {MergeOptions}      mergeOptions


### PR DESCRIPTION
Fixes a variety of documentation issues:

* Fixes cases where the docs said `Ref`, but meant `Reference`.
* Adds documentation for `DiffFile`.
  * NOTE: There's a bug in your doc generator, which causes `DiffFile` to display the invalid instance fields alongside my correct methods.
* Fixes `exports.module` => `module.exports` in a few places.

Let me know if you want me to squash these into one commit.