### PR TITLE
Add tests for AnnotatedCommit

### DIFF
--- a/test/tests/annotated_commit.js
+++ b/test/tests/annotated_commit.js
@@ -67,4 +67,27 @@ describe("AnnotatedCommit", function() {
         assert(id, annotatedCommit.id());
       });
   });
+
+  it("can lookup an AnnotatedCommit from a revspec", function() {
+    var test = this;
+
+    return AnnotatedCommit.fromRevspec(test.repository, "checkout-test")
+      .then(function(annotatedCommit) {
+        assert.equal(annotatedCommit.id().toString(),
+          "1729c73906bb8467f4095c2f4044083016b4dfde");
+      });
+  });
+
+  it("can lookup an AnnotatedCommit from a fetchhead", function() {
+    var test = this;
+
+    return AnnotatedCommit.fromFetchhead(test.repository,
+      "rev-walk",
+      "https://github.com/nodegit/test",
+      "32789a79e71fbc9e04d3eff7425e1771eb595150")
+      .then(function(annotatedCommit) {
+        assert.equal(annotatedCommit.id().toString(),
+          "32789a79e71fbc9e04d3eff7425e1771eb595150");
+      });
+  });
 });


### PR DESCRIPTION
Introduce tests for the last two functions in `AnnotatedCommit` that aren't currently covered by the test suite.

`fromFetchhead`
`fromRevspec`