### PR TITLE
Make Tree#createUpdated usable

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2593,6 +2593,10 @@
         }
       }
     },
+    "tree_update": {
+      "hasConstructor": true,
+      "ignoreInit": true
+    },
     "writestream": {
       "cType": "git_writestream",
       "needsForwardDeclaration": false

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2527,6 +2527,16 @@
     "tree": {
       "selfFreeing": true,
       "functions": {
+        "git_tree_create_updated": {
+          "args": {
+            "updates": {
+              "cType": "git_tree_update *",
+              "cppClassName": "Array",
+              "jsClassName": "Array",
+              "arrayElementCppClassName": "GitTreeUpdate"
+            }
+          }
+        },
         "git_tree_entry_byid": {
           "return": {
             "ownedByThis": true

--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -48,12 +48,12 @@
   {%elsif cppClassName == 'Array'%}
 
   Array *tmp_{{ name }} = Array::Cast(*info[{{ jsArg }}]);
-  from_{{ name }} = ({{ cType }})malloc(tmp_{{ name }}->Length() * sizeof({{ cType|replace '**' '*' }}));
+  from_{{ name }} = ({{ cType }})malloc(tmp_{{ name }}->Length() * sizeof({{ cType|unPointer }}));
       for (unsigned int i = 0; i < tmp_{{ name }}->Length(); i++) {
     {%--
       // FIXME: should recursively call convertFromv8.
     --%}
-      from_{{ name }}[i] = Nan::ObjectWrap::Unwrap<{{ arrayElementCppClassName }}>(tmp_{{ name }}->Get(Nan::New(static_cast<double>(i)))->ToObject())->GetValue();
+      from_{{ name }}[i] = {%if not cType|isDoublePointer %}*{%endif%}Nan::ObjectWrap::Unwrap<{{ arrayElementCppClassName }}>(tmp_{{ name }}->Get(Nan::New(static_cast<double>(i)))->ToObject())->GetValue();
       }
   {%elsif cppClassName == 'Function'%}
   {%elsif cppClassName == 'Buffer'%}

--- a/test/tests/tree.js
+++ b/test/tests/tree.js
@@ -39,6 +39,24 @@ describe("Tree", function() {
     }).done(done);
   });
 
+  it("updates a tree", function () {
+    var repo = this.existingRepo;
+    var update = new NodeGit.TreeUpdate();
+    update.action = NodeGit.Tree.UPDATE.REMOVE;
+    update.path = "README.md";
+    return this.commit.getTree().then(function(tree) {
+        return tree.createUpdated(repo, 1, [update]);
+      })
+      .then(function(treeOid) {
+        return repo.getTree(treeOid);
+      })
+      .then(function(updatedTree) {
+        assert.throws(function () {
+          updatedTree.entryByName("README.md");
+        });
+      });
+  });
+
   it("walks its entries and returns the same entries on both progress and end",
   function() {
     var repo = this.repository;


### PR DESCRIPTION
Currently, `Tree#createUpdated` is not usable as new `TreeUpdate`s cannot be constructed and `createUpdated(repo, nupdates, updates)` only accepts a single `TreeUpdate` as `updates`.

This pull request allows to `new TreeUpdate()` and turns `updates` into an `Array<TreeUpdate>`.

Usage is, e.g., as follows:

```javascript
#!/usr/bin/env node

const Git = require("nodegit");

(async () => {
  const repo = await Git.Repository.init("test", 1);
  const odb = await repo.odb();
  const emptyTree = await repo.getTree(await odb.write("", 0, Git.Object.TYPE.TREE));
  const oid = await odb.write("test\n", 5, Git.Object.TYPE.BLOB);

  const update = new Git.TreeUpdate();
  update.action = Git.Tree.UPDATE.UPSERT;
  update.filemode = Git.TreeEntry.FILEMODE.BLOB;
  update.id = oid;
  update.path = "directory1/file";

  const update2 = new Git.TreeUpdate();
  update2.action = Git.Tree.UPDATE.UPSERT;
  update2.filemode = Git.TreeEntry.FILEMODE.BLOB;
  update2.id = oid;
  update2.path = "directory2/file";

  const treeOid = await emptyTree.createUpdated(repo, 2, [update, update2]);
  console.log(treeOid);
})();
```