### PR TITLE
Travis documentation deploy fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ script:
     fi
 
 after_success:
-  - if [ -n "$TRAVIS_TAG" ]; then
+  - if [ -n "$TRAVIS_TAG" ] && [ "$EXTENDED_TESTING" != "true" ] && [ "$DEPLOY_DOCUMENTATION" != "true" ]; then
       npm install -g node-pre-gyp;
       npm install -g aws-sdk;
       node lifecycleScripts/clean;

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ after_success:
       node-pre-gyp publish --target_arch=$TARGET_ARCH;
     fi
 
-  - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$TRAVIS_TAG" ] && [ "$DEPLOY_DOCUMENTATION" == "true" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ -n "$TRAVIS_TAG" ] && [ "$DEPLOY_DOCUMENTATION" == "true" ]; then
       .travis/deploy-docs.sh;
     fi
 


### PR DESCRIPTION
I didn't test the requested change to only deploy on tags well enough.
This led to the situation that the documentation is never getting deployed.

Cause of this: On tags the variable TRAVIS_BRANCH has the name of the tag. TRAVIS_BRANCH == master needs to get removed.

Also don't try to deploy nodegit binaries on extending testing and documentation deploy.