### PR TITLE
Switch from strdup to memcpy to faithfully copy all bytes and prevent a crash in some cases.

### DIFF
--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -14,7 +14,9 @@
   {%if cppClassName == 'String'%}
 
   String::Utf8Value {{ name }}(info[{{ jsArg }}]->ToString());
-  from_{{ name }} = ({{ cType }}) strdup(*{{ name }});
+  from_{{ name }} = ({{ cType }}) malloc({{ name }}.length() + 1);
+  memcpy((void *)from_{{ name }}, *{{ name }}, {{ name }}.length());
+  memset((void *)(((char *)from_{{ name }}) + {{ name }}.length()), 0, 1);
   {%elsif cppClassName == 'GitStrarray' %}
 
   from_{{ name }} = StrArrayConverter::Convert(info[{{ jsArg }}]);
@@ -24,7 +26,9 @@
   {%elsif cppClassName == 'Wrapper'%}
 
   String::Utf8Value {{ name }}(info[{{ jsArg }}]->ToString());
-  from_{{ name }} = ({{ cType }}) strdup(*{{ name }});
+  from_{{ name }} = ({{ cType }}) malloc({{ name }}.length() + 1);
+  memcpy((void *)from_{{ name }}, *{{ name }}, {{ name }}.length());
+  memset((void *)(((char *)from_{{ name }}) + {{ name }}.length()), 0, 1);
   {%elsif cppClassName == 'Array'%}
 
   Array *tmp_{{ name }} = Array::Cast(*info[{{ jsArg }}]);

--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -14,8 +14,13 @@
   {%if cppClassName == 'String'%}
 
   String::Utf8Value {{ name }}(info[{{ jsArg }}]->ToString());
+  // malloc with one extra byte so we can add the terminating null character C-strings expect:
   from_{{ name }} = ({{ cType }}) malloc({{ name }}.length() + 1);
+  // copy the characters from the nodejs string into our C-string (used instead of strdup or strcpy because nulls in
+  // the middle of strings are valid coming from nodejs):
   memcpy((void *)from_{{ name }}, *{{ name }}, {{ name }}.length());
+  // ensure the final byte of our new string is null, extra casts added to ensure compatibility with various C types
+  // used in the nodejs binding generation:
   memset((void *)(((char *)from_{{ name }}) + {{ name }}.length()), 0, 1);
   {%elsif cppClassName == 'GitStrarray' %}
 
@@ -26,8 +31,13 @@
   {%elsif cppClassName == 'Wrapper'%}
 
   String::Utf8Value {{ name }}(info[{{ jsArg }}]->ToString());
+  // malloc with one extra byte so we can add the terminating null character C-strings expect:
   from_{{ name }} = ({{ cType }}) malloc({{ name }}.length() + 1);
+  // copy the characters from the nodejs string into our C-string (used instead of strdup or strcpy because nulls in
+  // the middle of strings are valid coming from nodejs):
   memcpy((void *)from_{{ name }}, *{{ name }}, {{ name }}.length());
+  // ensure the final byte of our new string is null, extra casts added to ensure compatibility with various C types
+  // used in the nodejs binding generation:
   memset((void *)(((char *)from_{{ name }}) + {{ name }}.length()), 0, 1);
   {%elsif cppClassName == 'Array'%}
 


### PR DESCRIPTION
This is a pull request to fix the issue I created over here: https://github.com/nodegit/nodegit/issues/965

To summarize over here why I'm making these changes:

- `strdup` expects a C-style null-terminated string, but sometimes we're using nodejs strings to pass in strings that contain nulls in the middle, thus failing to copy everything at best, and causing crashes from reading invalid memory locations at worst.
- Thus I changed to using `malloc`, `memcpy` and `memset` to prevent these issues.

To explain my changes a little bit:

- I make the malloc'ed string one byte longer so I can add a terminating null character, since it looks like these templates are used in a number of different places, and for things like a repo path, where we _do_ want things to end in a null character.
- I used `memset` instead of the more standard array-style access because most of the usages of these templates are `const char *`.
- The funky casts are because some places have `void *` instead of `const char *`, so to get the pointer arithmetic right, I had to specify the `char *`.

C code isn't what I normally write, so let me apologize in advance if these changes aren't quite what they should be :smile:

I'm happy to make any modifications necessary.

The limited testing I've done seems to show that everything is working perfectly well with these changes.