### PR TITLE
build safe convenience wrapper for git_remote_ls

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1972,6 +1972,13 @@
         }
       }
     },
+    "remote_head": {
+      "dependencies": [
+        "../include/functions/free.h"
+      ],
+      "freeFunctionName": "git_remote_head_free",
+      "selfFreeing": true
+    },
     "repository": {
       "dependencies": [
         "git2/sys/repository.h"

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1805,6 +1805,9 @@
       }
     },
     "remote": {
+      "dependencies": [
+        "../include/remote_head.h"
+      ],
       "cType": "git_remote",
       "selfFreeing": true,
       "functions": {
@@ -1968,9 +1971,6 @@
           "ignore": true
         }
       }
-    },
-    "remote_head": {
-      "ignore": true
     },
     "repository": {
       "dependencies": [

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -133,18 +133,6 @@
             "type": "std::vector<git_remote_head*> *"
           },
           {
-            "name": "callbacks",
-            "type": "git_remote_callbacks *"
-          },
-          {
-            "name": "proxy_opts",
-            "type": "git_proxy_options *"
-          },
-          {
-            "name": "custom_headers",
-            "type": "git_strarray *"
-          },
-          {
             "name": "remote",
             "type": "git_remote *"
           }

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -126,6 +126,40 @@
         },
         "group": "rebase"
       },
