### PR TITLE
Set parameter 'ancestor_tree' as optional in 'Merge.trees' method.

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1270,6 +1270,13 @@
             }
           }
         },
+        "git_merge_trees": {
+          "args": {
+            "ancestor_tree": {
+              "isOptional": true
+            }
+          }
+        },
         "git_merge_file": {
           "ignore": true
         },


### PR DESCRIPTION
This fixes #1061 !