### PR TITLE
Expose a proper JavaScript API for TreeEntry's `toObject`

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2590,6 +2590,17 @@
           "return": {
             "ownedByThis": true
           }
+        },
+        "git_tree_entry_to_object": {
+          "args": {
+            "object_out": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
         }
       }
     },

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -156,6 +156,28 @@ describe("TreeEntry", function() {
       });
   });
 
+  it("can convert entry into a blob", function() {
+    var repo = this.repository;
+    return this.commit.getEntry("README.md")
+      .then(function(entry) {
+        return entry.toObject(repo);
+      })
+      .then(function(object) {
+        assert.equal(object.isBlob(), true);
+      });
+  });
+
+  it("can convert entry into a tree", function() {
+    var repo = this.repository;
+    return this.commit.getEntry("example")
+      .then(function(entry) {
+        return entry.toObject(repo);
+      })
+      .then(function(object) {
+        assert.equal(object.isTree(), true);
+      });
+  });
+
   it("does not leak", function() {
     var test = this;
 


### PR DESCRIPTION
Fix #1268 by tweaking the generated code so that it doesn't take a pointer as a parameter.