### PR TITLE
Don't run postbuild when we detect electron install

### DIFF
--- a/lifecycleScripts/postinstall.js
+++ b/lifecycleScripts/postinstall.js
@@ -24,6 +24,11 @@ module.exports = function install() {
     // cleaning up
     return Promise.resolve();
   }
+  if (buildFlags.isElectron) {
+    // If we're building for electron, we're unable to require things so we should
+    // just assume success, unfortunately.
+    return Promise.resolve();
+  }
 
   return exec("node " + path.join(rootPath, "dist/nodegit.js"))
     .catch(function(e) {

--- a/lifecycleScripts/postinstall.js
+++ b/lifecycleScripts/postinstall.js
@@ -24,9 +24,9 @@ module.exports = function install() {
     // cleaning up
     return Promise.resolve();
   }
-  if (buildFlags.isElectron) {
-    // If we're building for electron, we're unable to require things so we should
-    // just assume success, unfortunately.
+  if (buildFlags.isElectron || buildFlags.isNWjs) {
+    // If we're building for electron or NWjs, we're unable to require the
+    // built library so we have to just assume success, unfortunately.
     return Promise.resolve();
   }
 

--- a/utils/buildFlags.js
+++ b/utils/buildFlags.js
@@ -11,7 +11,8 @@ try {
 }
 
 module.exports = {
-  debugBuild: process.env.BUILD_DEBUG,
+  debugBuild: !!process.env.BUILD_DEBUG,
+  isElectron: process.env.npm_config_runtime === "electron",
   isGitRepo: isGitRepo,
-  mustBuild: isGitRepo || process.env.BUILD_DEBUG || process.env.BUILD_ONLY,
+  mustBuild: !!(isGitRepo || process.env.BUILD_DEBUG || process.env.BUILD_ONLY)
 };

--- a/utils/buildFlags.js
+++ b/utils/buildFlags.js
@@ -14,5 +14,6 @@ module.exports = {
   debugBuild: !!process.env.BUILD_DEBUG,
   isElectron: process.env.npm_config_runtime === "electron",
   isGitRepo: isGitRepo,
+  isNwjs: process.env.npm_config_runtime === "node-webkit",
   mustBuild: !!(isGitRepo || process.env.BUILD_DEBUG || process.env.BUILD_ONLY)
 };


### PR DESCRIPTION
Since we can't require it from node if it's compiled for electron, we should just assume success for now

Addresses https://github.com/nodegit/nodegit/issues/1095