### PR TITLE
Add failing Revwalk test for fileHistoryWalk(*)

### DIFF
--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -311,6 +311,20 @@ describe("Revwalk", function() {
       });
   });
 
+  it("fileHistoryWalk finds merge commit", function() {
+    var repo = this.repository;
+    return repo.getCommit("8076e2d8e8c2e5de4383d65abcbf4a5b4ea9254d")
+      .then(function(commit){
+        var walker = repo.createRevWalk();
+        walker.push(commit);
+        walker.sorting(Revwalk.SORT.TIME);
+        return walker.fileHistoryWalk("package.json", 1);
+      })
+      .then(function(commits) {
+        assert.equal(commits.length, 1);
+      });
+  });
+
   it("does not leak", function() {
     var test = this;
 


### PR DESCRIPTION
It seems that `Revwalk`'s `fileHistoryWalk(*)` function does **not** find merge commits.

If you run `git log` on `test/repos/workdir/package.json` (that's what's done in the test, `./package.json` will work too), you can see that commit `8076e2d8e8c2e5de4383d65abcbf4a5b4ea9254d` is a merge commit that has affected the `package.json` file. However, `fileHistoryWalk(*)` will **not** find this commit as shown by the attached failing test.

This bug makes `fileHistoryWalk(*)` unsuitable for creating a graphical log of a file. Do you have any ideas, @implausible?