### PR TITLE
Fixed an issue where large buffer allocations in filters (> 256MB) causes a segfault

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -326,7 +326,8 @@
             "buffer": {
               "isReturn": true,
               "isSelf": false,
-              "shouldAlloc": true
+              "shouldAlloc": true,
+              "doNotConvert": true
             },
             "data": {
               "cppClassName": "Buffer",

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -173,7 +173,8 @@
             "out": {
               "isReturn": true,
               "cppClassName": "GitBuf",
-              "jsClassName": "Buffer"
+              "jsClassName": "Buffer",
+              "shouldAlloc": true
             },
             "blob": {
               "cppClassName": "GitBlob",
@@ -259,7 +260,8 @@
               "isReturn": true,
               "cppClassName": "GitBuf", 
               "jsClassName": "Buffer",
-              "cType": "git_buf *"
+              "cType": "git_buf *",
+              "shouldAlloc": true
             },
             "repo": {
               "cppClassName": "GitRepository",
@@ -307,9 +309,9 @@
           "jsFunctionName": "grow",
           "args": {
             "buffer": {
-              "isReturn": true,
-              "isSelf": false,
-              "shouldAlloc": true
+              "isReturn": false,
+              "isSelf": true,
+              "shouldAlloc": false
             }
           },
           "return": {
@@ -324,10 +326,9 @@
           "jsFunctionName": "set",
           "args": {
             "buffer": {
-              "isReturn": true,
-              "isSelf": false,
-              "shouldAlloc": true,
-              "doNotConvert": true
+              "isReturn": false,
+              "isSelf": true,
+              "shouldAlloc": false
             },
             "data": {
               "cppClassName": "Buffer",
@@ -538,6 +539,19 @@
           "return": {
             "ownedByThis": true
           }
+        },
+        "git_commit_header_field": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "isSelf": false,
+              "shouldAlloc": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },
@@ -602,6 +616,12 @@
         },
         "git_config_get_string_buf": {
           "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "shouldAlloc": true
+            }
+          },
           "return": {
             "isErrorCode": true
           }
@@ -673,6 +693,19 @@
           "isAsync": true,
           "return": {
             "isErrorCode": true
+          }
+        },
+        "git_config_find_programdata": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          },
+          "args": {
+            "out": {
+              "isReturn": true,
+              "isSelf": false,
+              "shouldAlloc": true
+            }
           }
         }
       },
