### PR TITLE
Expose error code in Status.file

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2533,10 +2533,10 @@
             "status_flags": {
               "isReturn": true,
               "shouldAlloc": true
-            },
-            "return": {
-              "isErrorCode": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_status_foreach": {

--- a/test/tests/status.js
+++ b/test/tests/status.js
@@ -102,7 +102,27 @@ describe("Status", function() {
           .then(function() {
             return Promise.reject(e);
           });
+      });
+  });
 
+  it("gets status on non-existent file results in error", function() {
+    var fileName = "non-existent-Status.file-test.txt";
+    var repo = this.repository;
+    var filePath = path.join(repo.workdir(), fileName);
+    return exec("git clean -xdf", {cwd: reposPath})
+      .then(function() {
+        assert.equal(false, fse.existsSync(filePath));
+        return Status.file(repo, filePath)
+        .then(function() {
+          assert.fail("Non-existent file should throw error on Status.file");
+        }, function(err) {
+          assert.equal(NodeGit.Error.CODE.ENOTFOUND, err.errno);
+          assert.equal("Status.file", err.errorFunction);
+          assert.equal(
+            "attempt to get status of nonexistent file '" + filePath + "'",
+            err.message
+          );
+        });
       });
   });
 });


### PR DESCRIPTION
```
Found non-matching argument named return in descriptor.json for C function git_status_file
```
The change I made for #1467 helped me discover an error in our wrapper for `git_status_file`. It seems like `Status.file` does not actually expose the C function's error code when an error occurs. I've fixed the descriptor and also added a test to hopefully ensure that this won't happen again in the future.