### PR TITLE
Stash.apply: Fix a typo in arguments to normalizeOptions

### DIFF
--- a/lib/stash.js
+++ b/lib/stash.js
@@ -32,7 +32,7 @@ Stash.apply = function(repo, index, options) {
 
   if (checkoutOptions) {
     options.checkoutOptions =
-      normalizeOptions(checkoutOptions, NodeGit.checkoutOptions);
+      normalizeOptions(checkoutOptions, NodeGit.CheckoutOptions);
   }
 
   return sApply(repo, index, options);


### PR DESCRIPTION
I tried to use `nodegit.Stash.apply` and it crashed... Looks like `NodeGit.CheckoutOptions` wasn't capitalized like it should've been.