### PR TITLE
build against shared library for libcurl

### DIFF
--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -482,6 +482,10 @@
               "type": "git_fetch_prune_t"
             },
             {
+              "name": "proxy_opts",
+              "type": "git_proxy_options"
+            },
+            {
               "name": "update_fetchhead",
               "type": "int"
             },

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -88,13 +88,22 @@
               }
             }
           }
-        ], [
+        ],
+        [
+          "OS=='linux' or OS=='mac'", {
+            "libraries": [
+              "-lcurl"
+            ]
+          }
+        ],
+        [
           "OS=='linux' and '<!(echo \"$CXX\")'=='clang++'", {
             "cflags": [
               "-Wno-c++11-extensions"
             ]
           }
-        ], [
+        ],
+        [
           "OS=='linux' and '<!(echo \"$CXX\")'!='clang++'", {
             "cflags": [
               "-std=c++0x"

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -78,6 +78,7 @@ var importExtension = function(name) {
 rawApi.Utils = {};
 require("./utils/lookup_wrapper");
 require("./utils/normalize_options");
+require("./utils/normalize_fetch_options");
 require("./utils/shallow_clone");
 
 // Load up extra types;

--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -78,8 +78,8 @@ var importExtension = function(name) {
 rawApi.Utils = {};
 require("./utils/lookup_wrapper");
 require("./utils/normalize_options");
-require("./utils/normalize_fetch_options");
 require("./utils/shallow_clone");
+require("./utils/normalize_fetch_options");
 
 // Load up extra types;
 require("./status_file");

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,5 +1,6 @@
 var NodeGit = require("../");
 var shallowClone = NodeGit.Utils.shallowClone;
+var normalizeFetchOptions = NodeGit.Utils.normalizeFetchOptions;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Clone = NodeGit.Clone;
@@ -15,28 +16,14 @@ var _clone = Clone.clone;
  * @return {Repository} repo
  */
 Clone.clone = function(url, local_path, options) {
-  var remoteCallbacks = {};
-  var fetchOpts = {};
+  var fetchOpts = normalizeFetchOptions(options && options.fetchOpts);
 
   if (options) {
     options = shallowClone(options);
-    if (options.fetchOpts) {
-      fetchOpts = shallowClone(options.fetchOpts);
-    }
     delete options.fetchOpts;
   }
 
   options = normalizeOptions(options, NodeGit.CloneOptions);
-
-  if (fetchOpts.callbacks) {
-    remoteCallbacks = shallowClone(fetchOpts.callbacks);
-    delete fetchOpts.callbacks;
-  }
-
-  fetchOpts = normalizeOptions(fetchOpts, NodeGit.FetchOptions);
-
-  fetchOpts.callbacks =
-    normalizeOptions(remoteCallbacks, NodeGit.RemoteCallbacks);
 
   if (options) {
     options.fetchOpts = fetchOpts;

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -9,6 +9,7 @@ var _connect = Remote.prototype.connect;
 var _download = Remote.prototype.download;
 var _fetch = Remote.prototype.fetch;
 var _push = Remote.prototype.push;
+var _upload = Remote.prototype.upload;
 
 /**
  * Retrieves the remote by name
@@ -54,24 +55,8 @@ Remote.prototype.connect = function(
  * @return {Number} error code
  */
 Remote.prototype.download = function(refspecs, opts) {
-  var callbacks;
-
-  if (opts) {
-    opts = shallowClone(opts);
-    callbacks = opts.callbacks;
-    delete opts.callbacks;
-  } else {
-    opts = {};
-  }
-
-  opts = normalizeOptions(opts, NodeGit.FetchOptions);
-
-  if (callbacks) {
-    opts.callbacks =
-      normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
-  }
-
-  return _download.call(this, refspecs, opts);
+  return _download
+    .call(this, refspecs, normalizeFetchOptions(opts));
 };
 
 /**
@@ -85,7 +70,8 @@ Remote.prototype.download = function(refspecs, opts) {
  * @return {Number} error code
  */
 Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
-  return _fetch.call(this, refspecs, normalizeFetchOptions(opts), reflog_message);
+  return _fetch
+    .call(this, refspecs, normalizeFetchOptions(opts), reflog_message);
 };
 
 /**
@@ -99,10 +85,14 @@ Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
  */
 Remote.prototype.push = function(refSpecs, opts) {
   var callbacks;
+  var proxyOpts;
+
   if (opts) {
     opts = shallowClone(opts);
     callbacks = opts.callbacks;
+    proxyOpts = opts.proxyOpts;
     delete opts.callbacks;
+    delete opts.proxyOpts;
   } else {
     opts = {};
   }
@@ -114,5 +104,63 @@ Remote.prototype.push = function(refSpecs, opts) {
       normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
   }
 
+  if (proxyOpts) {
+    opts.proxyOpts =
+      normalizeOptions(proxyOpts, NodeGit.ProxyOptions);
+  }
+
   return _push.call(this, refSpecs, opts);
+};
+
+/**
+ * Connects to a remote
+ *
+ * @async
+ * @param {Array} refSpecs The ref specs that should be pushed
+ * @param {FetchOptions} opts The fetch options for download, contains callbacks
+ * @param {String} message The message to use for the update reflog messages
+ * @param {Function} callback
+ * @return {Number} error code
+ */
+Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
+  return _fetch
+    .call(this, refspecs, normalizeFetchOptions(opts), reflog_message);
+};
+
+/**
+ * Pushes to a remote
+ *
+ * @async
+ * @param {Array} refSpecs The ref specs that should be pushed
+ * @param {PushOptions} options Options for the checkout
+ * @param {Function} callback
+ * @return {Number} error code
+ */
+Remote.prototype.upload = function(refSpecs, opts) {
+  var callbacks;
+  var proxyOpts;
+
+  if (opts) {
+    opts = shallowClone(opts);
+    callbacks = opts.callbacks;
+    proxyOpts = opts.proxyOpts;
+    delete opts.callbacks;
+    delete opts.proxyOpts;
+  } else {
+    opts = {};
+  }
+
+  opts = normalizeOptions(opts, NodeGit.PushOptions);
+
+  if (callbacks) {
+    opts.callbacks =
+      normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  }
+
+  if (proxyOpts) {
+    opts.proxyOpts =
+      normalizeOptions(proxyOpts, NodeGit.ProxyOptions);
+  }
+
+  return _upload.call(this, refSpecs, opts);
 };

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -85,11 +85,14 @@ Remote.prototype.download = function(refspecs, opts) {
  */
 Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
   var callbacks;
+  var proxyOpts;
 
   if (opts) {
     opts = shallowClone(opts);
     callbacks = opts.callbacks;
+    proxyOpts = opts.proxyOpts;
     delete opts.callbacks;
+    delete opts.proxyOpts;
   } else {
     opts = {};
   }
@@ -99,6 +102,11 @@ Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
   if (callbacks) {
     opts.callbacks =
       normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  }
+
+  if (proxyOpts) {
+    opts.proxyOpts =
+      normalizeOptions(proxyOpts, NodeGit.ProxyOptions);
   }
 
   return _fetch.call(this, refspecs, opts, reflog_message);

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -1,4 +1,5 @@
 var NodeGit = require("../");
+var normalizeFetchOptions = NodeGit.Utils.normalizeFetchOptions;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
 var lookupWrapper = NodeGit.Utils.lookupWrapper;
 var shallowClone = NodeGit.Utils.shallowClone;
@@ -84,32 +85,7 @@ Remote.prototype.download = function(refspecs, opts) {
  * @return {Number} error code
  */
 Remote.prototype.fetch = function(refspecs, opts, reflog_message) {
-  var callbacks;
-  var proxyOpts;
-
-  if (opts) {
-    opts = shallowClone(opts);
-    callbacks = opts.callbacks;
-    proxyOpts = opts.proxyOpts;
-    delete opts.callbacks;
-    delete opts.proxyOpts;
-  } else {
-    opts = {};
-  }
-
-  opts = normalizeOptions(opts, NodeGit.FetchOptions);
-
-  if (callbacks) {
-    opts.callbacks =
-      normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
-  }
-
-  if (proxyOpts) {
-    opts.proxyOpts =
-      normalizeOptions(proxyOpts, NodeGit.ProxyOptions);
-  }
-
-  return _fetch.call(this, refspecs, opts, reflog_message);
+  return _fetch.call(this, refspecs, normalizeFetchOptions(opts), reflog_message);
 };
 
 /**

--- a/lib/submodule.js
+++ b/lib/submodule.js
@@ -1,10 +1,40 @@
 var NodeGit = require("../");
+var normalizeFetchOptions = NodeGit.Utils.normalizeFetchOptions;
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+var shallowClone = NodeGit.Utils.shallowClone;
 
 var Submodule = NodeGit.Submodule;
 
 var _foreach = Submodule.foreach;
+var _update = Submodule.prototype.update;
 
 // Override Submodule.foreach to eliminate the need to pass null payload
 Submodule.foreach = function(repo, callback) {
   return _foreach(repo, callback, null);
+};
+
+/**
+ * Updates a submodule
+ *
+ * @async
+ * @param {Number} init Setting this to 1 will initialize submodule
+ *                      before updating
+ * @param {SubmoduleUpdateOptions} options Submodule update settings
+ * @return {Number} 0 on success, any non-zero return value from a callback
+ */
+Submodule.prototype.update = function(init, options) {
+  var fetchOpts = normalizeFetchOptions(options && options.fetchOpts);
+
+  if (options) {
+    options = shallowClone(options);
+    delete options.fetchOpts;
+  }
+
+  options = normalizeOptions(options, NodeGit.SubmoduleUpdateOptions);
+
+  if (options) {
+    options.fetchOpts = fetchOpts;
+  }
+
+  return _update.call(this, init, options);
 };

--- a/lib/utils/normalize_fetch_options.js
+++ b/lib/utils/normalize_fetch_options.js
@@ -1,6 +1,6 @@
 var NodeGit = require("../../");
-var normalizeOptions = require("./normalize_options");
-var shallowClone = require("./shallow_clone");
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+var shallowClone = NodeGit.Utils.shallowClone;
 
 /**
  * Normalize an object to match a struct.

--- a/lib/utils/normalize_fetch_options.js
+++ b/lib/utils/normalize_fetch_options.js
@@ -1,0 +1,43 @@
+var NodeGit = require("../../");
+var normalizeOptions = require("./normalize_options");
+var shallowClone = require("./shallow_clone");
+
+/**
+ * Normalize an object to match a struct.
+ *
+ * @param {String, Object} oid - The oid string or instance.
+ * @return {Object} An Oid instance.
+ */
+function normalizeFetchOptions(options) {
+  if (options instanceof NodeGit.FetchOptions) {
+    return options;
+  }
+
+  var callbacks;
+  var proxyOpts;
+
+  if (options) {
+    options = shallowClone(options);
+    callbacks = options.callbacks;
+    proxyOpts = options.proxyOpts;
+    delete options.callbacks;
+    delete options.proxyOpts;
+  } else {
+    options = {};
+  }
+
+  options = normalizeOptions(options, NodeGit.FetchOptions);
+
+  if (callbacks) {
+    options.callbacks =
+      normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  }
+
+  if (proxyOpts) {
+    options.proxyOpts =
+      normalizeOptions(proxyOpts, NodeGit.ProxyOptions);
+  }
+  return options;
+}
+
+NodeGit.Utils.normalizeFetchOptions = normalizeFetchOptions;

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -279,15 +279,21 @@
                 }
             }
         }],
+        ["OS=='mac' or OS=='linux' or OS.endswith('bsd')", {
+          "cflags": [
+            "-DGIT_CURL"
+          ],
+          "defines": [
+            "GIT_CURL"
+          ]
+        }],
         ["OS=='linux' or OS.endswith('bsd')" , {
           "cflags": [
-            "-DGIT_CURL",
             "-DGIT_SSH",
             "-DGIT_SSL",
             "-w",
           ],
           "defines": [
-            "GIT_CURL",
             "GIT_OPENSSL",
             "GIT_USE_STAT_MTIM"
           ],

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -71,6 +71,8 @@
         "libgit2/src/config_file.h",
         "libgit2/src/config.c",
         "libgit2/src/config.h",
+        "libgit2/src/curl_stream.c",
+        "libgit2/src/curl_stream.h",
         "libgit2/src/crlf.c",
         "libgit2/src/date.c",
         "libgit2/src/delta-apply.c",
@@ -279,11 +281,13 @@
         }],
         ["OS=='linux' or OS.endswith('bsd')" , {
           "cflags": [
+            "-DGIT_CURL",
             "-DGIT_SSH",
             "-DGIT_SSL",
             "-w",
           ],
           "defines": [
+            "GIT_CURL",
             "GIT_OPENSSL",
             "GIT_USE_STAT_MTIM"
           ],


### PR DESCRIPTION
To get proxy support into NodeGit, we will need to get libgit configured to use libcurl. To start, we will just try to build nodegit against libcurl using the -lcurl flag.

We will also expose and handle proxy_options, the goal of this PR is to get proxy support in full across all systems.

This should address https://github.com/nodegit/nodegit/issues/489