### PR TITLE
Fix compiling with clang

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -98,16 +98,9 @@
           }
         ],
         [
-          "OS=='linux' and '<!(echo \"$CXX\")'=='clang++'", {
+          "OS=='linux' or OS.endswith('bsd')", {
             "cflags": [
-              "-Wno-c++11-extensions"
-            ]
-          }
-        ],
-        [
-          "OS=='linux' and '<!(echo \"$CXX\")'!='clang++'", {
-            "cflags": [
-              "-std=c++0x"
+              "-std=c++11"
             ]
           }
         ]

--- a/vendor/openssl/openssl.gyp
+++ b/vendor/openssl/openssl.gyp
@@ -152,7 +152,7 @@
           }],
         ]
       }],
-      ['is_clang==1 or gcc_version>=43', {
+      ['gcc_version>=43', {
         'cflags': ['-Wno-old-style-declaration'],
       }],
       ['OS=="solaris"', {


### PR DESCRIPTION
Solves two issues:

  1. clang does not support `-Wno-c++11-extensions`
  2. nodegit uses c++11 and clang requires the `-std=c++11` flag to build with

Tested with clang-4, clang-5 and gcc-5.4