### PR TITLE
Make compatible with promisify-node 0.4.0

### DIFF
--- a/generate/templates/templates/nodegit.js
+++ b/generate/templates/templates/nodegit.js
@@ -34,14 +34,14 @@ catch (ex) {
           var _{{ idef.jsClassName }}_{{ fn.jsFunctionName}}
             = _{{ idef.jsClassName }}.prototype.{{ fn.jsFunctionName }};
           _{{ idef.jsClassName }}.prototype.{{ fn.jsFunctionName }}
-            = promisify(_{{ idef.jsClassName }}_{{ fn.jsFunctionName}});
+            = promisify(_{{ idef.jsClassName }}_{{ fn.jsFunctionName}}, function() { return true; });
 
         {% else %}
 
           var _{{ idef.jsClassName }}_{{ fn.jsFunctionName}}
             = _{{ idef.jsClassName }}.{{ fn.jsFunctionName }};
           _{{ idef.jsClassName }}.{{ fn.jsFunctionName }}
-            = promisify(_{{ idef.jsClassName }}_{{ fn.jsFunctionName}});
+            = promisify(_{{ idef.jsClassName }}_{{ fn.jsFunctionName}}, function() { return true; });
 
         {% endif %}
 
@@ -53,18 +53,18 @@ catch (ex) {
 
 var _ConvenientPatch = rawApi.ConvenientPatch;
 var _ConvenientPatch_hunks = _ConvenientPatch.prototype.hunks;
-_ConvenientPatch.prototype.hunks = promisify(_ConvenientPatch_hunks);
+_ConvenientPatch.prototype.hunks = promisify(_ConvenientPatch_hunks, function() { return true; });
 
 var _ConvenientHunk = rawApi.ConvenientHunk;
 var _ConvenientHunk_lines = _ConvenientHunk.prototype.lines;
-_ConvenientHunk.prototype.lines = promisify(_ConvenientHunk_lines);
+_ConvenientHunk.prototype.lines = promisify(_ConvenientHunk_lines, function() { return true; });
 
 var _FilterRegistry = rawApi.FilterRegistry;
 var _FilterRegistry_register = _FilterRegistry.register;
-_FilterRegistry.register = promisify(_FilterRegistry_register);
+_FilterRegistry.register = promisify(_FilterRegistry_register, function() { return true; });
 
 var _FilterRegistry_unregister = _FilterRegistry.unregister;
-_FilterRegistry.unregister = promisify(_FilterRegistry_unregister);
+_FilterRegistry.unregister = promisify(_FilterRegistry_unregister, function() { return true; });
 
 /* jshint ignore:end */
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nan": "^2.2.0",
     "node-gyp": "^3.5.0",
     "node-pre-gyp": "~0.6.32",
-    "promisify-node": "~0.3.0"
+    "promisify-node": "~0.4.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.3.19",


### PR DESCRIPTION
The `test` function is required to force promisify-node to promisify native functions, because async inference based on argument's names cannot work on native functions.

With promisify-node ~0.3.0, functions were always promisify, even if they were not considered asynchronous by async inference. The change of behavior was introduced "insidiously" in https://github.com/nodegit/promisify-node/pull/15.