### PR TITLE
Use type safe pointer instead of void * for New

### DIFF
--- a/generate/templates/manual/include/wrapper.h
+++ b/generate/templates/manual/include/wrapper.h
@@ -20,7 +20,7 @@ class Wrapper : public Nan::ObjectWrap {
     static void InitializeComponent (Local<v8::Object> target);
 
     void *GetValue();
-    static Local<v8::Value> New(void *raw);
+    static Local<v8::Value> New(const void *raw);
 
   private:
     Wrapper(void *raw);

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -303,7 +303,7 @@ NAN_METHOD(ConvenientPatch::OldFile) {
   git_diff_file *old_file = (git_diff_file *)malloc(sizeof(git_diff_file));
   *old_file = Nan::ObjectWrap::Unwrap<ConvenientPatch>(info.This())->GetOldFile();
 
-  to = GitDiffFile::New((void *)old_file, true);
+  to = GitDiffFile::New(old_file, true);
 
   return info.GetReturnValue().Set(to);
 }
@@ -315,7 +315,7 @@ NAN_METHOD(ConvenientPatch::NewFile) {
   git_diff_file *new_file = (git_diff_file *)malloc(sizeof(git_diff_file));
   *new_file = Nan::ObjectWrap::Unwrap<ConvenientPatch>(info.This())->GetNewFile();
   if (new_file != NULL) {
-    to = GitDiffFile::New((void *)new_file, true);
+    to = GitDiffFile::New(new_file, true);
   } else {
     to = Nan::Null();
   }

--- a/generate/templates/manual/src/wrapper.cc
+++ b/generate/templates/manual/src/wrapper.cc
@@ -42,7 +42,7 @@ NAN_METHOD(Wrapper::JSNewFunction) {
   info.GetReturnValue().Set(info.This());
 }
 
-Local<v8::Value> Wrapper::New(void *raw) {
+Local<v8::Value> Wrapper::New(const void *raw) {
   Nan::EscapableHandleScope scope;
 
   Local<v8::Value> argv[1] = { Nan::New<External>((void *)raw) };

--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -55,7 +55,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_async(uv_as
         {% if arg.isEnum %}
           Nan::New((int)baton->{{ arg.name }}),
         {% elsif arg.isLibgitType %}
-          {{ arg.cppClassName }}::New((void *)baton->{{ arg.name }}, false),
+          {{ arg.cppClassName }}::New(baton->{{ arg.name }}, false),
         {% elsif arg.cType == "size_t" %}
           // HACK: NAN should really have an overload for Nan::New to support size_t
           Nan::New((unsigned int)baton->{{ arg.name }}),

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -59,9 +59,9 @@
   if ({{= parsedName =}} != NULL) {
     // {{= cppClassName }} {{= parsedName }}
     {% if cppClassName == 'Wrapper' %}
-      to = {{ cppClassName }}::New((void *){{= parsedName =}});
+      to = {{ cppClassName }}::New({{= parsedName =}});
     {% else %}
-      to = {{ cppClassName }}::New((void *){{= parsedName =}}, false);
+      to = {{ cppClassName }}::New({{= parsedName =}}, false);
     {% endif %}
   }
   else {

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -149,7 +149,7 @@
               {% if arg.isEnum %}
                 Nan::New((int)baton->{{ arg.name }}),
               {% elsif arg.isLibgitType %}
-                {{ arg.cppClassName }}::New((void *)baton->{{ arg.name }}, false),
+                {{ arg.cppClassName }}::New(baton->{{ arg.name }}, false),
               {% elsif arg.cType == "size_t" %}
                 // HACK: NAN should really have an overload for Nan::New to support size_t
                 Nan::New((unsigned int)baton->{{ arg.name }}),

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -98,7 +98,7 @@ using namespace node;
     info.GetReturnValue().Set(info.This());
   }
 
-  Local<v8::Value> {{ cppClassName }}::New(void *raw, bool selfFreeing) {
+  Local<v8::Value> {{ cppClassName }}::New(const {{ cType }} *raw, bool selfFreeing) {
     Nan::EscapableHandleScope scope;
     Local<v8::Value> argv[2] = { Nan::New<External>((void *)raw), Nan::New(selfFreeing) };
     return scope.Escape(Nan::NewInstance(Nan::New({{ cppClassName }}::constructor_template), 2, argv).ToLocalChecked());

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -45,7 +45,7 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     {{ cType }} *GetValue();
     void ClearValue();
 
-    static Local<v8::Value> New(void *raw, bool selfFreeing);
+    static Local<v8::Value> New(const {{ cType }} *raw, bool selfFreeing);
     {%endif%}
     bool selfFreeing;
 

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -73,7 +73,7 @@ void {{ cppClassName }}::ConstructFields() {
       {% if not field.isEnum %}
         {% if field.hasConstructor |or field.isLibgitType %}
           Local<Object> {{ field.name }}Temp = {{ field.cppClassName }}::New(
-            &this->raw->{{ field.name }},
+            {%if not field.cType|isPointer %}&{%endif%}this->raw->{{ field.name }},
             false
           )->ToObject();
           this->{{ field.name }}.Reset({{ field.name }}Temp);
@@ -131,7 +131,7 @@ NAN_METHOD({{ cppClassName }}::JSNewFunction) {
   info.GetReturnValue().Set(info.This());
 }
 
-Local<v8::Value> {{ cppClassName }}::New(void* raw, bool selfFreeing) {
+Local<v8::Value> {{ cppClassName }}::New(const {{ cType }} * raw, bool selfFreeing) {
   Nan::EscapableHandleScope scope;
 
   Local<v8::Value> argv[2] = { Nan::New<External>((void *)raw), Nan::New<Boolean>(selfFreeing) };

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -30,7 +30,7 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     {{ cType }} *GetValue();
     void ClearValue();
 
-    static Local<v8::Value> New(void *raw, bool selfFreeing);
+    static Local<v8::Value> New(const {{ cType }} *raw, bool selfFreeing);
 
     bool selfFreeing;
 


### PR DESCRIPTION
Ran into this as part of https://github.com/nodegit/nodegit/pull/955.

Changing the `raw` pointer from `void *` to `const {{ cType }} *` to add type safety.  The change actually caught a problem in `struct_content.cc` where we were sometimes taking the address of a pointer and passing that in instead of the pointer (for `git_checkout_options.baseline`, we were sending in a `git_tree **` instead of a `git_tree *` to `New`).