### PR TITLE
BREAKING: Convert git_status_file to an async method

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2241,6 +2241,7 @@
           "isAsync": false
         },
         "git_status_file": {
+          "isAsync": true,
           "args": {
             "status_flags": {
               "isReturn": true

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -10,6 +10,11 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 
   baton->error_code = GIT_OK;
   baton->error = NULL;
+  {%if cppClassName == "GitStatus" %}
+    {%if cppFunctionName == "File" %}
+  baton->status_flags = (unsigned int *)malloc(sizeof(unsigned int));
+    {%endif%}
+  {%endif%}
 
   {%each args|argsInfo as arg %}
     {%if arg.globalPayload %}
@@ -259,6 +264,12 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       {%endif%}
     {%endeach%}
   }
+
+  {%if cppClassName == "GitStatus" %}
+    {%if cppFunctionName == "File" %}
+  free((void *)baton->status_flags);
+    {%endif%}
+  {%endif%}
 
   {%each args|argsInfo as arg %}
     {%if arg.isCppClassStringOrArray %}

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -150,15 +150,15 @@ function getPathHunks(repo, index, filePath, isStaged, additionalDiffOptions) {
       });
     })
     .then(function(diff) {
-      if (!(NodeGit.Status.file(repo, filePath) &
-          NodeGit.Status.STATUS.WT_MODIFIED) &&
-          !(NodeGit.Status.file(repo, filePath) &
-          NodeGit.Status.STATUS.INDEX_MODIFIED)) {
-        return Promise.reject
-          ("Selected staging is only available on modified files.");
-      }
-
-      return diff.patches();
+      return NodeGit.Status.file(repo, filePath)
+        .then(function(status) {
+          if (!(status & NodeGit.Status.STATUS.WT_MODIFIED) &&
+              !(status & NodeGit.Status.STATUS.INDEX_MODIFIED)) {
+            return Promise.reject
+              ("Selected staging is only available on modified files.");    
+          }
+          return diff.patches();
+        });
     })
     .then(function(patches) {
       var pathPatch = patches.filter(function(patch) {
@@ -1636,17 +1636,42 @@ Repository.prototype.stageFilemode =
     })
     .then(function(diff) {
       var origLength = filePaths.length;
-      filePaths = filePaths.filter(function(p) {
-        return (
-          (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.WT_MODIFIED) ||
-          (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.INDEX_MODIFIED)
-        );
-      });
-      if (filePaths.length === 0 && origLength > 0) {
-        return Promise.reject
-            ("Selected staging is only available on modified files.");
-      }
-      return diff.patches();
+      var fileFilterPromises = fp.map(function(p) {
+        return NodeGit.Status.file(repo, p)
+          .then(function(status) {
+            return {
+              path: p,
+              filter: (
+                (status & NodeGit.Status.STATUS.WT_MODIFIED) ||
+                (status & NodeGit.Status.STATUS.INDEX_MODIFIED)
+              )
+            };
+          });
+      }, filePaths);
+
+      return Promise.all(fileFilterPromises)
+        .then(function(results) {
+          filePaths = fp.flow([
+            fp.filter(function(filterResult) {
+              return filterResult.filter;
+            }),
+            fp.map(function(filterResult) {
+              return filterResult.path;
+            })
+          ])(results);
+
+          if (filePaths.length === 0 && origLength > 0) {
+            return Promise.reject
+                ("Selected staging is only available on modified files.");
+          }
+          return diff.patches();
+        });
+// filePaths = filePaths.filter(function(p) {
+//   return (
+//     (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.WT_MODIFIED) ||
+//     (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.INDEX_MODIFIED)
+//   );
+// });
     })
     .then(function(patches) {
       var pathPatches = patches.filter(function(patch) {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1666,12 +1666,6 @@ Repository.prototype.stageFilemode =
           }
           return diff.patches();
         });
-// filePaths = filePaths.filter(function(p) {
-//   return (
-//     (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.WT_MODIFIED) ||
-//     (NodeGit.Status.file(repo, p) & NodeGit.Status.STATUS.INDEX_MODIFIED)
-//   );
-// });
     })
     .then(function(patches) {
       var pathPatches = patches.filter(function(patch) {


### PR DESCRIPTION
Convert the NodeGit.Status.file routine to be an async routine. This is to help avoid deadlocks as functions that read from or write to disk should be asynchronous.  This is a breaking change since the function now returns a promise and not the status.