### PR TITLE
Write the index to a repository directly in merge-cleanly.js examples

### DIFF
--- a/examples/merge-cleanly.js
+++ b/examples/merge-cleanly.js
@@ -116,10 +116,7 @@ fse.remove(path.resolve(__dirname, repoDir))
 // the repository instead of just writing it.
 .then(function(index) {
   if (!index.hasConflicts()) {
-    return index.write()
-      .then(function() {
-        return index.writeTreeTo(repository);
-      });
+    return index.writeTreeTo(repository);
   }
 })
 


### PR DESCRIPTION
This fixes #1128. The returned index is only in-memory and doesn't know where to write the .git/index file to so we should just skip the `write()` call and to just only use `writeTreeTo()` instead.