### PR TITLE
Add @async tag to getEntry

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -100,7 +100,7 @@ Tree.prototype.entryByName = function(name) {
 /**
  * Get an entry at a path. Unlike by name, this takes a fully
  * qualified path, like `/foo/bar/baz.javascript`
- *
+ * @async
  * @param {String} filePath
  * @return {TreeEntry}
  */


### PR DESCRIPTION
Fix the documentation generation for Tree's getEntry method so that it'll be properly tagged as ASYNC in the [output](http://www.nodegit.org/api/tree/#getEntry).

This fixes [nodegit.github.com issue #41](https://github.com/nodegit/nodegit.github.com/issues/41).