### PR TITLE
Move reflog entry methods to ReflogEntry

### DIFF
--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -269,6 +269,15 @@
         ]
       ],
       [
+        "reflog_entry",
+        [
+          "git_reflog_entry_committer",
+          "git_reflog_entry_id_new",
+          "git_reflog_entry_id_old",
+          "git_reflog_entry_message"
+        ]
+      ],
+      [
         "revwalk",
         [
           "git_revwalk_fast_walk",
@@ -703,6 +712,14 @@
         "git_merge_head_from_id",
         "git_merge_head_from_ref",
         "git_merge_head_id"
+      ]
+    },
+    "reflog": {
+      "functions": [
+        "git_reflog_entry_committer",
+        "git_reflog_entry_id_new",
+        "git_reflog_entry_id_old",
+        "git_reflog_entry_message"
       ]
     },
     "status": {

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -367,11 +367,11 @@ describe("Commit", function() {
     }).then(function(reflog) {
       var reflogEntry = reflog.entryByIndex(0);
       assert.equal(
-        NodeGit.Reflog.entryMessage(reflogEntry),
+        reflogEntry.message(),
         customReflogMessage
       );
       assert.equal(
-        NodeGit.Reflog.entryIdNew(reflogEntry).toString(),
+        reflogEntry.idNew().toString(),
         oid
       );
       // only setTarget should have added to the entrycount


### PR DESCRIPTION
Better wrapping of reflog entry methods.  Will also help with #1006, so we're not lying when we say that for example `git_reflog_entry_id_new` returns an `oid` "ownedByThis" (this PR will make "This" the reflog entry).