### PR TITLE
Add JavaScript version of `git_tag_peel()`

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2696,6 +2696,14 @@
             "isErrorCode": true
           },
           "isAsync": true
+        },
+        "git_tag_peel": {
+          "args": {
+            "tag_target_out": {
+              "isReturn": true
+            }
+          },
+          "isAsync": true
         }
       }
     },

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -220,4 +220,14 @@ describe("Tag", function() {
         assert(object.type(), Obj.TYPE.TAG);
       });
   });
+
+  it("can peel a tag", function() {
+    return this.repository.getTagByName(tagName)
+      .then(function(tag) {
+        return tag.peel();
+      })
+      .then(function(object) {
+        assert.equal(object.isCommit(), true);
+      });
+  });
 });


### PR DESCRIPTION
The generated code for [`git_tag_peel()`](https://libgit2.github.com/libgit2/#v0.25.1/group/tag/git_tag_peel) is taking a pointer as a to return the peeled object. We should change the argument to be `isReturn` so that the generated API is sane from a JavaScript point of view.