+      "git_remote_reference_list": {
+        "args": [
+          {
+            "name": "out",
+            "type": "std::vector<git_remote_head*> *"
+          },
+          {
+            "name": "callbacks",
+            "type": "git_remote_callbacks *"
+          },
+          {
+            "name": "proxy_opts",
+            "type": "git_proxy_options *"
+          },
+          {
+            "name": "custom_headers",
+            "type": "git_strarray *"
+          },
+          {
+            "name": "remote",
+            "type": "git_remote *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/remote/ls.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "remote",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_reset": {
         "type": "function",
         "file": "reset.h",
@@ -275,6 +309,12 @@
           "git_reflog_entry_id_new",
           "git_reflog_entry_id_old",
           "git_reflog_entry_message"
+        ]
+      ],
+      [
+        "remote",
+        [
+          "git_remote_reference_list"
         ]
       ],
       [
@@ -610,6 +650,39 @@
           "used": {
             "needs": [
               "git_remote_init_callbacks"
+            ]
+          }
+        }
+      ],
+      [
+        "git_remote_head",
+        {
+          "types": "struct",
+          "fields": [
+            {
+              "type": "int",
+              "name": "local"
+            },
+            {
+              "type": "git_oid",
+              "name": "oid"
+            },
+            {
+              "type": "git_oid",
+              "name": "loid"
+            },
+            {
+              "type": "char *",
+              "name": "name"
+            },
+            {
+              "type": "char *",
+              "name": "symref_target"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_remote_reference_list"
             ]
           }
         }

--- a/generate/templates/manual/include/convenient_hunk.h
+++ b/generate/templates/manual/include/convenient_hunk.h
@@ -27,9 +27,9 @@ using namespace v8;
 class ConvenientHunk : public Nan::ObjectWrap {
   public:
     static Nan::Persistent<Function> constructor_template;
-    static void InitializeComponent (Local<v8::Object> target);
+    static void InitializeComponent (v8::Local<v8::Object> target);
 
-    static Local<v8::Value> New(void *raw);
+    static v8::Local<v8::Value> New(void *raw);
 
     HunkData *GetValue();
     char *GetHeader();

--- a/generate/templates/manual/include/convenient_patch.h
+++ b/generate/templates/manual/include/convenient_patch.h
@@ -38,9 +38,9 @@ using namespace v8;
 class ConvenientPatch : public Nan::ObjectWrap {
   public:
     static Nan::Persistent<Function> constructor_template;
-    static void InitializeComponent (Local<v8::Object> target);
+    static void InitializeComponent (v8::Local<v8::Object> target);
 
-    static Local<v8::Value> New(void *raw);
+    static v8::Local<v8::Value> New(void *raw);
 
     ConvenientLineStats GetLineStats();
     git_delta_t GetStatus();

--- a/generate/templates/manual/include/functions/copy.h
+++ b/generate/templates/manual/include/functions/copy.h
@@ -14,6 +14,8 @@ const git_index_time *git_index_time_dup(const git_index_time *arg);
 const git_time *git_time_dup(const git_time *arg);
 const git_diff_delta *git_diff_delta_dup(const git_diff_delta *arg);
 const git_diff_file *git_diff_file_dup(const git_diff_file *arg);
+git_remote_head *git_remote_head_dup(const git_remote_head *src);
+
 
 void git_time_dup(git_time **out, const git_time *arg);
 void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_progress *arg);

--- a/generate/templates/manual/include/functions/free.h
+++ b/generate/templates/manual/include/functions/free.h
@@ -1,0 +1,12 @@
+#include <v8.h>
+
+#include <string.h>
+
+#include "git2.h"
+
+#ifndef NODEGIT_FREE_FUNCTIONS
+#define NODEGIT_FREE_FUNCTIONS
+
+void git_remote_head_free(git_remote_head *remote_head);
+
+#endif

--- a/generate/templates/manual/include/git_buf_converter.h
+++ b/generate/templates/manual/include/git_buf_converter.h
@@ -10,7 +10,7 @@ using namespace v8;
 
 class StrArrayConverter {
   public:
-    static git_strarray *Convert (Local<v8::Value> val);
+    static git_strarray *Convert (v8::Local<v8::Value> val);
 };
 
 #endif

--- a/generate/templates/manual/include/str_array_converter.h
+++ b/generate/templates/manual/include/str_array_converter.h
@@ -11,11 +11,11 @@ using namespace v8;
 class StrArrayConverter {
   public:
 
-    static git_strarray *Convert (Local<v8::Value> val);
+    static git_strarray *Convert (v8::Local<v8::Value> val);
 
   private:
     static git_strarray *ConvertArray(Array *val);
-    static git_strarray *ConvertString(Local<String> val);
+    static git_strarray *ConvertString(v8::Local<String> val);
     static git_strarray *AllocStrArray(const size_t count);
     static git_strarray *ConstructStrArray(int argc, char** argv);
 };

--- a/generate/templates/manual/include/wrapper.h
+++ b/generate/templates/manual/include/wrapper.h
@@ -17,10 +17,10 @@ class Wrapper : public Nan::ObjectWrap {
   public:
 
     static Nan::Persistent<FunctionTemplate> constructor_template;
-    static void InitializeComponent (Local<v8::Object> target);
+    static void InitializeComponent (v8::Local<v8::Object> target);
 
     void *GetValue();
-    static Local<v8::Value> New(const void *raw);
+    static v8::Local<v8::Value> New(const void *raw);
 
   private:
     Wrapper(void *raw);

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -1,0 +1,127 @@
+NAN_METHOD(GitRemote::ReferenceList)
+{
+  if (info.Length() == 0 || !info[0]->IsObject()) {
+    return Nan::ThrowError("RemoteCallbacks callbacks is required.");
+  }
+  if (info.Length() == 1 || !info[1]->IsObject()) {
+    return Nan::ThrowError("ProxyOptions proxy_opts is required.");
+  }
+
+  if (info.Length() == 2 || !(Nan::To<bool>(info[2]).FromJust())) {
+    return Nan::ThrowError("Array, String Object, or string custom_headers is required.");
+  }
+  if (info.Length() == 3 || !info[3]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  ReferenceListBaton* baton = new ReferenceListBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->out = new std::vector<git_remote_head*>;
+  baton->remote = Nan::ObjectWrap::Unwrap<GitRemote>(info.This())->GetValue();
+  baton->callbacks = Nan::ObjectWrap::Unwrap<GitRemoteCallbacks>(info[0]->ToObject())->GetValue();
+  baton->proxy_opts = Nan::ObjectWrap::Unwrap<GitProxyOptions>(info[1]->ToObject())->GetValue();
+  baton->custom_headers = StrArrayConverter::Convert(info[2]);
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]));
+  ReferenceListWorker *worker = new ReferenceListWorker(baton, callback);
+  worker->SaveToPersistent("remote", info.This());
+  if (!info[1]->IsUndefined() && !info[0]->IsNull())
+    worker->SaveToPersistent("callbacks", info[0]->ToObject());
+  if (!info[2]->IsUndefined() && !info[1]->IsNull())
+    worker->SaveToPersistent("proxy_opts", info[1]->ToObject());
+  if (!info[3]->IsUndefined() && !info[2]->IsNull())
+    worker->SaveToPersistent("custom_headers", info[2]->ToObject());
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+void GitRemote::ReferenceListWorker::Execute()
+{
+  giterr_clear();
+  baton->error_code = git_remote_connect(
+    baton->remote,
+    GIT_DIRECTION_FETCH,
+    baton->callbacks,
+    baton->proxy_opts,
+    baton->custom_headers
+  );
+
+  if (baton->error_code != GIT_OK) {
+    baton->error = git_error_dup(giterr_last());
+    delete baton->out;
+    baton->out = NULL;
+    return;
+  }
+
+  const git_remote_head **remote_heads;
+  size_t num_remote_heads;
+  baton->error_code = git_remote_ls(
+    &remote_heads,
+    &num_remote_heads,
+    baton->remote
+  );
+
+  if (baton->error_code != GIT_OK) {
+    baton->error = git_error_dup(giterr_last());
+    delete baton->out;
+    baton->out = NULL;
+    return;
+  }
+
+  baton->out->reserve(num_remote_heads);
+
+  for (unsigned int head_index = 0; head_index < num_remote_heads; ++head_index) {
+    git_remote_head *remote_head = git_remote_head_dup(remote_heads[head_index]);
+    baton->out->push_back(remote_head);
+  }
+
+  git_remote_disconnect(baton->remote);
+}
+
+void GitRemote::ReferenceListWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    unsigned int size = baton->out->size();
+    Local<Array> result = Nan::New<Array>(size);
+    for (unsigned int i = 0; i < size; i++) {
+      Nan::Set(result, Nan::New<Number>(i), GitRemoteHead::New(baton->out->at(i), true));
+    }
+
+    delete baton->out;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv);
+    if (baton->error->message)
+    {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::Error("Method next has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv);
+  }
+  else
+  {
+    callback->Call(0, NULL);
+  }
+}

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -85,7 +85,7 @@ void GitRemote::ReferenceListWorker::HandleOKCallback()
   }
   else if (baton->error_code < 0)
   {
-    Local<v8::Object> err = Nan::Error("Method next has thrown an error.")->ToObject();
+    Local<v8::Object> err = Nan::Error("Reference List has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
     Local<v8::Value> argv[1] = {
       err

--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -20,3 +20,13 @@ void git_transfer_progress_dup(git_transfer_progress **out, const git_transfer_p
   *out = (git_transfer_progress *)malloc(sizeof(git_transfer_progress));
   memcpy(*out, arg, sizeof(git_transfer_progress));
 }
+
+git_remote_head *git_remote_head_dup(const git_remote_head *src) {
+  git_remote_head *dest = (git_remote_head *)malloc(sizeof(git_remote_head));
+  dest->local = src->local;
+  git_oid_cpy(&dest->oid, &src->oid);
+  git_oid_cpy(&dest->loid, &src->loid);
+  dest->name = strdup(src->name);
+  dest->symref_target = strdup(src->symref_target);
+  return dest;
+}

--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -26,7 +26,10 @@ git_remote_head *git_remote_head_dup(const git_remote_head *src) {
   dest->local = src->local;
   git_oid_cpy(&dest->oid, &src->oid);
   git_oid_cpy(&dest->loid, &src->loid);
-  dest->name = strdup(src->name);
+
+  dest->name = src->name
+    ? strdup(src->name)
+    : NULL;
   dest->symref_target = src->symref_target
     ? strdup(src->symref_target)
     : NULL;

--- a/generate/templates/manual/src/functions/copy.cc
+++ b/generate/templates/manual/src/functions/copy.cc
@@ -27,6 +27,8 @@ git_remote_head *git_remote_head_dup(const git_remote_head *src) {
   git_oid_cpy(&dest->oid, &src->oid);
   git_oid_cpy(&dest->loid, &src->loid);
   dest->name = strdup(src->name);
-  dest->symref_target = strdup(src->symref_target);
+  dest->symref_target = src->symref_target
+    ? strdup(src->symref_target)
+    : NULL;
   return dest;
 }

--- a/generate/templates/manual/src/functions/free.cc
+++ b/generate/templates/manual/src/functions/free.cc
@@ -1,0 +1,9 @@
+#include <cstring>
+
+#include "git2.h"
+
+void git_remote_head_free(git_remote_head *remote_head) {
+  free(remote_head->name);
+  free(remote_head->symref_target);
+  free(remote_head);
+}

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -61,7 +61,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
     {%endif%}
   {%endeach%}
 
-  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[{{args|jsArgsCount}}]));
+  Nan::Callback *callback = new Nan::Callback(v8::Local<Function>::Cast(info[{{args|jsArgsCount}}]));
   {{ cppFunctionName }}Worker *worker = new {{ cppFunctionName }}Worker(baton, callback);
   {%each args|argsInfo as arg %}
     {%if not arg.isReturn %}
@@ -129,14 +129,14 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
   if (baton->error_code == GIT_OK) {
   {%endif%}
     {%if return.isResultOrError %}
-    Local<v8::Value> result = Nan::New<v8::Number>(baton->error_code);
+    v8::Local<v8::Value> result = Nan::New<v8::Number>(baton->error_code);
 
     {%elsif not .|returnsCount %}
-    Local<v8::Value> result = Nan::Undefined();
+    v8::Local<v8::Value> result = Nan::Undefined();
     {%else%}
-    Local<v8::Value> to;
+    v8::Local<v8::Value> to;
       {%if .|returnsCount > 1 %}
-    Local<Object> result = Nan::New<Object>();
+    v8::Local<Object> result = Nan::New<Object>();
       {%endif%}
       {%each .|returnsInfo 0 1 as _return %}
         {%partial convertToV8 _return %}
@@ -145,17 +145,17 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         {%endif%}
       {%endeach%}
       {%if .|returnsCount == 1 %}
-    Local<v8::Value> result = to;
+    v8::Local<v8::Value> result = to;
       {%endif%}
     {%endif%}
-    Local<v8::Value> argv[2] = {
+    v8::Local<v8::Value> argv[2] = {
       Nan::Null(),
       result
     };
     callback->Call(2, argv);
   } else {
     if (baton->error) {
-      Local<v8::Value> argv[1] = {
+      v8::Local<v8::Value> argv[1] = {
         Nan::Error(baton->error->message)
       };
       callback->Call(1, argv);
@@ -163,7 +163,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         free((void *)baton->error->message);
       free((void *)baton->error);
     } else if (baton->error_code < 0) {
-      std::queue< Local<v8::Value> > workerArguments;
+      std::queue< v8::Local<v8::Value> > workerArguments;
 {%each args|argsInfo as arg %}
   {%if not arg.isReturn %}
     {%if not arg.isSelf %}
@@ -175,7 +175,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
 {%endeach%}
       bool callbackFired = false;
       while(!workerArguments.empty()) {
-        Local<v8::Value> node = workerArguments.front();
+        v8::Local<v8::Value> node = workerArguments.front();
         workerArguments.pop();
 
         if (
@@ -191,11 +191,11 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
           continue;
         }
 
-        Local<v8::Object> nodeObj = node->ToObject();
-        Local<v8::Value> checkValue = GetPrivate(nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
+        v8::Local<v8::Object> nodeObj = node->ToObject();
+        v8::Local<v8::Value> checkValue = GetPrivate(nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
 
         if (!checkValue.IsEmpty() && !checkValue->IsNull() && !checkValue->IsUndefined()) {
-          Local<v8::Value> argv[1] = {
+          v8::Local<v8::Value> argv[1] = {
             checkValue->ToObject()
           };
           callback->Call(1, argv);
@@ -203,10 +203,10 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
           break;
         }
 
-        Local<v8::Array> properties = nodeObj->GetPropertyNames();
+        v8::Local<v8::Array> properties = nodeObj->GetPropertyNames();
         for (unsigned int propIndex = 0; propIndex < properties->Length(); ++propIndex) {
-          Local<v8::String> propName = properties->Get(propIndex)->ToString();
-          Local<v8::Value> nodeToQueue = nodeObj->Get(propName);
+          v8::Local<v8::String> propName = properties->Get(propIndex)->ToString();
+          v8::Local<v8::Value> nodeToQueue = nodeObj->Get(propName);
           if (!nodeToQueue->IsUndefined()) {
             workerArguments.push(nodeToQueue);
           }
@@ -214,9 +214,9 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       }
 
       if (!callbackFired) {
-        Local<v8::Object> err = Nan::Error("Method {{ jsFunctionName }} has thrown an error.")->ToObject();
+        v8::Local<v8::Object> err = Nan::Error("Method {{ jsFunctionName }} has thrown an error.")->ToObject();
         err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
-        Local<v8::Value> argv[1] = {
+        v8::Local<v8::Value> argv[1] = {
           err
         };
         callback->Call(1, argv);

--- a/generate/templates/partials/callback_helpers.cc
+++ b/generate/templates/partials/callback_helpers.cc
@@ -30,7 +30,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_async(void 
     {% endif %}
   {% endeach %}
 
-  Local<Value> argv[{{ cbFunction.args|jsArgsCount }}] = {
+  v8::Local<Value> argv[{{ cbFunction.args|jsArgsCount }}] = {
     {% each cbFunction.args|argsInfo as arg %}
       {% if arg | isPayload %}
         {%-- payload is always the last arg --%}
@@ -54,7 +54,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_async(void 
   };
 
   Nan::TryCatch tryCatch;
-  Local<v8::Value> result = callback->Call({{ cbFunction.args|jsArgsCount }}, argv);
+  v8::Local<v8::Value> result = callback->Call({{ cbFunction.args|jsArgsCount }}, argv);
 
   if(PromiseCompletion::ForwardIfPromise(result, baton, {{ cppFunctionName }}_{{ cbFunction.name }}_promiseCompleted)) {
     return;
@@ -124,7 +124,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}_{{ cbFunction.name }}_promiseComp
     {{ cppClassName }}* instance = static_cast<{{ cppClassName }}*>(baton->{% each cbFunction.args|argsInfo as arg %}
       {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
     {% endeach %});
-    Local<v8::Object> parent = instance->handle();
+    v8::Local<v8::Object> parent = instance->handle();
     SetPrivate(parent, Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
     baton->result = {{ cbFunction.return.error }};

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -33,12 +33,12 @@
 
   {%-- // FIXME this is not general purpose enough. --%}
   {% if size %}
-    Local<Array> tmpArray = Nan::New<Array>({{= parsedName =}}->{{ size }});
+    v8::Local<Array> tmpArray = Nan::New<Array>({{= parsedName =}}->{{ size }});
     for (unsigned int i = 0; i < {{= parsedName =}}->{{ size }}; i++) {
       Nan::Set(tmpArray, Nan::New<Number>(i), Nan::New<String>({{= parsedName =}}->{{ key }}[i]).ToLocalChecked());
     }
   {% else %}
-    Local<Array> tmpArray = Nan::New<Array>({{= parsedName =}});
+    v8::Local<Array> tmpArray = Nan::New<Array>({{= parsedName =}});
   {% endif %}
 
   to = tmpArray;

--- a/generate/templates/partials/field_accessors.cc
+++ b/generate/templates/partials/field_accessors.cc
@@ -39,7 +39,7 @@
         }
 
       {% elsif field.isLibgitType %}
-        Local<Object> {{ field.name }}(value->ToObject());
+        v8::Local<Object> {{ field.name }}(value->ToObject());
 
         wrapper->{{ field.name }}.Reset({{ field.name }});
 
@@ -52,16 +52,16 @@
         if (value->IsFunction()) {
           callback = new Nan::Callback(value.As<Function>());
         } else if (value->IsObject()) {
-          Local<Object> object = value.As<Object>();
-          Local<String> callbackKey;
+          v8::Local<Object> object = value.As<Object>();
+          v8::Local<String> callbackKey;
           Nan::MaybeLocal<Value> maybeObjectCallback = Nan::Get(object, Nan::New("callback").ToLocalChecked());
           if (!maybeObjectCallback.IsEmpty()) {
-            Local<Value> objectCallback = maybeObjectCallback.ToLocalChecked();
+            v8::Local<Value> objectCallback = maybeObjectCallback.ToLocalChecked();
             if (objectCallback->IsFunction()) {
               callback = new Nan::Callback(objectCallback.As<Function>());
               Nan::MaybeLocal<Value> maybeObjectThrottle = Nan::Get(object, Nan::New("throttle").ToLocalChecked());
               if(!maybeObjectThrottle.IsEmpty()) {
-                Local<Value> objectThrottle = maybeObjectThrottle.ToLocalChecked();
+                v8::Local<Value> objectThrottle = maybeObjectThrottle.ToLocalChecked();
                 if (objectThrottle->IsNumber()) {
                   throttle = (int)objectThrottle.As<Number>()->Value();
                 }
@@ -153,7 +153,7 @@
           {% endif %}
         {% endeach %}
 
-        Local<Value> argv[{{ field.args|jsArgsCount }}] = {
+        v8::Local<Value> argv[{{ field.args|jsArgsCount }}] = {
           {% each field.args|argsInfo as arg %}
             {% if arg.name == "payload" %}
               {%-- payload is always the last arg --%}
@@ -176,7 +176,7 @@
         };
 
         Nan::TryCatch tryCatch;
-        Local<v8::Value> result = instance->{{ field.name }}.GetCallback()->Call({{ field.args|jsArgsCount }}, argv);
+        v8::Local<v8::Value> result = instance->{{ field.name }}.GetCallback()->Call({{ field.args|jsArgsCount }}, argv);
 
         if(PromiseCompletion::ForwardIfPromise(result, baton, {{ cppClassName }}::{{ field.name }}_promiseCompleted)) {
           return;
@@ -245,7 +245,7 @@
           {{ cppClassName }}* instance = static_cast<{{ cppClassName }}*>(baton->{% each field.args|argsInfo as arg %}
             {% if arg.payload == true %}{{arg.name}}{% elsif arg.lastArg %}{{arg.name}}{% endif %}
           {% endeach %});
-          Local<v8::Object> parent = instance->handle();
+          v8::Local<v8::Object> parent = instance->handle();
           SetPrivate(parent, Nan::New("NodeGitPromiseError").ToLocalChecked(), result);
 
           baton->result = {{ field.return.error }};

--- a/generate/templates/partials/fields.cc
+++ b/generate/templates/partials/fields.cc
@@ -1,7 +1,7 @@
 {% each fields|fieldsInfo as field %}
   {% if not field.ignore %}
     NAN_METHOD({{ cppClassName }}::{{ field.cppFunctionName }}) {
-      Local<v8::Value> to;
+      v8::Local<v8::Value> to;
 
       {% if field | isFixedLengthString %}
       char* {{ field.name }} = (char *)Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue()->{{ field.name }};

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -17,7 +17,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
       {%if not arg.isReturn %}
         {%partial convertFromV8 arg %}
         {%if arg.saveArg %}
-  Local<Object> {{ arg.name }}(info[{{ arg.jsArg }}]->ToObject());
+  v8::Local<Object> {{ arg.name }}(info[{{ arg.jsArg }}]->ToObject());
   {{ cppClassName }} *thisObj = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This());
 
   thisObj->{{ cppFunctionName }}_{{ arg.name }}.Reset({{ arg.name }});
@@ -108,9 +108,9 @@ if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL
     }
     {%endif%}
 
-    Local<v8::Value> to;
+    v8::Local<v8::Value> to;
     {%if .|returnsCount > 1 %}
-    Local<Object> toReturn = Nan::New<Object>();
+    v8::Local<Object> toReturn = Nan::New<Object>();
     {%endif%}
     {%each .|returnsInfo as _return %}
       {%partial convertToV8 _return %}

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -18,6 +18,7 @@
         "src/promise_completion.cc",
         "src/wrapper.cc",
         "src/functions/copy.cc",
+        "src/functions/free.cc",
         "src/convenient_patch.cc",
         "src/convenient_hunk.cc",
         "src/str_array_converter.cc",

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -43,10 +43,10 @@ using namespace node;
     {% endeach %}
   }
 
-  void {{ cppClassName }}::InitializeComponent(Local<v8::Object> target) {
+  void {{ cppClassName }}::InitializeComponent(v8::Local<v8::Object> target) {
     Nan::HandleScope scope;
 
-    Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction);
+    v8::Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction);
 
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
     tpl->SetClassName(Nan::New("{{ jsClassName }}").ToLocalChecked());
@@ -69,17 +69,17 @@ using namespace node;
 
     InitializeTemplate(tpl);
 
-    Local<Function> _constructor_template = Nan::GetFunction(tpl).ToLocalChecked();
+    v8::Local<Function> _constructor_template = Nan::GetFunction(tpl).ToLocalChecked();
     constructor_template.Reset(_constructor_template);
     Nan::Set(target, Nan::New("{{ jsClassName }}").ToLocalChecked(), _constructor_template);
   }
 
 {% else %}
 
-  void {{ cppClassName }}::InitializeComponent(Local<v8::Object> target) {
+  void {{ cppClassName }}::InitializeComponent(v8::Local<v8::Object> target) {
     Nan::HandleScope scope;
 
-    Local<Object> object = Nan::New<Object>();
+    v8::Local<Object> object = Nan::New<Object>();
 
     {% each functions as function %}
       {% if not function.ignore %}

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -52,7 +52,7 @@ class {{ cppClassName }} : public
     friend class NodeGitWrapper<{{ cppClassName }}Traits>;
   {%endif %}
   public:
-    static void InitializeComponent (Local<v8::Object> target);
+    static void InitializeComponent (v8::Local<v8::Object> target);
 
     {% each functions as function %}
       {% if not function.ignore %}
@@ -95,7 +95,7 @@ class {{ cppClassName }} : public
         {% endif %}
       )
     {}
-    {{ cppClassName }}({{ cType }} *raw, bool selfFreeing, Local<v8::Object> owner = Local<v8::Object>())
+    {{ cppClassName }}({{ cType }} *raw, bool selfFreeing, v8::Local<v8::Object> owner = v8::Local<v8::Object>())
       : NodeGitWrapper<{{ cppClassName }}Traits>(raw, selfFreeing, owner)
     {}
     ~{{ cppClassName }}();

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -121,7 +121,7 @@ void OpenSSL_ThreadSetup() {
 
 ThreadPool libgit2ThreadPool(10, uv_default_loop());
 
-extern "C" void init(Local<v8::Object> target) {
+extern "C" void init(v8::Local<v8::Object> target) {
   // Initialize thread safety in openssl and libssh2
   OpenSSL_ThreadSetup();
   init_ssh2();
@@ -146,7 +146,7 @@ extern "C" void init(Local<v8::Object> target) {
   NODE_SET_METHOD(target, "getThreadSafetyStatus", LockMasterGetStatus);
   NODE_SET_METHOD(target, "getThreadSafetyDiagnostics", LockMasterGetDiagnostics);
 
-  Local<v8::Object> threadSafety = Nan::New<v8::Object>();
+  v8::Local<v8::Object> threadSafety = Nan::New<v8::Object>();
   threadSafety->Set(Nan::New("DISABLED").ToLocalChecked(), Nan::New((int)LockMaster::Disabled));
   threadSafety->Set(Nan::New("ENABLED_FOR_ASYNC_ONLY").ToLocalChecked(), Nan::New((int)LockMaster::EnabledForAsyncOnly));
   threadSafety->Set(Nan::New("ENABLED").ToLocalChecked(), Nan::New((int)LockMaster::Enabled));

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -68,7 +68,7 @@ void {{ cppClassName }}::ConstructFields() {
     {% if not field.ignore %}
       {% if not field.isEnum %}
         {% if field.hasConstructor |or field.isLibgitType %}
-          Local<Object> {{ field.name }}Temp = {{ field.cppClassName }}::New(
+          v8::Local<Object> {{ field.name }}Temp = {{ field.cppClassName }}::New(
             {%if not field.cType|isPointer %}&{%endif%}this->raw->{{ field.name }},
             false
           )->ToObject();
@@ -82,7 +82,7 @@ void {{ cppClassName }}::ConstructFields() {
           this->raw->{{ fields|payloadFor field.name }} = (void *)this;
         {% elsif field.payloadFor %}
 
-          Local<Value> {{ field.name }} = Nan::Undefined();
+          v8::Local<Value> {{ field.name }} = Nan::Undefined();
           this->{{ field.name }}.Reset({{ field.name }});
         {% endif %}
       {% endif %}
@@ -90,10 +90,10 @@ void {{ cppClassName }}::ConstructFields() {
   {% endeach %}
 }
 
-void {{ cppClassName }}::InitializeComponent(Local<v8::Object> target) {
+void {{ cppClassName }}::InitializeComponent(v8::Local<v8::Object> target) {
   Nan::HandleScope scope;
 
-  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction);
+  v8::Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction);
 
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   tpl->SetClassName(Nan::New("{{ jsClassName }}").ToLocalChecked());
@@ -108,7 +108,7 @@ void {{ cppClassName }}::InitializeComponent(Local<v8::Object> target) {
 
   InitializeTemplate(tpl);
 
-  Local<Function> _constructor_template = Nan::GetFunction(tpl).ToLocalChecked();
+  v8::Local<Function> _constructor_template = Nan::GetFunction(tpl).ToLocalChecked();
   constructor_template.Reset(_constructor_template);
   Nan::Set(target, Nan::New("{{ jsClassName }}").ToLocalChecked(), _constructor_template);
 }

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -29,8 +29,8 @@ class {{ cppClassName }} : public NodeGitWrapper<{{ cppClassName }}Traits> {
     // grant full access to base class
     friend class NodeGitWrapper<{{ cppClassName }}Traits>;
   public:
-    {{ cppClassName }}({{ cType }}* raw, bool selfFreeing, v8::Local<v8::Object> owner = Local<v8::Object>());
-    static void InitializeComponent (Local<v8::Object> target);
+    {{ cppClassName }}({{ cType }}* raw, bool selfFreeing, v8::Local<v8::Object> owner = v8::Local<v8::Object>());
+    static void InitializeComponent (v8::Local<v8::Object> target);
 
     {% each fields as field %}
       {% if not field.ignore %}

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -9,7 +9,6 @@ var _connect = Remote.prototype.connect;
 var _download = Remote.prototype.download;
 var _fetch = Remote.prototype.fetch;
 var _push = Remote.prototype.push;
-var _referenceList = Remote.prototype.referenceList;
 var _upload = Remote.prototype.upload;
 
 /**
@@ -39,7 +38,7 @@ Remote.prototype.connect = function(
   proxyOpts,
   customHeaders
 ) {
-  callbacks = normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  callbacks = normalizeOptions(callbacks || {}, NodeGit.RemoteCallbacks);
   proxyOpts = normalizeOptions(proxyOpts || {}, NodeGit.ProxyOptions);
   customHeaders = customHeaders || [];
 
@@ -117,23 +116,11 @@ Remote.prototype.push = function(refSpecs, opts) {
  * Lists advertised references from a remote
  *
  * @async
- * @param {RemoteCallbacks} callbacks The callback functions for the connection
- * @param {ProxyOptions} proxyOpts Proxy settings
- * @param {Array<string>} customHeaders extra HTTP headers to use
- * @param {Function} callback
- * @return {Promise}
+ * @return {Promise<Array<RemoteHead>>} a list of the remote heads currently
+ *                                      available on the remote for download
  */
-Remote.prototype.referenceList = function(
-  callbacks,
-  proxyOpts,
-  customHeaders
-) {
-  callbacks = normalizeOptions(callbacks || {}, NodeGit.RemoteCallbacks);
-  proxyOpts = normalizeOptions(proxyOpts || {}, NodeGit.ProxyOptions);
-  customHeaders = customHeaders || [];
+Remote.prototype.referenceList = Remote.prototype.referenceList;
 
-  return _referenceList.call(this, callbacks, proxyOpts, customHeaders);
-};
 /**
  * Connects to a remote
  *

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -114,21 +114,21 @@ Remote.prototype.push = function(refSpecs, opts) {
 };
 
 /**
- * Lists advertised heads from remote
+ * Lists advertised references from a remote
  *
  * @async
  * @param {RemoteCallbacks} callbacks The callback functions for the connection
  * @param {ProxyOptions} proxyOpts Proxy settings
  * @param {Array<string>} customHeaders extra HTTP headers to use
  * @param {Function} callback
- * @return {Number} error code
+ * @return {Promise}
  */
 Remote.prototype.referenceList = function(
   callbacks,
   proxyOpts,
   customHeaders
 ) {
-  callbacks = normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  callbacks = normalizeOptions(callbacks || {}, NodeGit.RemoteCallbacks);
   proxyOpts = normalizeOptions(proxyOpts || {}, NodeGit.ProxyOptions);
   customHeaders = customHeaders || [];
 

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -113,11 +113,14 @@ Remote.prototype.push = function(refSpecs, opts) {
 };
 
 /**
- * Lists advertised references from a remote
+ * Lists advertised references from a remote. You must connect to the remote
+ * before using referenceList.
  *
  * @async
- * @return {Promise<Array<RemoteHead>>} a list of the remote heads currently
- *                                      available on the remote for download
+ * @return {Promise<Array<RemoteHead>>} a list of the remote heads the remote
+ *                                      had available at the last established
+ *                                      connection.
+ *
  */
 Remote.prototype.referenceList = Remote.prototype.referenceList;
 

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -9,6 +9,7 @@ var _connect = Remote.prototype.connect;
 var _download = Remote.prototype.download;
 var _fetch = Remote.prototype.fetch;
 var _push = Remote.prototype.push;
+var _referenceList = Remote.prototype.referenceList;
 var _upload = Remote.prototype.upload;
 
 /**
@@ -112,6 +113,27 @@ Remote.prototype.push = function(refSpecs, opts) {
   return _push.call(this, refSpecs, opts);
 };
 
+/**
+ * Lists advertised heads from remote
+ *
+ * @async
+ * @param {RemoteCallbacks} callbacks The callback functions for the connection
+ * @param {ProxyOptions} proxyOpts Proxy settings
+ * @param {Array<string>} customHeaders extra HTTP headers to use
+ * @param {Function} callback
+ * @return {Number} error code
+ */
+Remote.prototype.referenceList = function(
+  callbacks,
+  proxyOpts,
+  customHeaders
+) {
+  callbacks = normalizeOptions(callbacks, NodeGit.RemoteCallbacks);
+  proxyOpts = normalizeOptions(proxyOpts || {}, NodeGit.ProxyOptions);
+  customHeaders = customHeaders || [];
+
+  return _referenceList.call(this, callbacks, proxyOpts, customHeaders);
+};
 /**
  * Connects to a remote
  *

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -506,10 +506,13 @@ describe("Remote", function() {
           remote.connect(NodeGit.Enums.DIRECTION.FETCH)
         ]);
       })
-      .then(function([remote]) {
+      .then(function(results) {
+        var remote = results[0];
         return Promise.all([remote, remote.referenceList()]);
       })
-      .then(function([remote, remoteHeads]) {
+      .then(function(results) {
+        var remote = results[0];
+        var remoteHeads = results[1];
         var remoteHeadsBySha = fp.flow([
           fp.map(function(remoteHead) {
             return {

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -2,6 +2,7 @@ var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 var _ = require("lodash");
+var fp = require("lodash/fp");
 
 var garbageCollect = require("../utils/garbage_collect.js");
 
@@ -442,6 +443,89 @@ describe("Remote", function() {
         // the remote should be freed now
         assert.equal(startSelfFreeingCount,
           Remote.getSelfFreeingInstanceCount());
+      });
+  });
+
+  it("can retrieve the list of references advertised by a remote", function() {
+    var expectedRemoteHeads = {
+      HEAD: {
+        local: 0,
+        oid: "32789a79e71fbc9e04d3eff7425e1771eb595150",
+        loid: "0000000000000000000000000000000000000000",
+        name: "HEAD",
+        symrefTarget: "refs/heads/master"
+      },
+      "refs/heads/checkout-test": {
+        local: 0,
+        oid: "1729c73906bb8467f4095c2f4044083016b4dfde",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/heads/checkout-test",
+        symrefTarget: null
+      },
+      "refs/heads/master": {
+        local: 0,
+        oid: "32789a79e71fbc9e04d3eff7425e1771eb595150",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/heads/master",
+        symrefTarget: null
+      },
+      "refs/heads/rev-walk": {
+        local: 0,
+        oid: "32789a79e71fbc9e04d3eff7425e1771eb595150",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/heads/rev-walk",
+        symrefTarget: null
+      },
+      "refs/tags/annotated-tag": {
+        local: 0,
+        oid: "dc800017566123ff3c746b37284a24a66546667e",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/tags/annotated-tag",
+        symrefTarget: null
+      },
+      "refs/tags/annotated-tag^{}": {
+        local: 0,
+        oid: "32789a79e71fbc9e04d3eff7425e1771eb595150",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/tags/annotated-tag^{}",
+        symrefTarget: null
+      },
+      "refs/tags/light-weight-tag": {
+        local: 0,
+        oid: "32789a79e71fbc9e04d3eff7425e1771eb595150",
+        loid: "0000000000000000000000000000000000000000",
+        name: "refs/tags/light-weight-tag",
+        symrefTarget: null
+      }
+    };
+
+    return this.repository.getRemote("origin")
+      .then(function(remote) {
+        return remote.referenceList();
+      })
+      .then(function(remoteHeads) {
+        var remoteHeadsBySha = fp.flow([
+          fp.map(function(remoteHead) {
+            return {
+              local: remoteHead.local(),
+              oid: remoteHead.oid().toString(),
+              loid: remoteHead.loid().toString(),
+              name: remoteHead.name(),
+              symrefTarget: remoteHead.symrefTarget()
+            };
+          }),
+          fp.keyBy("name")
+        ])(remoteHeads);
+
+        fp.flow([
+          fp.keys,
+          fp.forEach(function(remoteHeadName) {
+            assert(fp.isEqual(
+              expectedRemoteHeads[remoteHeadName],
+              remoteHeadsBySha[remoteHeadName]
+            ), "Expectations for head " + remoteHeadName + " were not met.");
+          })
+        ])(expectedRemoteHeads);
       });
   });
 });


### PR DESCRIPTION
Documentation for `git_remote_ls` shows that for it to work, a connection must be established to a remote first. When a subsequent connection is made, retrieved remote heads are destroyed and replaced with a new set.

This manual template locks the remote during execution of 3 actions (git_remote_connect, git_remote_ls, git_remote_disconnect) and copies all the data retrieved from git_remote_ls into memory for nodegit consumption.

The other contributing factor for using a manual template here is git_remote_ls has the only triple pointer use case in libgit2, so writing additional handlers for one case is overkill, especially when considering the volatility of the memory being retrieved. Complications that will exist if there is ever a good reason to build triple pointer handling into our generation system will be handling the bounds of the retrieved double pointer, as there will probably be a corresponding size argument.