### PR TITLE
Memory management: duplicate time

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2453,6 +2453,9 @@
         }
       }
     },
+    "time": {
+      "dupFunction": "git_time_dup"
+    },
     "trace": {
       "functions": {
         "git_trace_set": {

--- a/generate/templates/manual/include/functions/copy.h
+++ b/generate/templates/manual/include/functions/copy.h
@@ -15,6 +15,7 @@ const git_time *git_time_dup(const git_time *arg);
 const git_diff_delta *git_diff_delta_dup(const git_diff_delta *arg);
 const git_diff_file *git_diff_file_dup(const git_diff_file *arg);
 
+void git_time_dup(git_time **out, const git_time *arg);
 void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_progress *arg);
 
 #endif

--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -11,6 +11,11 @@ const git_error *git_error_dup(const git_error *arg) {
   return result;
 }
 
+void git_time_dup(git_time **out, const git_time *arg) {
+  *out = (git_time *)malloc(sizeof(git_time));
+  memcpy(*out, arg, sizeof(git_time));
+}
+
 void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_progress *arg) {
   *out = (git_transfer_progress *)malloc(sizeof(git_transfer_progress));
   memcpy(*out, arg, sizeof(git_transfer_progress));


### PR DESCRIPTION
It's unsafe to use the signature's time directly since the signature could be freed. Instead duplicate the signature's time when it is requested and set it to `selfFreeing`.