### PR TITLE
Fix incorrect anchor link in TESTING.md

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -52,7 +52,7 @@ After you write your test make sure to run `npm run generateMissingTests` again 
 
 ### The test passes ###
 
-Excellent!! Make sure that the test is working correctly and testing what you're expecting it to test and then move onto the [next section](https://github.com/nodegit/nodegit/tree/master/test#making-a-pull-request).
+Excellent!! Make sure that the test is working correctly and testing what you're expecting it to test and then move onto the [next section](#making-a-pull-request).
 
 ### The test fails ###
 


### PR DESCRIPTION
Changed a link to point internally instead of unnecessarily using an
external link.