### PR TITLE
Add support for thread safety on async actions only

### DIFF
--- a/generate/templates/manual/src/lock_master.cc
+++ b/generate/templates/manual/src/lock_master.cc
@@ -87,7 +87,7 @@ NAN_GC_CALLBACK(LockMasterImpl::CleanupMutexes) {
   // this means that turning thread safety on and then off
   // could result in remaining mutexes - but they would get cleaned up
   // if thread safety is turned on again
-  if (!LockMaster::IsEnabled()) {
+  if (LockMaster::GetStatus() == LockMaster::Disabled) {
     return;
   }
 
@@ -243,4 +243,4 @@ void LockMaster::TemporaryUnlock::DestructorImpl() {
   impl->Lock(false);
 }
 
-bool LockMaster::enabled = false;
+LockMaster::Status LockMaster::status = LockMaster::Disabled;

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -80,9 +80,9 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 
 void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
   giterr_clear();
-  
+
   {
-    LockMaster lockMaster(true{%each args|argsInfo as arg %}
+    LockMaster lockMaster(/*asyncAction: */true{%each args|argsInfo as arg %}
       {%if arg.cType|isPointer%}{%if not arg.cType|isDoublePointer%}
         ,baton->{{ arg.name }}
       {%endif%}{%endif%}

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -35,9 +35,9 @@ if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL
 {% endif %}
 
   giterr_clear();
-  
+
   {
-    LockMaster lockMaster(true{%each args|argsInfo as arg %}
+    LockMaster lockMaster(/*asyncAction: */false{%each args|argsInfo as arg %}
       {%if arg.cType|isPointer%}{%if not arg.isReturn%}
         ,{%if arg.isSelf %}
     Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue()

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -25,12 +25,25 @@ void LockMasterEnable(const FunctionCallbackInfo<Value>& info) {
   LockMaster::Enable();
 }
 
-void LockMasterDisable(const FunctionCallbackInfo<Value>& info) {
-  LockMaster::Disable();
+void LockMasterSetStatus(const FunctionCallbackInfo<Value>& info) {
+  Nan::HandleScope scope;
+
+  // convert the first argument to Status
+  if(info.Length() >= 0 && info[0]->IsNumber()) {
+    v8::Local<v8::Int32> value = info[0]->ToInt32();
+    LockMaster::Status status = static_cast<LockMaster::Status>(value->Value());
+    if(status >= LockMaster::Disabled && status <= LockMaster::Enabled) {
+      LockMaster::SetStatus(status);
+      return;
+    }
+  }
+
+  // argument error
+  Nan::ThrowError("Argument must be one 0, 1 or 2");
 }
 
-void LockMasterIsEnabled(const FunctionCallbackInfo<Value>& info) {
-  info.GetReturnValue().Set(Nan::New(LockMaster::IsEnabled()));
+void LockMasterGetStatus(const FunctionCallbackInfo<Value>& info) {
+  info.GetReturnValue().Set(Nan::New(LockMaster::GetStatus()));
 }
 
 void LockMasterGetDiagnostics(const FunctionCallbackInfo<Value>& info) {
@@ -88,9 +101,16 @@ extern "C" void init(Local<v8::Object> target) {
   ConvenientPatch::InitializeComponent(target);
 
   NODE_SET_METHOD(target, "enableThreadSafety", LockMasterEnable);
-  NODE_SET_METHOD(target, "disableThreadSafety", LockMasterDisable);
-  NODE_SET_METHOD(target, "isThreadSafetyEnabled", LockMasterIsEnabled);
+  NODE_SET_METHOD(target, "setThreadSafetyStatus", LockMasterSetStatus);
+  NODE_SET_METHOD(target, "getThreadSafetyStatus", LockMasterGetStatus);
   NODE_SET_METHOD(target, "getThreadSafetyDiagnostics", LockMasterGetDiagnostics);
+
+  Local<v8::Object> threadSafety = Nan::New<v8::Object>();
+  threadSafety->Set(Nan::New("DISABLED").ToLocalChecked(), Nan::New((int)LockMaster::Disabled));
+  threadSafety->Set(Nan::New("ENABLED_FOR_ASYNC_ONLY").ToLocalChecked(), Nan::New((int)LockMaster::EnabledForAsyncOnly));
+  threadSafety->Set(Nan::New("ENABLED").ToLocalChecked(), Nan::New((int)LockMaster::Enabled));
+
+  target->Set(Nan::New("THREAD_SAFETY").ToLocalChecked(), threadSafety);
 
   LockMaster::Initialize();
 }

--- a/test/runner.js
+++ b/test/runner.js
@@ -6,7 +6,11 @@ var local = path.join.bind(path, __dirname);
 var NodeGit = require('..');
 
 if(process.env.NODEGIT_TEST_THREADSAFETY) {
+  console.log('Enabling thread safety in NodeGit');
   NodeGit.enableThreadSafety();
+} else if (process.env.NODEGIT_TEST_THREADSAFETY_ASYNC) {
+  console.log('Enabling thread safety for async actions only in NodeGit');
+  NodeGit.setThreadSafetyStatus(NodeGit.THREAD_SAFETY.ENABLED_FOR_ASYNC_ONLY);
 }
 
 // Have to wrap exec, since it has a weird callback signature.

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -31,7 +31,6 @@ describe("Index", function() {
 
   after(function() {
     this.index.clear();
-    NodeGit.disableThreadSafety();
   });
 
   it("can get the index of a repo and examine entries", function() {


### PR DESCRIPTION
Adds a middle-ground thread-safety level, which locks async functions but skips locking of sync functions, to avoid the risk of blocking the main thread.

/cc @johnhaley81 @joshaber