### PR TITLE
move BUILD_ONLY dependencies into dependencies list

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   ],
   "dependencies": {
     "fs-extra": "~0.26.2",
+    "lodash": "~3.10.1",
     "node-pre-gyp": "~0.6.15",
     "promisify-node": "~0.3.0"
   },
@@ -51,7 +52,6 @@
     "js-beautify": "~1.5.10",
     "jshint": "~2.8.0",
     "lcov-result-merger": "~1.0.2",
-    "lodash": "~3.10.1",
     "mocha": "~2.3.4",
     "nan": "^2.2.0",
     "node-gyp": "~3.0.3",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "node-pre-gyp"
   ],
   "dependencies": {
+    "combyne": "~0.8.1",
     "fs-extra": "~0.26.2",
+    "js-beautify": "~1.5.10",
     "lodash": "~3.10.1",
     "node-pre-gyp": "~0.6.15",
     "promisify-node": "~0.3.0"
@@ -46,10 +48,8 @@
     "babel-cli": "^6.7.7",
     "babel-preset-es2015": "^6.6.0",
     "clean-for-publish": "~1.0.2",
-    "combyne": "~0.8.1",
     "coveralls": "~2.11.4",
     "istanbul": "~0.3.20",
-    "js-beautify": "~1.5.10",
     "jshint": "~2.8.0",
     "lcov-result-merger": "~1.0.2",
     "mocha": "~2.3.4",


### PR DESCRIPTION
Lodash, combyne, and js-beautify are required for install when `BUILD_ONLY` is true. Without these present in the dependencies list, running `BUILD_ONLY=true npm install` from within my own app will create the following error:

```
[nodegit] Configuring libssh2.
ERROR - Could not generate native code
{ Error: Cannot find module 'lodash'
at Function.Module._resolveFilename (module.js:440:15)
at Function.Module._load (module.js:388:25)
at Module.require (module.js:468:17)
at require (internal/module.js:20:19)
at Object.<anonymous> (/tmp/app/node_modules/nodegit/generate/scripts/helpers.js:4:9)
at Module._compile (module.js:541:32)
at Object.Module._extensions..js (module.js:550:10)
at Module.load (module.js:458:32)
at tryModuleLoad (module.js:417:12)
at Function.Module._load (module.js:409:3) code: 'MODULE_NOT_FOUND' }
[nodegit] Everything is ready to go, attempting compilation
events.js:160
throw er; // Unhandled 'error' event
```

As a workaround, I can copy these dependencies into my own package.json.