### PR TITLE
Try freeing alloced fields appropriately.

### DIFF
--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -271,6 +271,8 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       {%endif%}
     {%elsif arg.globalPayload %}
   delete ({{ cppFunctionName}}_globalPayload*)baton->{{ arg.name }};
+    {%elsif arg.shouldAlloc %}
+  free((void *)baton->{{ arg.name }});
     {%endif%}
     {%if arg.cppClassName == "GitBuf" %}
   git_buf_free(baton->{{ arg.name }});


### PR DESCRIPTION
See  https://github.com/nodegit/nodegit/issues/1230

In the example provided there, `free((void *)baton->ignored);` gets added immediately preceding the delete baton.

@srajko You've been the leakyhelpy guy as of late, can you confirm this isn't going to cause double frees?

Edit: RIP