### PR TITLE
Fix details-for-tree-entry.js to access fields instead of calling a function

### DIFF
--- a/examples/details-for-tree-entry.js
+++ b/examples/details-for-tree-entry.js
@@ -17,10 +17,10 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
         var indexEntry = index.getByPath(treeEntry.path());
 
         // With the index entry we can now view the details for the tree entry
-        console.log("Entry path: " + indexEntry.path());
-        console.log("Entry time in seconds: " + indexEntry.mtime().seconds());
-        console.log("Entry oid: " + indexEntry.id().toString());
-        console.log("Entry size: " + indexEntry.fileSize());
+        console.log("Entry path: " + indexEntry.path);
+        console.log("Entry time in seconds: " + indexEntry.mtime.seconds());
+        console.log("Entry oid: " + indexEntry.id.toString());
+        console.log("Entry size: " + indexEntry.fileSize);
       });
     });
   })


### PR DESCRIPTION
The example [currently](https://github.com/nodegit/nodegit/blob/df960879f76450dea738629e72bcbc990bea14c7/examples/details-for-tree-entry.js#L20-L23) calls functions on the `IndexEntry` object but those are actually fields so they should be accessed as such.