### PR TITLE
Expose JavaScript function name in a rejected promise

### DIFF
--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -315,6 +315,7 @@ var Helpers = {
 
     fnDef.cppFunctionName = Helpers.cTypeToCppName(key, "git_" + typeDef.typeName);
     fnDef.jsFunctionName = Helpers.cTypeToJsName(key, "git_" + typeDef.typeName);
+    fnDef.jsClassName = typeDef.jsClassName;
 
     if (fnDef.cppFunctionName == typeDef.cppClassName) {
       fnDef.cppFunctionName = fnDef.cppFunctionName.replace("Git", "");

--- a/generate/templates/manual/patches/convenient_patches.cc
+++ b/generate/templates/manual/patches/convenient_patches.cc
@@ -102,6 +102,7 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
       err = Nan::Error("Method convenientFromDiff has thrown an error.")->ToObject();
     }
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Patch.convenientFromDiff").ToLocalChecked());
     Local<v8::Value> argv[1] = {
       err
     };
@@ -119,6 +120,7 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
   if (baton->error_code < 0) {
     Local<v8::Object> err = Nan::Error("method convenientFromDiff has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Patch.convenientFromDiff").ToLocalChecked());
     Local<v8::Value> argv[1] = {
       err
     };

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -87,6 +87,7 @@ void GitRemote::ReferenceListWorker::HandleOKCallback()
   {
     Local<v8::Object> err = Nan::Error("Reference List has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Remote.referenceList").ToLocalChecked());
     Local<v8::Value> argv[1] = {
       err
     };

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -95,6 +95,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
         err = Nan::Error("Method fastWalk has thrown an error.")->ToObject();
       }
       err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Revwalk.fastWalk").ToLocalChecked());
       Local<v8::Value> argv[1] = {
         err
       };
@@ -159,6 +160,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
       {
         Local<v8::Object> err = Nan::Error("Method next has thrown an error.")->ToObject();
         err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+        err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Revwalk.fastWalk").ToLocalChecked());
         Local<v8::Value> argv[1] = {
           err
         };

--- a/generate/templates/manual/revwalk/file_history_walk.cc
+++ b/generate/templates/manual/revwalk/file_history_walk.cc
@@ -296,6 +296,7 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
       err = Nan::Error("Method fileHistoryWalk has thrown an error.")->ToObject();
     }
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Revwalk.fileHistoryWalk").ToLocalChecked());
     Local<v8::Value> argv[1] = {
       err
     };
@@ -312,6 +313,7 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
   if (baton->error_code < 0) {
     Local<v8::Object> err = Nan::Error("Method next has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Revwalk.fileHistoryWalk").ToLocalChecked());
     Local<v8::Value> argv[1] = {
       err
     };

--- a/generate/templates/manual/src/filter_registry.cc
+++ b/generate/templates/manual/src/filter_registry.cc
@@ -107,6 +107,7 @@ void GitFilterRegistry::RegisterWorker::HandleOKCallback() {
       err = Nan::Error("Method register has thrown an error.")->ToObject();
     }
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("FilterRegistry.register").ToLocalChecked());
     v8::Local<v8::Value> argv[1] = {
       err
     };
@@ -118,6 +119,7 @@ void GitFilterRegistry::RegisterWorker::HandleOKCallback() {
   else if (baton->error_code < 0) {
     v8::Local<v8::Object> err = Nan::Error("Method register has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("FilterRegistry.register").ToLocalChecked());
     v8::Local<v8::Value> argv[1] = {
       err
     };
@@ -191,6 +193,7 @@ void GitFilterRegistry::UnregisterWorker::HandleOKCallback() {
       err = Nan::Error("Method register has thrown an error.")->ToObject();
     }
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("FilterRegistry.unregister").ToLocalChecked());
     v8::Local<v8::Value> argv[1] = {
       err
     };
@@ -202,6 +205,7 @@ void GitFilterRegistry::UnregisterWorker::HandleOKCallback() {
   else if (baton->error_code < 0) {
     v8::Local<v8::Object> err = Nan::Error("Method unregister has thrown an error.")->ToObject();
     err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("FilterRegistry.unregister").ToLocalChecked());
     v8::Local<v8::Value> argv[1] = {
       err
     };

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -161,6 +161,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         err = Nan::Error("Method {{ jsFunctionName }} has thrown an error.")->ToObject();
       }
       err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("{{ jsClassName }}.{{ jsFunctionName }}").ToLocalChecked());
       v8::Local<v8::Value> argv[1] = {
         err
       };
@@ -222,6 +223,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       if (!callbackFired) {
         v8::Local<v8::Object> err = Nan::Error("Method {{ jsFunctionName }} has thrown an error.")->ToObject();
         err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+        err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("{{ jsClassName }}.{{ jsFunctionName }}").ToLocalChecked());
         v8::Local<v8::Value> argv[1] = {
           err
         };

--- a/test/tests/merge.js
+++ b/test/tests/merge.js
@@ -1628,6 +1628,7 @@ describe("Merge", function() {
           "should not be able to retrieve common merge base"));
       }, function(err) {
         assert.equal("no merge base found", err.message);
+        assert.equal("Merge.base", err.errorFunction);
         assert.equal(NodeGit.Error.CODE.ENOTFOUND, err.errno);
       });
     });


### PR DESCRIPTION
I've modified the `async_function.cc` template to include both the names of the JavaScript class and function in the error thrown in a rejected promise. This should hopefully make debugging NodeGit a lot easier when there's a long promise chain.