### PR TITLE
Remove `Repository#openIndex`

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -19,10 +19,6 @@ var Tag = NodeGit.Tag;
 var Tree = NodeGit.Tree;
 var TreeBuilder = NodeGit.Treebuilder;
 
-Object.defineProperty(Repository.prototype, "openIndex", {
-  enumerable: false,
-  value: Repository.prototype.index
-});
 /**
  * Grabs a fresh copy of the index from the repository. Invalidates
  * all previously grabbed indexes


### PR DESCRIPTION
We should be using `Repository#index` or `Repository#refreshIndex` instead. All our code/examples have already been updated to use them.