### PR TITLE
Add Node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - export NODE_VERSION="0.12" TARGET_ARCH="x64"
     - export NODE_VERSION="4.1" TARGET_ARCH="x64"
     - export NODE_VERSION="5.8" TARGET_ARCH="x64"
+    - export NODE_VERSION="6" TARGET_ARCH="x64"
 
 matrix:
   fast_finish: true
@@ -28,6 +29,9 @@ matrix:
       sudo: required
     - os: linux
       env: export NODE_VERSION="5.8" TARGET_ARCH="ia32"
+      sudo: required
+    - os: linux
+      env: export NODE_VERSION="6" TARGET_ARCH="ia32"
       sudo: required
 
 git:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,9 @@ environment:
   matrix:
     # Node.js
     - nodejs_version: "0.12"
-    # Node.js
     - nodejs_version: "4.1"
     - nodejs_version: "5.8"
+    - nodejs_version: "6"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
~~People upgrading from 0.10/0.12 are probably going to be going to either Node 5/6 and not Node 4. Our build matrix is getting huge and I'd like to build binaries for Node 6 now. Thus I figured we could drop support for Node 4.~~

Put support for Node v4 back in.