### PR TITLE
Remote leak fix

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -143,7 +143,7 @@
         },
         "git_blob_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_blob_rawcontent": {
@@ -389,12 +389,12 @@
         },
         "git_commit_author": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_commit_committer": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_commit_create": {
@@ -424,17 +424,17 @@
         },
         "git_commit_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_commit_parent_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_commit_tree_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         }
       }
@@ -1594,12 +1594,12 @@
         },
         "git_reference_target": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_reference_target_peel": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         }
       }
@@ -1627,6 +1627,7 @@
     },
     "remote": {
       "cType": "git_remote",
+      "selfFreeing": true,
       "functions": {
         "git_remote_create": {
           "isAsync": false
@@ -1711,6 +1712,11 @@
           },
           "isAsync": true
         },
+        "git_remote_get_refspec": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
         "git_remote_list": {
           "args": {
             "out": {
@@ -1748,6 +1754,9 @@
         },
         "git_remote_set_push_refspecs": {
           "ignore": true
+        },
+        "git_remote_stats": {
+          "ownedByThis": true
         }
       }
     },
@@ -2182,7 +2191,7 @@
         },
         "git_tag_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tag_create_lightweight": {
@@ -2222,7 +2231,7 @@
         },
         "git_tag_tagger": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tag_target": {
@@ -2234,7 +2243,7 @@
         },
         "git_tag_target_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tag_delete": {
@@ -2251,6 +2260,9 @@
           "ignore": true
         }
       }
+    },
+    "transfer_progress": {
+      "dupFunction": "git_transfer_progress_dup"
     },
     "transport": {
       "cType": "git_transport",
@@ -2281,7 +2293,7 @@
       "functions": {
         "git_tree_entry_byid": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tree_entry_byindex": {
@@ -2289,12 +2301,12 @@
         },
         "git_tree_entry_byname": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tree_entry_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tree_entrycount": {
@@ -2302,7 +2314,7 @@
         },
         "git_tree_id": {
           "return": {
-            "shouldDuplicate": true
+            "ownedByThis": true
           }
         },
         "git_tree_walk": {

--- a/generate/templates/manual/include/functions/copy.h
+++ b/generate/templates/manual/include/functions/copy.h
@@ -15,4 +15,6 @@ const git_time *git_time_dup(const git_time *arg);
 const git_diff_delta *git_diff_delta_dup(const git_diff_delta *arg);
 const git_diff_file *git_diff_file_dup(const git_diff_file *arg);
 
+void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_progress *arg);
+
 #endif

--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -10,3 +10,8 @@ const git_error *git_error_dup(const git_error *arg) {
   result->message = strdup(arg->message);
   return result;
 }
+
+void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_progress *arg) {
+  *out = (git_transfer_progress *)malloc(sizeof(git_transfer_progress));
+  memcpy(*out, arg, sizeof(git_transfer_progress));
+}

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -61,7 +61,7 @@
     {% if cppClassName == 'Wrapper' %}
       to = {{ cppClassName }}::New({{= parsedName =}});
     {% else %}
