### PR TITLE
Replace then() with done(), so that error callback is not swalled by …

### DIFF
--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -37,7 +37,7 @@ Revwalk.prototype.walk = function(oid, callback) {
   this.push(oid);
 
   function walk() {
-    revwalk.next().then(function(oid) {
+    revwalk.next().done(function(oid) {
       if (!oid) {
         if (typeof callback === "function") {
           return callback();


### PR DESCRIPTION
When using the revwalk.walk function, if I make an error in the implementation of my callback, it is swalled by the code. Replacing then() with done() fixes the issue.