### PR TITLE
Updated input docs to allow for git_push_update_reference_cb to  generate

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -908,5 +908,27 @@
       "success": 0,
       "error": -1
     }
+  },
+  "git_push_update_reference_cb": {
+    "args": [
+      {
+        "name": "refname",
+        "cType": "const char *"
+      },
+      {
+        "name": "status",
+        "cType": "const char *"
+      },
+      {
+        "name": "data",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 1,
+      "success": 0,
+      "error": -1
+    }
   }
 }

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2137,9 +2137,6 @@
         "push_transfer_progress": {
           "ignore": true
         },
-        "push_update_reference": {
-          "ignore": true
-        },
         "sideband_progress": {
           "ignore": true
         },

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -632,6 +632,10 @@
               "ignore": true
             },
             {
+              "type": "git_push_update_reference_cb",
+              "name": "push_update_reference"
+            },
+            {
               "type": "void *",
               "name": "payload"
             }


### PR DESCRIPTION
Requires [libgit2 be bumped to the current master branch](https://github.com/nodegit/libgit2/pull/5) before this can be merged. These changes allow for the `git_push_update_reference_cb` to be generated in NodeGit, allowing for clients to determine if a remote ref rejected an update however still returned a valid response. An example would be when you push to a protected branch on GitHub.