### PR TITLE
patch libssh2 to work with vs2015

### DIFF
--- a/vendor/libssh2/win32/libssh2_config.h
+++ b/vendor/libssh2/win32/libssh2_config.h
@@ -23,6 +23,7 @@
 #define HAVE_SELECT
 
 #ifdef _MSC_VER
+#if _MSC_VER < 1900
 #define snprintf _snprintf
 #if _MSC_VER < 1500
 #define vsnprintf _vsnprintf
@@ -33,10 +34,10 @@
 #else
 #define strncasecmp strnicmp
 #define strcasecmp stricmp
+#endif
 #endif /* _MSC_VER */
 
 /* Enable newer diffie-hellman-group-exchange-sha1 syntax */
 #define LIBSSH2_DH_GEX_NEW 1
 
 #endif /* LIBSSH2_CONFIG_H */
-


### PR DESCRIPTION
When building with the windows SDK for vs2015, the build would die due to some duplicate defines. 

Found a variation of this patch on github.com/libssh2/libssh2 for libssh2 1.7, which we still need to update to, but for now this works. 