### PR TITLE
`Repository.checkoutBranch` does nothing if branch name matches tag name

### DIFF
--- a/test/tests/checkout.js
+++ b/test/tests/checkout.js
@@ -108,6 +108,29 @@ describe("Checkout", function() {
     });
   });
 
+  it("can checkout a branch with a name that conflicts with a tag", function() {
+    var test = this;
+    var commit;
+
+    return test.repository.getHeadCommit()
+    .then(function(headCommit) {
+      commit = headCommit;
+      return test.repository.createLightweightTag(commit.sha(), "conflict");
+    })
+    .then(function() {
+      return test.repository.createBranch("conflict", commit);
+    })
+    .then(function() {
+      return test.repository.checkoutBranch("conflict");
+    })
+    .then(function() {
+      return test.repository.head();
+    })
+    .then(function(ref) {
+      assert.equal(ref.name(), "refs/heads/conflict");
+    });
+  });
+
   it("can checkout an index with conflicts", function() {
     var test = this;
 


### PR DESCRIPTION
According to the [Git documentation](https://git-scm.com/docs/git-rev-parse.html#_specifying_revisions), `refs/tags/` will be searched before `refs/heads/` when looking up references. As a result, trying to use `getReference()` in [`checkoutBranch`](https://github.com/nodegit/nodegit/blob/950960eb523b0378caa53df20001c7fa07a3374b/lib/repository.js#L373-L377) will fail as it will return the tag instead of the branch.

I have included a failing test case that illustrates this problem.

---------------

**Solution A:**
Prepend `refs/heads/` to `branch` before calling `getReference(branch)`.

**Result A:**
Any existing NodeGit clients that currently pass in a fully qualified reference name will be broken in the next release.

---------------

**Solution B:**
Prepend `refs/heads/` to `branch` before calling `getReference(branch)` if and only if `branch` does not already have `refs/heads/` as its prefix.

**Result B:**
The API contract becomes a little weird. Some clients may want to pass in `refs/heads/branch` to checkout `refs/heads/refs/heads/branch` when NodeGit will in fact end up checking out `refs/heads/branch`. Of course, with the right documentation this might not be ambiguous at all to anyone using the API and most users of Git probably don't have a branch named `refs/heads/refs/heads/branch` in their repository.