### PR TITLE
Fix windows exception handling

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -80,26 +80,11 @@
                 "AdditionalOptions": [
                   "/EHsc"
                 ]
-              }
-            },
-            "configurations": {
-              "Debug": {
-                "msvs_settings": {
-                  "VCLinkerTool": {
-                    "AdditionalOptions": [
-                      "/FORCE:MULTIPLE"
-                    ]
-                  }
-                }
               },
-              "Release": {
-                "msvs_settings": {
-                  "VCLinkerTool": {
-                    "AdditionalOptions": [
-                      "/FORCE:MULTIPLE"
-                    ]
-                  }
-                }
+              "VCLinkerTool": {
+                "AdditionalOptions": [
+                  "/FORCE:MULTIPLE"
+                ]
               }
             }
           }

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -72,12 +72,16 @@
         ],
         [
           "OS=='win'", {
-            "cflags": [
-              "/EHsc"
-            ],
             "defines": [
               "_HAS_EXCEPTIONS=1"
             ],
+            "msvs_settings": {
+              "VCCLCompilerTool": {
+                "AdditionalOptions": [
+                  "/EHsc"
+                ]
+              }
+            },
             "configurations": {
               "Debug": {
                 "msvs_settings": {


### PR DESCRIPTION
Even though we had the `/EHsc` option in the `gyp` file, it was not being applied correctly.  With the change, the option does get applied, which also takes care of numerous build warnings like this one:
```
C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\include\xtree(839): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc (..\src\lock_master.cc) [C:\projects\nodegit\build\nodegit.vcxproj]
```