### PR TITLE
Output warning in JSON generator if an unmatched argument is found in descriptor.json

### DIFF
--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -322,6 +322,20 @@ var Helpers = {
     }
 
     var argOverrides = fnOverrides.args || {};
+    // loop over all the argument names explicitly written in descriptor.json
+    Object.keys(argOverrides).forEach(function(argOverride) {
+      // see if the argument names match a name in the C function
+      var found = fnDef.args.some(function(arg) {
+        return arg.name === argOverride;
+      });
+      if (!found) {
+        console.log(
+          "Found non-matching argument named %s in descriptor.json for C function %s",
+          argOverride,
+          fnDef.cFunctionName
+        );
+      }
+    });
     fnDef.args.forEach(function(arg) {
       Helpers.decorateArg(arg, fnDef.args, typeDef, fnDef, argOverrides[arg.name] || {}, enums);
 


### PR DESCRIPTION
When making additions or changes to NodeGit to match libgit2, we have to make changes to the `generate/input/descriptor.json` file. If we make a typo, it goes completely undetected until your test code fails or you when you manually inspect the generated C++ code. To make this feedback loop better, we should generate a warning if an argument name used in the descriptor does not match the name
in the C function. This fixes #1464 and will make everyone's lives a lot easier when adding new API to NodeGit.

The following is the new output from Travis CI.
```
[nodegit] Running pre-install script
[nodegit] Configuring libssh2.
[nodegit] Checking submodule status
[nodegit] Initializing submodules
[nodegit] Generating native code
Found non-matching argument named flags in descriptor.json for C function git_index_remove_all
Found non-matching argument named flags in descriptor.json for C function git_index_update_all
Found non-matching argument named force in descriptor.json for C function git_index_write
Found non-matching argument named signature in descriptor.json for C function git_rebase_init
Found non-matching argument named signature in descriptor.json for C function git_branch_create
Found non-matching argument named log_message in descriptor.json for C function git_branch_create
Found non-matching argument named log_message in descriptor.json for C function git_reset
Found non-matching argument named signature in descriptor.json for C function git_reset
Found non-matching argument named return in descriptor.json for C function git_status_file
[nodegit] Running install script
```