### PR TITLE
[WIP] Chain async actions in promises to prevent overlap

### DIFF
--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -3,8 +3,9 @@ var promisifyNode = require("promisify-node");
 var asyncPromise = Promise.resolve();
 
 function promisify(fn) {
+  var promisified = promisifyNode(fn);
+
   function chainedPromisified() {
-    var promisified = promisifyNode(fn);
     var _this = this;
     var _args = arguments;
 

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -1,4 +1,30 @@
-var promisify = require("promisify-node");
+var promisifyNode = require("promisify-node");
+
+var asyncPromise = Promise.resolve();
+
+function promisify(fn) {
+  function chainedPromisified() {
+    var promisified = promisifyNode(fn);
+    var _this = this;
+    var _args = arguments;
+
+    return new Promise(function(resolve, reject) {
+      function runPromisified() {
+        return promisified.apply(_this, _args)
+          .then(function(value) {
+            resolve(value);
+          }, function(error) {
+            reject(error);
+          });
+      }
+      asyncPromise = asyncPromise
+        .then(runPromisified);
+    });
+  }
+
+  return chainedPromisified;
+}
+
 var rawApi;
 
 // Attempt to load the production release first, if it fails fall back to the

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -19,7 +19,7 @@ function promisify(fn) {
           });
       }
       asyncPromise = asyncPromise
-        .then(runPromisified);
+        .then(runPromisified, runPromisified);
     });
   }
 

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -79,11 +79,13 @@ describe("TreeEntry", function() {
       return Promise.all(testPromises);
     };
 
+    function promiseDone() {
+      done();
+    }
+
     return this.commit.getTree()
       .then(testTree)
-      .done(function() {
-        done();
-      });
+      .then(promiseDone, promiseDone);
   });
 
   it("provides the blob representation of the entry", function() {


### PR DESCRIPTION
A possible fix for #907, opening PR to run tests.  If it works, it will merit a longer explanation / discussion.

Credit for the beautiful idea of using JS promises to prevent any overlap in async libgit2 calls goes to @johnhaley81.