@@ -882,6 +915,19 @@
         },
         "git_diff_status_char": {
           "ignore": true
+        },
+        "git_diff_to_buf": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          },
+          "args": {
+            "out": {
+              "isReturn": true,
+              "isSelf": false,
+              "shouldAlloc": true
+            }
+          }
         },
         "git_diff_tree_to_index": {
           "args": {
@@ -1969,7 +2015,9 @@
           "isAsync": true,
           "args": {
             "out": {
-              "isReturn": true
+              "isReturn": true,
+              "shouldAlloc": true,
+              "isSelf": false
             },
             "remote": {
               "isSelf": true
@@ -2116,6 +2164,13 @@
           "isAsync": true,
           "return": {
             "isErrorCode": true
+          },
+          "args": {
+            "out": {
+              "isReturn": true,
+              "isSelf": false,
+              "shouldAlloc": true
+            }
           }
         },
         "git_repository_init_init_options": {
@@ -2473,6 +2528,19 @@
             },
             "submodule": {
               "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_submodule_resolve_url": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "shouldAlloc": true,
+              "isSelf": false
             }
           },
           "return": {

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -15,15 +15,6 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
     {%if arg.globalPayload %}
   {{ cppFunctionName }}_globalPayload* globalPayload = new {{ cppFunctionName }}_globalPayload;
     {%endif%}
-    {%if arg.cppClassName == "GitBuf" %}
-      {%if cppFunctionName == "Set"%}
-        baton->{{arg.name}} = Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue();
-      {%else%}
-        baton->{{arg.name}} = ({{ arg.cType }})malloc(sizeof({{ arg.cType|replace '*' '' }}));
-        baton->{{arg.name}}->ptr = NULL;
-        baton->{{arg.name}}->size = baton->{{arg.name}}->asize = 0;
-      {%endif%}
-    {%endif%}
   {%endeach%}
 
   {%each args|argsInfo as arg %}
@@ -61,9 +52,10 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
         {%endif%}
       {%endif%}
     {%elsif arg.shouldAlloc %}
+      baton->{{arg.name}} = ({{ arg.cType }})malloc(sizeof({{ arg.cType|replace '*' '' }}));  
       {%if arg.cppClassName == "GitBuf" %}
-      {%else%}
-        baton->{{ arg.name }} = ({{ arg.cType }})malloc(sizeof({{ arg.cType|replace '*' '' }}));
+        baton->{{arg.name}}->ptr = NULL;
+        baton->{{arg.name}}->size = baton->{{arg.name}}->asize = 0;
       {%endif%}
     {%endif%}
   {%endeach%}

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -43,12 +43,16 @@
 
   to = tmpArray;
 {% elsif cppClassName == 'GitBuf' %}
+  {% if doNotConvert %}
+  to = Nan::Null();
+  {% else %}
   if ({{= parsedName =}}) {
     to = Nan::New<String>({{= parsedName =}}->ptr, {{= parsedName = }}->size).ToLocalChecked();
   }
   else {
     to = Nan::Null();
   }
+  {% endif %}
 {% else %}
   {% if copy %}
     if ({{= parsedName =}} != NULL) {

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -405,6 +405,7 @@ describe("Filter", function() {
     var message = "some new fancy filter";
     var length = message.length;
     var tempBuffer = new Buffer(message, "utf-8");
+    var largeBufferSize = 300000000;
 
     it("should not apply when check returns GIT_PASSTHROUGH", function(){
       var test = this;
@@ -560,11 +561,11 @@ describe("Filter", function() {
     it("applies the massive filter data on checkout", function() {
       this.timeout(350000);
       var test = this;
-      var largeBuffer = Buffer.alloc(300000000, "a");
+      var largeBuffer = Buffer.alloc(largeBufferSize, "a");
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {    
-          return to.set(largeBuffer, 300000000)
+          return to.set(largeBuffer, largeBufferSize)
             .then(function() {
               return NodeGit.Error.CODE.OK;
             });
@@ -578,17 +579,17 @@ describe("Filter", function() {
         })
         .then(function() {
           var fd = fse.openSync(readmePath, "r");
-          var readBuf = Buffer.alloc(300000000);
+          var readBuf = Buffer.allocUnsafe(largeBufferSize);
           var readLength = fse.readSync(
             fd,
             readBuf,
             0,
-            300000000,
+            largeBufferSize,
             0
           );
           fse.closeSync(fd);
 
-          assert.notStrictEqual(readLength, 300000000);
+          assert.notStrictEqual(readLength, largeBufferSize);
           fse.writeFileSync(readmePath, "whoa", "utf8");
 
           var opts = {
@@ -599,19 +600,19 @@ describe("Filter", function() {
         })
         .then(function() {
           var fd = fse.openSync(readmePath, "r");
-          var readBuf = Buffer.alloc(300000000);
+          var readBuf = Buffer.allocUnsafe(300000000);
           var readLength = fse.readSync(
             fd,
             readBuf,
             0,
-            300000000,
+            largeBufferSize,
             0
           );
           fse.closeSync(fd);
 
           assert.strictEqual(
             readLength,
-            300000000
+            largeBufferSize
           );
         });
     });

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -83,7 +83,7 @@ describe("Filter", function() {
       .then(function(emptyRepo) {
         test.emptyRepo = emptyRepo;
         return fse.writeFile(
-          path.join(reposPath, ".gitattributes"), 
+          path.join(reposPath, ".gitattributes"),
           "*.md filter=" + filterName + " -text",
           { encoding: "utf-8" }
         );
@@ -153,7 +153,7 @@ describe("Filter", function() {
 
     it("cannot unregister the filter twice", function() {
       return Registry.unregister(filterName)
-        .then(function(result) { 
+        .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return Registry.unregister(filterName);
         })
@@ -185,7 +185,7 @@ describe("Filter", function() {
       })
       .then(function() {
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout"
         );
       })
@@ -219,7 +219,7 @@ describe("Filter", function() {
         global.gc();
 
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout"
         );
       })
@@ -253,7 +253,7 @@ describe("Filter", function() {
       })
       .then(function() {
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout"
         );
       })
@@ -289,7 +289,7 @@ describe("Filter", function() {
         .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return fse.writeFile(
-            packageJsonPath, 
+            packageJsonPath,
             "Changing content to trigger checkout",
             { encoding: "utf-8" }
           );
@@ -309,7 +309,7 @@ describe("Filter", function() {
           assert.strictEqual(shutdown, true);
         });
     });
-    
+
     it("filter successfully shuts down on garbage collect", function() {
       var test = this;
       var shutdown = false;
@@ -325,7 +325,7 @@ describe("Filter", function() {
         .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return fse.writeFile(
-            packageJsonPath, 
+            packageJsonPath,
             "Changing content to trigger checkout",
             { encoding: "utf-8" }
           );
@@ -363,7 +363,7 @@ describe("Filter", function() {
         .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return fse.writeFile(
-            packageJsonPath, 
+            packageJsonPath,
             "Changing content to trigger checkout",
             { encoding: "utf-8" }
           );
@@ -389,7 +389,7 @@ describe("Filter", function() {
   });
 
   describe("Apply", function() {
-    before(function() { 
+    before(function() {
       var test = this;
       return fse.readFile(readmePath, "utf8")
         .then((function(content) {
@@ -410,7 +410,7 @@ describe("Filter", function() {
     it("should not apply when check returns GIT_PASSTHROUGH", function(){
       var test = this;
       var applied = false;
-      
+
       return Registry.register(filterName, {
         apply: function() {
           applied = true;
@@ -422,7 +422,7 @@ describe("Filter", function() {
         .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return fse.writeFile(
-            packageJsonPath, 
+            packageJsonPath,
             "Changing content to trigger checkout",
             { encoding: "utf-8" }
           );
@@ -454,8 +454,8 @@ describe("Filter", function() {
         .then(function(result) {
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
           return fse.writeFile(
-            packageJsonPath, 
-            "Changing content to trigger checkout", 
+            packageJsonPath,
+            "Changing content to trigger checkout",
             { encoding: "utf-8" }
           );
         })
@@ -490,13 +490,13 @@ describe("Filter", function() {
         })
         .then(function() {
           var readmeContent = fse.readFileSync(
-            packageJsonPath, 
+            packageJsonPath,
             "utf-8"
           );
           assert.notStrictEqual(readmeContent, message);
 
           return fse.writeFile(
-            packageJsonPath, 
+            packageJsonPath,
             "Changing content to trigger checkout"
           );
         })
@@ -509,7 +509,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var postInitializeReadmeContents = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
 
@@ -536,7 +536,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var readmeContent = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
           assert.notStrictEqual(readmeContent, message);
@@ -550,7 +550,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var postInitializeReadmeContents = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
 
@@ -558,22 +558,25 @@ describe("Filter", function() {
         });
     });
 
-    it("applies the massive filter data on checkout", function() {
-      this.timeout(350000);
-      var test = this;
-      var largeBuffer = Buffer.alloc(largeBufferSize, "a");
+    // this test is useless on 32 bit CI, because we cannot construct
+    // a buffer big enough to test anything of significance :)...
+    if (process.arch === "x64") {
+      it("applies the massive filter data on checkout", function() {
+        this.timeout(350000);
+        var test = this;
+        var largeBuffer = Buffer.alloc(largeBufferSize, "a");
 
-      return Registry.register(filterName, {
-        apply: function(to, from, source) {    
-          return to.set(largeBuffer, largeBufferSize)
+        return Registry.register(filterName, {
+          apply: function(to, from, source) {
+            return to.set(largeBuffer, largeBufferSize)
             .then(function() {
               return NodeGit.Error.CODE.OK;
             });
-        },
-        check: function(src, attr) {
-          return NodeGit.Error.CODE.OK;
-        }
-      }, 0)
+          },
+          check: function(src, attr) {
+            return NodeGit.Error.CODE.OK;
+          }
+        }, 0)
         .then(function(result) {
           assert.strictEqual(result, 0);
         })
@@ -615,7 +618,8 @@ describe("Filter", function() {
             largeBufferSize
           );
         });
-    });
+      });
+    }
 
     it("applies the filter data on checkout with gc", function() {
       var test = this;
@@ -636,7 +640,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var readmeContent = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
           assert.notStrictEqual(readmeContent, message);
@@ -651,7 +655,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var postInitializeReadmeContents = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
 
@@ -670,7 +674,7 @@ describe("Filter", function() {
             });
         },
         check: function(src, attr) {
-          return src.path() === "README.md" ? 
+          return src.path() === "README.md" ?
             0 : NodeGit.Error.CODE.PASSTHROUGH;
         },
         cleanup: function() {}
@@ -680,14 +684,14 @@ describe("Filter", function() {
         })
         .then(function() {
           var readmeContent = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
           assert.notStrictEqual(readmeContent, "testing commit contents");
         })
         .then(function() {
-          return commitFile(test.repository, "README.md", 
-            "testing commit contents", 
+          return commitFile(test.repository, "README.md",
+            "testing commit contents",
             "test commit"
           );
         })
@@ -696,7 +700,7 @@ describe("Filter", function() {
         })
         .then(function(commit) {
           var postInitializeReadmeContents = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
 
@@ -738,14 +742,14 @@ describe("Filter", function() {
         })
         .then(function() {
           var readmeContent = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
           assert.notStrictEqual(readmeContent, "testing commit contents");
         })
         .then(function() {
-          return commitFile(test.repository, "README.md", 
-            "testing commit contents", 
+          return commitFile(test.repository, "README.md",
+            "testing commit contents",
             "test commit"
           );
         })
@@ -755,7 +759,7 @@ describe("Filter", function() {
         })
         .then(function(commit) {
           var postInitializeReadmeContents = fse.readFileSync(
-            readmePath, 
+            readmePath,
             "utf-8"
           );
 
@@ -806,7 +810,7 @@ describe("Filter", function() {
         assert.notEqual(packageContent, "");
 
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout",
           { encoding: "utf-8" }
         );
@@ -845,14 +849,14 @@ describe("Filter", function() {
       })
       .then(function() {
         var packageContent = fse.readFileSync(
-          packageJsonPath, 
+          packageJsonPath,
           "utf-8"
         );
         assert.notEqual(packageContent, "");
 
         global.gc();
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout",
           { encoding: "utf-8" }
         );
@@ -892,11 +896,11 @@ describe("Filter", function() {
       })
       .then(function() {
         var packageContent = fse.readFileSync(
-          packageJsonPath, 
+          packageJsonPath,
           "utf-8"
         );
         var readmeContent = fse.readFileSync(
-          readmePath, 
+          readmePath,
           "utf-8"
         );
 
@@ -905,7 +909,7 @@ describe("Filter", function() {
       })
       .then(function() {
         return fse.writeFile(
-          packageJsonPath, 
+          packageJsonPath,
           "Changing content to trigger checkout",
           { encoding: "utf-8" }
         );

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -405,7 +405,7 @@ describe("Filter", function() {
     var message = "some new fancy filter";
     var length = message.length;
     var tempBuffer = new Buffer(message, "utf-8");
-    var largeBufferSize = 300000000;
+    var largeBufferSize = 500000000;
 
     it("should not apply when check returns GIT_PASSTHROUGH", function(){
       var test = this;
@@ -600,7 +600,7 @@ describe("Filter", function() {
         })
         .then(function() {
           var fd = fse.openSync(readmePath, "r");
-          var readBuf = Buffer.allocUnsafe(300000000);
+          var readBuf = Buffer.allocUnsafe(largeBufferSize);
           var readLength = fse.readSync(
             fd,
             readBuf,


### PR DESCRIPTION
In GitBuf::Set and GitBuf::Grow the buffers could only accept a maximum buffer of 256MB because of limits with v8 string sizes. Removed the conversion to string in those methods to allow for larger buffers.

Also removed some special case logic in the async_functions template that would prevent proper buffer method generation, and then updated descriptors for methods that require proper buffer allocations to be "shouldAlloc": true