### PR TITLE
Fix diffing blobs to buffers with unicode

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -68,7 +68,15 @@ Diff.blobToBuffer= function(
     binary_cb,
     hunk_cb,
     line_cb) {
-  var bufferLength = !buffer ? 0 : buffer.length;
+  var bufferText;
+  var bufferLength;
+  if (buffer instanceof Buffer) {
+    bufferText = buffer.toString("utf8");
+    bufferLength = buffer.length;
+  } else {
+    bufferText = buffer;
+    bufferLength = !buffer ? 0 : Buffer.byteLength(buffer, "utf8");
+  }
 
   opts = normalizeOptions(opts, NodeGit.DiffOptions);
 

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -8,6 +8,7 @@ describe("Diff", function() {
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Diff = NodeGit.Diff;
+  var Blob = NodeGit.Blob;
 
   var reposPath = local("../repos/workdir");
   var oid = "fce88902e66c72b5b93e75bdb5ae717038b221f6";
@@ -217,6 +218,33 @@ describe("Diff", function() {
             );
             done();
           });
+      });
+  });
+
+  it("can diff the contents of a file to a string with unicode characters",
+    function(done) {
+    var evilString = "Unicode’s fun!\nAnd it’s good for you!\n";
+    var buffer = new Buffer(evilString);
+    var oid = Blob.createFromBuffer(this.repository, buffer, buffer.length);
+    Blob.lookup(this.repository, oid)
+      .then(function(blob) {
+        blob.repo = this.repository;
+        return Diff.blobToBuffer(
+          blob,
+          null,
+          evilString,
+          null,
+          null,
+          null,
+          null,
+          function(delta, hunk, payload) {
+            assert.fail(
+              "There aren't any changes so this shouldn't be called.");
+            done();
+          });
+      })
+      .then(function() {
+        done();
       });
   });
 


### PR DESCRIPTION
libgit2 wants the string’s byte count, while `String.length`gives us the number of characters. These aren’t necessarily the same thing in unicode land.