### PR TITLE
Fix patch crash

### DIFF
--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -88,7 +88,7 @@ PatchData *createFromRaw(git_patch *raw) {
           calculatedContentLength > noNewlineStringLength &&
           !strncmp(
               &line->content[calculatedContentLength - noNewlineStringLength],
-              "\n\\ No newline at end of file\n", std::min(calculatedContentLength, noNewlineStringLength)
+              "\n\\ No newline at end of file\n", (std::min)(calculatedContentLength, noNewlineStringLength)
         )) {
           EOFFlag = true;
         }

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -83,13 +83,12 @@ PatchData *createFromRaw(git_patch *raw) {
       }
 
       if (j == 0) {
-        // calculate strlen only once for the first line of the first hunk.
-        int calculatedContentLength = strlen(line->content);
+        int calculatedContentLength = line->content_len;
         if (
           calculatedContentLength > noNewlineStringLength &&
-          !strcmp(
+          !strncmp(
               &line->content[calculatedContentLength - noNewlineStringLength],
-              "\n\\ No newline at end of file\n"
+              "\n\\ No newline at end of file\n", std::min(calculatedContentLength, noNewlineStringLength)
         )) {
           EOFFlag = true;
         }

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -56,8 +56,12 @@ PatchData *createFromRaw(git_patch *raw) {
 
   for (unsigned int i = 0; i < patch->numHunks; ++i) {
     HunkData *hunkData = new HunkData;
-    const git_diff_hunk *hunk;
-    git_patch_get_hunk(&hunk, &hunkData->numLines, raw, i);
+    const git_diff_hunk *hunk = NULL;
+    int result = git_patch_get_hunk(&hunk, &hunkData->numLines, raw, i);
+    if (result != 0) {
+      continue;
+    }
+
     hunkData->hunk.old_start = hunk->old_start;
     hunkData->hunk.old_lines = hunk->old_lines;
     hunkData->hunk.new_start = hunk->new_start;
@@ -72,8 +76,11 @@ PatchData *createFromRaw(git_patch *raw) {
     bool EOFFlag = false;
     for (unsigned int j = 0; j < hunkData->numLines; ++j) {
       git_diff_line *storeLine = (git_diff_line *)malloc(sizeof(git_diff_line));
-      const git_diff_line *line;
-      git_patch_get_line_in_hunk(&line, raw, i, j);
+      const git_diff_line *line = NULL;
+      int result = git_patch_get_line_in_hunk(&line, raw, i, j);
+      if (result != 0) {
+        continue;
+      }
 
       if (j == 0) {
         // calculate strlen only once for the first line of the first hunk.


### PR DESCRIPTION
[Libgit2 documents](https://github.com/libgit2/libgit2/blob/d8f721592817cb300339c827579bc545844b276f/include/git2/diff.h#L555) that `content` isn’t NUL-terminated, so we can’t
call `strlen` on it. If we do, we’ll probably crash.