### PR TITLE
Fix debug build on windows

### DIFF
--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -1,7 +1,7 @@
 // This is a generated file, modify: generate/templates/nodegit.cc.
+#include <node.h>
 #include <v8.h>
 
-#include <node.h>
 #include <git2.h>
 #include <map>
 #include <algorithm>


### PR DESCRIPTION
There was a linking exception that was fixed by changing the order of includes for node and v8 headers