-      to = {{ cppClassName }}::New({{= parsedName =}}, {{ selfFreeing|toBool }} {% if shouldDuplicate %}, true{% endif %});
+      to = {{ cppClassName }}::New({{= parsedName =}}, {{ selfFreeing|toBool }} {% if ownedByThis %}, info.This(){% endif %});
     {% endif %}
   }
   else {

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -49,7 +49,7 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
     {{ cType }} *GetValue();
     void ClearValue();
 
-    static Local<v8::Value> New(const {{ cType }} *raw, bool selfFreeing, bool shouldDuplicate = false);
+    static Local<v8::Value> New(const {{ cType }} *raw, bool selfFreeing, Local<v8::Object> owner = Local<v8::Object>());
     {%endif%}
     bool selfFreeing;
 
@@ -82,10 +82,15 @@ class {{ cppClassName }} : public Nan::ObjectWrap {
 
 
   private:
-
+    // owner of the object, in the memory management sense. only populated
+    // when using ownedByThis, and the type doesn't have a dupFunction
+    // CopyablePersistentTraits are used to get the reset-on-destruct behavior.
+    {%if not dupFunction %}
+    Nan::Persistent<Object, Nan::CopyablePersistentTraits<Object> > owner;
+    {%endif%}
 
     {%if cType%}
-    {{ cppClassName }}({{ cType }} *raw, bool selfFreeing, bool shouldDuplicate = false);
+    {{ cppClassName }}({{ cType }} *raw, bool selfFreeing, Local<v8::Object> owner = Local<v8::Object>());
     ~{{ cppClassName }}();
     {%endif%}
 

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -2,31 +2,15 @@ var assert = require("assert");
 var path = require("path");
 var promisify = require("promisify-node");
 var fse = promisify(require("fs-extra"));
+
+var garbageCollect = require("../utils/garbage_collect.js");
+
 var local = path.join.bind(path, __dirname);
 
 // Have to wrap exec, since it has a weird callback signature.
 var exec = promisify(function(command, opts, callback) {
   return require("child_process").exec(command, opts, callback);
 });
-
-// aggressively collects garbage until we fail to improve terminatingIterations
-// times.
-function garbageCollect() {
-  var terminatingIterations = 3;
-  var usedBeforeGC = Number.MAX_VALUE;
-  var nondecreasingIterations = 0;
-  for ( ; ; ) {
-    global.gc();
-    var usedAfterGC = process.memoryUsage().heapUsed;
-    if (usedAfterGC >= usedBeforeGC) {
-      nondecreasingIterations++;
-      if (nondecreasingIterations >= terminatingIterations) {
-        break;
-      }
-    }
-    usedBeforeGC = usedAfterGC;
-  }
-}
 
 describe("Commit", function() {
   var NodeGit = require("../../");

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -315,7 +315,7 @@ describe("Revwalk", function() {
       var walker = repository.createRevWalk();
 
       repository.getMasterCommit().then(function(firstCommitOnMaster) {
-        walker.walk(firstCommitOnMaster, function(err, commit) {
+        walker.walk(firstCommitOnMaster.id(), function(err, commit) {
           if (err && err.errno === NodeGit.Error.CODE.ITEROVER) {
             return done();
           }

--- a/test/tests/submodule.js
+++ b/test/tests/submodule.js
@@ -107,9 +107,11 @@ describe("Submodule", function() {
   });
 
   it("can setup and finalize submodule add", function() {
+    this.timeout(30000);
+
     var repo = this.repository;
-    var submodulePath = "hellogitworld";
-    var submoduleUrl = "https://github.com/githubtraining/hellogitworld.git";
+    var submodulePath = "nodegittest";
+    var submoduleUrl = "https://github.com/nodegit/test.git";
 
     var submodule;
     var submoduleRepo;
@@ -134,7 +136,7 @@ describe("Submodule", function() {
         return reference.peel(NodeGit.Object.TYPE.COMMIT);
       })
       .then(function(commit) {
-        return submoduleRepo.createBranch("master", commit);
+        return submoduleRepo.createBranch("master", commit.id());
       })
       .then(function() {
         return submodule.addFinalize();

--- a/test/utils/garbage_collect.js
+++ b/test/utils/garbage_collect.js
@@ -1,0 +1,20 @@
+// aggressively collects garbage until we fail to improve terminatingIterations
+// times.
+function garbageCollect() {
+  var terminatingIterations = 3;
+  var usedBeforeGC = Number.MAX_VALUE;
+  var nondecreasingIterations = 0;
+  for ( ; ; ) {
+    global.gc();
+    var usedAfterGC = process.memoryUsage().heapUsed;
+    if (usedAfterGC >= usedBeforeGC) {
+      nondecreasingIterations++;
+      if (nondecreasingIterations >= terminatingIterations) {
+        break;
+      }
+    }
+    usedBeforeGC = usedAfterGC;
+  }
+}
+
+module.exports = garbageCollect;


### PR DESCRIPTION
Makes remotes self-freeing.

I needed to add new functionality for https://libgit2.github.com/libgit2/#HEAD/group/remote/git_remote_get_refspec, because the returned refspec belongs to the remote (and gets freed with it), but there is no way to duplicate the refspec (it is an opaque struct).  AFAICT this requires an ownership mechanism, allowing the refspec to keep a handle on its owner remote so it doesn't get freed.

So I extended `shouldDuplicate` into `ownedByThis`: when `ownedByThis` is turned on we duplicate if the type has a `dupFunction`, otherwise we keep a handle on the owner.