### PR TITLE
[WIP] Cache repository / owner values in persistent handle

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1767,6 +1767,7 @@
       "ignore": true
     },
     "repository": {
+      "cacheResult": true,
       "functions": {
         "git_repository__cleanup": {
           "ignore": true

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -179,6 +179,7 @@ var Helpers = {
     typeDef.filename = typeDef.typeName;
     typeDef.isLibgitType = true;
     typeDef.dependencies = [];
+    typeDef.cacheResult = Boolean(typeDefOverrides.cacheResult);
     typeDef.selfFreeing = Boolean(typeDefOverrides.selfFreeing);
 
     if (typeDefOverrides.freeFunctionName) {

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -44,6 +44,16 @@ using namespace node;
       NonSelfFreeingConstructedCount++;
     }
 
+    
+	{%each functions as function%}
+      {%if not function.ignore %}
+        {%if not function.isAsync %}
+          {%if function.return.cacheResult %}
+            {{ function.cppFunctionName }}_cache(); // populate cached value
+          {%endif%}
+        {%endif%}
+      {%endif%}
+    {%endeach%}
   }
 
   {{ cppClassName }}::~{{ cppClassName }}() {

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -141,6 +141,14 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
       private:
         {{ function.cppFunctionName }}Baton *baton;
     };
+        {%else%}
+    {%if function.return.cacheResult %}
+    // For simple sync functions that return a wrapped object and pass `raw`
+    // as the the only parameter to libgit2, we cache the results.
+    // CopyablePersistentTraits are used to get the reset-on-destruct behavior.
+    void {{ function.cppFunctionName }}_cache();
+    Nan::Persistent<Value, Nan::CopyablePersistentTraits<Value> > {{ function.cppFunctionName }}_cachedResult;
+    {%endif%}
         {%endif%}
 
     static NAN_METHOD({{ function.cppFunctionName }});

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -404,6 +404,12 @@ describe("Commit", function() {
     assert.ok(owner instanceof Repository);
   });
 
+  it("caches its owner", function() {
+    var owner = this.commit.owner();
+    var ownerAgain = this.commit.owner();
+    assert.ok(owner === ownerAgain);
+  });
+
   it("can walk its repository's history", function(done) {
     var historyCount = 0;
     var expectedHistoryCount = 364;

--- a/test/tests/submodule.js
+++ b/test/tests/submodule.js
@@ -134,7 +134,7 @@ describe("Submodule", function() {
         return reference.peel(NodeGit.Object.TYPE.COMMIT);
       })
       .then(function(commit) {
-        return submoduleRepo.createBranch("master", commit);
+        return submoduleRepo.createBranch("master", commit.id());
       })
       .then(function() {
         return submodule.addFinalize();


### PR DESCRIPTION
This works towards #955.  Once we free repositories on wrapper GC, any object that can return a repository (for example, a `GitCommit`) can potentially return a freed repository.  This PR adds persistent handles to any object that returns a repository.  Once we enforce a 1-1 relationship between `git_repository` objects and `GitRepository` wrappers, this will ensure that the wrapper does not get GCd until all objects that can return the repository can get GCed as well.

The stand-alone benefit of this PR is just that we don't create a new wrapper each time we return a repository from an object.

Also, the caching mechanism might be helpful beyond holding a handle - we can extend it to cache any similar value and avoid calling into the libgit2 layer for sync functions (this can help with thread safety without requiring locking).
