### PR TITLE
Generate script: Don't write .cc or .h files if unchanged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 /lib/nodegit.js
 /node_modules/
 /src/
-/temp/
 /test/coverage/
 /test/home/
 /test/repos/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /lib/nodegit.js
 /node_modules/
 /src/
+/temp/
 /test/coverage/
 /test/home/
 /test/repos/

--- a/generate/scripts/generateJson.js
+++ b/generate/scripts/generateJson.js
@@ -231,7 +231,7 @@ module.exports = function generateJson() {
   }
 
 
-  utils.writeFile(path.join(__dirname, "..", "output", "idefs.json"), output);
+  utils.writeLocalFile("output/idefs.json", output);
 };
 
 if (require.main === module) {

--- a/generate/scripts/generateJson.js
+++ b/generate/scripts/generateJson.js
@@ -231,8 +231,7 @@ module.exports = function generateJson() {
   }
 
 
-  utils.writeFile("output/idefs.json", output);
-
+  utils.writeFile(path.join(__dirname, "..", "output", "idefs.json"), output);
 };
 
 if (require.main === module) {

--- a/generate/scripts/generateMissingTests.js
+++ b/generate/scripts/generateMissingTests.js
@@ -12,7 +12,7 @@ module.exports = function generateMissingTests() {
       var testFilePath = path.join(testFilesPath, idef.filename + ".js");
       var result = {};
 
-      var file = utils.readFile(testFilePath);
+      var file = utils.readLocalFile(testFilePath);
       if (file) {
         var fieldsResult = [];
         var functionsResult = [];

--- a/generate/scripts/generateMissingTests.js
+++ b/generate/scripts/generateMissingTests.js
@@ -58,7 +58,7 @@ module.exports = function generateMissingTests() {
 
   Promise.all(promises).then(
     function() {
-      utils.writeFile("output/missing-tests.json", output);
+      utils.writeFile(path.join(__dirname, "..", "/output/missing-tests.json"), output);
     },
     function(fail) {
       console.error(fail);

--- a/generate/scripts/generateMissingTests.js
+++ b/generate/scripts/generateMissingTests.js
@@ -58,7 +58,7 @@ module.exports = function generateMissingTests() {
 
   Promise.all(promises).then(
     function() {
-      utils.writeFile(path.join(__dirname, "..", "/output/missing-tests.json"), output);
+      utils.writeLocalFile("/output/missing-tests.json", output);
     },
     function(fail) {
       console.error(fail);

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -113,9 +113,9 @@ module.exports = function generateNativeCode() {
     return fse.copy(path.resolve(__dirname, "../templates/manual/src"), tempSrcDirPath);
   }).then(function() {
     // Write out single purpose templates.
-    utils.writeFile("../binding.gyp", beautify(templates.binding.render(enabled)), "binding.gyp");
+    utils.writeLocalFile("../binding.gyp", beautify(templates.binding.render(enabled)), "binding.gyp");
     utils.writeFile(path.join(tempSrcDirPath, "nodegit.cc"), templates.nodegitCC.render(enabled), "nodegit.cc");
-    utils.writeFile("../lib/nodegit.js", beautify(templates.nodegitJS.render(enabled)), "nodegit.js");
+    utils.writeLocalFile("../lib/nodegit.js", beautify(templates.nodegitJS.render(enabled)), "nodegit.js");
     // Write out all the classes.
     enabled.forEach(function(idef) {
       if (idef.type && idef.type != "enum") {
@@ -133,7 +133,7 @@ module.exports = function generateNativeCode() {
       }
     });
 
-    utils.writeFile("../lib/enums.js", beautify(templates.enums.render(enabled)), "enums.js");
+    utils.writeLocalFile("../lib/enums.js", beautify(templates.enums.render(enabled)), "enums.js");
   }).then(function() {
     return exec("command -v astyle").then(function(astyle) {
       if (astyle) {

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -120,13 +120,13 @@ module.exports = function generateNativeCode() {
     enabled.forEach(function(idef) {
       if (idef.type && idef.type != "enum") {
         utils.writeFile(
-          path.format({dir: tempSrcDirPath, name: idef.filename, ext: ".cc"}),
+          path.join(tempSrcDirPath, idef.filename + ".cc"),
           templates[idef.type + "_content"].render(idef),
           idef.type + "_content.cc"
         );
 
         utils.writeFile(
-          path.format({dir: tempIncludeDirPath, name: idef.filename, ext: ".h"}),
+          path.join(tempIncludeDirPath, idef.filename + ".h"),
           templates[idef.type + "_header"].render(idef),
           idef.type + "_header.h"
         );

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -1,4 +1,5 @@
 const fse = require("fs-extra");
+const walk = require("walk");
 
 const fs = require("fs");
 const path = require("path");
@@ -10,9 +11,18 @@ var util = {
   pointerRegex: /\s*\*\s*/,
   doublePointerRegex: /\s*\*\*\s*/,
 
-  readFile: function(file) {
+  readLocalFile: function(file) {
     try {
       return fs.readFileSync(local(file)).toString();
+    }
+    catch (unhandledException) {
+      return "";
+    }
+  },
+
+  readFile: function(filePath) {
+    try {
+      return fs.readFileSync(filePath).toString();
     }
     catch (unhandledException) {
       return "";
@@ -62,14 +72,84 @@ var util = {
     }).join("");
   },
 
+  getFilePathsRelativeToDir: function(dir) {
+    const files = [];
+    const walker = walk.walk(dir, { followLinks: false });
+    if (!util.isDirectory(dir)) {
+      return Promise.resolve([]);
+    }
+
+    return new Promise(function(resolve, reject) {
+      walker.on('file', function(root, stat, next) {
+        files.push(path.relative(dir, path.join(root, stat.name)));
+        next();
+      });
+
+      walker.on('end', function() {
+        resolve(files);
+      });
+
+      walker.on('errors', function() {
+        reject();
+      });
+    });
+  },
+
+  isFile: function(path) {
+    var isFile;
+    try {
+      isFile = fse.statSync(path).isFile();
+    } catch(e) {
+      isFile = false;
+    }
+
+    return isFile;
+  },
+
+  isDirectory: function(path) {
+    var isDirectory;
+    try {
+      isDirectory = fse.statSync(path).isDirectory();
+    } catch(e) {
+      isDirectory = false;
+    }
+
+    return isDirectory;
+  },
+
   isPointer: function(type) {
     return util.pointerRegex.test(type) || util.doublePointerRegex.test(type);
   },
 
   isDoublePointer: function(type) {
     return util.doublePointerRegex.test(type);
-  }
+  },
 
+  syncDirs: function(fromDir, toDir) {
+    return Promise.all([
+      util.getFilePathsRelativeToDir(toDir),
+      util.getFilePathsRelativeToDir(fromDir)
+    ]).then(function(filePaths) {
+      const toFilePaths = filePaths[0];
+      const fromFilePaths = filePaths[1];
+
+      // Delete files that aren't in fromDir
+      toFilePaths.forEach(function(filePath) {
+        if (!util.isFile(path.join(fromDir, filePath))) {
+          fse.remove(path.join(toDir, filePath));
+        }
+      });
+
+      // Copy files that don't exist in toDir or have different contents
+      fromFilePaths.forEach(function(filePath) {
+        const toFilePath = path.join(toDir, filePath);
+        const fromFilePath = path.join(fromDir, filePath);
+        if (!util.isFile(toFilePath) || util.readFile(toFilePath) !== util.readFile(fromFilePath)) {
+          fse.copy(fromFilePath, toFilePath);
+        }
+      });
+    });
+  }
 };
 
 module.exports = util;

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -11,13 +11,8 @@ var util = {
   pointerRegex: /\s*\*\s*/,
   doublePointerRegex: /\s*\*\*\s*/,
 
-  readLocalFile: function(file) {
-    try {
-      return fs.readFileSync(local(file)).toString();
-    }
-    catch (unhandledException) {
-      return "";
-    }
+  readLocalFile: function(filePath) {
+    return util.readFile(local(filePath));
   },
 
   readFile: function(filePath) {
@@ -27,6 +22,10 @@ var util = {
     catch (unhandledException) {
       return "";
     }
+  },
+
+  writeLocalFile: function(filePath, content, header) {
+    return util.writeFile(local(filePath), content, header);
   },
 
   writeFile: function(filePath, content, header) {

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -29,9 +29,8 @@ var util = {
     }
   },
 
-  writeFile: function(file, content, header) {
+  writeFile: function(filePath, content, header) {
     try {
-      var file = local(file);
       if (typeof content == "object") {
         content = JSON.stringify(content, null, 2)
       }
@@ -45,8 +44,8 @@ var util = {
           content;
       }
 
-      fse.ensureFileSync(file);
-      fse.writeFileSync(file, content);
+      fse.ensureFileSync(filePath);
+      fse.writeFileSync(filePath, content);
       return true;
     }
     catch (exception) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "js-beautify": "~1.5.10",
     "jshint": "~2.8.0",
     "lcov-result-merger": "~1.0.2",
-    "mocha": "~2.3.4"
+    "mocha": "~2.3.4",
+    "walk": "^2.3.9"
   },
   "vendorDependencies": {
     "libssh2": "1.7.0",


### PR DESCRIPTION
The generation script now checks whether the file has changed before writing it to `/src` or `/include`. This is to improve compilation time when testing changes to generated code.

It works by creating a `/temp` directory, writing the generated code to `/temp/src` and `/temp/include`, then syncing those folders with `/src` and `/include` by deleting files  that no longer exist and copying files that have changed or been added since the last code generation. Finally the `/temp` directory is deleted

If `/src` and `/include` don't exist (i.e. it's the first time the generation script has been run), `/temp/src` will be copied to `/src` and `/temp/include` will be copied to `/include`.
