### PR TITLE
Docs: improved Merge.merge param docs

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -29,7 +29,7 @@ Merge.commits = function(repo, ourCommit, theirCommit, options) {
  * Merge a commit into HEAD and writes the results to the working directory.
  *
  * @param {Repository} repo Repository that contains the given commits
- * @param {Commit} theirHead The annotated to merge into HEAD
+ * @param {AnnotatedCommit} theirHead The annotated commit to merge into HEAD
  * @param {MergeOptions} [mergeOpts] The merge tree options (null for default)
  * @param {CheckoutOptions} [checkoutOpts] The checkout options
  *                                         (null for default)


### PR DESCRIPTION
Clarify that their commit should be an `AnnotatedCommit` not a `Commit`