### PR TITLE
Checkout's tree(*) function does not support Oid as a parameter

### DIFF
--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -40,7 +40,7 @@ Checkout.index = function(repo, index, options) {
 *
 * @async
 * @param {Repository} repo
-* @param {Oid|Tree|Commit|Reference} treeish
+* @param {String|Tree|Commit|Reference} treeish
 * @param {CheckoutOptions} [options]
 * @return {Void} checkout complete
 */


### PR DESCRIPTION
The docs incorrectly spec that an `Oid` can be used as a `treeish` but the libgit2 [`git_checkout_tree`](https://libgit2.github.com/libgit2/#HEAD/group/checkout/git_checkout_tree) API actually only supports "a commit, tag or tree".

The following code will reproduce the problem.
```
> node bug.js
[Error: Object to checkout does not match repository]
```
```JavaScript
var git = require("nodegit");
git.Repository.open("myrepo")
.then(function(repo) {
  return repo.getTagByName('v1.0.0').then(function(tag) {
    git.Checkout.tree(repo, tag.id(), { checkoutStrategy: git.Checkout.STRATEGY.SAFE_CREATE })
    .then(function() {
      console.log("ok");
    }).catch(function(err) {
      console.log(err);
    });
  });
});
```