### PR TITLE
Fix postinstall script crash when install location has spaces in its path

### DIFF
--- a/lifecycleScripts/postinstall.js
+++ b/lifecycleScripts/postinstall.js
@@ -30,7 +30,7 @@ module.exports = function install() {
     return Promise.resolve();
   }
 
-  return exec("node " + path.join(rootPath, "dist/nodegit.js"))
+  return exec("node \"" + path.join(rootPath, "dist/nodegit.js\""))
     .catch(function(e) {
       if (~e.toString().indexOf("Module version mismatch")) {
         console.warn(


### PR DESCRIPTION
After installing `nodegit` in a directory which had spaces along its path, the postinstall script crashed as a result (`Error: Cannot find module 'C:\<path up to the first space>'`) - wrapping this `node` call's target in quotes fixes the issue.
