### PR TITLE
Revert "Merge pull request #931 from nodegit/bump-http-parser"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   matrix:
     - export NODE_VERSION="0.12"
     - export NODE_VERSION="4.1"
-    - export NODE_VERSION="5.6"
+    - export NODE_VERSION="5.0"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ environment:
     - nodejs_version: "0.12"
     # Node.js
     - nodejs_version: "4.1"
-    - nodejs_version: "5.6"
+    - nodejs_version: "5.0"
 
 matrix:
   fast_finish: true

--- a/vendor/http_parser/.gitignore
+++ b/vendor/http_parser/.gitignore
@@ -12,8 +12,6 @@ parsertrace_g
 *.mk
 *.Makefile
 *.so.*
-*.exe.*
-*.exe
 *.a
 
 

--- a/vendor/http_parser/AUTHORS
+++ b/vendor/http_parser/AUTHORS
@@ -65,4 +65,3 @@ Romain Giraud <giraud.romain@gmail.com>
 Jay Satiro <raysatiro@yahoo.com>
 Arne Steen <Arne.Steen@gmx.de>
 Kjell Schubert <kjell.schubert@gmail.com>
-Olivier Mengué <dolmen@cpan.org>

--- a/vendor/http_parser/Makefile
+++ b/vendor/http_parser/Makefile
@@ -19,19 +19,7 @@
 # IN THE SOFTWARE.
 
 PLATFORM ?= $(shell sh -c 'uname -s | tr "[A-Z]" "[a-z]"')
-HELPER ?=
-BINEXT ?=
-ifeq (darwin,$(PLATFORM))
-SONAME ?= libhttp_parser.2.6.1.dylib
-SOEXT ?= dylib
-else ifeq (wine,$(PLATFORM))
-CC = winegcc
-BINEXT = .exe.so
-HELPER = wine
-else
-SONAME ?= libhttp_parser.so.2.6.1
-SOEXT ?= so
-endif
+SONAME ?= libhttp_parser.so.2.5.0
 
 CC?=gcc
 AR?=ar
@@ -65,8 +53,8 @@ LDFLAGS_LIB += -Wl,-soname=$(SONAME)
 endif
 
 test: test_g test_fast
-	$(HELPER) ./test_g$(BINEXT)
-	$(HELPER) ./test_fast$(BINEXT)
+	./test_g
+	./test_fast
 
 test_g: http_parser_g.o test_g.o
 	$(CC) $(CFLAGS_DEBUG) $(LDFLAGS) http_parser_g.o test_g.o -o $@
@@ -93,7 +81,7 @@ http_parser.o: http_parser.c http_parser.h Makefile
 	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) -c http_parser.c
 
 test-run-timed: test_fast
-	while(true) do time $(HELPER) ./test_fast$(BINEXT) > /dev/null; done
+	while(true) do time ./test_fast > /dev/null; done
 
 test-valgrind: test_g
 	valgrind ./test_g
@@ -114,10 +102,10 @@ url_parser_g: http_parser_g.o contrib/url_parser.c
 	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o $@
 
 parsertrace: http_parser.o contrib/parsertrace.c
-	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) $^ -o parsertrace$(BINEXT)
+	$(CC) $(CPPFLAGS_FAST) $(CFLAGS_FAST) $^ -o parsertrace
 
 parsertrace_g: http_parser_g.o contrib/parsertrace.c
-	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o parsertrace_g$(BINEXT)
+	$(CC) $(CPPFLAGS_DEBUG) $(CFLAGS_DEBUG) $^ -o parsertrace_g
 
 tags: http_parser.c http_parser.h test.c
 	ctags $^
@@ -125,12 +113,12 @@ tags: http_parser.c http_parser.h test.c
 install: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
 
 install-strip: library
 	$(INSTALL) -D  http_parser.h $(INCLUDEDIR)/http_parser.h
 	$(INSTALL) -D -s $(SONAME) $(LIBDIR)/$(SONAME)
-	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.$(SOEXT)
+	ln -s $(LIBDIR)/$(SONAME) $(LIBDIR)/libhttp_parser.so
 
 uninstall:
 	rm $(INCLUDEDIR)/http_parser.h
@@ -140,8 +128,7 @@ uninstall:
 clean:
 	rm -f *.o *.a tags test test_fast test_g \
 		http_parser.tar libhttp_parser.so.* \
-		url_parser url_parser_g parsertrace parsertrace_g \
-		*.exe *.exe.so
+		url_parser url_parser_g parsertrace parsertrace_g
 
 contrib/url_parser.c:	http_parser.h
 contrib/parsertrace.c:	http_parser.h

--- a/vendor/http_parser/README.md
+++ b/vendor/http_parser/README.md
@@ -1,7 +1,7 @@
 HTTP Parser
 ===========
 
