### PR TITLE
Fix segfault in `Branch.name`

### DIFF
--- a/generate/templates/filters/args_info.js
+++ b/generate/templates/filters/args_info.js
@@ -22,6 +22,7 @@ module.exports = function(args) {
 
     arg.cArg = cArg;
     arg.isCppClassStringOrArray = ~["String", "Array"].indexOf(arg.cppClassName);
+    arg.isConst = ~arg.cType.indexOf("const ");
 
     // if we have a callback then we also need the corresponding payload for that callback
     if (arg.isCallbackFunction) {

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -250,7 +250,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
     {%if arg.isCppClassStringOrArray %}
       {%if arg.freeFunctionName %}
   {{ arg.freeFunctionName }}(baton->{{ arg.name }});
-      {%else%}
+      {%elsif not arg.isConst%}
   free((void *)baton->{{ arg.name }});
       {%endif%}
     {%elsif arg | isOid %}

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -68,4 +68,13 @@ describe("Branch", function() {
         assert.equal(upstream.shorthand(), upstreamName);
       });
   });
+
+  it("can get the name of a branch", function() {
+    var branch = this.branch;
+
+    return NodeGit.Branch.name(branch)
+      .then(function(branchNameToTest) {
+        assert.equal(branchNameToTest, branchName);
+      });
+  });
 });


### PR DESCRIPTION
The generated C++ code was freeing the out parameter because it was a string even though the string was of type `const`. Now we have a safeguard in place so we aren't freeing things that we shouldn't be in this case.