### PR TITLE
Added tests for Branch

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -183,6 +183,7 @@
           }
         },
         "git_branch_create_from_annotated": {
+          "isAsync": true,
           "args": {
             "ref_out": {
               "isReturn": true
@@ -193,6 +194,9 @@
             "force": {
               "isOptional": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_branch_next": {

--- a/test/tests/branch.js
+++ b/test/tests/branch.js
@@ -6,9 +6,14 @@ describe("Branch", function() {
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
   var Branch = NodeGit.Branch;
+  var AnnotatedCommit = NodeGit.AnnotatedCommit;
   var branchName = "test-branch";
+  var branchName2 = "test-branch2";
   var fullBranchName = "refs/heads/" + branchName;
+  var fullBranchName2 = "refs/heads/" + branchName2;
   var upstreamName = "origin/master";
+  var fullUpstreamName = "refs/remotes/origin/master";
+  var nonHeadCommit = "c82fb078a192ea221c9f1093c64321c60d64aa0d";
 
   var reposPath = local("../repos/workdir");
 
@@ -27,6 +32,8 @@ describe("Branch", function() {
       })
       .then(function(branch) {
         test.branch = branch;
+        return test.repository.createBranch(
+          branchName2, test.masterCommit, true);
       });
   });
 
@@ -75,6 +82,65 @@ describe("Branch", function() {
     return NodeGit.Branch.name(branch)
       .then(function(branchNameToTest) {
         assert.equal(branchNameToTest, branchName);
+      });
+  });
+
+  it("can rename a branch", function() {
+    var branch = this.branch;
+
+    // don't force the move
+    return Branch.move(branch, branchName2, 0)
+      .then(function(branch) {
+        return Promise.reject(new Error(
+          "should not be able to rename the branch"));
+      }, function(error) {
+        return Promise.resolve()
+          .then(function() {
+            // force the move
+            return Branch.move(branch, branchName2, 1);
+          })
+          .then(function(branch) {
+            assert.equal(branch.name(), fullBranchName2);
+          });
+      });
+  });
+
+  it("can lookup a branch", function() {
+    var repo = this.repository;
+
+    return Branch.lookup(repo, branchName, Branch.BRANCH.LOCAL)
+      .then(function(branch) {
+        assert.equal(branch.name(), fullBranchName);
+        return Branch.lookup(repo, upstreamName, Branch.BRANCH.REMOTE);
+      })
+      .then(function(branch) {
+        assert.equal(branch.name(), fullUpstreamName);
+      });
+  });
+
+  it("can create branch from annotated commit", function() {
+    var repo = this.repository;
+    var annotatedCommit = null;
+
+    return AnnotatedCommit.fromRevspec(repo, nonHeadCommit)
+      .then(function(theAnnotatedCommit) {
+        annotatedCommit = theAnnotatedCommit;
+        return Branch.createFromAnnotated(
+          repo, branchName, annotatedCommit, 0);
+      })
+      .then(function(branch) {
+        return Promise.reject(new Error(
+          "should not be able to create the branch"));
+      }, function(error) {
+        return Promise.resolve()
+          .then(function() {
+            // force the branch creation
+            return Branch.createFromAnnotated(
+              repo, branchName, annotatedCommit, 1);
+          })
+          .then(function(branch) {
+            assert.equal(branch.name(), fullBranchName);
+          });
       });
   });
 });


### PR DESCRIPTION
```
move
lookup
createFromAnnotated
```

Note that the test for `createFromAnnotated` is failing for me. It seems like the branch is being created even when the `force` flag has **not** been set. I would have expected the conflict in the branch's name to prevent the tag from being created but that's not happening.

The returned annotated commit does have the correct SHA-1 hash so that is not the issue. The branch that gets returned by the promise from `createFromAnnotated` has the same SHA-1 hash as what it was originally pointing at (ergo, the master commit) so it's almost as if the function call never happened! :thinking: