### PR TITLE
Fix two typos in the documentation for Commit#parents:

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -148,9 +148,8 @@ Commit.prototype.getParents = function(limit, callback) {
 };
 
 /**
- * Retrieve the commit"s parent shas.
+ * Retrieve the commit's parent shas.
  *
- * @param {Function} callback
  * @return {Array<Oid>} array of oids
  */
 Commit.prototype.parents = function() {


### PR DESCRIPTION
1. It doesn't take a callback
2. Possessive form needs a single quote instead of a double quote.