### PR TITLE
Generate default options for Revert.revert to prevent an exception

### DIFF
--- a/lib/revert.js
+++ b/lib/revert.js
@@ -1,8 +1,10 @@
 var NodeGit = require("../");
+var shallowClone = NodeGit.Utils.shallowClone;
 var normalizeOptions = NodeGit.Utils.normalizeOptions;
 
 var Revert = NodeGit.Revert;
 var _commit = Revert.commit;
+var _revert = Revert.revert;
 
 /**
  * Reverts the given commit against the given "our" commit, producing an index
@@ -43,4 +45,41 @@ Revert.commit = function(
 
       return result;
     }, callback);
+};
+
+/**
+ * Reverts the given commit, producing changes in the index and
+ * working directory.
+ * 
+ * @async
+ * @param {Repository} repo the repository to perform the revert in
+ * @param {Commit} commit the commit to revert
+ * @param {RevertOptions} revert_options the revert options
+ *                                       (or null for defaults)
+ */
+Revert.revert = function(repo, commit, revertOpts) {
+  var mergeOpts;
+  var checkoutOpts;
+
+  if (revertOpts) {
+    revertOpts = shallowClone(revertOpts);
+    mergeOpts = revertOpts.mergeOpts;
+    checkoutOpts = revertOpts.checkoutOpts;
+    delete revertOpts.mergeOpts;
+    delete revertOpts.checkoutOpts;
+  }
+
+  revertOpts = normalizeOptions(revertOpts, NodeGit.RevertOptions);
+
+  if (revertOpts) {
+    revertOpts.mergeOpts =
+      normalizeOptions(mergeOpts, NodeGit.MergeOptions);
+  }
+
+  if (checkoutOpts) {
+    revertOpts.checkoutOpts =
+      normalizeOptions(checkoutOpts, NodeGit.CheckoutOptions);
+  }
+
+  return _revert.call(this, repo, commit, revertOpts);
 };

--- a/test/tests/revert.js
+++ b/test/tests/revert.js
@@ -61,7 +61,14 @@ describe("Revert", function() {
     });
   });
 
-  it("RevertOptions is optional", function() {
+  it("RevertOptions is optional (unspecified)", function() {
+    return Revert.revert(test.repository, test.firstCommit)
+      .catch(function(error) {
+        throw error;
+      });
+  });
+
+  it("RevertOptions is optional (null)", function() {
     return Revert.revert(test.repository, test.firstCommit, null)
       .catch(function(error) {
         throw error;


### PR DESCRIPTION
If no options are specified for `Revert.revert`, the promise callback becomes the third parameter for the generated C++ revert.cc file and the (expected) fourth parameter as the promise callback will be unsatisfied which will lead to an exception. To fix this, we should generate a default options for the function instead of the callee doesn't provide one.

This fixes #1403.