### PR TITLE
Fix callback out values in callbacks from C++

### DIFF
--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -27,12 +27,6 @@
     }
   }
 
-  {% each cbFunction|returnsInfo false true as _return %}
-    {% if _return.isOutParam %}
-    *{{ _return.name }} = *baton->{{ _return.name }};
-    {% endif %}
-  {% endeach %}
-
   return baton->result;
 }
 
@@ -92,7 +86,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_async(uv_as
       {{ _return.cppClassName }}* wrapper = Nan::ObjectWrap::Unwrap<{{ _return.cppClassName }}>(result->ToObject());
       wrapper->selfFreeing = false;
 
-      baton->{{ _return.name }} = wrapper->GetRefValue();
+      *baton->{{ _return.name }} = wrapper->GetValue();
       baton->result = {{ cbFunction.return.success }};
       {% else %}
       if (result->IsNumber()) {
@@ -126,7 +120,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_promiseComp
         {{ _return.cppClassName }}* wrapper = Nan::ObjectWrap::Unwrap<{{ _return.cppClassName }}>(result->ToObject());
         wrapper->selfFreeing = false;
 
-        baton->{{ _return.name }} = wrapper->GetRefValue();
+        *baton->{{ _return.name }} = wrapper->GetValue();
         baton->result = {{ cbFunction.return.success }};
         {% else %}
         if (result->IsNumber()) {

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -100,19 +100,13 @@
         uv_async_init(uv_default_loop(), &baton->req, (uv_async_cb) {{ field.name }}_async);
         {
           LockMaster::TemporaryUnlock temporaryUnlock;
-          
+
           uv_async_send(&baton->req);
 
           while(!baton->done) {
             sleep_for_ms(1);
           }
         }
-
-        {% each field|returnsInfo false true as _return %}
-          {% if _return.isOutParam %}
-          *{{ _return.name }} = *baton->{{ _return.name }};
-          {% endif %}
-        {% endeach %}
 
         return baton->result;
       }
@@ -186,7 +180,7 @@
             {{ _return.cppClassName }}* wrapper = Nan::ObjectWrap::Unwrap<{{ _return.cppClassName }}>(result->ToObject());
             wrapper->selfFreeing = false;
 
-            baton->{{ _return.name }} = wrapper->GetRefValue();
+            *baton->{{ _return.name }} = wrapper->GetValue();
             baton->result = {{ field.return.success }};
             {% else %}
             if (result->IsNumber()) {
@@ -219,7 +213,7 @@
               {{ _return.cppClassName }}* wrapper = Nan::ObjectWrap::Unwrap<{{ _return.cppClassName }}>(result->ToObject());
               wrapper->selfFreeing = false;
 
-              baton->{{ _return.name }} = wrapper->GetRefValue();
+              *baton->{{ _return.name }} = wrapper->GetValue();
               baton->result = {{ field.return.success }};
               {% else %}
               if (result->IsNumber()) {


### PR DESCRIPTION
We were passing back the memory address that was actually controlled by V8 to all C/C++ callbacks which could get randomly moved by V8 at random times causing random segfaults randomly.

http://i.imgur.com/rB4Hux7.gif