### PR TITLE
Node 7.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   matrix:
     - export NODE_VERSION="4" TARGET_ARCH="x64"
     - export NODE_VERSION="6.5" TARGET_ARCH="x64"
+    - export NODE_VERSION="7.4" TARGET_ARCH="x64"
 
 matrix:
   fast_finish: true
@@ -24,6 +25,9 @@ matrix:
       sudo: required
     - os: linux
       env: export NODE_VERSION="6.5" TARGET_ARCH="ia32"
+      sudo: required
+    - os: linux
+      env: export NODE_VERSION="7.4" TARGET_ARCH="ia32"
       sudo: required
 
 git:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ environment:
     # Node.js
     - nodejs_version: "4"
     - nodejs_version: "6"
+    - nodejs_version: "7"
 
 matrix:
   fast_finish: true

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "fs-extra": "~0.26.2",
     "lodash": "^4.13.1",
     "nan": "^2.2.0",
-    "node-gyp": "^3.3.1",
-    "node-pre-gyp": "~0.6.15",
+    "node-gyp": "^3.5.0",
+    "node-pre-gyp": "~0.6.32",
     "promisify-node": "~0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Testing out build support on Travis... built locally, but hitting weird error:

```

#
# Fatal error in ../deps/v8/src/api.cc, line 1051
# Check failed: !value_obj->IsJSReceiver() || value_obj->IsTemplateInfo().
#

==== C stack trace ===============================

    /usr/bin/node(v8::base::debug::StackTrace::StackTrace()+0x16) [0x106bda6]
    /usr/bin/node(V8_Fatal+0xe8) [0x1069fe8]
    /usr/bin/node(v8::Template::Set(v8::Local<v8::Name>, v8::Local<v8::Data>, v8::PropertyAttribute)+0xff) [0x76094f]
    /home/tim/git/nodegit/nodegit/build/Release/nodegit.node(Wrapper::InitializeComponent(v8::Local<v8::Object>)+0x26d) [0x7fc0c190f58d]
    /home/tim/git/nodegit/nodegit/build/Release/nodegit.node(init+0x43) [0x7fc0c190d8a3]
    /usr/bin/node(node::DLOpen(v8::FunctionCallbackInfo<v8::Value> const&)+0x365) [0xf51285]
    /usr/bin/node(v8::internal::FunctionCallbackArguments::Call(void (*)(v8::FunctionCallbackInfo<v8::Value> const&))+0x12f) [0x78d6ef]
    /usr/bin/node() [0x7f2bb8]
    /usr/bin/node() [0x7f2f50]
    /usr/bin/node(v8::internal::Builtin_HandleApiCall(int, v8::internal::Object**, v8::internal::Isolate*)+0x2b) [0x7f312b]
    [0x3856731063a7]
```