### PR TITLE
8.4.0 currently breaks builds, locking to 8.3.0 temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 
 env:
   matrix:
-    - export NODE_VERSION="stable" TARGET_ARCH="x64"
+    - export NODE_VERSION="8.3.0" TARGET_ARCH="x64"
     - export NODE_VERSION="7.4" TARGET_ARCH="x64"
     - export NODE_VERSION="6.5" TARGET_ARCH="x64"
 
@@ -21,7 +21,7 @@ matrix:
   fast_finish: true
   include:
     - os: linux
-      env: export NODE_VERSION="stable" TARGET_ARCH="ia32"
+      env: export NODE_VERSION="8.3.0" TARGET_ARCH="ia32"
     - os: linux
       env: export NODE_VERSION="7.4" TARGET_ARCH="ia32"
     - os: linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ environment:
   GYP_MSVS_VERSION: 2013
   matrix:
     # Node.js
-    - nodejs_version: "stable"
+    - nodejs_version: "8.3.0"
     - nodejs_version: "7"
     - nodejs_version: "6"
 


### PR DESCRIPTION
Last 8.3.0 build: https://ci.appveyor.com/project/TimBranyen/nodegit/build/3364
  - this had a separate failure, but stable passed on this

First 8.4.0 build: https://ci.appveyor.com/project/TimBranyen/nodegit/build/3365
  - all builds on windows stable after this build fail with the same error

We'll wait for an 8.4.1 patch release, and continue building for 8.3.0