### PR TITLE
expose merge options and diff flags

### DIFF
--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -547,12 +547,17 @@
             {
               "type": "git_checkout_options",
               "name": "checkout_options"
+            },
+            {
+              "type": "git_merge_options",
+              "name": "merge_options"
             }
           ],
           "used": {
             "needs": [
               "git_rebase_init_options",
-              "git_checkout_init_options"
+              "git_checkout_init_options",
+              "git_merge_init_options"
             ]
           }
         }

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -18,28 +18,51 @@ var shallowClone = require("./utils/shallow_clone");
  * @param {Function} callback
  * @return {Remote}
  */
- var init = Rebase.init;
-Rebase.init = function(repository, branch, upstream, onto, options) {
+
+function defaultRebaseOptions(options, checkoutStrategy) {
   var checkoutOptions;
+  var mergeOptions;
 
   if (options) {
     options = shallowClone(options);
     checkoutOptions = options.checkoutOptions;
+    mergeOptions = options.mergeOptions;
     delete options.checkoutOptions;
+    delete options.mergeOptions;
 
     options = normalizeOptions(options, NodeGit.RebaseOptions);
   } else {
     options = normalizeOptions({}, NodeGit.RebaseOptions);
-    checkoutOptions = {
-      checkoutStrategy: NodeGit.Checkout.STRATEGY.FORCE
-    };
+    if (checkoutStrategy) {
+      checkoutOptions = {
+        checkoutStrategy: checkoutStrategy
+      };
+    }
   }
 
   if (checkoutOptions) {
-    options.checkoutOptions =
-      normalizeOptions(checkoutOptions, NodeGit.CheckoutOptions);
+    options.checkoutOptions = normalizeOptions(
+      checkoutOptions,
+      NodeGit.CheckoutOptions
+    );
   }
 
+  if (mergeOptions) {
+    options.mergeOptions = normalizeOptions(
+      mergeOptions,
+      NodeGit.MergeOptions
+    );
+  }
+
+  return options;
+}
+
+ var init = Rebase.init;
+Rebase.init = function(repository, branch, upstream, onto, options) {
+  options = defaultRebaseOptions(
+    options,
+    NodeGit.Checkout.STRATEGY.FORCE
+  );
   return init(repository, branch, upstream, onto, options);
 };
 
@@ -54,25 +77,9 @@ Rebase.init = function(repository, branch, upstream, onto, options) {
  */
 var rebaseOpen = Rebase.open;
 Rebase.open = function(repository, options) {
-  var checkoutOptions;
-
-  if (options) {
-    options = shallowClone(options);
-    checkoutOptions = options.checkoutOptions;
-    delete options.checkoutOptions;
-
-    options = normalizeOptions(options, NodeGit.RebaseOptions);
-  } else {
-    options = normalizeOptions({}, NodeGit.RebaseOptions);
-    checkoutOptions = {
-      checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE
-    };
-  }
-
-  if (checkoutOptions) {
-    options.checkoutOptions =
-      normalizeOptions(checkoutOptions, NodeGit.CheckoutOptions);
-  }
-
+  options = defaultRebaseOptions(
+    options,
+    NodeGit.Checkout.STRATEGY.SAFE
+  );
   return rebaseOpen(repository, options);
 };

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -979,14 +979,15 @@ Repository.prototype.rebaseBranches = function(
   upstream,
   onto,
   signature,
-  beforeNextFn
+  beforeNextFn,
+  rebaseOptions
 )
 {
   var repo = this;
   var branchCommit;
   var upstreamCommit;
   var ontoCommit;
-
+  var mergeOptions = (rebaseOptions || {}).mergeOptions;
   signature = signature || repo.defaultSignature();
 
   return Promise.all([
@@ -1011,7 +1012,7 @@ Repository.prototype.rebaseBranches = function(
   .then(function(oid) {
     if (oid.toString() === branchCommit.id().toString()) {
       // we just need to fast-forward
-      return repo.mergeBranches(branch, upstream)
+      return repo.mergeBranches(branch, upstream, null, null, mergeOptions)
         .then(function() {
           // checkout 'branch' to match the behavior of rebase
           return repo.checkoutBranch(branch);
@@ -1022,7 +1023,13 @@ Repository.prototype.rebaseBranches = function(
       return repo.checkoutBranch(branch);
     }
 
-    return NodeGit.Rebase.init(repo, branchCommit, upstreamCommit, ontoCommit)
+    return NodeGit.Rebase.init(
+      repo,
+      branchCommit,
+      upstreamCommit,
+      ontoCommit,
+      rebaseOptions
+    )
       .then(function(rebase) {
         return performRebase(repo, rebase, signature, beforeNextFn);
       })

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1240,14 +1240,19 @@ Repository.prototype.mergeheadForeach = function(callback) {
  * @param {Boolean} stageNew Set to stage new filemode. Unset to unstage.
  * @return {Number} 0 or an error code
  */
-Repository.prototype.stageFilemode = function(filePath, stageNew) {
+Repository.prototype.stageFilemode =
+  function(filePath, stageNew, additionalDiffOptions) {
   var repo = this;
   var index;
+  var diffOptions = additionalDiffOptions ? {
+    flags: additionalDiffOptions
+  } : undefined;
   var diffPromise = stageNew ?
     NodeGit.Diff.indexToWorkdir(repo, index, {
         flags:
           NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
-          NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
+          NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS |
+          (additionalDiffOptions || 0)
       })
     :
     repo.getHeadCommit()
@@ -1255,7 +1260,7 @@ Repository.prototype.stageFilemode = function(filePath, stageNew) {
         return commit.getTree();
       })
       .then(function getDiffFromTree(tree) {
-        return NodeGit.Diff.treeToIndex(repo, tree, index);
+        return NodeGit.Diff.treeToIndex(repo, tree, index, diffOptions);
       });
   var filePaths = (filePath instanceof Array) ? filePath : [filePath];
 
@@ -1311,7 +1316,11 @@ Repository.prototype.stageFilemode = function(filePath, stageNew) {
     });
 };
 
-function getPathHunks(repo, index, filePath, isStaged) {
+function getPathHunks(repo, index, filePath, isStaged, additionalDiffOptions) {
+  var diffOptions = additionalDiffOptions ? {
+    flags: additionalDiffOptions
+  } : undefined;
+
   return Promise.resolve()
     .then(function() {
       if (isStaged) {
@@ -1320,14 +1329,15 @@ function getPathHunks(repo, index, filePath, isStaged) {
             return commit.getTree();
           })
           .then(function getDiffFromTree(tree) {
-            return NodeGit.Diff.treeToIndex(repo, tree, index);
+            return NodeGit.Diff.treeToIndex(repo, tree, index, diffOptions);
           });
       }
 
       return NodeGit.Diff.indexToWorkdir(repo, index, {
         flags:
           NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
-          NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
+          NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS |
+          (additionalDiffOptions || 0)
       });
     })
     .then(function(diff) {
@@ -1465,7 +1475,7 @@ function applySelectedLinesToTarget
  * @return {Number} 0 or an error code
  */
 Repository.prototype.stageLines =
-  function(filePath, selectedLines, isSelectionStaged) {
+  function(filePath, selectedLines, isSelectionStaged, additionalDiffOptions) {
 
   var repo = this;
   var index;
@@ -1479,7 +1489,8 @@ Repository.prototype.stageLines =
     return NodeGit.Diff.indexToWorkdir(repo, index, {
       flags:
         NodeGit.Diff.OPTION.SHOW_UNTRACKED_CONTENT |
-        NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS
+        NodeGit.Diff.OPTION.RECURSE_UNTRACKED_DIRS |
+        (additionalDiffOptions || 0)
     })
     .then(function(diff) {
       return diff.patches();
@@ -1516,7 +1527,13 @@ Repository.prototype.stageLines =
     .then(function(blob) {
       originalBlob = blob;
 
-      return getPathHunks(repo, index, filePath, isSelectionStaged);
+      return getPathHunks(
+        repo,
+        index,
+        filePath,
+        isSelectionStaged,
+        additionalDiffOptions
+      );
     })
     .then(function(hunks) {
       return applySelectedLinesToTarget(
@@ -1559,7 +1576,8 @@ Repository.prototype.stageLines =
  *                            selected for discarding
  * @return {Number} 0 or an error code
  */
-Repository.prototype.discardLines = function(filePath, selectedLines) {
+Repository.prototype.discardLines =
+  function(filePath, selectedLines, additionalDiffOptions) {
   var repo = this;
   var fullFilePath = path.join(repo.workdir(), filePath);
   var index;
@@ -1574,7 +1592,7 @@ Repository.prototype.discardLines = function(filePath, selectedLines) {
     .then(function(content) {
       originalContent = content;
 
-      return getPathHunks(repo, index, filePath, false);
+      return getPathHunks(repo, index, filePath, false, additionalDiffOptions);
     })
     .then(function(hunks) {
       return applySelectedLinesToTarget(


### PR DESCRIPTION
Merge options should be exposed in rebase options, so that rebases are more configurable.

Also exposes diffOptions flags field to the public anywhere NodeGit uses NodeGit.Diff methods that have options.