### PR TITLE
Remove `GetRefValue`

### DIFF
--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -69,18 +69,10 @@
     {%endif%}
   }
   else {
-    {%if cType|isDoublePointer %}
-    from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetRefValue();
-    {%else%}
-    from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetValue();
-    {%endif%}
+    {%if cType|isDoublePointer %}*{%endif%}from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetValue();
   }
   {%else%}
-    {%if cType|isDoublePointer %}
-  from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetRefValue();
-    {%else%}
-  from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetValue();
-    {%endif%}
+    {%if cType|isDoublePointer %}*{%endif%}from_{{ name }} = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info[{{ jsArg }}]->ToObject())->GetValue();
   {%endif%}
 
   {%if isBoolean %}

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -109,10 +109,6 @@ using namespace node;
     return this->raw;
   }
 
-  {{ cType }} **{{ cppClassName }}::GetRefValue() {
-    return this->raw == NULL ? NULL : &this->raw;
-  }
-
   void {{ cppClassName }}::ClearValue() {
     this->raw = NULL;
   }

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -44,7 +44,6 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
 
     {%if cType%}
     {{ cType }} *GetValue();
-    {{ cType }} **GetRefValue();
     void ClearValue();
 
     static Local<v8::Value> New(void *raw, bool selfFreeing);

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -62,7 +62,7 @@ using namespace std;
       {% endif %}
     {% endif %}
   {% endeach %}
-  
+
   if (this->selfFreeing) {
     free(this->raw);
   }
@@ -141,10 +141,6 @@ Local<v8::Value> {{ cppClassName }}::New(void* raw, bool selfFreeing) {
 
 {{ cType }} *{{ cppClassName }}::GetValue() {
   return this->raw;
-}
-
-{{ cType }} **{{ cppClassName }}::GetRefValue() {
-  return this->raw == NULL ? NULL : &this->raw;
 }
 
 void {{ cppClassName }}::ClearValue() {

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -29,7 +29,6 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     static void InitializeComponent (Local<v8::Object> target);
 
     {{ cType }} *GetValue();
-    {{ cType }} **GetRefValue();
     void ClearValue();
 
     static Local<v8::Value> New(void *raw, bool selfFreeing);


### PR DESCRIPTION
Using `GetRefValue` would return the V8 handled pointer instead of the pointer to the libgit2 value and the V8 handled pointer could be changed at any moment.

Removing this function and setting the pointer value to the underlying C object will prevent V8 GC screwing up a NodeGit app.