### PR TITLE
Optimize rename detection in historywalk

### DIFF
--- a/generate/templates/manual/revwalk/file_history_walk.cc
+++ b/generate/templates/manual/revwalk/file_history_walk.cc
@@ -175,13 +175,20 @@ void GitRevwalk::FileHistoryWalkWorker::Execute()
         const git_diff_delta *delta = git_patch_get_delta(nextPatch);
         bool isEqualOldFile = !strcmp(delta->old_file.path, baton->file_path);
         bool isEqualNewFile = !strcmp(delta->new_file.path, baton->file_path);
+        int oldLen = strlen(delta->old_file.path);
+        int newLen = strlen(delta->new_file.path);
+        char *outPair = new char[oldLen + newLen + 2];
+        strcpy(outPair, delta->new_file.path);
+        outPair[newLen] = '\n';
+        outPair[newLen + 1] = '\0';
+        strcat(outPair, delta->old_file.path);
 
         if (isEqualNewFile) {
           std::pair<git_commit *, std::pair<char *, git_delta_t> > *historyEntry;
           if (!isEqualOldFile) {
             historyEntry = new std::pair<git_commit *, std::pair<char *, git_delta_t> >(
               nextCommit,
-              std::pair<char *, git_delta_t>(strdup(delta->old_file.path), delta->status)
+              std::pair<char *, git_delta_t>(strdup(outPair), delta->status)
             );
           } else {
             historyEntry = new std::pair<git_commit *, std::pair<char *, git_delta_t> >(
@@ -195,11 +202,13 @@ void GitRevwalk::FileHistoryWalkWorker::Execute()
           std::pair<git_commit *, std::pair<char *, git_delta_t> > *historyEntry;
           historyEntry = new std::pair<git_commit *, std::pair<char *, git_delta_t> >(
             nextCommit,
-            std::pair<char *, git_delta_t>(strdup(delta->new_file.path), delta->status)
+            std::pair<char *, git_delta_t>(strdup(outPair), delta->status)
           );
           baton->out->push_back(historyEntry);
           flag = true;
         }
+
+        delete[] outPair;
 
         git_patch_free(nextPatch);
 
@@ -255,7 +264,13 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
       Nan::Set(historyEntry, Nan::New("commit").ToLocalChecked(), GitCommit::New(batonResult->first, true));
       Nan::Set(historyEntry, Nan::New("status").ToLocalChecked(), Nan::New<Number>(batonResult->second.second));
       if (batonResult->second.second == GIT_DELTA_RENAMED) {
-        Nan::Set(historyEntry, Nan::New("altname").ToLocalChecked(), Nan::New(batonResult->second.first).ToLocalChecked());
+        char *namePair = batonResult->second.first;
+        char *split = strchr(namePair, '\n');
+        *split = '\0';
+        char *oldName = split + 1;
+
+        Nan::Set(historyEntry, Nan::New("oldName").ToLocalChecked(), Nan::New(oldName).ToLocalChecked());
+        Nan::Set(historyEntry, Nan::New("newName").ToLocalChecked(), Nan::New(namePair).ToLocalChecked());
       }
       Nan::Set(result, Nan::New<Number>(i), historyEntry);
 

--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -129,7 +129,9 @@ Revwalk.prototype.getCommits = function(count) {
  * @type {Object}
  * @property {Commit} commit the commit for this entry
  * @property {Number} status the status of the file in the commit
- * @property {String} altname the other name that is provided when status is
+ * @property {String} newName the new name that is provided when status is
+ *                            renamed
+ * @property {String} oldName the old name that is provided when status is
  *                            renamed
  */
 

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -286,7 +286,8 @@ describe("Revwalk", function() {
       })
       .then(function(results) {
         assert.equal(results[0].status, NodeGit.Diff.DELTA.RENAMED);
-        assert.equal(results[0].altname, fileNameA);
+        assert.equal(results[0].newName, fileNameB);
+        assert.equal(results[0].oldName, fileNameA);
       })
       .then(function() {
         var walker = repo.createRevWalk();
@@ -296,7 +297,8 @@ describe("Revwalk", function() {
       })
       .then(function(results) {
         assert.equal(results[0].status, NodeGit.Diff.DELTA.RENAMED);
-        assert.equal(results[0].altname, fileNameB);
+        assert.equal(results[0].newName, fileNameB);
+        assert.equal(results[0].oldName, fileNameA);
       })
       .then(function() {
         return fse.remove(repoPath);


### PR DESCRIPTION
Only calculate full diffs (without pathspec) in case we believe there is a rename.