### PR TITLE
Fix git_tree_entry double free

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2529,19 +2529,22 @@
       "functions": {
         "git_tree_entry_byid": {
           "return": {
-            "ownedByThis": true
+            "ownedByThis": true,
+            "selfFreeing": false
           }
         },
         "git_tree_entry_byindex": {
           "jsFunctionName": "_entryByIndex",
           "return": {
-            "ownedByThis": true
+            "ownedByThis": true,
+            "selfFreeing": false
           }
         },
         "git_tree_entry_byname": {
           "jsFunctionName": "_entryByName",
           "return": {
-            "ownedByThis": true
+            "ownedByThis": true,
+            "selfFreeing": false
           }
         },
         "git_tree_entrycount": {
@@ -2564,6 +2567,7 @@
         },
         "git_treebuilder_get": {
           "return": {
+            "selfFreeing": false,
             "ownedByThis": true
           }
         },
@@ -2571,6 +2575,7 @@
           "isAsync": false,
           "args": {
             "out": {
+              "selfFreeing": false,
               "ownedByThis": true
             }
           }
@@ -2595,7 +2600,7 @@
       }
     },
     "tree_entry": {
-      "selfFreeing": false,
+      "selfFreeing": true,
       "dupFunction": "git_tree_entry_dup",
       "freeFunctionName": "git_tree_entry_free",
       "functions": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2562,6 +2562,19 @@
         "git_treebuilder_filter": {
           "ignore": true
         },
+        "git_treebuilder_get": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_treebuilder_insert": {
+          "isAsync": false,
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          }
+        },
         "git_treebuilder_write": {
           "args": {
             "id": {
@@ -2582,7 +2595,7 @@
       }
     },
     "tree_entry": {
-      "selfFreeing": true,
+      "selfFreeing": false,
       "dupFunction": "git_tree_entry_dup",
       "freeFunctionName": "git_tree_entry_free",
       "functions": {

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -2,8 +2,6 @@ var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 
-var leakTest = require("../utils/leak_test");
-
 describe("TreeEntry", function() {
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
@@ -176,16 +174,5 @@ describe("TreeEntry", function() {
       .then(function(object) {
         assert.equal(object.isTree(), true);
       });
-  });
-
-  it("does not leak", function() {
-    var test = this;
-
-    return leakTest(NodeGit.TreeEntry, function() {
-      return test.commit.getTree()
-        .then(function(tree) {
-          return tree.entryByPath("example");
-        });
-    });
   });
 });

--- a/test/tests/tree_entry.js
+++ b/test/tests/tree_entry.js
@@ -2,6 +2,8 @@ var assert = require("assert");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
 
+var leakTest = require("../utils/leak_test");
+
 describe("TreeEntry", function() {
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
@@ -174,5 +176,16 @@ describe("TreeEntry", function() {
       .then(function(object) {
         assert.equal(object.isTree(), true);
       });
+  });
+
+  it("does not leak", function() {
+    var test = this;
+
+    return leakTest(NodeGit.TreeEntry, function() {
+      return test.commit.getTree()
+        .then(function(tree) {
+          return tree.entryByPath("example");
+        });
+    });
   });
 });


### PR DESCRIPTION
git_tree_entry is marked as self freeing. But libgit2 only requires free'ing these in cases where the entry is retrieved from git_tree_entry_dup or git_tree_entry_bypath. Neither of which is exposed by nodegit.

This can lead to memory corruption and/or double free. This PR updates the default to make this not self freeing.

It also updates the treebuilder side to mark itself as the owner. The docs indicate https://libgit2.github.com/libgit2/#HEAD/group/treebuilder/git_treebuilder_insert that the returned tree_entry in a git_treebuilder_insert may not be valid past the next builder call. I couldn't find a way with the current generator to either fill this field in with NULL to not return the entry at all. Or duplicate it prior to returning.