### PR TITLE
Use diff options even if the commit has no parent

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -197,7 +197,7 @@ Commit.prototype.getDiffWithOptions = function(options, callback) {
           });
         });
       } else {
-        diffs = [thisTree.diff(null)];
+        diffs = [thisTree.diffWithOptions(null, options)];
       }
 
       return Promise.all(diffs);


### PR DESCRIPTION
`Commit#getDiffWithOptions` did not use the diff options passed in if the commit did not have a parent.