### PR TITLE
fixes #852 should not be an array with null in it

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -535,9 +535,9 @@ Repository.prototype.createCommitOnHead = function(
     .then(function(treeOid) {
       return repo.getHeadCommit()
         .then(function(parent) {
-            if (parent !== null) { // To handle a fresh repo with no commits
-             parent = [parent];
-            }
+          if (parent !== null) { // To handle a fresh repo with no commits
+            parent = [parent];
+          }
           return repo.createCommit(
             "HEAD",
             author,

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -535,13 +535,16 @@ Repository.prototype.createCommitOnHead = function(
     .then(function(treeOid) {
       return repo.getHeadCommit()
         .then(function(parent) {
+            if (parent !== null) { // To handle a fresh repo with no commits
+             parent = [parent];
+            }
           return repo.createCommit(
             "HEAD",
             author,
             committer,
             message,
             treeOid,
-            [parent]
+            parent
           );
         });
     }, callback);

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -231,4 +231,33 @@ describe("Repository", function() {
         assert(!commit);
       });
   });
+
+  it("can commit on head on a empty repo with createCommitOnHead", function() {
+    var fileName = "my-new-file-that-shouldnt-exist.file";
+    var fileContent = "new file from repository test";
+    var repo = this.emptyRepo;
+    var filePath = path.join(repo.workdir(), fileName);
+    var authSig = repo.defaultSignature();
+    var commitSig = repo.defaultSignature();
+    var commitMsg = "Doug this has been commited";
+
+    return fse.writeFile(filePath, fileContent)
+      .then(function() {
+        return repo.createCommitOnHead(
+          [filePath],
+          authSig,
+          commitSig,
+          commitMsg
+        );
+      })
+      .then(function(oidResult) {
+          return repo.getHeadCommit()
+            .then(function(commit) {
+              assert.equal(
+                commit.toString(),
+                oidResult.toString()
+              );
+            });
+      });
+  });
 });


### PR DESCRIPTION
I'm not sure if this is the intended behaviour, but my take on it as a convenience method it should be able to handle creating the initial commit on a empty repo.