### PR TITLE
Make `Reset.fromAnnotated` the same as `Reset.reset`

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2097,6 +2097,17 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_reset_from_annotated": {
+          "args": {
+            "checkout_opts": {
+              "isOptional": true
+            }
+          },
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -4,6 +4,7 @@ var normalizeOptions = NodeGit.Utils.normalizeOptions;
 var Reset = NodeGit.Reset;
 var _default = Reset.default;
 var _reset = Reset.reset;
+var _fromAnnotated = Reset.fromAnnotated;
 
 /**
  * Look up a refs's commit.
@@ -49,4 +50,26 @@ Reset.reset = function(repo, target, resetType, opts) {
   opts = normalizeOptions(opts, NodeGit.CheckoutOptions);
 
   return _reset.call(this, repo, target, resetType, opts);
+};
+
+/**
+ * Sets the current head to the specified commit oid and optionally
+ * resets the index and working tree to match.
+ * 
+ * This behaves like reset but takes an annotated commit, which lets
+ * you specify which extended sha syntax string was specified by a
+ * user, allowing for more exact reflog messages.
+ * 
+ * See the documentation for reset.
+ * 
+ * @async
+ * @param {Repository} repo
+ * @param {AnnotatedCommit} target
+ * @param {Number} resetType
+ * @param {CheckoutOptions} opts
+ */
+Reset.fromAnnotated = function(repo, target, resetType, opts) {
+  opts = normalizeOptions(opts, NodeGit.CheckoutOptions);
+
+  return _fromAnnotated.call(this, repo, target, resetType, opts);
 };


### PR DESCRIPTION
The `fromAnnotated` function should be asynchronous in addition to having its `checkout_opts` parameter be optional as the function delegates to the same function as `reset` internally in libgit2.