### PR TITLE
`ceiling_dirs` parameter in `Repository.discover` is optional

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2245,6 +2245,9 @@
             "isErrorCode": true
           },
           "args": {
+            "ceiling_dirs": {
+              "isOptional": true
+            },
             "out": {
               "isReturn": true,
               "isSelf": false,

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -200,13 +200,23 @@ describe("Repository", function() {
     });
   });
 
-  it("can discover if a path is part of a repository", function() {
+  function discover(ceiling) {
     var testPath = path.join(reposPath, "lib", "util", "normalize_oid.js");
     var expectedPath = path.join(reposPath, ".git");
-    return NodeGit.Repository.discover(testPath, 0, "")
+    return NodeGit.Repository.discover(testPath, 0, ceiling)
       .then(function(foundPath) {
         assert.equal(expectedPath, foundPath);
       });
+  }
+
+  it("can discover if a path is part of a repository, null ceiling",
+      function() {
+    return discover(null);
+  });
+
+  it("can discover if a path is part of a repository, empty ceiling",
+      function() {
+    return discover("");
   });
 
   it("can create a repo using initExt", function() {


### PR DESCRIPTION
libgit2's [`git_repository_discover`](https://libgit2.github.com/libgit2/#v0.25.1/group/repository/git_repository_discover) function has an optional `ceiling_dirs` parameter. We should flag it as such in our JSON file.