### PR TITLE
Make Ignore.pathIsIgnored async

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -949,9 +949,11 @@
         "git_ignore_path_is_ignored": {
           "args": {
             "ignored": {
+              "shouldAlloc": true,
               "isReturn": true
             }
-          }
+          },
+          "isAsync": true
         }
       }
     },

--- a/test/tests/ignore.js
+++ b/test/tests/ignore.js
@@ -18,7 +18,16 @@ describe("Ignore", function() {
   });
 
   it("can determine if a path is ignored", function() {
-    assert.equal(Ignore.pathIsIgnored(this.repository, ".git"), true);
-    assert.equal(Ignore.pathIsIgnored(this.repository, "LICENSE"), false);
+    function expectIgnoreState(repo, fileName, expected) {
+      return Ignore.pathIsIgnored(repo, fileName)
+        .then(function(ignored) {
+          assert.equal(ignored, expected);
+        });
+    }
+
+    return Promise.all([
+      expectIgnoreState(this.repository, ".git", true),
+      expectIgnoreState(this.repository, "LICENSE", false)
+    ]);
   });
 });


### PR DESCRIPTION
Since it’s potentially doing IO and touching global state, it should be async.