### PR TITLE
`RevertOptions` parameter in `Revert.revert` is actually optional

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2044,6 +2044,11 @@
       "functions": {
         "git_revert": {
           "isAsync": true,
+          "args": {
+            "given_opts": {
+              "isOptional": true
+            }
+          },
           "return": {
             "isErrorCode": true
           }

--- a/test/tests/revert.js
+++ b/test/tests/revert.js
@@ -60,4 +60,11 @@ describe("Revert", function() {
       assert.ok(_.endsWith(fileName, entries[0].path));
     });
   });
+
+  it("RevertOptions is optional", function() {
+    return Revert.revert(test.repository, test.firstCommit, null)
+      .catch(function(error) {
+        throw error;
+      });
+  });
 });


### PR DESCRIPTION
libgit2's `git_revert` function does not actually require the revert options to be specified. It is merely a [documentation oversight](https://github.com/libgit2/libgit2/pull/4108) on their website. We should flag the `given_opts` argument as being `isOptional` so that `null` can be passed into the JavaScript function.