### PR TITLE
Error message on libstdc missing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "rebuild": "node generate && node-gyp configure build",
     "recompileDebug": "node-gyp configure --debug build",
     "rebuildDebug": "node generate && node-gyp configure --debug build",
-    "xcodeDebug": "node-gyp configure -- -f xcode"
+    "xcodeDebug": "node-gyp configure -- -f xcode", 
+    "postinstall": "./postinstall.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "recompileDebug": "node-gyp configure --debug build",
     "rebuildDebug": "node generate && node-gyp configure --debug build",
     "xcodeDebug": "node-gyp configure -- -f xcode", 
-    "postinstall": "./postinstall.sh"
+    "postinstall": "bash postinstall.sh"
   }
 }

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ -n "$(node lib/nodegit.js 2>&1 | grep libstdc++)" ]; then
-	echo "[ERROR] Seems like you the latest libstdc++ is missing on your system!"
+	echo "[ERROR] Seems like the latest libstdc++ is missing on your system!"
 	echo ""
 	echo "On Ubuntu you can install it using:"
 	echo ""

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+if [ -n "$(node lib/nodegit.js 2>&1 | grep libstdc++)" ]; then
+	echo "[ERROR] Seems like you the latest libstdc++ is missing on your system!"
+	echo ""
+	echo "On Ubuntu you can install it using:"
+	echo ""
+	echo "$ sudo add-apt-repository ppa:ubuntu-toolchain-r/test"
+	echo "$ sudo apt-get update"
+	echo "$ sudo apt-get install libstdc++-4.9-dev"
+	exit 1
+fi


### PR DESCRIPTION
`nodegit` is usually used as library for other projects. Nodegit is also, unfortunately, depends on a version of libstdc++ that is not installed on many linux systems. Any person that uses nodegit as a library would need to explain this problem in their issues. In order to reduce the work of libraries/tools that depend on nodegit this PR adds an error message on postinstall if the dependency is missing and adds steps on how to mitigate that issue.

_Note: This has been a follow-up on #969._