### PR TITLE
Fix submodule check

### DIFF
--- a/lifecycleScripts/submodules/getStatus.js
+++ b/lifecycleScripts/submodules/getStatus.js
@@ -40,5 +40,11 @@ module.exports = function getStatus() {
         .split("\n")
         .map(getStatusPromiseFromLine)
       );
+    })
+    .catch(function() {
+      // In the case that NodeGit is required from another project via npm we
+      // won't be able to run submodule commands but that's ok since the
+      // correct version of libgit2 is published with nodegit.
+      return Promise.resolve([]);
     });
 };


### PR DESCRIPTION
When installing NodeGit from npm as a dependency if the user had to build the binary it would fail on the submodule check. Now we just bypass that check on and error since the package would be published with the correct version of libgit2 in it and we don't need to grab it as a submodule at that point anyways so the check and logic is useless.