### PR TITLE
diff.blobToBuffer: Fix passing in Buffers instead of strings.

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -84,7 +84,7 @@ Diff.blobToBuffer= function(
     this,
     old_blob,
     old_as_path,
-    buffer,
+    bufferText,
     bufferLength,
     buffer_as_path,
     opts,

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -72,7 +72,7 @@ Diff.blobToBuffer= function(
   var bufferLength;
   if (buffer instanceof Buffer) {
     bufferText = buffer.toString("utf8");
-    bufferLength = buffer.length;
+    bufferLength = Buffer.byteLength(buffer, "utf8");
   } else {
     bufferText = buffer;
     bufferLength = !buffer ? 0 : Buffer.byteLength(buffer, "utf8");


### PR DESCRIPTION
Been seeing some strageness with `blobToBuffer` (see the issue I created over here, for example: https://github.com/nodegit/nodegit/issues/963 )

This pull requests fixes the fact that if you pass in an object of type Buffer, it is turned into a string, but then that string is never used (and because of the way the C bindings are written, because the object isn't of type string, it gets turned into a null, and you get a diff that looks like there's no content in the file.)