### PR TITLE
Use curl-config to find curl

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -91,9 +91,9 @@
           }
         ],
         [
-          "OS=='linux' or OS=='mac'", {
+          "OS=='linux' or OS=='mac' or OS.endswith('bsd')", {
             "libraries": [
-              "-lcurl"
+              "<!(curl-config --libs)"
             ]
           }
         ],

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -293,7 +293,8 @@
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd')", {
           "cflags": [
-            "-DGIT_CURL"
+            "-DGIT_CURL",
+            "<!(curl-config --cflags)"
           ],
           "defines": [
             "GIT_CURL"


### PR DESCRIPTION
On BSDs headers will be in /usr/local/include which
is not added to the include path automatically.

Follow-up-to: #1195