### PR TITLE
Fix `fast_walk.cc` when there was an error

### DIFF
--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -56,7 +56,7 @@ void GitRevwalk::FastWalkWorker::Execute()
         baton->out = NULL;
       }
       else {
-        baton->error_code == GIT_OK;
+        baton->error_code = GIT_OK;
       }
 
       break;


### PR DESCRIPTION
In the error state, fast walk would just do an equality check instead of an assignment of the error. I'm an idiot :(