### PR TITLE
Use example.com domain for default signature.

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -681,7 +681,7 @@ Repository.prototype.defaultSignature = function() {
   var result = NodeGit.Signature.default(this);
 
   if (!result || !result.name()) {
-    result = NodeGit.Signature.now("unknown", "unknown@unknown.com");
+    result = NodeGit.Signature.now("unknown", "unknown@example.com");
   }
 
   return result;

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -72,7 +72,7 @@ describe("Signature", function() {
     .then(function(repo) {
       var sig = repo.defaultSignature();
       assert.equal(sig.name(), "unknown");
-      assert.equal(sig.email(), "unknown@unknown.com");
+      assert.equal(sig.email(), "unknown@example.com");
     })
     .then(cleanUp)
     .then(done)


### PR DESCRIPTION
This domain is guaranteed to be unused (see RFC2606).  It is
inappropriate to use a real domain for a made-up email address.