### PR TITLE
Fix example by forcing backslashes with path.posix

### DIFF
--- a/examples/add-and-commit.js
+++ b/examples/add-and-commit.js
@@ -46,7 +46,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
 })
 .then(function() {
   // this file is in a subdirectory and can use a relative path
-  return index.addByPath(path.join(directoryName, fileName));
+  return index.addByPath(path.posix.join(directoryName, fileName));
 })
 .then(function() {
   // this will write both files to the index


### PR DESCRIPTION
A user reported in #1339 that an error will occur if you try to run the `examples/add-and-commit.js` example on Windows.
```
$ node add-and-commit.js
nodegit\node_modules\nodegit-promise\lib\done.js:10
      throw err;
      ^

Error: invalid path: 'salad\toast\strangerinastrangeland\theresnowaythisexists\newfile.txt'
    at Error (native)
```
This is because `addByPath` from of `Index` seems to only accept paths with forward slashes. Replacing the [`path.join`](https://github.com/nodegit/nodegit/blob/113493a9d3028a42ff30896ca32791835e8d68d9/examples/add-and-commit.js#L49) with `path.posix.join` will resolve the problem.