### PR TITLE
Specify acceptable types for `lookup` and `dwim` in Reference

### DIFF
--- a/lib/reset.js
+++ b/lib/reset.js
@@ -10,8 +10,8 @@ var _reset = Reset.reset;
  *
  * @async
  * @param {Repository} repo Repository where to perform the reset operation.
- * @param {Object} target The committish which content will be used to reset the
- *                        content of the index.
+ * @param {Commit|Tag} target The committish which content will be used to reset
+ *                        the content of the index.
  * @param {Strarray} pathspecs List of pathspecs to operate on.
  *
  * @return {Number} 0 on success or an error code
@@ -26,11 +26,12 @@ Reset.default = function(repo, target, pathspecs) {
  * @async
  * @param {Repository} repo Repository where to perform the reset operation.
  *
- * @param {Object} target Committish to which the Head should be moved to. This
- *                        object must belong to the given `repo` and can either
- *                        be a git_commit or a git_tag. When a git_tag is being
- *                        passed, it should be dereferencable to a git_commit
- *                        which oid will be used as the target of the branch.
+ * @param {Commit|Tag} target Committish to which the Head should be moved to.
+ *                        This object must belong to the given `repo` and can
+ *                        either be a git_commit or a git_tag. When a git_tag is
+ *                        being passed, it should be dereferencable to a
+ *                        git_commit which oid will be used as the target of the
+ *                        branch.
  * @param {Number} resetType Kind of reset operation to perform.
  *
  * @param {CheckoutOptions} opts Checkout options to be used for a HARD reset.


### PR DESCRIPTION
According to libgit2's APIs, only git_commits and git_tags are acceptable. Update the documentation to accurately reflect this instead of just taking in an `Object`.

https://libgit2.github.com/libgit2/#HEAD/group/reset/git_reset

https://libgit2.github.com/libgit2/#HEAD/group/reset/git_reset_default