-[![Build Status](https://api.travis-ci.org/nodejs/http-parser.svg?branch=master)](https://travis-ci.org/nodejs/http-parser)
+[![Build Status](https://travis-ci.org/joyent/http-parser.png?branch=master)](https://travis-ci.org/joyent/http-parser)
 
 This is a parser for HTTP messages written in C. It parses both requests and
 responses. The parser is designed to be used in performance HTTP
@@ -94,7 +94,7 @@ The Special Problem of Upgrade
 ------------------------------
 
 HTTP supports upgrading the connection to a different protocol. An
-increasingly common example of this is the WebSocket protocol which sends
+increasingly common example of this is the Web Socket protocol which sends
 a request like
 
         GET /demo HTTP/1.1
@@ -106,8 +106,8 @@ a request like
 
 followed by non-HTTP data.
 
-(See [RFC6455](https://tools.ietf.org/html/rfc6455) for more information the
-WebSocket protocol.)
+(See http://tools.ietf.org/html/draft-hixie-thewebsocketprotocol-75 for more
+information the Web Socket protocol.)
 
 To support this, the parser will treat this as a normal HTTP message without a
 body, issuing both on_headers_complete and on_message_complete callbacks. However
@@ -136,69 +136,6 @@ There are two types of callbacks:
 
 Callbacks must return 0 on success. Returning a non-zero value indicates
 error to the parser, making it exit immediately.
-
-For cases where it is necessary to pass local information to/from a callback,
-the `http_parser` object's `data` field can be used.
-An example of such a case is when using threads to handle a socket connection,
-parse a request, and then give a response over that socket. By instantiation
-of a thread-local struct containing relevant data (e.g. accepted socket,
-allocated memory for callbacks to write into, etc), a parser's callbacks are
-able to communicate data between the scope of the thread and the scope of the
-callback in a threadsafe manner. This allows http-parser to be used in
-multi-threaded contexts.
-
-Example:
-```
- typedef struct {
-  socket_t sock;
-  void* buffer;
-  int buf_len;
- } custom_data_t;
-
-
-int my_url_callback(http_parser* parser, const char *at, size_t length) {
-  /* access to thread local custom_data_t struct.
-  Use this access save parsed data for later use into thread local
-  buffer, or communicate over socket
-  */
-  parser->data;
-  ...
-  return 0;
-}
-
-...
-
-void http_parser_thread(socket_t sock) {
- int nparsed = 0;
- /* allocate memory for user data */
- custom_data_t *my_data = malloc(sizeof(custom_data_t));
-
- /* some information for use by callbacks.
- * achieves thread -> callback information flow */
- my_data->sock = sock;
-
- /* instantiate a thread-local parser */
- http_parser *parser = malloc(sizeof(http_parser));
- http_parser_init(parser, HTTP_REQUEST); /* initialise parser */
- /* this custom data reference is accessible through the reference to the
- parser supplied to callback functions */
- parser->data = my_data;
-
- http_parser_settings settings; / * set up callbacks */
- settings.on_url = my_url_callback;
-
- /* execute parser */
- nparsed = http_parser_execute(parser, &settings, buf, recved);
-
- ...
- /* parsed information copied from callback.
- can now perform action on data copied into thread-local memory from callbacks.
- achieves callback -> thread information flow */
- my_data->buffer;
- ...
-}
-
-```
 
 In case you parse HTTP message in chunks (i.e. `read()` request line
 from socket, parse, read half headers, parse, etc) your data callbacks

--- a/vendor/http_parser/contrib/url_parser.c
+++ b/vendor/http_parser/contrib/url_parser.c
@@ -35,7 +35,6 @@ int main(int argc, char ** argv) {
   connect = strcmp("connect", argv[1]) == 0 ? 1 : 0;
   printf("Parsing %s, connect %d\n", argv[2], connect);
 
-  http_parser_url_init(&u);
   result = http_parser_parse_url(argv[2], len, connect, &u);
   if (result != 0) {
     printf("Parse error : %d\n", result);

--- a/vendor/http_parser/http_parser.c
+++ b/vendor/http_parser/http_parser.c
@@ -400,8 +400,6 @@ enum http_host_state
   , s_http_host
   , s_http_host_v6
   , s_http_host_v6_end
-  , s_http_host_v6_zone_start
-  , s_http_host_v6_zone
   , s_http_host_port_start
   , s_http_host_port
 };
@@ -435,12 +433,6 @@ enum http_host_state
   (IS_ALPHANUM(c) || (c) == '.' || (c) == '-' || (c) == '_')
 #endif
 
-/**
- * Verify that a char is a valid visible (printable) US-ASCII
- * character or %x80-FF
- **/
-#define IS_HEADER_CHAR(ch)                                                     \
-  (ch == CR || ch == LF || ch == 9 || (ch > 31 && ch != 127))
 
 #define start_state (parser->type == HTTP_REQUEST ? s_start_req : s_start_res)
 
@@ -645,7 +637,6 @@ size_t http_parser_execute (http_parser *parser,
   const char *body_mark = 0;
   const char *status_mark = 0;
   enum state p_state = (enum state) parser->state;
-  const unsigned int lenient = parser->lenient_http_headers;
 
   /* We're in an error state. Don't bother doing anything. */
   if (HTTP_PARSER_ERRNO(parser) != HPE_OK) {
@@ -966,23 +957,21 @@ reexecute:
         parser->method = (enum http_method) 0;
         parser->index = 1;
         switch (ch) {
-          case 'A': parser->method = HTTP_ACL; break;
-          case 'B': parser->method = HTTP_BIND; break;
           case 'C': parser->method = HTTP_CONNECT; /* or COPY, CHECKOUT */ break;
           case 'D': parser->method = HTTP_DELETE; break;
           case 'G': parser->method = HTTP_GET; break;
           case 'H': parser->method = HTTP_HEAD; break;
-          case 'L': parser->method = HTTP_LOCK; /* or LINK */ break;
+          case 'L': parser->method = HTTP_LOCK; break;
           case 'M': parser->method = HTTP_MKCOL; /* or MOVE, MKACTIVITY, MERGE, M-SEARCH, MKCALENDAR */ break;
           case 'N': parser->method = HTTP_NOTIFY; break;
           case 'O': parser->method = HTTP_OPTIONS; break;
           case 'P': parser->method = HTTP_POST;
             /* or PROPFIND|PROPPATCH|PUT|PATCH|PURGE */
             break;
-          case 'R': parser->method = HTTP_REPORT; /* or REBIND */ break;
+          case 'R': parser->method = HTTP_REPORT; break;
           case 'S': parser->method = HTTP_SUBSCRIBE; /* or SEARCH */ break;
           case 'T': parser->method = HTTP_TRACE; break;
-          case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE, UNBIND, UNLINK */ break;
+          case 'U': parser->method = HTTP_UNLOCK; /* or UNSUBSCRIBE */ break;
           default:
             SET_ERRNO(HPE_INVALID_METHOD);
             goto error;
@@ -1007,40 +996,69 @@ reexecute:
           UPDATE_STATE(s_req_spaces_before_url);
         } else if (ch == matcher[parser->index]) {
           ; /* nada */
-        } else if (IS_ALPHA(ch)) {
-
-          switch (parser->method << 16 | parser->index << 8 | ch) {
-#define XX(meth, pos, ch, new_meth) \
-            case (HTTP_##meth << 16 | pos << 8 | ch): \
-              parser->method = HTTP_##new_meth; break;
-
-            XX(POST,      1, 'U', PUT)
-            XX(POST,      1, 'A', PATCH)
-            XX(CONNECT,   1, 'H', CHECKOUT)
-            XX(CONNECT,   2, 'P', COPY)
-            XX(MKCOL,     1, 'O', MOVE)
-            XX(MKCOL,     1, 'E', MERGE)
-            XX(MKCOL,     2, 'A', MKACTIVITY)
-            XX(MKCOL,     3, 'A', MKCALENDAR)
-            XX(SUBSCRIBE, 1, 'E', SEARCH)
-            XX(REPORT,    2, 'B', REBIND)
-            XX(POST,      1, 'R', PROPFIND)
-            XX(PROPFIND,  4, 'P', PROPPATCH)
-            XX(PUT,       2, 'R', PURGE)
-            XX(LOCK,      1, 'I', LINK)
-            XX(UNLOCK,    2, 'S', UNSUBSCRIBE)
-            XX(UNLOCK,    2, 'B', UNBIND)
-            XX(UNLOCK,    3, 'I', UNLINK)
-#undef XX
-
-            default:
+        } else if (parser->method == HTTP_CONNECT) {
+          if (parser->index == 1 && ch == 'H') {
+            parser->method = HTTP_CHECKOUT;
+          } else if (parser->index == 2  && ch == 'P') {
+            parser->method = HTTP_COPY;
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+          }
+        } else if (parser->method == HTTP_MKCOL) {
+          if (parser->index == 1 && ch == 'O') {
+            parser->method = HTTP_MOVE;
+          } else if (parser->index == 1 && ch == 'E') {
+            parser->method = HTTP_MERGE;
+          } else if (parser->index == 1 && ch == '-') {
+            parser->method = HTTP_MSEARCH;
+          } else if (parser->index == 2 && ch == 'A') {
+            parser->method = HTTP_MKACTIVITY;
+          } else if (parser->index == 3 && ch == 'A') {
+            parser->method = HTTP_MKCALENDAR;
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+          }
+        } else if (parser->method == HTTP_SUBSCRIBE) {
+          if (parser->index == 1 && ch == 'E') {
+            parser->method = HTTP_SEARCH;
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+          }
+        } else if (parser->index == 1 && parser->method == HTTP_POST) {
+          if (ch == 'R') {
+            parser->method = HTTP_PROPFIND; /* or HTTP_PROPPATCH */
+          } else if (ch == 'U') {
+            parser->method = HTTP_PUT; /* or HTTP_PURGE */
+          } else if (ch == 'A') {
+            parser->method = HTTP_PATCH;
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
+          }
+        } else if (parser->index == 2) {
+          if (parser->method == HTTP_PUT) {
+            if (ch == 'R') {
+              parser->method = HTTP_PURGE;
+            } else {
               SET_ERRNO(HPE_INVALID_METHOD);
               goto error;
+            }
+          } else if (parser->method == HTTP_UNLOCK) {
+            if (ch == 'S') {
+              parser->method = HTTP_UNSUBSCRIBE;
+            } else {
+              SET_ERRNO(HPE_INVALID_METHOD);
+              goto error;
+            }
+          } else {
+            SET_ERRNO(HPE_INVALID_METHOD);
+            goto error;
           }
-        } else if (ch == '-' &&
-                   parser->index == 1 &&
-                   parser->method == HTTP_MKCOL) {
-          parser->method = HTTP_MSEARCH;
+        } else if (parser->index == 4 && parser->method == HTTP_PROPFIND && ch == 'P') {
+          parser->method = HTTP_PROPPATCH;
         } else {
           SET_ERRNO(HPE_INVALID_METHOD);
           goto error;
@@ -1366,12 +1384,7 @@ reexecute:
                   || c != CONTENT_LENGTH[parser->index]) {
                 parser->header_state = h_general;
               } else if (parser->index == sizeof(CONTENT_LENGTH)-2) {
-                if (parser->flags & F_CONTENTLENGTH) {
-                  SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
-                  goto error;
-                }
                 parser->header_state = h_content_length;
-                parser->flags |= F_CONTENTLENGTH;
               }
               break;
 
@@ -1521,11 +1534,6 @@ reexecute:
             parser->header_state = h_state;
             CALLBACK_DATA_NOADVANCE(header_value);
             REEXECUTE();
-          }
-
-          if (!lenient && !IS_HEADER_CHAR(ch)) {
-            SET_ERRNO(HPE_INVALID_HEADER_TOKEN);
-            goto error;
           }
 
           c = LOWER(ch);
@@ -1695,10 +1703,7 @@ reexecute:
 
       case s_header_almost_done:
       {
-        if (UNLIKELY(ch != LF)) {
-          SET_ERRNO(HPE_LF_EXPECTED);
-          goto error;
-        }
+        STRICT_CHECK(ch != LF);
 
         UPDATE_STATE(s_header_value_lws);
         break;
@@ -1782,14 +1787,6 @@ reexecute:
           REEXECUTE();
         }
 
-        /* Cannot use chunked encoding and a content-length header together
-           per the HTTP specification. */
-        if ((parser->flags & F_CHUNKED) &&
-            (parser->flags & F_CONTENTLENGTH)) {
-          SET_ERRNO(HPE_UNEXPECTED_CONTENT_LENGTH);
-          goto error;
-        }
-
         UPDATE_STATE(s_headers_done);
 
         /* Set this here so that on_headers_complete() callbacks can see it */
@@ -1831,12 +1828,11 @@ reexecute:
 
       case s_headers_done:
       {
-        int hasBody;
         STRICT_CHECK(ch != LF);
 
         parser->nread = 0;
 
-        hasBody = parser->flags & F_CHUNKED ||
+        int hasBody = parser->flags & F_CHUNKED ||
           (parser->content_length > 0 && parser->content_length != ULLONG_MAX);
         if (parser->upgrade && (parser->method == HTTP_CONNECT ||
                                 (parser->flags & F_SKIPBODY) || !hasBody)) {
@@ -1861,7 +1857,8 @@ reexecute:
             /* Content-Length header given and non-zero */
             UPDATE_STATE(s_body_identity);
           } else {
-            if (!http_message_needs_eof(parser)) {
+            if (parser->type == HTTP_REQUEST ||
+                !http_message_needs_eof(parser)) {
               /* Assume content-length 0 - read the next */
               UPDATE_STATE(NEW_MESSAGE());
               CALLBACK_NOTIFY(message_complete);
@@ -2156,13 +2153,15 @@ http_parser_settings_init(http_parser_settings *settings)
 
 const char *
 http_errno_name(enum http_errno err) {
-  assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+  assert(((size_t) err) <
+      (sizeof(http_strerror_tab) / sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].name;
 }
 
 const char *
 http_errno_description(enum http_errno err) {
-  assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+  assert(((size_t) err) <
+      (sizeof(http_strerror_tab) / sizeof(http_strerror_tab[0])));
   return http_strerror_tab[err].description;
 }
 
@@ -2215,23 +2214,6 @@ http_parse_host_char(enum http_host_state s, const char ch) {
         return s_http_host_v6;
       }
 
-      if (s == s_http_host_v6 && ch == '%') {
-        return s_http_host_v6_zone_start;
-      }
-      break;
-
-    case s_http_host_v6_zone:
-      if (ch == ']') {
-        return s_http_host_v6_end;
-      }
-
-    /* FALLTHROUGH */
-    case s_http_host_v6_zone_start:
-      /* RFC 6874 Zone ID consists of 1*( unreserved / pct-encoded) */
-      if (IS_ALPHANUM(ch) || ch == '%' || ch == '.' || ch == '-' || ch == '_' ||
-          ch == '~') {
-        return s_http_host_v6_zone;
-      }
       break;
 
     case s_http_host_port:
@@ -2250,7 +2232,6 @@ http_parse_host_char(enum http_host_state s, const char ch) {
 
 static int
 http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
-  assert(u->field_set & (1 << UF_HOST));
   enum http_host_state s;
 
   const char *p;
@@ -2279,11 +2260,6 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
         if (s != s_http_host_v6) {
           u->field_data[UF_HOST].off = p - buf;
         }
-        u->field_data[UF_HOST].len++;
-        break;
-
-      case s_http_host_v6_zone_start:
-      case s_http_host_v6_zone:
         u->field_data[UF_HOST].len++;
         break;
 
@@ -2316,8 +2292,6 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
     case s_http_host_start:
     case s_http_host_v6_start:
     case s_http_host_v6:
-    case s_http_host_v6_zone_start:
-    case s_http_host_v6_zone:
     case s_http_host_port_start:
     case s_http_userinfo:
     case s_http_userinfo_start:
@@ -2327,11 +2301,6 @@ http_parse_host(const char * buf, struct http_parser_url *u, int found_at) {
   }
 
   return 0;
-}
-
-void
-http_parser_url_init(struct http_parser_url *u) {
-  memset(u, 0, sizeof(*u));
 }
 
 int
@@ -2407,12 +2376,7 @@ http_parser_parse_url(const char *buf, size_t buflen, int is_connect,
 
   /* host must be present if there is a schema */
   /* parsing http:///toto will fail */
-  if ((u->field_set & (1 << UF_SCHEMA)) &&
-      (u->field_set & (1 << UF_HOST)) == 0) {
-    return 1;
-  }
-
-  if (u->field_set & (1 << UF_HOST)) {
+  if ((u->field_set & ((1 << UF_SCHEMA) | (1 << UF_HOST))) != 0) {
     if (http_parse_host(buf, u, found_at) != 0) {
       return 1;
     }

--- a/vendor/http_parser/http_parser.h
+++ b/vendor/http_parser/http_parser.h
@@ -26,12 +26,11 @@ extern "C" {
 
 /* Also update SONAME in the Makefile whenever you change these. */
 #define HTTP_PARSER_VERSION_MAJOR 2
-#define HTTP_PARSER_VERSION_MINOR 6
-#define HTTP_PARSER_VERSION_PATCH 1
+#define HTTP_PARSER_VERSION_MINOR 5
+#define HTTP_PARSER_VERSION_PATCH 0
 
 #include <sys/types.h>
-#if defined(_WIN32) && !defined(__MINGW32__) && \
-  (!defined(_MSC_VER) || _MSC_VER<1600) && !defined(__WINE__)
+#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
 #include <BaseTsd.h>
 #include <stddef.h>
 typedef __int8 int8_t;
@@ -96,7 +95,7 @@ typedef int (*http_cb) (http_parser*);
   XX(5,  CONNECT,     CONNECT)      \
   XX(6,  OPTIONS,     OPTIONS)      \
   XX(7,  TRACE,       TRACE)        \
-  /* WebDAV */                      \
+  /* webdav */                      \
   XX(8,  COPY,        COPY)         \
   XX(9,  LOCK,        LOCK)         \
   XX(10, MKCOL,       MKCOL)        \
@@ -105,28 +104,21 @@ typedef int (*http_cb) (http_parser*);
   XX(13, PROPPATCH,   PROPPATCH)    \
   XX(14, SEARCH,      SEARCH)       \
   XX(15, UNLOCK,      UNLOCK)       \
-  XX(16, BIND,        BIND)         \
-  XX(17, REBIND,      REBIND)       \
-  XX(18, UNBIND,      UNBIND)       \
-  XX(19, ACL,         ACL)          \
   /* subversion */                  \
-  XX(20, REPORT,      REPORT)       \
-  XX(21, MKACTIVITY,  MKACTIVITY)   \
-  XX(22, CHECKOUT,    CHECKOUT)     \
-  XX(23, MERGE,       MERGE)        \
+  XX(16, REPORT,      REPORT)       \
+  XX(17, MKACTIVITY,  MKACTIVITY)   \
+  XX(18, CHECKOUT,    CHECKOUT)     \
+  XX(19, MERGE,       MERGE)        \
   /* upnp */                        \
-  XX(24, MSEARCH,     M-SEARCH)     \
-  XX(25, NOTIFY,      NOTIFY)       \
-  XX(26, SUBSCRIBE,   SUBSCRIBE)    \
-  XX(27, UNSUBSCRIBE, UNSUBSCRIBE)  \
+  XX(20, MSEARCH,     M-SEARCH)     \
+  XX(21, NOTIFY,      NOTIFY)       \
+  XX(22, SUBSCRIBE,   SUBSCRIBE)    \
+  XX(23, UNSUBSCRIBE, UNSUBSCRIBE)  \
   /* RFC-5789 */                    \
-  XX(28, PATCH,       PATCH)        \
-  XX(29, PURGE,       PURGE)        \
+  XX(24, PATCH,       PATCH)        \
+  XX(25, PURGE,       PURGE)        \
   /* CalDAV */                      \
-  XX(30, MKCALENDAR,  MKCALENDAR)   \
-  /* RFC-2068, section 19.6.1.2 */  \
-  XX(31, LINK,        LINK)         \
-  XX(32, UNLINK,      UNLINK)       \
+  XX(26, MKCALENDAR,  MKCALENDAR)   \
 
 enum http_method
   {
@@ -148,12 +140,11 @@ enum flags
   , F_TRAILING              = 1 << 4
   , F_UPGRADE               = 1 << 5
   , F_SKIPBODY              = 1 << 6
-  , F_CONTENTLENGTH         = 1 << 7
   };
 
 
 /* Map for errno-related constants
- *
+ * 
  * The provided argument should be a macro that takes 2 arguments.
  */
 #define HTTP_ERRNO_MAP(XX)                                           \
@@ -191,8 +182,6 @@ enum flags
   XX(INVALID_HEADER_TOKEN, "invalid character in header")            \
   XX(INVALID_CONTENT_LENGTH,                                         \
      "invalid character in content-length header")                   \
-  XX(UNEXPECTED_CONTENT_LENGTH,                                      \
-     "unexpected content-length header")                             \
   XX(INVALID_CHUNK_SIZE,                                             \
      "invalid character in chunk size header")                       \
   XX(INVALID_CONSTANT, "invalid constant string")                    \
@@ -217,11 +206,10 @@ enum http_errno {
 struct http_parser {
   /** PRIVATE **/
   unsigned int type : 2;         /* enum http_parser_type */
-  unsigned int flags : 8;        /* F_* values from 'flags' enum; semi-public */
+  unsigned int flags : 7;        /* F_* values from 'flags' enum; semi-public */
   unsigned int state : 7;        /* enum state from http_parser.c */
-  unsigned int header_state : 7; /* enum header_state from http_parser.c */
-  unsigned int index : 7;        /* index into current matcher */
-  unsigned int lenient_http_headers : 1;
+  unsigned int header_state : 8; /* enum header_state from http_parser.c */
+  unsigned int index : 8;        /* index into current matcher */
 
   uint32_t nread;          /* # bytes read in various scenarios */
   uint64_t content_length; /* # bytes in body (0 if no Content-Length header) */
@@ -336,9 +324,6 @@ const char *http_errno_name(enum http_errno err);
 
 /* Return a string description of the given error */
 const char *http_errno_description(enum http_errno err);
-
-/* Initialize all http_parser_url members to 0 */
-void http_parser_url_init(struct http_parser_url *u);
 
 /* Parse a URL; return nonzero on failure */
 int http_parser_parse_url(const char *buf, size_t buflen,

--- a/vendor/http_parser/test.c
+++ b/vendor/http_parser/test.c
@@ -1101,58 +1101,6 @@ const struct message requests[] =
   ,.body= ""
   }
 
-/* Examples from the Internet draft for LINK/UNLINK methods:
- * https://tools.ietf.org/id/draft-snell-link-method-01.html#rfc.section.5
- */
-
-#define LINK_REQUEST 40
-, {.name = "link request"
-  ,.type= HTTP_REQUEST
-  ,.raw= "LINK /images/my_dog.jpg HTTP/1.1\r\n"
-         "Host: example.com\r\n"
-         "Link: <http://example.com/profiles/joe>; rel=\"tag\"\r\n"
-         "Link: <http://example.com/profiles/sally>; rel=\"tag\"\r\n"
-         "\r\n"
-  ,.should_keep_alive= TRUE
-  ,.message_complete_on_eof= FALSE
-  ,.http_major= 1
-  ,.http_minor= 1
-  ,.method= HTTP_LINK
-  ,.request_path= "/images/my_dog.jpg"
-  ,.request_url= "/images/my_dog.jpg"
-  ,.query_string= ""
-  ,.fragment= ""
-  ,.num_headers= 3
-  ,.headers= { { "Host", "example.com" }
-             , { "Link", "<http://example.com/profiles/joe>; rel=\"tag\"" }
-	     , { "Link", "<http://example.com/profiles/sally>; rel=\"tag\"" }
-             }
-  ,.body= ""
-  }
-
-#define UNLINK_REQUEST 41
-, {.name = "link request"
-  ,.type= HTTP_REQUEST
-  ,.raw= "UNLINK /images/my_dog.jpg HTTP/1.1\r\n"
-         "Host: example.com\r\n"
-         "Link: <http://example.com/profiles/sally>; rel=\"tag\"\r\n"
-         "\r\n"
-  ,.should_keep_alive= TRUE
-  ,.message_complete_on_eof= FALSE
-  ,.http_major= 1
-  ,.http_minor= 1
-  ,.method= HTTP_UNLINK
-  ,.request_path= "/images/my_dog.jpg"
-  ,.request_url= "/images/my_dog.jpg"
-  ,.query_string= ""
-  ,.fragment= ""
-  ,.num_headers= 2
-  ,.headers= { { "Host", "example.com" }
-	     , { "Link", "<http://example.com/profiles/sally>; rel=\"tag\"" }
-             }
-  ,.body= ""
-  }
-
 , {.name= NULL } /* sentinel */
 };
 
@@ -2444,7 +2392,7 @@ upgrade_message_fix(char *body, const size_t nread, const size_t nmsgs, ...) {
   va_list ap;
   size_t i;
   size_t off = 0;
-
+ 
   va_start(ap, nmsgs);
 
   for (i = 0; i < nmsgs; i++) {
@@ -2970,59 +2918,6 @@ const struct url_test url_tests[] =
   ,.rv=1 /* s_dead */
   }
 
-, {.name="ipv6 address with Zone ID"
-  ,.url="http://[fe80::a%25eth0]/"
-  ,.is_connect=0
-  ,.u=
-    {.field_set= (1<<UF_SCHEMA) | (1<<UF_HOST) | (1<<UF_PATH)
-    ,.port=0
-    ,.field_data=
-      {{  0,  4 } /* UF_SCHEMA */
-      ,{  8, 14 } /* UF_HOST */
-      ,{  0,  0 } /* UF_PORT */
-      ,{ 23,  1 } /* UF_PATH */
-      ,{  0,  0 } /* UF_QUERY */
-      ,{  0,  0 } /* UF_FRAGMENT */
-      ,{  0,  0 } /* UF_USERINFO */
-      }
-    }
-  ,.rv=0
-  }
-
-, {.name="ipv6 address with Zone ID, but '%' is not percent-encoded"
-  ,.url="http://[fe80::a%eth0]/"
-  ,.is_connect=0
-  ,.u=
-    {.field_set= (1<<UF_SCHEMA) | (1<<UF_HOST) | (1<<UF_PATH)
-    ,.port=0
-    ,.field_data=
-      {{  0,  4 } /* UF_SCHEMA */
-      ,{  8, 12 } /* UF_HOST */
-      ,{  0,  0 } /* UF_PORT */
-      ,{ 21,  1 } /* UF_PATH */
-      ,{  0,  0 } /* UF_QUERY */
-      ,{  0,  0 } /* UF_FRAGMENT */
-      ,{  0,  0 } /* UF_USERINFO */
-      }
-    }
-  ,.rv=0
-  }
-
-, {.name="ipv6 address ending with '%'"
-  ,.url="http://[fe80::a%]/"
-  ,.rv=1 /* s_dead */
-  }
-
-, {.name="ipv6 address with Zone ID including bad character"
-  ,.url="http://[fe80::a%$HOME]/"
-  ,.rv=1 /* s_dead */
-  }
-
-, {.name="just ipv6 Zone ID"
-  ,.url="http://[%eth0]/"
-  ,.rv=1 /* s_dead */
-  }
-
 #if HTTP_PARSER_STRICT
 
 , {.name="tab in URL"
@@ -3268,155 +3163,6 @@ test_simple (const char *buf, enum http_errno err_expected)
         http_errno_name(err_expected), http_errno_name(err), buf);
     abort();
   }
-}
-
-void
-test_invalid_header_content (int req, const char* str)
-{
-  http_parser parser;
-  http_parser_init(&parser, req ? HTTP_REQUEST : HTTP_RESPONSE);
-  size_t parsed;
-  const char *buf;
-  buf = req ?
-    "GET / HTTP/1.1\r\n" :
-    "HTTP/1.1 200 OK\r\n";
-  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
-  assert(parsed == strlen(buf));
-
-  buf = str;
-  size_t buflen = strlen(buf);
-
-  parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
-  if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_INVALID_HEADER_TOKEN);
-    return;
-  }
-
-  fprintf(stderr,
-          "\n*** Error expected but none in invalid header content test ***\n");
-  abort();
-}
-
-void
-test_invalid_header_field_content_error (int req)
-{
-  test_invalid_header_content(req, "Foo: F\01ailure");
-  test_invalid_header_content(req, "Foo: B\02ar");
-}
-
-void
-test_invalid_header_field (int req, const char* str)
-{
-  http_parser parser;
-  http_parser_init(&parser, req ? HTTP_REQUEST : HTTP_RESPONSE);
-  size_t parsed;
-  const char *buf;
-  buf = req ?
-    "GET / HTTP/1.1\r\n" :
-    "HTTP/1.1 200 OK\r\n";
-  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
-  assert(parsed == strlen(buf));
-
-  buf = str;
-  size_t buflen = strlen(buf);
-
-  parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
-  if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_INVALID_HEADER_TOKEN);
-    return;
-  }
-
-  fprintf(stderr,
-          "\n*** Error expected but none in invalid header token test ***\n");
-  abort();
-}
-
-void
-test_invalid_header_field_token_error (int req)
-{
-  test_invalid_header_field(req, "Fo@: Failure");
-  test_invalid_header_field(req, "Foo\01\test: Bar");
-}
-
-void
-test_double_content_length_error (int req)
-{
-  http_parser parser;
-  http_parser_init(&parser, req ? HTTP_REQUEST : HTTP_RESPONSE);
-  size_t parsed;
-  const char *buf;
-  buf = req ?
-    "GET / HTTP/1.1\r\n" :
-    "HTTP/1.1 200 OK\r\n";
-  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
-  assert(parsed == strlen(buf));
-
-  buf = "Content-Length: 0\r\nContent-Length: 1\r\n\r\n";
-  size_t buflen = strlen(buf);
-
-  parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
-  if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_UNEXPECTED_CONTENT_LENGTH);
-    return;
-  }
-
-  fprintf(stderr,
-          "\n*** Error expected but none in double content-length test ***\n");
-  abort();
-}
-
-void
-test_chunked_content_length_error (int req)
-{
-  http_parser parser;
-  http_parser_init(&parser, req ? HTTP_REQUEST : HTTP_RESPONSE);
-  size_t parsed;
-  const char *buf;
-  buf = req ?
-    "GET / HTTP/1.1\r\n" :
-    "HTTP/1.1 200 OK\r\n";
-  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
-  assert(parsed == strlen(buf));
-
-  buf = "Transfer-Encoding: chunked\r\nContent-Length: 1\r\n\r\n";
-  size_t buflen = strlen(buf);
-
-  parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
-  if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_UNEXPECTED_CONTENT_LENGTH);
-    return;
-  }
-
-  fprintf(stderr,
-          "\n*** Error expected but none in chunked content-length test ***\n");
-  abort();
-}
-
-void
-test_header_cr_no_lf_error (int req)
-{
-  http_parser parser;
-  http_parser_init(&parser, req ? HTTP_REQUEST : HTTP_RESPONSE);
-  size_t parsed;
-  const char *buf;
-  buf = req ?
-    "GET / HTTP/1.1\r\n" :
-    "HTTP/1.1 200 OK\r\n";
-  parsed = http_parser_execute(&parser, &settings_null, buf, strlen(buf));
-  assert(parsed == strlen(buf));
-
-  buf = "Foo: 1\rBar: 1\r\n\r\n";
-  size_t buflen = strlen(buf);
-
-  parsed = http_parser_execute(&parser, &settings_null, buf, buflen);
-  if (parsed != buflen) {
-    assert(HTTP_PARSER_ERRNO(&parser) == HPE_LF_EXPECTED);
-    return;
-  }
-
-  fprintf(stderr,
-          "\n*** Error expected but none in header whitespace test ***\n");
-  abort();
 }
 
 void
@@ -3845,18 +3591,6 @@ main (void)
   test_header_content_length_overflow_error();
   test_chunk_content_length_overflow_error();
 
-  //// HEADER FIELD CONDITIONS
-  test_double_content_length_error(HTTP_REQUEST);
-  test_chunked_content_length_error(HTTP_REQUEST);
-  test_header_cr_no_lf_error(HTTP_REQUEST);
-  test_invalid_header_field_token_error(HTTP_REQUEST);
-  test_invalid_header_field_content_error(HTTP_REQUEST);
-  test_double_content_length_error(HTTP_RESPONSE);
-  test_chunked_content_length_error(HTTP_RESPONSE);
-  test_header_cr_no_lf_error(HTTP_RESPONSE);
-  test_invalid_header_field_token_error(HTTP_RESPONSE);
-  test_invalid_header_field_content_error(HTTP_RESPONSE);
-
   //// RESPONSES
 
   for (i = 0; i < response_count; i++) {
@@ -3956,12 +3690,7 @@ main (void)
     "MOVE",
     "PROPFIND",
     "PROPPATCH",
-    "SEARCH",
     "UNLOCK",
-    "BIND",
-    "REBIND",
-    "UNBIND",
-    "ACL",
     "REPORT",
     "MKACTIVITY",
     "CHECKOUT",
@@ -3971,10 +3700,6 @@ main (void)
     "SUBSCRIBE",
     "UNSUBSCRIBE",
     "PATCH",
-    "PURGE",
-    "MKCALENDAR",
-    "LINK",
-    "UNLINK",
     0 };
   const char **this_method;
   for (this_method = all_methods; *this_method; this_method++) {


### PR DESCRIPTION
Bumping `http-parser` to 2.6.1 broke fetching/pulling from bitbucket in earlier versions of node somehow. This undoes that change and we'll have to look into fixing node v5.6.x later.