### PR TITLE
Updated descriptors for git_index_find and git_index_find_prefix

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1213,7 +1213,28 @@
           "jsFunctionName": "entryCount"
         },
         "git_index_find": {
-          "ignore": true
+          "isAsync": true,
+          "args": {
+            "at_pos": {
+              "isReturn": true,
+              "shouldAlloc": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_index_find_prefix": {
+          "isAsync": true,
+          "args": {
+            "at_pos": {
+              "isReturn": true,
+              "shouldAlloc": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_index_free": {
           "ignore": true

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -13,6 +13,7 @@ describe("Index", function() {
   var RepoUtils = require("../utils/repository_setup");
   var NodeGit = require("../../");
   var Repository = NodeGit.Repository;
+  var ErrorCodes = NodeGit.Error.CODE;
 
   var reposPath = local("../repos/workdir");
 
@@ -357,6 +358,69 @@ describe("Index", function() {
       })
       .then(function(index) {
         assert(index.hasConflicts());
+      });
+  });
+
+  it("can find the specified file in the index", function() {
+    var test = this;
+
+    return test.index.find("src/wrapper.cc")
+      .then(function(position) {
+        assert.notEqual(position, null);
+      });
+  });
+
+  it("cannot find the specified file in the index", function() {
+    var test = this;
+
+    return test.index.find("src/thisisfake.cc")
+      .then(function(position) {
+        assert.fail("the item should not be found");
+      })
+      .catch(function(error) {
+        assert.strictEqual(error.errno, ErrorCodes.ENOTFOUND);
+      });
+  });
+
+  it("cannot find the directory in the index", function() {
+    var test = this;
+
+    return test.index.find("src")
+      .then(function(position) {
+        assert.fail("the item should not be found");
+      })
+      .catch(function(error) {
+        assert.strictEqual(error.errno, ErrorCodes.ENOTFOUND);
+      });
+  });
+
+  it("can find the specified prefix in the index", function() {
+    var test = this;
+
+    return test.index.findPrefix("src/")
+      .then(function(position) {
+        assert.notEqual(position, null);
+      });
+  });
+
+  it("cannot find the specified prefix in the index", function() {
+    var test = this;
+
+    return test.index.find("testing123/")
+      .then(function(position) {
+        assert.fail("the item should not be found");
+      })
+      .catch(function(error) {
+        assert.strictEqual(error.errno, ErrorCodes.ENOTFOUND);
+      });
+  });
+
+  it("can find the prefix when a file shares the name", function() {
+    var test = this;
+
+    return test.index.find("LICENSE")
+      .then(function(position) {
+        assert.notEqual(position, null);
       });
   });
 });


### PR DESCRIPTION
`git_index_find` and `git_index_find_prefix` were not properly defined. Added definitions and tests for both routines, as well as made them asynchronous.