### PR TITLE
Add `Repository#refreshIndex`

### DIFF
--- a/examples/add-and-commit.js
+++ b/examples/add-and-commit.js
@@ -35,11 +35,10 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   );
 })
 .then(function() {
-  return repo.openIndex();
+  return repo.refreshIndex();
 })
 .then(function(indexResult) {
   index = indexResult;
-  return index.read(1);
 })
 .then(function() {
   // this file is in the root of the directory and doesn't need a full path

--- a/examples/create-new-repo.js
+++ b/examples/create-new-repo.js
@@ -20,11 +20,10 @@ fse.ensureDir(path.resolve(__dirname, repoDir))
   return fse.writeFile(path.join(repository.workdir(), fileName), fileContent);
 })
 .then(function(){
-  return repository.openIndex();
+  return repository.refreshIndex();
 })
 .then(function(idx) {
   index = idx;
-  return index.read(1);
 })
 .then(function() {
   return index.addByPath(fileName);

--- a/examples/details-for-tree-entry.js
+++ b/examples/details-for-tree-entry.js
@@ -13,7 +13,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
 
       // Tree entry doesn't have any data associated with the actual entry
       // To get that we need to get the index entry that this points to
-      return repo.openIndex().then(function(index) {
+      return repo.refreshIndex().then(function(index) {
         var indexEntry = index.getByPath(treeEntry.path());
 
         // With the index entry we can now view the details for the tree entry

--- a/examples/general.js
+++ b/examples/general.js
@@ -319,7 +319,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
 
     // The [index file API][gi] allows you to read, traverse, update and write
     // the Git index file (sometimes thought of as the staging area).
-    return repo.openIndex();
+    return repo.refreshIndex();
   })
 
   .then(function(index) {

--- a/examples/index-add-and-remove.js
+++ b/examples/index-add-and-remove.js
@@ -5,7 +5,7 @@ var fse = promisify(require("fs-extra"));
 
 nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   .then(function(repo) {
-    return repo.openIndex()
+    return repo.refreshIndex()
     .then(function(index) {
       var fileContent = {
         newFile1: "this has some content",

--- a/examples/merge-cleanly.js
+++ b/examples/merge-cleanly.js
@@ -43,10 +43,9 @@ fse.remove(path.resolve(__dirname, repoDir))
 
 // Load up the repository index and make our initial commit to HEAD
 .then(function() {
-  return repository.openIndex();
+  return repository.refreshIndex();
 })
 .then(function(index) {
-  index.read(1);
   index.addByPath(ourFileName);
   index.write();
 
@@ -79,10 +78,9 @@ fse.remove(path.resolve(__dirname, repoDir))
   );
 })
 .then(function() {
-  return repository.openIndex();
+  return repository.refreshIndex();
 })
 .then(function(index) {
-  index.read(1);
   index.addByPath(theirFileName);
   index.write();
 

--- a/examples/merge-with-conflicts.js
+++ b/examples/merge-with-conflicts.js
@@ -49,10 +49,9 @@ fse.remove(path.resolve(__dirname, repoDir))
 
 // Load up the repository index and make our initial commit to HEAD
 .then(function() {
-  return repository.openIndex();
+  return repository.refreshIndex();
 })
 .then(function(index) {
-  index.read(1);
   index.addByPath(fileName);
   index.write();
 
@@ -94,9 +93,8 @@ fse.remove(path.resolve(__dirname, repoDir))
   );
 })
 .then(function() {
-  return repository.openIndex()
+  return repository.refreshIndex()
     .then(function(index) {
-      index.read(1);
       index.addByPath(fileName);
       index.write();
 
@@ -122,8 +120,7 @@ fse.remove(path.resolve(__dirname, repoDir))
   );
 })
 .then(function() {
-  return repository.openIndex().then(function(index) {
-    index.read(1);
+  return repository.refreshIndex().then(function(index) {
     index.addByPath(fileName);
     index.write();
 
@@ -173,9 +170,8 @@ fse.remove(path.resolve(__dirname, repoDir))
 // we need to get a new index as the other one isnt backed to
 // the repository in the usual fashion, and just behaves weirdly
 .then(function() {
-  return repository.openIndex().then(function(index) {
+  return repository.refreshIndex().then(function(index) {
 
-    index.read(1);
     index.addByPath(fileName);
     index.write();
 

--- a/examples/push.js
+++ b/examples/push.js
@@ -30,10 +30,9 @@ fse.remove(path.resolve(__dirname, repoDir))
 
 // Load up the repository index and make our initial commit to HEAD
 .then(function() {
-  return repository.openIndex();
+  return repository.refreshIndex();
 })
 .then(function(index) {
-  index.read(1);
   index.addByPath(fileName);
   index.write();
 

--- a/examples/remove-and-commit.js
+++ b/examples/remove-and-commit.js
@@ -17,11 +17,10 @@ var _oid;
 nodegit.Repository.open(path.resolve(__dirname, "../.git"))
   .then(function(repo) {
     _repository = repo;
-    return repo.openIndex();
+    return repo.refreshIndex();
   })
   .then(function(index){
     _index = index;
-    return _index.read();
   })
   .then(function() {
     //remove the file from the index...

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1833,7 +1833,11 @@
           }
         },
         "git_repository_set_index": {
-          "ignore": true
+          "args": {
+            "index": {
+              "isOptional": true
+            }
+          }
         },
         "git_repository_set_odb": {
           "ignore": true

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -23,6 +23,27 @@ Object.defineProperty(Repository.prototype, "openIndex", {
   enumerable: false,
   value: Repository.prototype.index
 });
+/**
+ * Grabs a fresh copy of the index from the repository. Invalidates
+ * all previously grabbed indexes
+ *
+ * @async
+ * @return {Index}
+ */
+Repository.prototype.refreshIndex = function(callback) {
+  var repo = this;
+
+  repo.setIndex(); // clear the index
+
+  return repo.index()
+    .then(function(index) {
+      if (typeof callback === "function") {
+        callback(null, index);
+      }
+
+      return index;
+    }, callback);
+};
 
 /**
  * Creates a branch with the passed in name pointing to the commit
@@ -521,10 +542,9 @@ Repository.prototype.createCommitOnHead = function(
   var index;
   var repo = this;
 
-  return repo.openIndex()
+  return repo.refreshIndex()
     .then(function(index_) {
       index = index_;
-      index.read(1);
       if (!filesToAdd) { filesToAdd = []; }
       filesToAdd.forEach(function(filePath) {
         index.addByPath(filePath);
@@ -907,7 +927,7 @@ function performRebase(repository, rebase, signature, beforeNextFn) {
   function getPromise() {
     return rebase.next()
       .then(function() {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
             if (index.hasConflicts()) {
               throw index;
@@ -1033,7 +1053,7 @@ Repository.prototype.continueRebase = function(signature, beforeNextFn) {
 
   signature = signature || repo.defaultSignature();
 
-  return repo.openIndex()
+  return repo.refreshIndex()
     .then(function(index) {
       if (index.hasConflicts()) {
         throw index;
@@ -1241,11 +1261,10 @@ Repository.prototype.stageFilemode = function(filePath, stageNew) {
 
   return fse.remove(indexLock)
     .then(function() {
-      return repo.openIndex();
+      return repo.refreshIndex();
     })
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return diffPromise;
@@ -1449,10 +1468,9 @@ Repository.prototype.stageLines =
       });
     };
 
-  return repo.openIndex()
+  return repo.refreshIndex()
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return diffPromise();

--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -126,9 +126,8 @@ describe("Checkout", function() {
     .then(function(branch) {
       fse.writeFileSync(packageJsonPath, "\n");
 
-      return test.repository.openIndex()
+      return test.repository.refreshIndex()
         .then(function(index) {
-          index.read(1);
           index.addByPath(packageJsonName);
           index.write();
 

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -55,11 +55,10 @@ describe("Commit", function() {
 
     return fse.writeFile(path.join(repo.workdir(), fileName), fileContent)
     .then(function() {
-      return repo.openIndex();
+      return repo.refreshIndex();
     })
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return index.addByPath(fileName);
@@ -162,11 +161,10 @@ describe("Commit", function() {
       return fse.writeFile(path.join(repo.workdir(), fileName), fileContent);
     })
     .then(function() {
-      return repo.openIndex();
+      return repo.refreshIndex();
     })
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return index.addByPath(fileName);
@@ -242,11 +240,10 @@ describe("Commit", function() {
       return fse.writeFile(path.join(repo.workdir(), fileName), fileContent);
     })
     .then(function() {
-      return repo.openIndex();
+      return repo.refreshIndex();
     })
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return index.addByPath(fileName);
@@ -290,11 +287,10 @@ describe("Commit", function() {
       );
     })
     .then(function() {
-      return repo.openIndex();
+      return repo.refreshIndex();
     })
     .then(function(indexResult) {
       index = indexResult;
-      return index.read(1);
     })
     .then(function() {
       return index.addByPath(newFileName);

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -27,7 +27,7 @@ describe("Diff", function() {
     return Repository.open(reposPath).then(function(repository) {
       test.repository = repository;
 
-      return repository.openIndex();
+      return repository.refreshIndex();
     })
     .then(function(index) {
       test.index = index;
@@ -307,7 +307,7 @@ describe("Diff", function() {
     return Repository.open(reposPath).then(function(repository) {
       test.repository = repository;
 
-      return repository.openIndex();
+      return repository.refreshIndex();
     })
     .then(function(index) {
       test.index = index;

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -22,7 +22,7 @@ describe("Index", function() {
     return Repository.open(reposPath)
       .then(function(repo) {
         test.repository = repo;
-        return repo.openIndex();
+        return repo.refreshIndex();
       })
       .then(function(index) {
         test.index = index;
@@ -342,7 +342,7 @@ describe("Index", function() {
         return RepoUtils.addFileToIndex(repo, fileName);
       })
       .then(function() {
-        return repo.openIndex();
+        return repo.index();
       })
       .then(function(index) {
         assert.ok(!index.hasConflicts());
@@ -353,7 +353,7 @@ describe("Index", function() {
         );
       })
       .then(function() {
-        return repo.openIndex();
+        return repo.index();
       })
       .then(function(index) {
         assert(index.hasConflicts());

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -44,9 +44,8 @@ describe("Merge", function() {
         ourFileContent)
       // Load up the repository index and make our initial commit to HEAD
       .then(function() {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
-            index.read(1);
             index.addByPath(ourFileName);
             index.write();
 
@@ -80,9 +79,8 @@ describe("Merge", function() {
           theirFileContent);
       })
       .then(function() {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
-            index.read(1);
             index.addByPath(theirFileName);
             index.write();
 
@@ -149,9 +147,8 @@ describe("Merge", function() {
       ourFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -185,9 +182,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -261,9 +257,8 @@ describe("Merge", function() {
       ourFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -297,9 +292,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -380,9 +374,8 @@ describe("Merge", function() {
       initialFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(initialFileName);
         index.write();
 
@@ -418,9 +411,8 @@ describe("Merge", function() {
       ourFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -447,9 +439,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -519,9 +510,8 @@ describe("Merge", function() {
       ourFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -555,9 +545,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -635,9 +624,8 @@ describe("Merge", function() {
       initialFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(initialFileName);
         index.write();
 
@@ -673,9 +661,8 @@ describe("Merge", function() {
       ourFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -702,9 +689,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -776,9 +762,8 @@ describe("Merge", function() {
       initialFileContent)
     // Load up the repository index and make our initial commit to HEAD
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(initialFileName);
         index.write();
 
@@ -814,9 +799,8 @@ describe("Merge", function() {
       ourFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(ourFileName);
         index.write();
 
@@ -843,9 +827,8 @@ describe("Merge", function() {
       theirFileContent);
     })
     .then(function() {
-      return repository.openIndex()
+      return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.addByPath(theirFileName);
         index.write();
 
@@ -903,9 +886,8 @@ describe("Merge", function() {
     return fse.writeFile(path.join(repository.workdir(), fileName),
       baseFileContent)
       .then(function() {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
-            index.read(1);
             index.addByPath(fileName);
             index.write();
 
@@ -945,8 +927,7 @@ describe("Merge", function() {
           ourFileContent);
       })
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -973,8 +954,7 @@ describe("Merge", function() {
           theirFileContent);
       })
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -1011,8 +991,7 @@ describe("Merge", function() {
           finalFileContent);
       })
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -1072,8 +1051,7 @@ describe("Merge", function() {
     return fse.writeFile(path.join(repository.workdir(), fileName),
       baseFileContent)
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -1107,8 +1085,7 @@ describe("Merge", function() {
           baseFileContent + theirFileContent);
       })
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -1130,8 +1107,7 @@ describe("Merge", function() {
           baseFileContent + ourFileContent);
       })
       .then(function() {
-        return repository.openIndex().then(function(index) {
-          index.read(1);
+        return repository.refreshIndex().then(function(index) {
           index.addByPath(fileName);
           index.write();
 
@@ -1199,9 +1175,8 @@ describe("Merge", function() {
           conflictSolvedFileContent);
       })
       .then(function() {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
-            index.read(1);
             index.addByPath(fileName);
             index.write();
 

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -15,7 +15,7 @@ describe("Patch", function() {
     return Repository.open(reposPath).then(function(repository) {
         test.repository = repository;
 
-        return repository.openIndex();
+        return repository.refreshIndex();
       })
       .then(function(index) {
         test.index = index;

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -13,9 +13,8 @@ describe("Rebase", function() {
   var theirBranchName = "theirs";
 
   var removeFileFromIndex = function(repository, fileName) {
-    return repository.openIndex()
+    return repository.refreshIndex()
       .then(function(index) {
-        index.read(1);
         index.removeByPath(fileName);
         index.write();
 
@@ -454,7 +453,7 @@ describe("Rebase", function() {
         assert.equal(rebaseOperation.id().toString(),
           "28cfeb17f66132edb3c4dacb7ff38e8dd48a1844");
 
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
             assert.ok(index.hasConflicts());
           });
@@ -472,7 +471,7 @@ describe("Rebase", function() {
         return RepoUtils.addFileToIndex(repository, fileName);
       })
       .then(function(oid) {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
             assert.ok(!index.hasConflicts());
 
@@ -1039,7 +1038,7 @@ describe("Rebase", function() {
         return RepoUtils.addFileToIndex(repository, fileName);
       })
       .then(function(oid) {
-        return repository.openIndex()
+        return repository.refreshIndex()
           .then(function(index) {
             assert.ok(!index.hasConflicts());
 

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -54,7 +54,7 @@ describe("Reset", function() {
 
     return Reset.default(test.repo, test.previousCommit, filePath)
     .then(function() {
-      return test.repo.openIndex();
+      return test.repo.refreshIndex();
     })
     .then(function(index) {
       return index.writeTree();
@@ -80,7 +80,7 @@ describe("Reset", function() {
       return Reset.default(test.repo, test.currentCommit, filePath);
     })
     .then(function() {
-      return test.repo.openIndex();
+      return test.repo.refreshIndex();
     })
     .then(function(index) {
       return index.writeTree();
@@ -109,7 +109,7 @@ describe("Reset", function() {
 
     return Reset.reset(test.repo, test.previousCommit, Reset.TYPE.SOFT)
     .then(function() {
-      return test.repo.openIndex();
+      return test.repo.refreshIndex();
     })
     .then(function(index) {
       return index.writeTree();
@@ -143,7 +143,7 @@ describe("Reset", function() {
 
     return Reset.reset(test.repo, test.previousCommit, Reset.TYPE.MIXED)
     .then(function() {
-      return test.repo.openIndex();
+      return test.repo.refreshIndex();
     })
     .then(function(index) {
       return index.writeTree();
@@ -183,7 +183,7 @@ describe("Reset", function() {
 
     return Reset.reset(test.repo, test.previousCommit, Reset.TYPE.HARD)
     .then(function() {
-      return test.repo.openIndex();
+      return test.repo.refreshIndex();
     })
     .then(function(index) {
       return index.writeTree();

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -253,9 +253,8 @@ describe("Revwalk", function() {
         );
       })
       .then(function() {
-        return repo.openIndex()
+        return repo.refreshIndex()
           .then(function(index) {
-            index.read(1);
             index.addByPath(fileNameB);
             index.removeByPath(fileNameA);
             index.write();

--- a/test/tests/submodule.js
+++ b/test/tests/submodule.js
@@ -146,7 +146,7 @@ describe("Submodule", function() {
       .then(function(submodule) {
         assert.equal(submodule.name(), submodulePath);
         // check whether .gitmodules and the submodule are in the index
-        return repo.openIndex();
+        return repo.refreshIndex();
       })
       .then(function(index) {
         var entries = index.entries();

--- a/test/tests/thread_safety.js
+++ b/test/tests/thread_safety.js
@@ -14,7 +14,7 @@ describe("ThreadSafety", function() {
     return Repository.open(reposPath)
       .then(function(repo) {
         test.repository = repo;
-        return repo.openIndex();
+        return repo.refreshIndex();
       })
       .then(function(index) {
         test.index = index;

--- a/test/utils/repository_setup.js
+++ b/test/utils/repository_setup.js
@@ -7,9 +7,8 @@ var fse = promisify(require("fs-extra"));
 var RepositorySetup = {
 	addFileToIndex:
 	function addFileToIndex(repository, fileName) {
-		return repository.openIndex()
+		return repository.refreshIndex()
 			.then(function(index) {
-				index.read(1);
 				index.addByPath(fileName);
 				index.write();
 


### PR DESCRIPTION
`Repository#refreshIndex` will return an `Index` object back that has the latest data loaded off of disk.

This removes the need for the `Repository#index` then `Index#read(1)` pattern that was being used which seemed to have some weird timing issues that could have wrong data loaded into the returned index.

Calling this function also clears the `Index` that's cached in the `Repository` object.