### PR TITLE
Make `Commit.create` async

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -416,15 +416,19 @@
             "update_ref": {
               "isOptional": true
             }
+          },
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
           }
-        },
-        "git_commit_create_buffer": {
-          "ignore": true
         },
         "git_commit_create_from_callback": {
           "ignore": true
         },
         "git_commit_create_from_ids": {
+          "ignore": true
+        },
+        "git_commit_create_from_v": {
           "ignore": true
         },
         "git_commit_extract_signature": {

--- a/test/tests/stage.js
+++ b/test/tests/stage.js
@@ -304,15 +304,19 @@ describe("Stage", function() {
         return index.writeTree();
       })
       .then(function (oid) {
-        var signature = NodeGit.Signature.create("Foo bar",
-          "foo@bar.com", 123456789, 60);
-        return test.repository.createCommit("HEAD", signature, signature,
-            "initial commit", oid, []);
+        return test.repository.getHeadCommit()
+          .then(function(parent) {
+            var signature = NodeGit.Signature.create("Foo bar",
+            "foo@bar.com", 123456789, 60);
+            return test.repository.createCommit("HEAD", signature, signature,
+            "initial commit", oid, [parent]);
+          });
         //... alright, we did a commit.
       })
-      //Now if we compare head commit to index, should be a filemode change
+      // Now if we compare head commit to the workdir,
+      // there shouldn't be a filemode change
       .then(function() {
-        return compareFilemodes(false, index, 0111 /* expect +x */);
+        return compareFilemodes(true, null, 0);
       });
     });
 


### PR DESCRIPTION
Creating a commit should be an async action, this makes it so.