### PR TITLE
Preempt nan to fix deprecated calls to Get/SetHiddenValue

### DIFF
--- a/generate/templates/manual/include/nodegit.h
+++ b/generate/templates/manual/include/nodegit.h
@@ -5,4 +5,11 @@
 
 extern ThreadPool libgit2ThreadPool;
 
+v8::Local<v8::Value> GetPrivate(v8::Local<v8::Object> object,
+                                    v8::Local<v8::String> key);
+
+void SetPrivate(v8::Local<v8::Object> object,
+                    v8::Local<v8::String> key,
+                    v8::Local<v8::Value> value);
+
 #endif

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -124,7 +124,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
         }
 
         Local<v8::Object> nodeObj = node->ToObject();
-        Local<v8::Value> checkValue = nodeObj->GetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked());
+        Local<v8::Value> checkValue = GetPrivate(nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
 
         if (!checkValue.IsEmpty() && !checkValue->IsNull() && !checkValue->IsUndefined())
         {

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -124,7 +124,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
         }
 
         Local<v8::Object> nodeObj = node->ToObject();
-        Local<v8::Value> checkValue = nodeObj->GetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked());
+        Local<v8::Value> checkValue = nodeObj->GetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked());
 
         if (!checkValue.IsEmpty() && !checkValue->IsNull() && !checkValue->IsUndefined())
         {

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -192,7 +192,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         }
 
         Local<v8::Object> nodeObj = node->ToObject();
-        Local<v8::Value> checkValue = nodeObj->GetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked());
+        Local<v8::Value> checkValue = nodeObj->GetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked());
 
         if (!checkValue.IsEmpty() && !checkValue->IsNull() && !checkValue->IsUndefined()) {
           Local<v8::Value> argv[1] = {

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -192,7 +192,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         }
 
         Local<v8::Object> nodeObj = node->ToObject();
-        Local<v8::Value> checkValue = nodeObj->GetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked());
+        Local<v8::Value> checkValue = GetPrivate(nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
 
         if (!checkValue.IsEmpty() && !checkValue->IsNull() && !checkValue->IsUndefined()) {
           Local<v8::Value> argv[1] = {

--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -128,7 +128,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_promiseComp
       {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
     {% endeach %});
     Local<v8::Object> parent = instance->handle();
-    parent->SetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
+    SetPrivate(parent, Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
     baton->result = {{ cbFunction.return.error }};
   }

--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -128,7 +128,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_promiseComp
       {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
     {% endeach %});
     Local<v8::Object> parent = instance->handle();
-    parent->SetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
+    parent->SetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
     baton->result = {{ cbFunction.return.error }};
   }

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -249,7 +249,7 @@
             {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
           {% endeach %});
           Local<v8::Object> parent = instance->handle();
-          parent->SetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
+          SetPrivate(parent, Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
           baton->result = {{ field.return.error }};
         }

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -249,7 +249,7 @@
             {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
           {% endeach %});
           Local<v8::Object> parent = instance->handle();
-          parent->SetHiddenValue(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
+          parent->SetPrivate(Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
           baton->result = {{ field.return.error }};
         }

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -8,6 +8,7 @@ extern "C" {
   {% endeach %}
 }
 
+#include "../include/nodegit.h"
 #include "../include/lock_master.h"
 #include "../include/functions/copy.h"
 #include "../include/{{ filename }}.h"

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -22,6 +22,44 @@
 #include "../include/convenient_patch.h"
 #include "../include/convenient_hunk.h"
 
+#if (NODE_MODULE_VERSION > 48)
+  v8::Local<v8::Value> GetPrivate(v8::Local<v8::Object> object,
+                                      v8::Local<v8::String> key) {
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+    v8::Local<v8::Value> value;
+    v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
+    if (!(result.IsJust() && result.FromJust()))
+      return v8::Local<v8::Value>();
+    if (object->GetPrivate(context, privateKey).ToLocal(&value))
+      return value;
+    return v8::Local<v8::Value>();
+  }
+
+  void SetPrivate(v8::Local<v8::Object> object,
+                      v8::Local<v8::String> key,
+                      v8::Local<v8::Value> value) {
+    if (value.IsEmpty())
+      return;
+    v8::Isolate* isolate = v8::Isolate::GetCurrent();
+    v8::Local<v8::Context> context = isolate->GetCurrentContext();
+    v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+    object->SetPrivate(context, privateKey, value);
+  }
+#else
+  v8::Local<v8::Value> GetPrivate(v8::Local<v8::Object> object,
+                                      v8::Local<v8::String> key) {
+    return object->GetHiddenValue(key);
+  }
+
+  void SetPrivate(v8::Local<v8::Object> object,
+                      v8::Local<v8::String> key,
+                      v8::Local<v8::Value> value) {
+    object->SetHiddenValue(key, value);
+  }
+#endif
+
 void LockMasterEnable(const FunctionCallbackInfo<Value>& info) {
   LockMaster::Enable();
 }

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -14,6 +14,7 @@ extern "C" {
 }
 
 #include <iostream>
+#include "../include/nodegit.h"
 #include "../include/lock_master.h"
 #include "../include/functions/copy.h"
 #include "../include/{{ filename }}.h"


### PR DESCRIPTION
In v8 5.2 (modules v49), Get/SetHiddenValue are removed (they've long been deprecated). But, the replacements (Get/SetPrivate) don't exist in node 4's version. NAN is planning on supporting this eventually (see: https://github.com/nodejs/nan/issues/587), but we need something shorter term as electron 1.3 has already bumped v8. 
Fixes https://github.com/nodegit/nodegit/issues/1089