### PR TITLE
Index.conflictAdd should have nullable entries

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -998,7 +998,20 @@
           }
         },
         "git_index_conflict_add": {
-          "isAsync": true,
+          "args": {
+            "index": {
+              "isSelf": true
+            },
+            "ancestor_entry": {
+              "isOptional": true
+            },
+            "our_entry": {
+              "isOptional": true
+            },
+            "their_entry": {
+              "isOptional": true
+            }
+          },
           "return": {
             "isErrorCode": true
           }


### PR DESCRIPTION
when you run into a conflict, sometimes one of the entries just plain old doesn't exist. An example being you create a file in 2 branches and try to merge them. They have no ancestor_entry because they were both created in their respective branches. Therefore, ancestor_entry should be null. The same can apply to our_entry and their_entry