### PR TITLE
Fixed documentation error

### DIFF
--- a/lib/revwalk.js
+++ b/lib/revwalk.js
@@ -112,7 +112,6 @@ Revwalk.prototype.sorting = function() {
  *
  * @param  {Oid} oid
  * @param  {Function} callback
- * @return {Commit}
  */
 Revwalk.prototype.walk = function(oid, callback) {
   var revwalk = this;


### PR DESCRIPTION
Removed unnecessary annotation about return value.
Initial annotation was added in [ecf03e4216001e6844026770414f1e78cedf9dff]