### PR TITLE
OpenSSL and libssh2 thread safety

### DIFF
--- a/generate/templates/manual/include/init_ssh2.h
+++ b/generate/templates/manual/include/init_ssh2.h
@@ -1,0 +1,6 @@
+#ifndef INIT_SSH2
+#define INIT_SSH2
+
+void init_ssh2();
+
+#endif

--- a/generate/templates/manual/src/init_ssh2.cc
+++ b/generate/templates/manual/src/init_ssh2.cc
@@ -1,0 +1,12 @@
+// We are initializing libssh2 from a separate .cc file to avoid ssize_t
+// redefinition conflicts caused by incliding both node.h and libssh2.h from
+// the same file (e.g. nodegit.cc)
+//
+// The redefinition can also be avoided by #defines but that is risky in case
+// the libraries depend on the different definitions.
+
+#include <libssh2.h>
+
+void init_ssh2() {
+  libssh2_init(0);
+}

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -16,6 +16,7 @@
       "sources": [
         "src/lock_master.cc",
         "src/nodegit.cc",
+        "src/init_ssh2.cc",
         "src/promise_completion.cc",
         "src/wrapper.cc",
         "src/functions/copy.cc",

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -32,6 +32,7 @@
 
       "include_dirs": [
         "vendor/libv8-convert",
+        "vendor/libssh2/include",
         "<!(node -e \"require('nan')\")"
       ],
 

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -33,6 +33,7 @@
       "include_dirs": [
         "vendor/libv8-convert",
         "vendor/libssh2/include",
+        "vendor/openssl/openssl/include",
         "<!(node -e \"require('nan')\")"
       ],
 

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -8,12 +8,8 @@
 #include <set>
 
 #include <openssl/crypto.h>
-// we have to include <libssh2.h> first so it defines ssize_t
-// and then node.h with _SSIZE_T_ defined to prevent it from redefining
-// in a conflicting way on 32 bit windows
-#define ssize_t ssize_t
-#include <libssh2.h>
 
+#include "../include/init_ssh2.h"
 #include "../include/lock_master.h"
 #include "../include/wrapper.h"
 #include "../include/promise_completion.h"
@@ -75,7 +71,7 @@ void OpenSSL_ThreadSetup() {
 extern "C" void init(Local<v8::Object> target) {
   // Initialize thread safety in openssl and libssh2
   OpenSSL_ThreadSetup();
-  libssh2_init(0);
+  init_ssh2();
   // Initialize libgit2.
   git_libgit2_init();
 

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -1,13 +1,18 @@
 // This is a generated file, modify: generate/templates/nodegit.cc.
 #include <v8.h>
+
 #include <node.h>
 #include <git2.h>
 #include <map>
 #include <algorithm>
 #include <set>
 
-#include <libssh2.h>
 #include <openssl/crypto.h>
+// we have to include <libssh2.h> first so it defines ssize_t
+// and then node.h with _SSIZE_T_ defined to prevent it from redefining
+// in a conflicting way on 32 bit windows
+#define ssize_t ssize_t
+#include <libssh2.h>
 
 #include "../include/lock_master.h"
 #include "../include/wrapper.h"

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <set>
 
+#include <libssh2.h>
+
 #include "../include/lock_master.h"
 #include "../include/wrapper.h"
 #include "../include/promise_completion.h"
@@ -40,6 +42,7 @@ void LockMasterGetDiagnostics(const FunctionCallbackInfo<Value>& info) {
 }
 
 extern "C" void init(Local<v8::Object> target) {
+  libssh2_init(0);
   // Initialize libgit2.
   git_libgit2_init();
 

--- a/lifecycleScripts/configureLibssh2.js
+++ b/lifecycleScripts/configureLibssh2.js
@@ -9,9 +9,19 @@ module.exports = function retrieveExternalDependencies() {
 
   return new Promise(function(resolve, reject) {
     console.info("[nodegit] Configuring libssh2.");
-    cp.execFile(
-      rooted("vendor/libssh2/") + "configure",
-      {cwd: rooted("vendor/libssh2/")},
+    var opensslDir = rooted("vendor/openssl/openssl");
+    var newEnv = {};
+    Object.keys(process.env).forEach(function(key) {
+      newEnv[key] = process.env[key];
+    });
+    newEnv.CPPFLAGS = newEnv.CPPFLAGS || "";
+    newEnv.CPPFLAGS += " -I" + path.join(opensslDir, "include");
+    newEnv.CPPFLAGS = newEnv.CPPFLAGS.trim();
+
+    cp.exec(
+      rooted("vendor/libssh2/configure") +
+        " --with-libssl-prefix=" + opensslDir,
+      {cwd: rooted("vendor/libssh2/"), env: newEnv},
       function(err, stdout, stderr) {
         if (err) {
           console.error(err);

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -128,6 +128,6 @@ function build() {
       else {
         resolve();
       }
-    })
+    });
   });
 }


### PR DESCRIPTION
Provide openssl with the locking setup it needs for thread safety.

Initialize libssh2 to avoid the possibility of its subsequent thread-unsafe init.