### PR TITLE
CI: Update Node.js versions + some deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,22 @@ sudo: false
 
 env:
   matrix:
-    - export NODE_VERSION="8.3.0" TARGET_ARCH="x64"
-    - export NODE_VERSION="7.4" TARGET_ARCH="x64"
-    - export NODE_VERSION="6.5" TARGET_ARCH="x64"
+    - export NODE_VERSION="9.6" TARGET_ARCH="x64"
+    - export NODE_VERSION="8.9" TARGET_ARCH="x64"
+    - export NODE_VERSION="7.10" TARGET_ARCH="x64"
+    - export NODE_VERSION="6.13" TARGET_ARCH="x64"
 
 matrix:
   fast_finish: true
   include:
     - os: linux
-      env: export NODE_VERSION="8.3.0" TARGET_ARCH="ia32"
+      env: export NODE_VERSION="9.6" TARGET_ARCH="ia32"
     - os: linux
-      env: export NODE_VERSION="7.4" TARGET_ARCH="ia32"
+      env: export NODE_VERSION="8.9" TARGET_ARCH="ia32"
     - os: linux
-      env: export NODE_VERSION="6.5" TARGET_ARCH="ia32"
+      env: export NODE_VERSION="7.10" TARGET_ARCH="ia32"
+    - os: linux
+      env: export NODE_VERSION="6.13" TARGET_ARCH="ia32"
 
 git:
   depth: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
-os: Windows Server 2012 R2
 image: Visual Studio 2015
 
 platform:
@@ -24,7 +23,7 @@ init:
 environment:
   JOBS: 4
   GIT_SSH: c:\projects\nodegit\vendor\plink.exe
-  GYP_MSVS_VERSION: 2013
+  GYP_MSVS_VERSION: 2015
   matrix:
     # Node.js
     - nodejs_version: "9"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ environment:
   GYP_MSVS_VERSION: 2013
   matrix:
     # Node.js
-    - nodejs_version: "8.3.0"
+    - nodejs_version: "9"
+    - nodejs_version: "8"
     - nodejs_version: "7"
     - nodejs_version: "6"
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "node": ">= 4"
   },
   "dependencies": {
-    "fs-extra": "~0.26.2",
+    "fs-extra": "~0.27.0",
     "lodash": "^4.13.1",
-    "nan": "^2.2.0",
-    "node-gyp": "^3.5.0",
-    "node-pre-gyp": "~0.6.32",
+    "nan": "^2.9.2",
+    "node-gyp": "^3.6.2",
+    "node-pre-gyp": "~0.6.39",
     "promisify-node": "~0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
  * updated each minor Node.js version to the latest
  * added Node.js 9
  * https://travis-ci.org/inexorgame/nodegit/builds/346067294
  * https://ci.appveyor.com/project/inexorgame/nodegit/build/4
  * updates several deps to support more modern env setups (e.g. node-gyp 3.6.0 has fixes for VS2017)