### PR TITLE
String `message` argument of `Stash.save` is optional

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2175,6 +2175,11 @@
           }
         },
         "git_stash_save": {
+          "args": {
+            "message": {
+              "isOptional": true
+            }
+          },
           "isAsync": true,
           "return": {
             "isErrorCode": true

--- a/test/tests/stash.js
+++ b/test/tests/stash.js
@@ -31,15 +31,13 @@ describe("Stash", function() {
       });
   });
 
-  it("can save and drop a stash", function() {
+  function saveDropStash(repo, stashMessage) {
     var fileName = "README.md";
     var fileContent = "Cha-cha-cha-chaaaaaangessssss";
-    var repo = this.repository;
     var filePath = path.join(repo.workdir(), fileName);
     var oldContent;
     var stashes = [];
     var stashOid;
-    var stashMessage = "stash test";
 
     return fse.readFile(filePath)
       .then(function(content) {
@@ -82,6 +80,14 @@ describe("Stash", function() {
             return Promise.reject(e);
           });
       });
+  }
+
+  it("can save and drop a stash", function() {
+    saveDropStash(this.repository, "stash test");
+  });
+
+  it("can save a stash with no message and drop it", function() {
+    saveDropStash(this.repository, null);
   });
 
   it("can save and pop a stash", function() {


### PR DESCRIPTION
If you look at libgit2's [stash.h](https://github.com/libgit2/libgit2/blob/d02720d8a653bc564b84c27bfa01a6876bf5bec2/include/git2/stash.h#L59) file, you will see that the `message` parameter is actually optional. We should flag the argument as being optional in NodeGit's JSON file as well.