### PR TITLE
Add regression test for libgit2 #4102

### DIFF
--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -311,6 +311,18 @@ describe("Revwalk", function() {
       });
   });
 
+  it("regression test for libgit2 #4102", function() {
+    this.walker.sorting(NodeGit.Revwalk.SORT.TOPOLOGICAL);
+    this.walker.pushRange("32789a7..c82fb07");
+    return this.walker.next()
+      .then(function(commit) {
+        return Promise.reject(new Error("shouldn't be able to iterate"));
+      })
+      .catch(function(err) {
+        assert.equal(err.errno, NodeGit.Error.CODE.ITEROVER);
+      });
+  });
+
   it("does not leak", function() {
     var test = this;
 


### PR DESCRIPTION
If `Revwalk.SORT.TOPOLOGICAL` is used in a revwalk, Node will crash. This is caused by [libgit #4102](https://github.com/libgit2/libgit2/issues/4102).

This is [blocking](https://bugs.eclipse.org/bugs/show_bug.cgi?id=511822) the Orion project from upgrading to NodeGit 0.17.0.