### PR TITLE
Use wider int to calculate throttle window

### DIFF
--- a/generate/templates/manual/include/callback_wrapper.h
+++ b/generate/templates/manual/include/callback_wrapper.h
@@ -47,7 +47,7 @@ public:
     }
     // throttle if needed
     uint64_t now = uv_hrtime();
-    if(lastCallTime > 0 && now < lastCallTime + throttle * 1000000) {
+    if(lastCallTime > 0 && now < lastCallTime + throttle * (uint64_t)1000000) {
       // throttled
       return true;
     } else {


### PR DESCRIPTION
Sufficiently large throttle values would cause an overflow - the cast coerces the computation into a sufficiently large int