### PR TITLE
README.md needs to show where to get Slack invitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ NodeGit
 
 ## Have a problem? Come chat with us! ##
 
-https://libgit2.slack.com/
+Visit [slack.libgit2.org](http://slack.libgit2.org/) to sign up, then join us in #nodegit.
 
 ## Maintained by ##
 Tim Branyen [@tbranyen](http://twitter.com/tbranyen),


### PR DESCRIPTION
Users can't access https://libgit2.slack.com/ directly. They need to go to http://slack.libgit2.org/ first to get an invitation. This information should be reflected in the `README.md`.