### PR TITLE
Fix compilation for systems != windows and crash in diff function

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -333,6 +333,9 @@
             # 'InterlockedDecrement' undefined; assuming extern returning int.
             4013,
           ],
+          "include_dirs": [
+            "libgit2/deps/regex"
+          ],
           "sources": [
             "libgit2/src/win32/w32_buffer.c",
             "libgit2/src/win32/w32_buffer.h",
@@ -390,8 +393,7 @@
       ],
       "include_dirs": [
         "libgit2/include",
-        "libgit2/src",
-        "libgit2/deps/regex"
+        "libgit2/src"
       ],
       "direct_dependent_settings": {
         "include_dirs": [
@@ -427,9 +429,15 @@
         "STDC",
         "NO_GZIP",
       ],
+      "conditions": [
+        ["OS=='win'", {
+          "include_dirs": [
+            "libgit2/deps/regex"
+          ]
+        }]
+      ],
       "include_dirs": [
-        "libgit2/include",
-        "libgit2/deps/regex",
+        "libgit2/include"
       ],
       "direct_dependent_settings": {
         "include_dirs": [


### PR DESCRIPTION
Hi,

Atom crashed because of https://github.com/atom/atom/issues/10965
Here's the same fix we've used for git-utils https://github.com/atom/git-utils/pull/61
Full story about this bug in libgit2 issues tracker here https://github.com/libgit2/libgit2/issues/2586

Please review as this makes library unusable in a lot of use-cases. :(