### PR TITLE
Initialize pointers to fix compiler warnings about uninitialized local variables

### DIFF
--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -1,6 +1,12 @@
 {%if not isPayload %}
 // start convert_from_v8 block
+  {%if cType|isPointer %}
+  {{ cType }} from_{{ name }} = NULL;
+  {%elsif cType|isDoublePointer %}
+  {{ cType }} from_{{ name }} = NULL;
+  {%else%}
   {{ cType }} from_{{ name }};
+  {%endif%}
   {%if isOptional | or isBoolean %}
 
     {%if cppClassName == 'GitStrarray'%}


### PR DESCRIPTION
When compiling the C++ bridge code, you will see several warnings about the use of uninitialized variables.

**Linux / OSX**
```
../src/config.cc:376:2: warning: variable 'from_tx' is uninitialized when used here [-Wuninitialized]
*from_tx = Nan::ObjectWrap::Unwrap<GitTransaction>(info[0]->ToObject())->GetValue();
 ^~~~~~~
../src/config.cc:375:29: note: initialize the variable 'from_tx' to silence this warning
  git_transaction ** from_tx;
                            ^
                             = nullptr
```
**Windows**
```
nodegit\src\tree.cc(588): warning C4700: uninitialized local variable 'from_dest' used [nodegit\build\nodegit.vcxproj]
nodegit\src\rebase.cc(486): warning C4700: uninitialized local variable 'from_index' used [nodegit\build\nodegit.vcxproj]
nodegit\src\libgit2.cc(164): warning C4700: uninitialized local variable 'from_major' used [nodegit\build\nodegit.vcxproj]
nodegit\src\libgit2.cc(168): warning C4700: uninitialized local variable 'from_minor' used [nodegit\build\nodegit.vcxproj]
nodegit\src\libgit2.cc(172): warning C4700: uninitialized local variable 'from_rev' used [nodegit\build\nodegit.vcxproj]
nodegit\src\config.cc(362): warning C4700: uninitialized local variable 'from_tx' used [nodegit\build\nodegit.vcxproj]
nodegit\src\index.cc(1511): warning C4700: uninitialized local variable 'from_at_pos' used [nodegit\build\nodegit.vcxproj]
nodegit\src\tree_entry.cc(219): warning C4700: uninitialized local variable 'from_object_out' used [nodegit\build\nodegit.vcxproj]
nodegit\src\commit.cc(2364): warning C4700: uninitialized local variable 'from_tree_out' used [nodegit\build\nodegit.vcxproj]
nodegit\src\tag.cc(1767): warning C4700: uninitialized local variable 'from_tag_target_out' used [nodegit\build\nodegit.vcxproj]
nodegit\src\status.cc(665): warning C4700: uninitialized local variable 'from_ignored' used [nodegit\build\nodegit.vcxproj]
nodegit\src\revparse.cc(67): warning C4700: uninitialized local variable 'from_object_out' used [nodegit\build\nodegit.vcxproj]
nodegit\src\revparse.cc(71): warning C4700: uninitialized local variable 'from_reference_out' used [nodegit\build\nodegit.vcxproj]
```
The warnings above can easily be fixed by initializing these pointer variables to `NULL`. We should strive to have as few warnings as possible in the code (if not zero) to make the compilation logs more readable by improving the signal to noise ratio wherever possible.