### PR TITLE
Fix tree.walk() and add test

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,8 @@
   "maxlen": 80,
   "node": true,
   "predef": [
-    "Promise"
+    "Promise",
+    "Set"
   ],
   "proto": true,
   "quotmark": "double",

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -128,6 +128,7 @@ Tree.prototype.walk = function(blobsOnly) {
 
   var total = 1;
   var entries = new Set();
+  var finalEntires = [];
 
   // This looks like a DFS, but it is a BFS because of implicit queueing in
   // the recursive call to `entry.getTree(bfs)`
@@ -142,6 +143,10 @@ Tree.prototype.walk = function(blobsOnly) {
       if (!blobsOnly || entry.isFile() && !entries.has(entry)) {
         event.emit("entry", entry);
         entries.add(entry);
+
+        // Node 0.12 doesn't support either [v for (v of entries)] nor
+        // Array.from so we'll just maintain our own list.
+        finalEntires.push(entry);
       }
 
       if (entry.isTree()) {
@@ -151,7 +156,7 @@ Tree.prototype.walk = function(blobsOnly) {
     });
 
     if (total === 0) {
-      event.emit("end", Array.from(entries));
+      event.emit("end", finalEntires);
     }
   }
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -127,7 +127,7 @@ Tree.prototype.walk = function(blobsOnly) {
   var event = new events.EventEmitter();
 
   var total = 1;
-  var entries = [];
+  var entries = new Set();
 
   // This looks like a DFS, but it is a BFS because of implicit queueing in
   // the recursive call to `entry.getTree(bfs)`
@@ -139,9 +139,9 @@ Tree.prototype.walk = function(blobsOnly) {
     }
 
     tree.entries().forEach(function (entry, entryIndex) {
-      if (!blobsOnly || entry.isFile()) {
+      if (!blobsOnly || entry.isFile() && !entries.has(entry)) {
         event.emit("entry", entry);
-        entries.push(entry);
+        entries.add(entry);
       }
 
       if (entry.isTree()) {
@@ -151,7 +151,7 @@ Tree.prototype.walk = function(blobsOnly) {
     });
 
     if (total === 0) {
-      event.emit("end", entries);
+      event.emit("end", Array.from(entries));
     }
   }
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -127,6 +127,7 @@ Tree.prototype.walk = function(blobsOnly) {
   var event = new events.EventEmitter();
 
   var total = 1;
+  var entries = [];
 
   // This looks like a DFS, but it is a BFS because of implicit queueing in
   // the recursive call to `entry.getTree(bfs)`
@@ -136,8 +137,8 @@ Tree.prototype.walk = function(blobsOnly) {
     if (error) {
       return event.emit("error", error);
     }
-    var entries = tree.entries();
-    entries.forEach(function (entry, entryIndex) {
+
+    tree.entries().forEach(function (entry, entryIndex) {
       if (!blobsOnly || entry.isFile()) {
         event.emit("entry", entry);
         entries.push(entry);

--- a/test/tests/tree.js
+++ b/test/tests/tree.js
@@ -1,0 +1,77 @@
+var assert = require("assert");
+var path = require("path");
+var local = path.join.bind(path, __dirname);
+var promisify = require("promisify-node");
+var fse = promisify(require("fs-extra"));
+
+describe("Tree", function() {
+  var RepoUtils = require("../utils/repository_setup");
+
+  var repoPath = local("../repos/tree");
+
+  beforeEach(function() {
+    var test = this;
+    return RepoUtils.createRepository(repoPath)
+      .then(function(repo) {
+        test.repository = repo;
+      });
+  });
+
+  after(function() {
+    return fse.remove(repoPath);
+  });
+
+  it("walks its entries and returns the same entries on both progress and end",
+  function() {
+    var repo = this.repository;
+    var progressEntries = [];
+    var endEntries;
+
+    return RepoUtils.commitFileToRepo(repo, "test.txt", "")
+      .then(function(commit) {
+        return RepoUtils.commitFileToRepo(repo, "foo/bar.txt", "", commit);
+      })
+      .then(function(commit) {
+        return commit.getTree();
+      })
+      .then(function(tree) {
+        assert(tree);
+
+        return new Promise(function (resolve, reject) {
+          var walker = tree.walk();
+
+          walker.on("entry", function(entry) {
+            progressEntries.push(entry);
+          });
+          walker.on("end", function(entries) {
+            endEntries = entries;
+            resolve();
+          });
+          walker.on("error", reject);
+
+          walker.start();
+        });
+      })
+      .then(function() {
+        assert(progressEntries.length);
+        assert(endEntries && endEntries.length);
+
+        assert.equal(
+          progressEntries.length, endEntries.length,
+          "Different number of progress entries and end entries"
+        );
+
+        function getEntryPath(entry) {
+          return entry.path();
+        }
+
+        var progressFilePaths = progressEntries.map(getEntryPath).sort();
+        var endFilePaths = endEntries.map(getEntryPath);
+
+        assert.deepEqual(
+          progressFilePaths.sort(), endFilePaths.sort(),
+          "progress entries do not match end entries"
+        );
+      });
+  });
+});

--- a/test/tests/tree.js
+++ b/test/tests/tree.js
@@ -26,7 +26,8 @@ describe("Tree", function() {
     var repo = this.repository;
     var file1 = "test.txt";
     var file2 = "foo/bar.txt";
-    var expectedPaths = [file1, file2];
+    // index.addByPath doesn't like \s so normalize only for the expected paths
+    var expectedPaths = [file1, path.normalize(file2)];
     var progressEntries = [];
     var endEntries;
 

--- a/test/tests/tree.js
+++ b/test/tests/tree.js
@@ -24,12 +24,15 @@ describe("Tree", function() {
   it("walks its entries and returns the same entries on both progress and end",
   function() {
     var repo = this.repository;
+    var file1 = "test.txt";
+    var file2 = "foo/bar.txt";
+    var expectedPaths = [file1, file2];
     var progressEntries = [];
     var endEntries;
 
-    return RepoUtils.commitFileToRepo(repo, "test.txt", "")
+    return RepoUtils.commitFileToRepo(repo, file1, "")
       .then(function(commit) {
-        return RepoUtils.commitFileToRepo(repo, "foo/bar.txt", "", commit);
+        return RepoUtils.commitFileToRepo(repo, file2, "", commit);
       })
       .then(function(commit) {
         return commit.getTree();
@@ -56,21 +59,21 @@ describe("Tree", function() {
         assert(progressEntries.length);
         assert(endEntries && endEntries.length);
 
-        assert.equal(
-          progressEntries.length, endEntries.length,
-          "Different number of progress entries and end entries"
-        );
-
         function getEntryPath(entry) {
           return entry.path();
         }
 
-        var progressFilePaths = progressEntries.map(getEntryPath).sort();
+        var progressFilePaths = progressEntries.map(getEntryPath);
         var endFilePaths = endEntries.map(getEntryPath);
 
         assert.deepEqual(
-          progressFilePaths.sort(), endFilePaths.sort(),
-          "progress entries do not match end entries"
+          expectedPaths, progressFilePaths,
+          "progress entry paths do not match expected paths"
+        );
+
+        assert.deepEqual(
+          expectedPaths, endFilePaths,
+          "end entry paths do not match expected paths"
         );
       });
   });


### PR DESCRIPTION
Fix for https://github.com/nodegit/nodegit/issues/928

This is the non-api breaking change.
How does anyone feel about changing `walk` to return a promise (with a `progress` callback) instead of an event emitter? (ex: `tree.walk().then(entries => ...)`)