### PR TITLE
Memory management: Self freeing fix

### DIFF
--- a/generate/templates/manual/src/nodegit_wrapper.cc
+++ b/generate/templates/manual/src/nodegit_wrapper.cc
@@ -11,6 +11,7 @@ NodeGitWrapper<Traits>::NodeGitWrapper(typename Traits::cType *raw, bool selfFre
     } else {
       this->owner.Reset(owner);
       this->raw = raw;
+      selfFreeing = false;
     }
   } else {
     this->raw = raw;


### PR DESCRIPTION
If trait is owned and is non-duplicable, disallow it from marking itself as selfFreeing