### PR TITLE
Bump to libgit2 v0.27.0

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -3011,6 +3011,22 @@
         }
       }
     },
+    "worktree": {
+      "selfFreeing": true,
+      "cType": "git_worktree",
+      "freeFunctionName": "git_worktree_free",
+      "functions": {
+        "git_worktree_free": {
+          "ignore": true
+        },
+        "git_worktree_add_init_options": {
+          "ignore": true
+        },
+        "git_worktree_prune_init_options": {
+          "ignore": true
+        }
+      }
+    },
     "writestream": {
       "cType": "git_writestream",
       "needsForwardDeclaration": false

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -95,14 +95,21 @@
             "value_out": {
               "isReturn": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_attr_get_many": {
+          "isAsync": true,
           "args": {
             "values_out": {
               "isReturn": true,
               "jsClassName": "Array"
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         }
       }
@@ -139,6 +146,9 @@
               "cppClassName": "Buffer",
               "jsClassName": "Buffer"
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_blob_create_fromworkdir": {
@@ -475,6 +485,9 @@
             "update_ref": {
               "isOptional": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_commit_author": {
@@ -1475,6 +1488,9 @@
     },
     "mempack": {
       "functions": {
+        "git_mempack_dump": {
+          "ignore": true
+        },
         "git_mempack_new": {
           "ignore": true
         },
@@ -1556,6 +1572,9 @@
     "message": {
       "functions": {
         "git_message_prettify": {
+          "ignore": true
+        },
+        "git_message_trailers": {
           "ignore": true
         }
       }
@@ -1814,6 +1833,9 @@
         "git_patch_free": {
           "ignore": true
         },
+        "git_patch_from_blob_and_buffer": {
+          "ignore": true
+        },
         "git_patch_from_buffers": {
           "ignore": true
         },
@@ -2030,7 +2052,10 @@
               "key": "strings"
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_reference_next": {
           "ignore": true
@@ -2184,7 +2209,10 @@
               "key": "strings"
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_remote_get_push_refspecs": {
           "args": {
@@ -2197,7 +2225,10 @@
               "key": "strings"
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_remote_get_refspec": {
           "return": {
@@ -2533,10 +2564,10 @@
             "status_flags": {
               "isReturn": true,
               "shouldAlloc": true
-            },
-            "return": {
-              "isErrorCode": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_status_foreach": {
@@ -2783,7 +2814,10 @@
               "key": "strings"
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_tag_tagger": {
           "return": {
@@ -2791,10 +2825,14 @@
           }
         },
         "git_tag_target": {
+          "isAsync": true,
           "args": {
             "target_out": {
               "isReturn": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_tag_target_id": {
@@ -2814,7 +2852,10 @@
               "isReturn": true
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },
@@ -2822,8 +2863,17 @@
       "dupFunction": "git_time_dup",
       "dependencies": [
         "git2/sys/time.h"
-      ]
-
+      ],
+      "fields": {
+        "sign": {
+          "ignore": true
+        }
+      },
+      "functions": {
+        "git_time_sign": {
+          "ignore": true
+        }
+      }
     },
     "trace": {
       "functions": {
@@ -2916,10 +2966,14 @@
           }
         },
         "git_treebuilder_write": {
+          "isAsync": true,
           "args": {
             "id": {
               "isReturn": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_treebuilder_write_with_buffer": {

--- a/generate/input/libgit2-docs.json
+++ b/generate/input/libgit2-docs.json
@@ -76,10 +76,11 @@
         "git_branch_name",
         "git_branch_upstream",
         "git_branch_set_upstream",
-        "git_branch_is_head"
+        "git_branch_is_head",
+        "git_branch_is_checked_out"
       ],
       "meta": {},
-      "lines": 246
+      "lines": 258
     },
     {
       "file": "buffer.h",
@@ -162,7 +163,7 @@
         "git_commit_dup"
       ],
       "meta": {},
-      "lines": 471
+      "lines": 474
     },
     {
       "file": "common.h",
@@ -172,7 +173,7 @@
         "git_libgit2_opts"
       ],
       "meta": {},
-      "lines": 312
+      "lines": 352
     },
     {
       "file": "config.h",
@@ -222,7 +223,7 @@
         "git_config_lock"
       ],
       "meta": {},
-      "lines": 724
+      "lines": 751
     },
     {
       "file": "cred_helpers.h",
@@ -283,10 +284,12 @@
         "git_diff_stats_free",
         "git_diff_format_email",
         "git_diff_commit_as_email",
-        "git_diff_format_email_init_options"
+        "git_diff_format_email_init_options",
+        "git_diff_patchid_init_options",
+        "git_diff_patchid"
       ],
       "meta": {},
-      "lines": 1401
+      "lines": 1452
     },
     {
       "file": "errors.h",
@@ -297,7 +300,7 @@
         "giterr_set_oom"
       ],
       "meta": {},
-      "lines": 145
+      "lines": 149
     },
     {
       "file": "filter.h",
@@ -331,7 +334,7 @@
         "git_graph_descendant_of"
       ],
       "meta": {},
-      "lines": 51
+      "lines": 54
     },
     {
       "file": "ignore.h",
@@ -389,7 +392,7 @@
         "git_index_conflict_iterator_free"
       ],
       "meta": {},
-      "lines": 805
+      "lines": 806
     },
     {
       "file": "indexer.h",
@@ -423,15 +426,17 @@
         "git_merge"
       ],
       "meta": {},
-      "lines": 579
+      "lines": 585
     },
     {
       "file": "message.h",
       "functions": [
-        "git_message_prettify"
+        "git_message_prettify",
+        "git_message_trailers",
+        "git_message_trailer_array_free"
       ],
       "meta": {},
-      "lines": 39
+      "lines": 79
     },
     {
       "file": "net.h",
@@ -446,20 +451,24 @@
       "functions": [
         "git_note_foreach_cb",
         "git_note_iterator_new",
+        "git_note_commit_iterator_new",
         "git_note_iterator_free",
         "git_note_next",
         "git_note_read",
+        "git_note_commit_read",
         "git_note_author",
         "git_note_committer",
         "git_note_message",
         "git_note_id",
         "git_note_create",
+        "git_note_commit_create",
         "git_note_remove",
+        "git_note_commit_remove",
         "git_note_free",
         "git_note_foreach"
       ],
       "meta": {},
-      "lines": 213
+      "lines": 302
     },
     {
       "file": "object.h",
@@ -520,7 +529,7 @@
         "git_odb_get_backend"
       ],
       "meta": {},
-      "lines": 537
+      "lines": 544
     },
     {
       "file": "odb_backend.h",
@@ -627,7 +636,7 @@
         "git_pathspec_match_list_failed_entry"
       ],
       "meta": {},
-      "lines": 260
+      "lines": 277
     },
     {
       "file": "proxy.h",
@@ -733,7 +742,7 @@
         "git_reference_shorthand"
       ],
       "meta": {},
-      "lines": 741
+      "lines": 744
     },
     {
       "file": "refspec.h",
@@ -757,6 +766,7 @@
         "git_remote_create",
         "git_remote_create_with_fetchspec",
         "git_remote_create_anonymous",
+        "git_remote_create_detached",
         "git_remote_lookup",
         "git_remote_dup",
         "git_remote_owner",
@@ -780,6 +790,7 @@
         "git_remote_list",
         "git_push_transfer_progress",
         "git_push_negotiation",
+        "git_push_update_reference_cb",
         "git_remote_init_callbacks",
         "git_fetch_init_options",
         "git_push_init_options",
@@ -799,12 +810,13 @@
         "git_remote_default_branch"
       ],
       "meta": {},
-      "lines": 820
+      "lines": 850
     },
     {
       "file": "repository.h",
       "functions": [
         "git_repository_open",
+        "git_repository_open_from_worktree",
         "git_repository_wrap_odb",
         "git_repository_discover",
         "git_repository_open_ext",
@@ -814,13 +826,17 @@
         "git_repository_init_init_options",
         "git_repository_init_ext",
         "git_repository_head",
+        "git_repository_head_for_worktree",
         "git_repository_head_detached",
         "git_repository_head_unborn",
         "git_repository_is_empty",
+        "git_repository_item_path",
         "git_repository_path",
         "git_repository_workdir",
+        "git_repository_commondir",
         "git_repository_set_workdir",
         "git_repository_is_bare",
+        "git_repository_is_worktree",
         "git_repository_config",
         "git_repository_config_snapshot",
         "git_repository_odb",
@@ -844,7 +860,7 @@
         "git_repository_set_ident"
       ],
       "meta": {},
-      "lines": 771
+      "lines": 862
     },
     {
       "file": "reset.h",
@@ -943,7 +959,7 @@
         "git_status_should_ignore"
       ],
       "meta": {},
-      "lines": 366
+      "lines": 370
     },
     {
       "file": "strarray.h",
@@ -1010,7 +1026,7 @@
         "git_config_add_backend"
       ],
       "meta": {},
-      "lines": 123
+      "lines": 126
     },
     {
       "file": "sys/diff.h",
@@ -1041,11 +1057,12 @@
         "git_filter_check_fn",
         "git_filter_apply_fn",
         "git_filter_cleanup_fn",
+        "git_filter_init",
         "git_filter_register",
         "git_filter_unregister"
       ],
       "meta": {},
-      "lines": 317
+      "lines": 328
     },
     {
       "file": "sys/hashsig.h",
@@ -1062,10 +1079,11 @@
       "file": "sys/mempack.h",
       "functions": [
         "git_mempack_new",
+        "git_mempack_dump",
         "git_mempack_reset"
       ],
       "meta": {},
-      "lines": 81
+      "lines": 82
     },
     {
       "file": "sys/merge.h",
@@ -1083,7 +1101,7 @@
         "git_odb_init_backend"
       ],
       "meta": {},
-      "lines": 117
+      "lines": 118
     },
     {
       "file": "sys/openssl.h",
@@ -1151,17 +1169,20 @@
         "git_transport_init",
         "git_transport_new",
         "git_transport_ssh_with_paths",
+        "git_transport_register",
         "git_transport_unregister",
         "git_transport_dummy",
         "git_transport_local",
         "git_transport_smart",
         "git_transport_smart_certificate_check",
+        "git_transport_smart_credentials",
+        "git_transport_smart_proxy_options",
         "git_smart_subtransport_http",
         "git_smart_subtransport_git",
         "git_smart_subtransport_ssh"
       ],
       "meta": {},
-      "lines": 379
+      "lines": 389
     },
     {
       "file": "tag.h",
@@ -1258,7 +1279,7 @@
         "git_tree_create_updated"
       ],
       "meta": {},
-      "lines": 478
+      "lines": 479
     },
     {
       "file": "types.h",
@@ -1268,7 +1289,27 @@
         "git_transport_certificate_check_cb"
       ],
       "meta": {},
-      "lines": 425
+      "lines": 429
+    },
+    {
+      "file": "worktree.h",
+      "functions": [
+        "git_worktree_list",
+        "git_worktree_lookup",
+        "git_worktree_open_from_repository",
+        "git_worktree_free",
+        "git_worktree_validate",
+        "git_worktree_add_init_options",
+        "git_worktree_add",
+        "git_worktree_lock",
+        "git_worktree_unlock",
+        "git_worktree_is_locked",
+        "git_worktree_prune_init_options",
+        "git_worktree_is_prunable",
+        "git_worktree_prune"
+      ],
+      "meta": {},
+      "lines": 216
     }
   ],
   "functions": {
@@ -1302,7 +1343,12 @@
       },
       "description": "<p>Creates a <code>git_annotated_commit</code> from the given reference.\n The resulting git_annotated_commit must be freed with\n <code>git_annotated_commit_free</code>.</p>\n",
       "comments": "",
-      "group": "annotated"
+      "group": "annotated",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_annotated_commit_from_ref-1"
+        ]
+      }
     },
     "git_annotated_commit_from_fetchhead": {
       "type": "function",
@@ -1376,7 +1422,12 @@
       },
       "description": "<p>Creates a <code>git_annotated_commit</code> from the given commit id.\n The resulting git_annotated_commit must be freed with\n <code>git_annotated_commit_free</code>.</p>\n",
       "comments": "<p>An annotated commit contains information about how it was looked up, which may be useful for functions like merge or rebase to provide context to the operation.  For example, conflict files will include the name of the source or target branches being merged.  It is therefore preferable to use the most specific function (eg <code>git_annotated_commit_from_ref</code>) instead of this one when that data is known.</p>\n",
-      "group": "annotated"
+      "group": "annotated",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_annotated_commit_lookup-2"
+        ]
+      }
     },
     "git_annotated_commit_from_revspec": {
       "type": "function",
@@ -1430,7 +1481,14 @@
       },
       "description": "<p>Gets the commit ID that the given <code>git_annotated_commit</code> refers to.</p>\n",
       "comments": "",
-      "group": "annotated"
+      "group": "annotated",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_annotated_commit_id-3",
+          "ex/HEAD/merge.html#git_annotated_commit_id-4",
+          "ex/HEAD/merge.html#git_annotated_commit_id-5"
+        ]
+      }
     },
     "git_annotated_commit_free": {
       "type": "function",
@@ -2630,39 +2688,12 @@
       },
       "description": "<p>Return the name of the given local or remote branch.</p>\n",
       "comments": "<p>The name of the branch matches the definition of the name for git_branch_lookup. That is, if the returned name is given to git_branch_lookup() then the reference is returned that was given to this function.</p>\n",
-      "group": "branch"
-    },
-    "git_branch_remote_name": {
-      "type": "function",
-      "file": "branch.h",
-      "line": 274,
-      "lineto": 277,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_buf *",
-          "comment": "where the name is stored."
-        },
-        {
-          "name": "repo",
-          "type": "git_respository *",
-          "comment": "the repo to check."
-        },
-        {
-          "name": "canonical_branch_name",
-          "type": "const char *",
-          "comment": "the ref name of the branch"
-        }
-      ],
-      "argline": "git_buf *out, git_repository *repo, const char *canonical_branch_name",
-      "sig": "git_buf *::git_repository *::const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success; otherwise an error code (e.g., if the\n  ref is no local or remote branch)."
-      },
-      "description": "<p>Return the name of the given remote branch.</p>\n",
-      "comments": "<p></p>\n",
-      "group": "branch"
+      "group": "branch",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_branch_name-6"
+        ]
+      }
     },
     "git_branch_upstream": {
       "type": "function",
@@ -2737,6 +2768,28 @@
         "comment": " 1 if HEAD points at the branch, 0 if it isn't,\n error code otherwise."
       },
       "description": "<p>Determine if the current local branch is pointed at by HEAD.</p>\n",
+      "comments": "",
+      "group": "branch"
+    },
+    "git_branch_is_checked_out": {
+      "type": "function",
+      "file": "branch.h",
+      "line": 257,
+      "lineto": 258,
+      "args": [
+        {
+          "name": "branch",
+          "type": "const git_reference *",
+          "comment": "Reference to the branch."
+        }
+      ],
+      "argline": "const git_reference *branch",
+      "sig": "const git_reference *",
+      "return": {
+        "type": "int",
+        "comment": " 1 if branch is checked out, 0 if it isn't,\n error code otherwise."
+      },
+      "description": "<p>Determine if the current branch is checked out in any linked\n repository.</p>\n",
       "comments": "",
       "group": "branch"
     },
@@ -2992,7 +3045,12 @@
       },
       "description": "<p>Updates files in the index and working tree to match the content of the\n tree pointed at by the treeish.</p>\n",
       "comments": "",
-      "group": "checkout"
+      "group": "checkout",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_checkout_tree-7"
+        ]
+      }
     },
     "git_cherrypick_init_options": {
       "type": "function",
@@ -3208,6 +3266,9 @@
         ],
         "log.c": [
           "ex/HEAD/log.html#git_commit_lookup-1"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_commit_lookup-8"
         ]
       }
     },
@@ -3398,7 +3459,8 @@
         ],
         "log.c": [
           "ex/HEAD/log.html#git_commit_message-9",
-          "ex/HEAD/log.html#git_commit_message-10"
+          "ex/HEAD/log.html#git_commit_message-10",
+          "ex/HEAD/log.html#git_commit_message-11"
         ],
         "tag.c": [
           "ex/HEAD/tag.html#git_commit_message-2"
@@ -3550,7 +3612,7 @@
           "ex/HEAD/general.html#git_commit_committer-20"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_committer-11"
+          "ex/HEAD/log.html#git_commit_committer-12"
         ]
       }
     },
@@ -3584,8 +3646,8 @@
           "ex/HEAD/general.html#git_commit_author-22"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_author-12",
-          "ex/HEAD/log.html#git_commit_author-13"
+          "ex/HEAD/log.html#git_commit_author-13",
+          "ex/HEAD/log.html#git_commit_author-14"
         ]
       }
     },
@@ -3639,11 +3701,11 @@
       "group": "commit",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_commit_tree-14",
           "ex/HEAD/log.html#git_commit_tree-15",
           "ex/HEAD/log.html#git_commit_tree-16",
           "ex/HEAD/log.html#git_commit_tree-17",
-          "ex/HEAD/log.html#git_commit_tree-18"
+          "ex/HEAD/log.html#git_commit_tree-18",
+          "ex/HEAD/log.html#git_commit_tree-19"
         ]
       }
     },
@@ -3703,8 +3765,8 @@
           "ex/HEAD/general.html#git_commit_parentcount-23"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parentcount-19",
-          "ex/HEAD/log.html#git_commit_parentcount-20"
+          "ex/HEAD/log.html#git_commit_parentcount-20",
+          "ex/HEAD/log.html#git_commit_parentcount-21"
         ]
       }
     },
@@ -3744,8 +3806,8 @@
           "ex/HEAD/general.html#git_commit_parent-24"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parent-21",
-          "ex/HEAD/log.html#git_commit_parent-22"
+          "ex/HEAD/log.html#git_commit_parent-22",
+          "ex/HEAD/log.html#git_commit_parent-23"
         ]
       }
     },
@@ -3780,7 +3842,7 @@
           "ex/HEAD/cat-file.html#git_commit_parent_id-9"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parent_id-23"
+          "ex/HEAD/log.html#git_commit_parent_id-24"
         ]
       }
     },
@@ -3819,13 +3881,13 @@
     "git_commit_header_field": {
       "type": "function",
       "file": "commit.h",
-      "line": 264,
-      "lineto": 264,
+      "line": 265,
+      "lineto": 265,
       "args": [
         {
           "name": "out",
           "type": "git_buf *",
-          "comment": "the buffer to fill"
+          "comment": "the buffer to fill; existing content will be\n overwritten"
         },
         {
           "name": "commit",
@@ -3851,18 +3913,18 @@
     "git_commit_extract_signature": {
       "type": "function",
       "file": "commit.h",
-      "line": 282,
-      "lineto": 282,
+      "line": 285,
+      "lineto": 285,
       "args": [
         {
           "name": "signature",
           "type": "git_buf *",
-          "comment": "the signature block"
+          "comment": "the signature block; existing content will be\n overwritten"
         },
         {
           "name": "signed_data",
           "type": "git_buf *",
-          "comment": "signed data; this is the commit contents minus the signature block"
+          "comment": "signed data; this is the commit contents minus the signature block;\n existing content will be overwritten"
         },
         {
           "name": "repo",
@@ -3893,8 +3955,8 @@
     "git_commit_create": {
       "type": "function",
       "file": "commit.h",
-      "line": 328,
-      "lineto": 338,
+      "line": 331,
+      "lineto": 341,
       "args": [
         {
           "name": "id",
@@ -3955,13 +4017,18 @@
       },
       "description": "<p>Create new commit in the repository from a list of <code>git_object</code> pointers</p>\n",
       "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that with the <code>git_message_prettify()</code> function.</p>\n",
-      "group": "commit"
+      "group": "commit",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_commit_create-9"
+        ]
+      }
     },
     "git_commit_create_v": {
       "type": "function",
       "file": "commit.h",
-      "line": 354,
-      "lineto": 364,
+      "line": 357,
+      "lineto": 367,
       "args": [
         {
           "name": "id",
@@ -4030,8 +4097,8 @@
     "git_commit_amend": {
       "type": "function",
       "file": "commit.h",
-      "line": 387,
-      "lineto": 395,
+      "line": 390,
+      "lineto": 398,
       "args": [
         {
           "name": "id",
@@ -4087,8 +4154,8 @@
     "git_commit_create_buffer": {
       "type": "function",
       "file": "commit.h",
-      "line": 432,
-      "lineto": 441,
+      "line": 435,
+      "lineto": 444,
       "args": [
         {
           "name": "out",
@@ -4149,8 +4216,8 @@
     "git_commit_create_with_signature": {
       "type": "function",
       "file": "commit.h",
-      "line": 457,
-      "lineto": 462,
+      "line": 460,
+      "lineto": 465,
       "args": [
         {
           "name": "out",
@@ -4191,8 +4258,8 @@
     "git_commit_dup": {
       "type": "function",
       "file": "commit.h",
-      "line": 471,
-      "lineto": 471,
+      "line": 474,
+      "lineto": 474,
       "args": [
         {
           "name": "out",
@@ -4266,8 +4333,8 @@
     "git_libgit2_opts": {
       "type": "function",
       "file": "common.h",
-      "line": 312,
-      "lineto": 312,
+      "line": 352,
+      "lineto": 352,
       "args": [
         {
           "name": "option",
@@ -4282,7 +4349,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set or query a library global option</p>\n",
-      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time        by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must       &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,       &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.        &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path      &gt; applied to shared attributes and ignore files, too.       &gt;       &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.      &gt;   Pass NULL to reset to the default (generally based on environment       &gt;   variables).  Use magic path `$PATH` to include the old value        &gt;   of the path (if you want to prepend or append, for instance).       &gt;       &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,      &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or       &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be      &gt; considered eligible for caching in memory.  Setting to value to       &gt; zero means that that type of object will not be cached.       &gt; Defaults to 0 for GIT_OBJ_BLOB (i.e. won&#39;t cache blobs) and 4k        &gt; for GIT_OBJ_COMMIT, GIT_OBJ_TREE, and GIT_OBJ_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory     &gt; across all repositories before libgit2 starts evicting objects        &gt; from the cache.  This is a soft limit, in that the library might      &gt; briefly exceed it, but will start aggressively evicting objects       &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.     &gt;       &gt; Because caches are repository-specific, disabling the cache       &gt; cannot immediately clear all cached objects, but each cache will      &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be      &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.        &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.        &gt;       &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.      &gt;       &gt; - `file` is the location of a file containing several     &gt;   certificates concatenated together.     &gt; - `path` is the location of a directory holding several       &gt;   certificates, one per file.     &gt;       &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be       &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.      &gt;       &gt; - `user_agent` is the value that will be delivered as the     &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects      &gt; to ensure that all inputs to the new objects are valid.  For      &gt; example, when this is enabled, the parent(s) and tree inputs      &gt; will be validated when creating a new commit.  This defaults      &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For      &gt; example, `foobar` is not a valid ref, therefore `foobar` is       &gt; not a valid target for a symbolic ref by default, whereas     &gt; `refs/heads/foobar` is.  Disabling this bypasses validation       &gt; so that an arbitrary strings such as `foobar` can be used     &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.        &gt;       &gt; - `ciphers` is the list of ciphers that are eanbled.\n</code></pre>\n",
+      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time        by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must       &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,       &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.        &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path      &gt; applied to shared attributes and ignore files, too.       &gt;       &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.      &gt;   Pass NULL to reset to the default (generally based on environment       &gt;   variables).  Use magic path `$PATH` to include the old value        &gt;   of the path (if you want to prepend or append, for instance).       &gt;       &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,      &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or       &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be      &gt; considered eligible for caching in memory.  Setting to value to       &gt; zero means that that type of object will not be cached.       &gt; Defaults to 0 for GIT_OBJ_BLOB (i.e. won&#39;t cache blobs) and 4k        &gt; for GIT_OBJ_COMMIT, GIT_OBJ_TREE, and GIT_OBJ_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory     &gt; across all repositories before libgit2 starts evicting objects        &gt; from the cache.  This is a soft limit, in that the library might      &gt; briefly exceed it, but will start aggressively evicting objects       &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.     &gt;       &gt; Because caches are repository-specific, disabling the cache       &gt; cannot immediately clear all cached objects, but each cache will      &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be      &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.        &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.        &gt;       &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.      &gt;       &gt; - `file` is the location of a file containing several     &gt;   certificates concatenated together.     &gt; - `path` is the location of a directory holding several       &gt;   certificates, one per file.     &gt;       &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be       &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.      &gt;       &gt; - `user_agent` is the value that will be delivered as the     &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.        &gt; For more information, see the documentation for CreateFile.       &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is      &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects      &gt; to ensure that all inputs to the new objects are valid.  For      &gt; example, when this is enabled, the parent(s) and tree inputs      &gt; will be validated when creating a new commit.  This defaults      &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For      &gt; example, `foobar` is not a valid ref, therefore `foobar` is       &gt; not a valid target for a symbolic ref by default, whereas     &gt; `refs/heads/foobar` is.  Disabling this bypasses validation       &gt; so that an arbitrary strings such as `foobar` can be used     &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.        &gt;       &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,     &gt; and the negotiation of them when talking to a remote server.      &gt; Offset deltas store a delta base location as an offset into the       &gt; packfile from the current location, which provides a shorter encoding     &gt; and thus smaller resultant packfiles.     &gt; Packfiles containing offset deltas can still be read.     &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`       &gt; (or the platform equivalent) to ensure that new object data       &gt; is written to permanent storage, not simply cached.  This     &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading        &gt; objects from disk. This may impact performance due to an      &gt; additional checksum calculation on each object. This defaults     &gt; to enabled.\n</code></pre>\n",
       "group": "libgit2"
     },
     "git_config_entry_free": {
@@ -4442,8 +4509,8 @@
     "git_config_add_file_ondisk": {
       "type": "function",
       "file": "config.h",
-      "line": 206,
-      "lineto": 210,
+      "line": 208,
+      "lineto": 213,
       "args": [
         {
           "name": "cfg",
@@ -4461,13 +4528,18 @@
           "comment": "the priority level of the backend"
         },
         {
+          "name": "repo",
+          "type": "const git_repository *",
+          "comment": "optional repository to allow parsing of\n  conditional includes"
+        },
+        {
           "name": "force",
           "type": "int",
           "comment": "replace config file at the given priority level"
         }
       ],
-      "argline": "git_config *cfg, const char *path, git_config_level_t level, int force",
-      "sig": "git_config *::const char *::git_config_level_t::int",
+      "argline": "git_config *cfg, const char *path, git_config_level_t level, const git_repository *repo, int force",
+      "sig": "git_config *::const char *::git_config_level_t::const git_repository *::int",
       "return": {
         "type": "int",
         "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0),\n  GIT_ENOTFOUND when the file doesn't exist or error code"
@@ -4479,8 +4551,8 @@
     "git_config_open_ondisk": {
       "type": "function",
       "file": "config.h",
-      "line": 224,
-      "lineto": 224,
+      "line": 227,
+      "lineto": 227,
       "args": [
         {
           "name": "out",
@@ -4511,8 +4583,8 @@
     "git_config_open_level": {
       "type": "function",
       "file": "config.h",
-      "line": 242,
-      "lineto": 245,
+      "line": 245,
+      "lineto": 248,
       "args": [
         {
           "name": "out",
@@ -4543,8 +4615,8 @@
     "git_config_open_global": {
       "type": "function",
       "file": "config.h",
-      "line": 259,
-      "lineto": 259,
+      "line": 262,
+      "lineto": 262,
       "args": [
         {
           "name": "out",
@@ -4570,8 +4642,8 @@
     "git_config_snapshot": {
       "type": "function",
       "file": "config.h",
-      "line": 275,
-      "lineto": 275,
+      "line": 278,
+      "lineto": 278,
       "args": [
         {
           "name": "out",
@@ -4597,8 +4669,8 @@
     "git_config_free": {
       "type": "function",
       "file": "config.h",
-      "line": 282,
-      "lineto": 282,
+      "line": 285,
+      "lineto": 285,
       "args": [
         {
           "name": "cfg",
@@ -4625,8 +4697,8 @@
     "git_config_get_entry": {
       "type": "function",
       "file": "config.h",
-      "line": 294,
-      "lineto": 297,
+      "line": 297,
+      "lineto": 300,
       "args": [
         {
           "name": "out",
@@ -4657,8 +4729,8 @@
     "git_config_get_int32": {
       "type": "function",
       "file": "config.h",
-      "line": 311,
-      "lineto": 311,
+      "line": 314,
+      "lineto": 314,
       "args": [
         {
           "name": "out",
@@ -4687,15 +4759,16 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_get_int32-29"
+          "ex/HEAD/general.html#git_config_get_int32-29",
+          "ex/HEAD/general.html#git_config_get_int32-30"
         ]
       }
     },
     "git_config_get_int64": {
       "type": "function",
       "file": "config.h",
-      "line": 325,
-      "lineto": 325,
+      "line": 328,
+      "lineto": 328,
       "args": [
         {
           "name": "out",
@@ -4726,8 +4799,8 @@
     "git_config_get_bool": {
       "type": "function",
       "file": "config.h",
-      "line": 342,
-      "lineto": 342,
+      "line": 345,
+      "lineto": 345,
       "args": [
         {
           "name": "out",
@@ -4758,8 +4831,8 @@
     "git_config_get_path": {
       "type": "function",
       "file": "config.h",
-      "line": 360,
-      "lineto": 360,
+      "line": 363,
+      "lineto": 363,
       "args": [
         {
           "name": "out",
@@ -4790,8 +4863,8 @@
     "git_config_get_string": {
       "type": "function",
       "file": "config.h",
-      "line": 378,
-      "lineto": 378,
+      "line": 381,
+      "lineto": 381,
       "args": [
         {
           "name": "out",
@@ -4820,15 +4893,16 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_get_string-30"
+          "ex/HEAD/general.html#git_config_get_string-31",
+          "ex/HEAD/general.html#git_config_get_string-32"
         ]
       }
     },
     "git_config_get_string_buf": {
       "type": "function",
       "file": "config.h",
-      "line": 394,
-      "lineto": 394,
+      "line": 397,
+      "lineto": 397,
       "args": [
         {
           "name": "out",
@@ -4859,8 +4933,8 @@
     "git_config_get_multivar_foreach": {
       "type": "function",
       "file": "config.h",
-      "line": 408,
-      "lineto": 408,
+      "line": 415,
+      "lineto": 415,
       "args": [
         {
           "name": "cfg",
@@ -4895,14 +4969,14 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar in a foreach callback</p>\n",
-      "comments": "<p>The callback will be called on each variable found</p>\n",
+      "comments": "<p>The callback will be called on each variable found</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_multivar_iterator_new": {
       "type": "function",
       "file": "config.h",
-      "line": 419,
-      "lineto": 419,
+      "line": 430,
+      "lineto": 430,
       "args": [
         {
           "name": "out",
@@ -4932,14 +5006,14 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar</p>\n",
-      "comments": "",
+      "comments": "<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_next": {
       "type": "function",
       "file": "config.h",
-      "line": 431,
-      "lineto": 431,
+      "line": 442,
+      "lineto": 442,
       "args": [
         {
           "name": "entry",
@@ -4965,8 +5039,8 @@
     "git_config_iterator_free": {
       "type": "function",
       "file": "config.h",
-      "line": 438,
-      "lineto": 438,
+      "line": 449,
+      "lineto": 449,
       "args": [
         {
           "name": "iter",
@@ -4987,8 +5061,8 @@
     "git_config_set_int32": {
       "type": "function",
       "file": "config.h",
-      "line": 449,
-      "lineto": 449,
+      "line": 460,
+      "lineto": 460,
       "args": [
         {
           "name": "cfg",
@@ -5019,8 +5093,8 @@
     "git_config_set_int64": {
       "type": "function",
       "file": "config.h",
-      "line": 460,
-      "lineto": 460,
+      "line": 471,
+      "lineto": 471,
       "args": [
         {
           "name": "cfg",
@@ -5051,8 +5125,8 @@
     "git_config_set_bool": {
       "type": "function",
       "file": "config.h",
-      "line": 471,
-      "lineto": 471,
+      "line": 482,
+      "lineto": 482,
       "args": [
         {
           "name": "cfg",
@@ -5083,8 +5157,8 @@
     "git_config_set_string": {
       "type": "function",
       "file": "config.h",
-      "line": 485,
-      "lineto": 485,
+      "line": 496,
+      "lineto": 496,
       "args": [
         {
           "name": "cfg",
@@ -5115,8 +5189,8 @@
     "git_config_set_multivar": {
       "type": "function",
       "file": "config.h",
-      "line": 495,
-      "lineto": 495,
+      "line": 508,
+      "lineto": 508,
       "args": [
         {
           "name": "cfg",
@@ -5146,14 +5220,14 @@
         "comment": null
       },
       "description": "<p>Set a multivar in the local config file.</p>\n",
-      "comments": "",
+      "comments": "<p>The regular expression is applied case-sensitively on the value.</p>\n",
       "group": "config"
     },
     "git_config_delete_entry": {
       "type": "function",
       "file": "config.h",
-      "line": 504,
-      "lineto": 504,
+      "line": 517,
+      "lineto": 517,
       "args": [
         {
           "name": "cfg",
@@ -5179,8 +5253,8 @@
     "git_config_delete_multivar": {
       "type": "function",
       "file": "config.h",
-      "line": 515,
-      "lineto": 515,
+      "line": 530,
+      "lineto": 530,
       "args": [
         {
           "name": "cfg",
@@ -5205,14 +5279,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Deletes one or several entries from a multivar in the local config file.</p>\n",
-      "comments": "",
+      "comments": "<p>The regular expression is applied case-sensitively on the value.</p>\n",
       "group": "config"
     },
     "git_config_foreach": {
       "type": "function",
       "file": "config.h",
-      "line": 533,
-      "lineto": 536,
+      "line": 548,
+      "lineto": 551,
       "args": [
         {
           "name": "cfg",
@@ -5243,8 +5317,8 @@
     "git_config_iterator_new": {
       "type": "function",
       "file": "config.h",
-      "line": 547,
-      "lineto": 547,
+      "line": 562,
+      "lineto": 562,
       "args": [
         {
           "name": "out",
@@ -5270,8 +5344,8 @@
     "git_config_iterator_glob_new": {
       "type": "function",
       "file": "config.h",
-      "line": 559,
-      "lineto": 559,
+      "line": 578,
+      "lineto": 578,
       "args": [
         {
           "name": "out",
@@ -5296,14 +5370,14 @@
         "comment": null
       },
       "description": "<p>Iterate over all the config variables whose name matches a pattern</p>\n",
-      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n",
+      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_foreach_match": {
       "type": "function",
       "file": "config.h",
-      "line": 577,
-      "lineto": 581,
+      "line": 600,
+      "lineto": 604,
       "args": [
         {
           "name": "cfg",
@@ -5333,14 +5407,14 @@
         "comment": " 0 or the return value of the callback which didn't return 0"
       },
       "description": "<p>Perform an operation on each config variable matching a regular expression.</p>\n",
-      "comments": "<p>This behaviors like <code>git_config_foreach</code> with an additional filter of a regular expression that filters which config keys are passed to the callback.</p>\n\n<p>The pointers passed to the callback are only valid as long as the iteration is ongoing.</p>\n",
+      "comments": "<p>This behaviors like <code>git_config_foreach</code> with an additional filter of a regular expression that filters which config keys are passed to the callback.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the case-insensitive parts are lower-case.</p>\n",
       "group": "config"
     },
     "git_config_get_mapped": {
       "type": "function",
       "file": "config.h",
-      "line": 617,
-      "lineto": 622,
+      "line": 640,
+      "lineto": 645,
       "args": [
         {
           "name": "out",
@@ -5381,8 +5455,8 @@
     "git_config_lookup_map_value": {
       "type": "function",
       "file": "config.h",
-      "line": 632,
-      "lineto": 636,
+      "line": 655,
+      "lineto": 659,
       "args": [
         {
           "name": "out",
@@ -5418,8 +5492,8 @@
     "git_config_parse_bool": {
       "type": "function",
       "file": "config.h",
-      "line": 648,
-      "lineto": 648,
+      "line": 671,
+      "lineto": 671,
       "args": [
         {
           "name": "out",
@@ -5445,8 +5519,8 @@
     "git_config_parse_int32": {
       "type": "function",
       "file": "config.h",
-      "line": 660,
-      "lineto": 660,
+      "line": 683,
+      "lineto": 683,
       "args": [
         {
           "name": "out",
@@ -5472,8 +5546,8 @@
     "git_config_parse_int64": {
       "type": "function",
       "file": "config.h",
-      "line": 672,
-      "lineto": 672,
+      "line": 695,
+      "lineto": 695,
       "args": [
         {
           "name": "out",
@@ -5499,8 +5573,8 @@
     "git_config_parse_path": {
       "type": "function",
       "file": "config.h",
-      "line": 687,
-      "lineto": 687,
+      "line": 710,
+      "lineto": 710,
       "args": [
         {
           "name": "out",
@@ -5526,8 +5600,8 @@
     "git_config_backend_foreach_match": {
       "type": "function",
       "file": "config.h",
-      "line": 701,
-      "lineto": 705,
+      "line": 728,
+      "lineto": 732,
       "args": [
         {
           "name": "backend",
@@ -5557,14 +5631,14 @@
         "comment": null
       },
       "description": "<p>Perform an operation on each config variable in given config backend\n matching a regular expression.</p>\n",
-      "comments": "<p>This behaviors like <code>git_config_foreach_match</code> except instead of all config entries it just enumerates through the given backend entry.</p>\n",
+      "comments": "<p>This behaviors like <code>git_config_foreach_match</code> except instead of all config entries it just enumerates through the given backend entry.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_lock": {
       "type": "function",
       "file": "config.h",
-      "line": 724,
-      "lineto": 724,
+      "line": 751,
+      "lineto": 751,
       "args": [
         {
           "name": "tx",
@@ -5765,8 +5839,8 @@
     "git_diff_init_options": {
       "type": "function",
       "file": "diff.h",
-      "line": 441,
-      "lineto": 443,
+      "line": 447,
+      "lineto": 449,
       "args": [
         {
           "name": "opts",
@@ -5792,8 +5866,8 @@
     "git_diff_find_init_options": {
       "type": "function",
       "file": "diff.h",
-      "line": 736,
-      "lineto": 738,
+      "line": 742,
+      "lineto": 744,
       "args": [
         {
           "name": "opts",
@@ -5819,8 +5893,8 @@
     "git_diff_free": {
       "type": "function",
       "file": "diff.h",
-      "line": 752,
-      "lineto": 752,
+      "line": 758,
+      "lineto": 758,
       "args": [
         {
           "name": "diff",
@@ -5842,16 +5916,16 @@
           "ex/HEAD/diff.html#git_diff_free-2"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_free-24",
-          "ex/HEAD/log.html#git_diff_free-25"
+          "ex/HEAD/log.html#git_diff_free-25",
+          "ex/HEAD/log.html#git_diff_free-26"
         ]
       }
     },
     "git_diff_tree_to_tree": {
       "type": "function",
       "file": "diff.h",
-      "line": 770,
-      "lineto": 775,
+      "line": 776,
+      "lineto": 781,
       "args": [
         {
           "name": "diff",
@@ -5893,16 +5967,16 @@
           "ex/HEAD/diff.html#git_diff_tree_to_tree-3"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_tree_to_tree-26",
-          "ex/HEAD/log.html#git_diff_tree_to_tree-27"
+          "ex/HEAD/log.html#git_diff_tree_to_tree-27",
+          "ex/HEAD/log.html#git_diff_tree_to_tree-28"
         ]
       }
     },
     "git_diff_tree_to_index": {
       "type": "function",
       "file": "diff.h",
-      "line": 796,
-      "lineto": 801,
+      "line": 802,
+      "lineto": 807,
       "args": [
         {
           "name": "diff",
@@ -5948,8 +6022,8 @@
     "git_diff_index_to_workdir": {
       "type": "function",
       "file": "diff.h",
-      "line": 823,
-      "lineto": 827,
+      "line": 829,
+      "lineto": 833,
       "args": [
         {
           "name": "diff",
@@ -5990,8 +6064,8 @@
     "git_diff_tree_to_workdir": {
       "type": "function",
       "file": "diff.h",
-      "line": 852,
-      "lineto": 856,
+      "line": 858,
+      "lineto": 862,
       "args": [
         {
           "name": "diff",
@@ -6032,8 +6106,8 @@
     "git_diff_tree_to_workdir_with_index": {
       "type": "function",
       "file": "diff.h",
-      "line": 871,
-      "lineto": 875,
+      "line": 877,
+      "lineto": 881,
       "args": [
         {
           "name": "diff",
@@ -6074,8 +6148,8 @@
     "git_diff_index_to_index": {
       "type": "function",
       "file": "diff.h",
-      "line": 889,
-      "lineto": 894,
+      "line": 895,
+      "lineto": 900,
       "args": [
         {
           "name": "diff",
@@ -6116,8 +6190,8 @@
     "git_diff_merge": {
       "type": "function",
       "file": "diff.h",
-      "line": 909,
-      "lineto": 911,
+      "line": 915,
+      "lineto": 917,
       "args": [
         {
           "name": "onto",
@@ -6143,8 +6217,8 @@
     "git_diff_find_similar": {
       "type": "function",
       "file": "diff.h",
-      "line": 925,
-      "lineto": 927,
+      "line": 931,
+      "lineto": 933,
       "args": [
         {
           "name": "diff",
@@ -6175,8 +6249,8 @@
     "git_diff_num_deltas": {
       "type": "function",
       "file": "diff.h",
-      "line": 945,
-      "lineto": 945,
+      "line": 951,
+      "lineto": 951,
       "args": [
         {
           "name": "diff",
@@ -6195,15 +6269,15 @@
       "group": "diff",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_diff_num_deltas-28"
+          "ex/HEAD/log.html#git_diff_num_deltas-29"
         ]
       }
     },
     "git_diff_num_deltas_of_type": {
       "type": "function",
       "file": "diff.h",
-      "line": 958,
-      "lineto": 959,
+      "line": 964,
+      "lineto": 965,
       "args": [
         {
           "name": "diff",
@@ -6229,8 +6303,8 @@
     "git_diff_get_delta": {
       "type": "function",
       "file": "diff.h",
-      "line": 978,
-      "lineto": 979,
+      "line": 984,
+      "lineto": 985,
       "args": [
         {
           "name": "diff",
@@ -6256,8 +6330,8 @@
     "git_diff_is_sorted_icase": {
       "type": "function",
       "file": "diff.h",
-      "line": 987,
-      "lineto": 987,
+      "line": 993,
+      "lineto": 993,
       "args": [
         {
           "name": "diff",
@@ -6278,8 +6352,8 @@
     "git_diff_foreach": {
       "type": "function",
       "file": "diff.h",
-      "line": 1015,
-      "lineto": 1021,
+      "line": 1021,
+      "lineto": 1027,
       "args": [
         {
           "name": "diff",
@@ -6325,8 +6399,8 @@
     "git_diff_status_char": {
       "type": "function",
       "file": "diff.h",
-      "line": 1034,
-      "lineto": 1034,
+      "line": 1040,
+      "lineto": 1040,
       "args": [
         {
           "name": "status",
@@ -6347,8 +6421,8 @@
     "git_diff_print": {
       "type": "function",
       "file": "diff.h",
-      "line": 1059,
-      "lineto": 1063,
+      "line": 1065,
+      "lineto": 1069,
       "args": [
         {
           "name": "diff",
@@ -6385,15 +6459,15 @@
           "ex/HEAD/diff.html#git_diff_print-9"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_print-29"
+          "ex/HEAD/log.html#git_diff_print-30"
         ]
       }
     },
     "git_diff_to_buf": {
       "type": "function",
       "file": "diff.h",
-      "line": 1075,
-      "lineto": 1078,
+      "line": 1081,
+      "lineto": 1084,
       "args": [
         {
           "name": "out",
@@ -6424,8 +6498,8 @@
     "git_diff_blobs": {
       "type": "function",
       "file": "diff.h",
-      "line": 1115,
-      "lineto": 1125,
+      "line": 1121,
+      "lineto": 1131,
       "args": [
         {
           "name": "old_blob",
@@ -6491,8 +6565,8 @@
     "git_diff_blob_to_buffer": {
       "type": "function",
       "file": "diff.h",
-      "line": 1152,
-      "lineto": 1163,
+      "line": 1158,
+      "lineto": 1169,
       "args": [
         {
           "name": "old_blob",
@@ -6563,8 +6637,8 @@
     "git_diff_buffers": {
       "type": "function",
       "file": "diff.h",
-      "line": 1186,
-      "lineto": 1198,
+      "line": 1192,
+      "lineto": 1204,
       "args": [
         {
           "name": "old_buffer",
@@ -6640,8 +6714,8 @@
     "git_diff_from_buffer": {
       "type": "function",
       "file": "diff.h",
-      "line": 1219,
-      "lineto": 1222,
+      "line": 1225,
+      "lineto": 1228,
       "args": [
         {
           "name": "out",
@@ -6672,8 +6746,8 @@
     "git_diff_get_stats": {
       "type": "function",
       "file": "diff.h",
-      "line": 1258,
-      "lineto": 1260,
+      "line": 1264,
+      "lineto": 1266,
       "args": [
         {
           "name": "out",
@@ -6704,8 +6778,8 @@
     "git_diff_stats_files_changed": {
       "type": "function",
       "file": "diff.h",
-      "line": 1268,
-      "lineto": 1269,
+      "line": 1274,
+      "lineto": 1275,
       "args": [
         {
           "name": "stats",
@@ -6726,8 +6800,8 @@
     "git_diff_stats_insertions": {
       "type": "function",
       "file": "diff.h",
-      "line": 1277,
-      "lineto": 1278,
+      "line": 1283,
+      "lineto": 1284,
       "args": [
         {
           "name": "stats",
@@ -6748,8 +6822,8 @@
     "git_diff_stats_deletions": {
       "type": "function",
       "file": "diff.h",
-      "line": 1286,
-      "lineto": 1287,
+      "line": 1292,
+      "lineto": 1293,
       "args": [
         {
           "name": "stats",
@@ -6770,8 +6844,8 @@
     "git_diff_stats_to_buf": {
       "type": "function",
       "file": "diff.h",
-      "line": 1298,
-      "lineto": 1302,
+      "line": 1304,
+      "lineto": 1308,
       "args": [
         {
           "name": "out",
@@ -6812,8 +6886,8 @@
     "git_diff_stats_free": {
       "type": "function",
       "file": "diff.h",
-      "line": 1310,
-      "lineto": 1310,
+      "line": 1316,
+      "lineto": 1316,
       "args": [
         {
           "name": "stats",
@@ -6839,8 +6913,8 @@
     "git_diff_format_email": {
       "type": "function",
       "file": "diff.h",
-      "line": 1362,
-      "lineto": 1365,
+      "line": 1368,
+      "lineto": 1371,
       "args": [
         {
           "name": "out",
@@ -6871,8 +6945,8 @@
     "git_diff_commit_as_email": {
       "type": "function",
       "file": "diff.h",
-      "line": 1381,
-      "lineto": 1388,
+      "line": 1387,
+      "lineto": 1394,
       "args": [
         {
           "name": "out",
@@ -6923,8 +6997,8 @@
     "git_diff_format_email_init_options": {
       "type": "function",
       "file": "diff.h",
-      "line": 1399,
-      "lineto": 1401,
+      "line": 1405,
+      "lineto": 1407,
       "args": [
         {
           "name": "opts",
@@ -6947,11 +7021,70 @@
       "comments": "<p>Equivalent to creating an instance with GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
+    "git_diff_patchid_init_options": {
+      "type": "function",
+      "file": "diff.h",
+      "line": 1428,
+      "lineto": 1430,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_diff_patchid_options *",
+          "comment": null
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": null
+        }
+      ],
+      "argline": "git_diff_patchid_options *opts, unsigned int version",
+      "sig": "git_diff_patchid_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Initialize <code>git_diff_patchid_options</code> structure.</p>\n",
+      "comments": "<p>Initializes the structure with default values. Equivalent to creating an instance with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code>.</p>\n",
+      "group": "diff"
+    },
+    "git_diff_patchid": {
+      "type": "function",
+      "file": "diff.h",
+      "line": 1452,
+      "lineto": 1452,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_oid *",
+          "comment": "Pointer where the calculated patch ID shoul be\n  stored"
+        },
+        {
+          "name": "diff",
+          "type": "git_diff *",
+          "comment": "The diff to calculate the ID for"
+        },
+        {
+          "name": "opts",
+          "type": "git_diff_patchid_options *",
+          "comment": "Options for how to calculate the patch ID. This is\n  intended for future changes, as currently no options are\n  available."
+        }
+      ],
+      "argline": "git_oid *out, git_diff *diff, git_diff_patchid_options *opts",
+      "sig": "git_oid *::git_diff *::git_diff_patchid_options *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, an error code otherwise."
+      },
+      "description": "<p>Calculate the patch ID for the given patch.</p>\n",
+      "comments": "<p>Calculate a stable patch ID for the given patch by summing the hash of the file diffs, ignoring whitespace and line numbers. This can be used to derive whether two diffs are the same with a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as defined in git-patch-id(1), and should in fact generate the same IDs as the upstream git project does.</p>\n",
+      "group": "diff"
+    },
     "giterr_last": {
       "type": "function",
       "file": "errors.h",
-      "line": 111,
-      "lineto": 111,
+      "line": 115,
+      "lineto": 115,
       "args": [],
       "argline": "",
       "sig": "",
@@ -6964,22 +7097,22 @@
       "group": "giterr",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#giterr_last-31"
+          "ex/HEAD/general.html#giterr_last-33"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#giterr_last-10",
+          "ex/HEAD/merge.html#giterr_last-11"
         ],
         "network/clone.c": [
           "ex/HEAD/network/clone.html#giterr_last-2"
-        ],
-        "network/git2.c": [
-          "ex/HEAD/network/git2.html#giterr_last-1",
-          "ex/HEAD/network/git2.html#giterr_last-2"
         ]
       }
     },
     "giterr_clear": {
       "type": "function",
       "file": "errors.h",
-      "line": 116,
-      "lineto": 116,
+      "line": 120,
+      "lineto": 120,
       "args": [],
       "argline": "",
       "sig": "",
@@ -6994,8 +7127,8 @@
     "giterr_set_str": {
       "type": "function",
       "file": "errors.h",
-      "line": 134,
-      "lineto": 134,
+      "line": 138,
+      "lineto": 138,
       "args": [
         {
           "name": "error_class",
@@ -7021,8 +7154,8 @@
     "giterr_set_oom": {
       "type": "function",
       "file": "errors.h",
-      "line": 145,
-      "lineto": 145,
+      "line": 149,
+      "lineto": 149,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7345,7 +7478,7 @@
         "comment": " the number of initializations of the library, or an error code."
       },
       "description": "<p>Init the global state</p>\n",
-      "comments": "<p>This function must the called before any other libgit2 function in order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number of times the initialization has been called (including this one) that have not subsequently been shutdown.</p>\n",
+      "comments": "<p>This function must be called before any other libgit2 function in order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number of times the initialization has been called (including this one) that have not subsequently been shutdown.</p>\n",
       "group": "libgit2",
       "examples": {
         "blame.c": [
@@ -7361,16 +7494,16 @@
           "ex/HEAD/diff.html#git_libgit2_init-13"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_libgit2_init-32"
+          "ex/HEAD/general.html#git_libgit2_init-34"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_libgit2_init-2"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_libgit2_init-30"
+          "ex/HEAD/log.html#git_libgit2_init-31"
         ],
-        "network/git2.c": [
-          "ex/HEAD/network/git2.html#git_libgit2_init-3"
+        "merge.c": [
+          "ex/HEAD/merge.html#git_libgit2_init-12"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_libgit2_init-2"
@@ -7418,10 +7551,10 @@
           "ex/HEAD/init.html#git_libgit2_shutdown-3"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_libgit2_shutdown-31"
+          "ex/HEAD/log.html#git_libgit2_shutdown-32"
         ],
-        "network/git2.c": [
-          "ex/HEAD/network/git2.html#git_libgit2_shutdown-4"
+        "merge.c": [
+          "ex/HEAD/merge.html#git_libgit2_shutdown-13"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_libgit2_shutdown-3"
@@ -7482,8 +7615,8 @@
     "git_graph_descendant_of": {
       "type": "function",
       "file": "graph.h",
-      "line": 48,
-      "lineto": 51,
+      "line": 51,
+      "lineto": 54,
       "args": [
         {
           "name": "repo",
@@ -7508,7 +7641,7 @@
         "comment": " 1 if the given commit is a descendant of the potential ancestor,\n 0 if not, error code otherwise."
       },
       "description": "<p>Determine if a commit is the descendant of another commit.</p>\n",
-      "comments": "",
+      "comments": "<p>Note that a commit is not considered a descendant of itself, in contrast to <code>git merge-base --is-ancestor</code>.</p>\n",
       "group": "graph"
     },
     "git_ignore_add_rule": {
@@ -7664,7 +7797,7 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_free-33"
+          "ex/HEAD/general.html#git_index_free-35"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_index_free-4"
@@ -7940,6 +8073,9 @@
       "examples": {
         "init.c": [
           "ex/HEAD/init.html#git_index_write_tree-5"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_index_write_tree-14"
         ]
       }
     },
@@ -7998,7 +8134,7 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_entrycount-34"
+          "ex/HEAD/general.html#git_index_entrycount-36"
         ]
       }
     },
@@ -8052,7 +8188,7 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_get_byindex-35"
+          "ex/HEAD/general.html#git_index_get_byindex-37"
         ]
       }
     },
@@ -8317,8 +8453,8 @@
     "git_index_add_all": {
       "type": "function",
       "file": "index.h",
-      "line": 617,
-      "lineto": 622,
+      "line": 618,
+      "lineto": 623,
       "args": [
         {
           "name": "index",
@@ -8353,14 +8489,14 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Add or update index entries matching files in the working directory.</p>\n",
-      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will matched against files in the repository&#39;s working directory.  Each file that matches will be added to the index (either updating an existing entry or adding a new entry).  You can disable glob expansion and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code> flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>). If a file is already tracked in the index, then it <em>will</em> be updated even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains the exact path of an ignored file (when not using FORCE), add the <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry in the <code>pathspec</code> that is an exact match to a filename on disk is either not ignored or already in the index.  If this check fails, the function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files will no longer be marked as conflicting.  The data about the conflicts will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the working directory immediately <em>before</em> it is added to / updated in the index.  Returning zero will add the item to the index, greater than zero will skip the item, and less than zero will abort the scan and return that value to the caller.</p>\n",
+      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will be matched against files in the repository&#39;s working directory.  Each file that matches will be added to the index (either updating an existing entry or adding a new entry).  You can disable glob expansion and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code> flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>). If a file is already tracked in the index, then it <em>will</em> be updated even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains the exact path of an ignored file (when not using FORCE), add the <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry in the <code>pathspec</code> that is an exact match to a filename on disk is either not ignored or already in the index.  If this check fails, the function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files will no longer be marked as conflicting.  The data about the conflicts will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the working directory immediately <em>before</em> it is added to / updated in the index.  Returning zero will add the item to the index, greater than zero will skip the item, and less than zero will abort the scan and return that value to the caller.</p>\n",
       "group": "index"
     },
     "git_index_remove_all": {
       "type": "function",
       "file": "index.h",
-      "line": 639,
-      "lineto": 643,
+      "line": 640,
+      "lineto": 644,
       "args": [
         {
           "name": "index",
@@ -8396,8 +8532,8 @@
     "git_index_update_all": {
       "type": "function",
       "file": "index.h",
-      "line": 668,
-      "lineto": 672,
+      "line": 669,
+      "lineto": 673,
       "args": [
         {
           "name": "index",
@@ -8433,8 +8569,8 @@
     "git_index_find": {
       "type": "function",
       "file": "index.h",
-      "line": 683,
-      "lineto": 683,
+      "line": 684,
+      "lineto": 684,
       "args": [
         {
           "name": "at_pos",
@@ -8465,8 +8601,8 @@
     "git_index_find_prefix": {
       "type": "function",
       "file": "index.h",
-      "line": 694,
-      "lineto": 694,
+      "line": 695,
+      "lineto": 695,
       "args": [
         {
           "name": "at_pos",
@@ -8497,8 +8633,8 @@
     "git_index_conflict_add": {
       "type": "function",
       "file": "index.h",
-      "line": 719,
-      "lineto": 723,
+      "line": 720,
+      "lineto": 724,
       "args": [
         {
           "name": "index",
@@ -8534,8 +8670,8 @@
     "git_index_conflict_get": {
       "type": "function",
       "file": "index.h",
-      "line": 739,
-      "lineto": 744,
+      "line": 740,
+      "lineto": 745,
       "args": [
         {
           "name": "ancestor_out",
@@ -8576,8 +8712,8 @@
     "git_index_conflict_remove": {
       "type": "function",
       "file": "index.h",
-      "line": 753,
-      "lineto": 753,
+      "line": 754,
+      "lineto": 754,
       "args": [
         {
           "name": "index",
@@ -8603,8 +8739,8 @@
     "git_index_conflict_cleanup": {
       "type": "function",
       "file": "index.h",
-      "line": 761,
-      "lineto": 761,
+      "line": 762,
+      "lineto": 762,
       "args": [
         {
           "name": "index",
@@ -8625,8 +8761,8 @@
     "git_index_has_conflicts": {
       "type": "function",
       "file": "index.h",
-      "line": 768,
-      "lineto": 768,
+      "line": 769,
+      "lineto": 769,
       "args": [
         {
           "name": "index",
@@ -8642,13 +8778,18 @@
       },
       "description": "<p>Determine if the index contains entries representing file conflicts.</p>\n",
       "comments": "",
-      "group": "index"
+      "group": "index",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_index_has_conflicts-15"
+        ]
+      }
     },
     "git_index_conflict_iterator_new": {
       "type": "function",
       "file": "index.h",
-      "line": 779,
-      "lineto": 781,
+      "line": 780,
+      "lineto": 782,
       "args": [
         {
           "name": "iterator_out",
@@ -8669,13 +8810,18 @@
       },
       "description": "<p>Create an iterator for the conflicts in the index.</p>\n",
       "comments": "<p>The index must not be modified while iterating; the results are undefined.</p>\n",
-      "group": "index"
+      "group": "index",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_index_conflict_iterator_new-16"
+        ]
+      }
     },
     "git_index_conflict_next": {
       "type": "function",
       "file": "index.h",
-      "line": 793,
-      "lineto": 797,
+      "line": 794,
+      "lineto": 798,
       "args": [
         {
           "name": "ancestor_out",
@@ -8706,13 +8852,18 @@
       },
       "description": "<p>Returns the current conflict (ancestor, ours and theirs entry) and\n advance the iterator internally to the next value.</p>\n",
       "comments": "",
-      "group": "index"
+      "group": "index",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_index_conflict_next-17"
+        ]
+      }
     },
     "git_index_conflict_iterator_free": {
       "type": "function",
       "file": "index.h",
-      "line": 804,
-      "lineto": 805,
+      "line": 805,
+      "lineto": 806,
       "args": [
         {
           "name": "iterator",
@@ -8728,7 +8879,12 @@
       },
       "description": "<p>Frees a <code>git_index_conflict_iterator</code>.</p>\n",
       "comments": "",
-      "group": "index"
+      "group": "index",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_index_conflict_iterator_free-18"
+        ]
+      }
     },
     "git_indexer_new": {
       "type": "function",
@@ -8940,8 +9096,8 @@
     "git_merge_file_init_options": {
       "type": "function",
       "file": "merge.h",
-      "line": 208,
-      "lineto": 210,
+      "line": 214,
+      "lineto": 216,
       "args": [
         {
           "name": "opts",
@@ -8967,8 +9123,8 @@
     "git_merge_init_options": {
       "type": "function",
       "file": "merge.h",
-      "line": 305,
-      "lineto": 307,
+      "line": 311,
+      "lineto": 313,
       "args": [
         {
           "name": "opts",
@@ -8994,8 +9150,8 @@
     "git_merge_analysis": {
       "type": "function",
       "file": "merge.h",
-      "line": 376,
-      "lineto": 381,
+      "line": 382,
+      "lineto": 387,
       "args": [
         {
           "name": "analysis_out",
@@ -9031,13 +9187,18 @@
       },
       "description": "<p>Analyzes the given branch(es) and determines the opportunities for\n merging them into the HEAD of the repository.</p>\n",
       "comments": "",
-      "group": "merge"
+      "group": "merge",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_merge_analysis-19"
+        ]
+      }
     },
     "git_merge_base": {
       "type": "function",
       "file": "merge.h",
-      "line": 392,
-      "lineto": 396,
+      "line": 398,
+      "lineto": 402,
       "args": [
         {
           "name": "out",
@@ -9071,7 +9232,7 @@
       "group": "merge",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_merge_base-32"
+          "ex/HEAD/log.html#git_merge_base-33"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_merge_base-3"
@@ -9081,8 +9242,8 @@
     "git_merge_bases": {
       "type": "function",
       "file": "merge.h",
-      "line": 407,
-      "lineto": 411,
+      "line": 413,
+      "lineto": 417,
       "args": [
         {
           "name": "out",
@@ -9118,8 +9279,8 @@
     "git_merge_base_many": {
       "type": "function",
       "file": "merge.h",
-      "line": 422,
-      "lineto": 426,
+      "line": 428,
+      "lineto": 432,
       "args": [
         {
           "name": "out",
@@ -9155,8 +9316,8 @@
     "git_merge_bases_many": {
       "type": "function",
       "file": "merge.h",
-      "line": 437,
-      "lineto": 441,
+      "line": 443,
+      "lineto": 447,
       "args": [
         {
           "name": "out",
@@ -9192,8 +9353,8 @@
     "git_merge_base_octopus": {
       "type": "function",
       "file": "merge.h",
-      "line": 452,
-      "lineto": 456,
+      "line": 458,
+      "lineto": 462,
       "args": [
         {
           "name": "out",
@@ -9229,8 +9390,8 @@
     "git_merge_file": {
       "type": "function",
       "file": "merge.h",
-      "line": 474,
-      "lineto": 479,
+      "line": 480,
+      "lineto": 485,
       "args": [
         {
           "name": "out",
@@ -9271,8 +9432,8 @@
     "git_merge_file_from_index": {
       "type": "function",
       "file": "merge.h",
-      "line": 495,
-      "lineto": 501,
+      "line": 501,
+      "lineto": 507,
       "args": [
         {
           "name": "out",
@@ -9318,8 +9479,8 @@
     "git_merge_file_result_free": {
       "type": "function",
       "file": "merge.h",
-      "line": 508,
-      "lineto": 508,
+      "line": 514,
+      "lineto": 514,
       "args": [
         {
           "name": "result",
@@ -9340,8 +9501,8 @@
     "git_merge_trees": {
       "type": "function",
       "file": "merge.h",
-      "line": 526,
-      "lineto": 532,
+      "line": 532,
+      "lineto": 538,
       "args": [
         {
           "name": "out",
@@ -9387,8 +9548,8 @@
     "git_merge_commits": {
       "type": "function",
       "file": "merge.h",
-      "line": 549,
-      "lineto": 554,
+      "line": 555,
+      "lineto": 560,
       "args": [
         {
           "name": "out",
@@ -9429,8 +9590,8 @@
     "git_merge": {
       "type": "function",
       "file": "merge.h",
-      "line": 574,
-      "lineto": 579,
+      "line": 580,
+      "lineto": 585,
       "args": [
         {
           "name": "repo",
@@ -9466,13 +9627,18 @@
       },
       "description": "<p>Merges the given commit(s) into HEAD, writing the results into the working\n directory.  Any changes are staged for commit and any conflicts are written\n to the index.  Callers should inspect the repository&#39;s index after this\n completes, resolve any conflicts and prepare a commit.</p>\n",
       "comments": "<p>For compatibility with git, the repository is put into a merging state. Once the commit is done (or if the uses wishes to abort), you should clear this state by calling <code>git_repository_state_cleanup()</code>.</p>\n",
-      "group": "merge"
+      "group": "merge",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_merge-20"
+        ]
+      }
     },
     "git_message_prettify": {
       "type": "function",
       "file": "message.h",
-      "line": 39,
-      "lineto": 39,
+      "line": 38,
+      "lineto": 38,
       "args": [
         {
           "name": "out",
@@ -9501,8 +9667,57 @@
         "type": "int",
         "comment": " 0 or an error code."
       },
-      "description": "<p>Clean up message from excess whitespace and make sure that the last line\n ends with a &#39;</p>\n\n<p>&#39;.</p>\n",
-      "comments": "<p>Optionally, can remove lines starting with a &quot;#&quot;.</p>\n",
+      "description": "<p>Clean up excess whitespace and make sure there is a trailing newline in the message.</p>\n",
+      "comments": "<p>Optionally, it can remove lines which start with the comment character.</p>\n",
+      "group": "message"
+    },
+    "git_message_trailers": {
+      "type": "function",
+      "file": "message.h",
+      "line": 73,
+      "lineto": 73,
+      "args": [
+        {
+          "name": "arr",
+          "type": "git_message_trailer_array *",
+          "comment": "A pre-allocated git_message_trailer_array struct to be filled in\n            with any trailers found during parsing."
+        },
+        {
+          "name": "message",
+          "type": "const char *",
+          "comment": "The message to be parsed"
+        }
+      ],
+      "argline": "git_message_trailer_array *arr, const char *message",
+      "sig": "git_message_trailer_array *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or non-zero on error."
+      },
+      "description": "<p>Parse trailers out of a message, filling the array pointed to by +arr+.</p>\n",
+      "comments": "<p>Trailers are key/value pairs in the last paragraph of a message, not including any patches or conflicts that may be present.</p>\n",
+      "group": "message"
+    },
+    "git_message_trailer_array_free": {
+      "type": "function",
+      "file": "message.h",
+      "line": 79,
+      "lineto": 79,
+      "args": [
+        {
+          "name": "arr",
+          "type": "git_message_trailer_array *",
+          "comment": null
+        }
+      ],
+      "argline": "git_message_trailer_array *arr",
+      "sig": "git_message_trailer_array *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Clean&#39;s up any allocated memory in the git_message_trailer_array filled by\n a call to git_message_trailers.</p>\n",
+      "comments": "",
       "group": "message"
     },
     "git_note_iterator_new": {
@@ -9537,11 +9752,38 @@
       "comments": "<p>The iterator must be freed manually by the user.</p>\n",
       "group": "note"
     },
+    "git_note_commit_iterator_new": {
+      "type": "function",
+      "file": "notes.h",
+      "line": 64,
+      "lineto": 66,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_note_iterator **",
+          "comment": "pointer to the iterator"
+        },
+        {
+          "name": "notes_commit",
+          "type": "git_commit *",
+          "comment": "a pointer to the notes commit object"
+        }
+      ],
+      "argline": "git_note_iterator **out, git_commit *notes_commit",
+      "sig": "git_note_iterator **::git_commit *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Creates a new iterator for notes from a commit</p>\n",
+      "comments": "<p>The iterator must be freed manually by the user.</p>\n",
+      "group": "note"
+    },
     "git_note_iterator_free": {
       "type": "function",
       "file": "notes.h",
-      "line": 59,
-      "lineto": 59,
+      "line": 73,
+      "lineto": 73,
       "args": [
         {
           "name": "it",
@@ -9562,8 +9804,8 @@
     "git_note_next": {
       "type": "function",
       "file": "notes.h",
-      "line": 72,
-      "lineto": 75,
+      "line": 86,
+      "lineto": 89,
       "args": [
         {
           "name": "note_id",
@@ -9594,8 +9836,8 @@
     "git_note_read": {
       "type": "function",
       "file": "notes.h",
-      "line": 91,
-      "lineto": 95,
+      "line": 105,
+      "lineto": 109,
       "args": [
         {
           "name": "out",
@@ -9628,11 +9870,48 @@
       "comments": "<p>The note must be freed manually by the user.</p>\n",
       "group": "note"
     },
+    "git_note_commit_read": {
+      "type": "function",
+      "file": "notes.h",
+      "line": 124,
+      "lineto": 128,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_note **",
+          "comment": "pointer to the read note; NULL in case of error"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "repository where to look up the note"
+        },
+        {
+          "name": "notes_commit",
+          "type": "git_commit *",
+          "comment": "a pointer to the notes commit object"
+        },
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": "OID of the git object to read the note from"
+        }
+      ],
+      "argline": "git_note **out, git_repository *repo, git_commit *notes_commit, const git_oid *oid",
+      "sig": "git_note **::git_repository *::git_commit *::const git_oid *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Read the note for an object from a note commit</p>\n",
+      "comments": "<p>The note must be freed manually by the user.</p>\n",
+      "group": "note"
+    },
     "git_note_author": {
       "type": "function",
       "file": "notes.h",
-      "line": 103,
-      "lineto": 103,
+      "line": 136,
+      "lineto": 136,
       "args": [
         {
           "name": "note",
@@ -9653,8 +9932,8 @@
     "git_note_committer": {
       "type": "function",
       "file": "notes.h",
-      "line": 111,
-      "lineto": 111,
+      "line": 144,
+      "lineto": 144,
       "args": [
         {
           "name": "note",
@@ -9675,8 +9954,8 @@
     "git_note_message": {
       "type": "function",
       "file": "notes.h",
-      "line": 120,
-      "lineto": 120,
+      "line": 153,
+      "lineto": 153,
       "args": [
         {
           "name": "note",
@@ -9697,8 +9976,8 @@
     "git_note_id": {
       "type": "function",
       "file": "notes.h",
-      "line": 129,
-      "lineto": 129,
+      "line": 162,
+      "lineto": 162,
       "args": [
         {
           "name": "note",
@@ -9719,8 +9998,8 @@
     "git_note_create": {
       "type": "function",
       "file": "notes.h",
-      "line": 146,
-      "lineto": 154,
+      "line": 179,
+      "lineto": 187,
       "args": [
         {
           "name": "out",
@@ -9773,11 +10052,73 @@
       "comments": "",
       "group": "note"
     },
+    "git_note_commit_create": {
+      "type": "function",
+      "file": "notes.h",
+      "line": 209,
+      "lineto": 218,
+      "args": [
+        {
+          "name": "notes_commit_out",
+          "type": "git_oid *",
+          "comment": "pointer to store the commit (optional);\n\t\t\t\t\tNULL in case of error"
+        },
+        {
+          "name": "notes_blob_out",
+          "type": "git_oid *",
+          "comment": "a point to the id of a note blob (optional)"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "repository where the note will live"
+        },
+        {
+          "name": "parent",
+          "type": "git_commit *",
+          "comment": "Pointer to parent note\n\t\t\t\t\tor NULL if this shall start a new notes tree"
+        },
+        {
+          "name": "author",
+          "type": "const git_signature *",
+          "comment": "signature of the notes commit author"
+        },
+        {
+          "name": "committer",
+          "type": "const git_signature *",
+          "comment": "signature of the notes commit committer"
+        },
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": "OID of the git object to decorate"
+        },
+        {
+          "name": "note",
+          "type": "const char *",
+          "comment": "Content of the note to add for object oid"
+        },
+        {
+          "name": "allow_note_overwrite",
+          "type": "int",
+          "comment": "Overwrite existing note"
+        }
+      ],
+      "argline": "git_oid *notes_commit_out, git_oid *notes_blob_out, git_repository *repo, git_commit *parent, const git_signature *author, const git_signature *committer, const git_oid *oid, const char *note, int allow_note_overwrite",
+      "sig": "git_oid *::git_oid *::git_repository *::git_commit *::const git_signature *::const git_signature *::const git_oid *::const char *::int",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Add a note for an object from a commit</p>\n",
+      "comments": "<p>This function will create a notes commit for a given object, the commit is a dangling commit, no reference is created.</p>\n",
+      "group": "note"
+    },
     "git_note_remove": {
       "type": "function",
       "file": "notes.h",
-      "line": 169,
-      "lineto": 174,
+      "line": 232,
+      "lineto": 237,
       "args": [
         {
           "name": "repo",
@@ -9815,11 +10156,58 @@
       "comments": "",
       "group": "note"
     },
+    "git_note_commit_remove": {
+      "type": "function",
+      "file": "notes.h",
+      "line": 257,
+      "lineto": 263,
+      "args": [
+        {
+          "name": "notes_commit_out",
+          "type": "git_oid *",
+          "comment": "pointer to store the new notes commit (optional);\n\t\t\t\t\tNULL in case of error.\n\t\t\t\t\tWhen removing a note a new tree containing all notes\n\t\t\t\t\tsans the note to be removed is created and a new commit\n\t\t\t\t\tpointing to that tree is also created.\n\t\t\t\t\tIn the case where the resulting tree is an empty tree\n\t\t\t\t\ta new commit pointing to this empty tree will be returned."
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "repository where the note lives"
+        },
+        {
+          "name": "notes_commit",
+          "type": "git_commit *",
+          "comment": "a pointer to the notes commit object"
+        },
+        {
+          "name": "author",
+          "type": "const git_signature *",
+          "comment": "signature of the notes commit author"
+        },
+        {
+          "name": "committer",
+          "type": "const git_signature *",
+          "comment": "signature of the notes commit committer"
+        },
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": "OID of the git object to remove the note from"
+        }
+      ],
+      "argline": "git_oid *notes_commit_out, git_repository *repo, git_commit *notes_commit, const git_signature *author, const git_signature *committer, const git_oid *oid",
+      "sig": "git_oid *::git_repository *::git_commit *::const git_signature *::const git_signature *::const git_oid *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Remove the note for an object</p>\n",
+      "comments": "",
+      "group": "note"
+    },
     "git_note_free": {
       "type": "function",
       "file": "notes.h",
-      "line": 181,
-      "lineto": 181,
+      "line": 270,
+      "lineto": 270,
       "args": [
         {
           "name": "note",
@@ -9840,8 +10228,8 @@
     "git_note_foreach": {
       "type": "function",
       "file": "notes.h",
-      "line": 209,
-      "lineto": 213,
+      "line": 298,
+      "lineto": 302,
       "args": [
         {
           "name": "repo",
@@ -9912,7 +10300,10 @@
       "group": "object",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_object_lookup-33"
+          "ex/HEAD/log.html#git_object_lookup-34"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_object_lookup-21"
         ]
       }
     },
@@ -10028,10 +10419,10 @@
           "ex/HEAD/cat-file.html#git_object_id-13"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_object_id-34",
           "ex/HEAD/log.html#git_object_id-35",
           "ex/HEAD/log.html#git_object_id-36",
-          "ex/HEAD/log.html#git_object_id-37"
+          "ex/HEAD/log.html#git_object_id-37",
+          "ex/HEAD/log.html#git_object_id-38"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_object_id-4",
@@ -10160,10 +10551,13 @@
           "ex/HEAD/cat-file.html#git_object_free-17"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_object_free-36"
+          "ex/HEAD/general.html#git_object_free-38"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_object_free-38"
+          "ex/HEAD/log.html#git_object_free-39"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_object_free-22"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_object_free-9",
@@ -10207,8 +10601,8 @@
           "ex/HEAD/cat-file.html#git_object_type2string-21"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_object_type2string-37",
-          "ex/HEAD/general.html#git_object_type2string-38"
+          "ex/HEAD/general.html#git_object_type2string-39",
+          "ex/HEAD/general.html#git_object_type2string-40"
         ]
       }
     },
@@ -10439,7 +10833,7 @@
           "ex/HEAD/cat-file.html#git_odb_free-22"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_free-39"
+          "ex/HEAD/general.html#git_odb_free-41"
         ]
       }
     },
@@ -10479,7 +10873,7 @@
           "ex/HEAD/cat-file.html#git_odb_read-23"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_read-40"
+          "ex/HEAD/general.html#git_odb_read-42"
         ]
       }
     },
@@ -10750,7 +11144,7 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_write-41"
+          "ex/HEAD/general.html#git_odb_write-43"
         ]
       }
     },
@@ -10907,13 +11301,23 @@
     "git_odb_open_rstream": {
       "type": "function",
       "file": "odb.h",
-      "line": 364,
-      "lineto": 364,
+      "line": 366,
+      "lineto": 371,
       "args": [
         {
           "name": "out",
           "type": "git_odb_stream **",
           "comment": "pointer where to store the stream"
+        },
+        {
+          "name": "len",
+          "type": "size_t *",
+          "comment": "pointer where to store the length of the object"
+        },
+        {
+          "name": "type",
+          "type": "git_otype *",
+          "comment": "pointer where to store the type of the object"
         },
         {
           "name": "db",
@@ -10926,8 +11330,8 @@
           "comment": "oid of the object the stream will read from"
         }
       ],
-      "argline": "git_odb_stream **out, git_odb *db, const git_oid *oid",
-      "sig": "git_odb_stream **::git_odb *::const git_oid *",
+      "argline": "git_odb_stream **out, size_t *len, git_otype *type, git_odb *db, const git_oid *oid",
+      "sig": "git_odb_stream **::size_t *::git_otype *::git_odb *::const git_oid *",
       "return": {
         "type": "int",
         "comment": " 0 if the stream was created; error code otherwise"
@@ -10939,8 +11343,8 @@
     "git_odb_write_pack": {
       "type": "function",
       "file": "odb.h",
-      "line": 384,
-      "lineto": 388,
+      "line": 391,
+      "lineto": 395,
       "args": [
         {
           "name": "out",
@@ -10976,8 +11380,8 @@
     "git_odb_hash": {
       "type": "function",
       "file": "odb.h",
-      "line": 402,
-      "lineto": 402,
+      "line": 409,
+      "lineto": 409,
       "args": [
         {
           "name": "out",
@@ -11013,8 +11417,8 @@
     "git_odb_hashfile": {
       "type": "function",
       "file": "odb.h",
-      "line": 417,
-      "lineto": 417,
+      "line": 424,
+      "lineto": 424,
       "args": [
         {
           "name": "out",
@@ -11045,8 +11449,8 @@
     "git_odb_object_dup": {
       "type": "function",
       "file": "odb.h",
-      "line": 431,
-      "lineto": 431,
+      "line": 438,
+      "lineto": 438,
       "args": [
         {
           "name": "dest",
@@ -11072,8 +11476,8 @@
     "git_odb_object_free": {
       "type": "function",
       "file": "odb.h",
-      "line": 441,
-      "lineto": 441,
+      "line": 448,
+      "lineto": 448,
       "args": [
         {
           "name": "object",
@@ -11095,15 +11499,15 @@
           "ex/HEAD/cat-file.html#git_odb_object_free-24"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_free-42"
+          "ex/HEAD/general.html#git_odb_object_free-44"
         ]
       }
     },
     "git_odb_object_id": {
       "type": "function",
       "file": "odb.h",
-      "line": 451,
-      "lineto": 451,
+      "line": 458,
+      "lineto": 458,
       "args": [
         {
           "name": "object",
@@ -11124,8 +11528,8 @@
     "git_odb_object_data": {
       "type": "function",
       "file": "odb.h",
-      "line": 464,
-      "lineto": 464,
+      "line": 471,
+      "lineto": 471,
       "args": [
         {
           "name": "object",
@@ -11144,15 +11548,15 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_data-43"
+          "ex/HEAD/general.html#git_odb_object_data-45"
         ]
       }
     },
     "git_odb_object_size": {
       "type": "function",
       "file": "odb.h",
-      "line": 475,
-      "lineto": 475,
+      "line": 482,
+      "lineto": 482,
       "args": [
         {
           "name": "object",
@@ -11174,15 +11578,15 @@
           "ex/HEAD/cat-file.html#git_odb_object_size-25"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_size-44"
+          "ex/HEAD/general.html#git_odb_object_size-46"
         ]
       }
     },
     "git_odb_object_type": {
       "type": "function",
       "file": "odb.h",
-      "line": 483,
-      "lineto": 483,
+      "line": 490,
+      "lineto": 490,
       "args": [
         {
           "name": "object",
@@ -11201,15 +11605,15 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_type-45"
+          "ex/HEAD/general.html#git_odb_object_type-47"
         ]
       }
     },
     "git_odb_add_backend": {
       "type": "function",
       "file": "odb.h",
-      "line": 498,
-      "lineto": 498,
+      "line": 505,
+      "lineto": 505,
       "args": [
         {
           "name": "odb",
@@ -11234,14 +11638,14 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB</p>\n",
-      "comments": "<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Read <odb_backends.h> for more information.</p>\n",
+      "comments": "<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_add_alternate": {
       "type": "function",
       "file": "odb.h",
-      "line": 519,
-      "lineto": 519,
+      "line": 526,
+      "lineto": 526,
       "args": [
         {
           "name": "odb",
@@ -11266,14 +11670,14 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB; this\n backend will work as an alternate.</p>\n",
-      "comments": "<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read <odb_backends.h> for more information.</p>\n",
+      "comments": "<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_num_backends": {
       "type": "function",
       "file": "odb.h",
-      "line": 527,
-      "lineto": 527,
+      "line": 534,
+      "lineto": 534,
       "args": [
         {
           "name": "odb",
@@ -11294,8 +11698,8 @@
     "git_odb_get_backend": {
       "type": "function",
       "file": "odb.h",
-      "line": 537,
-      "lineto": 537,
+      "line": 544,
+      "lineto": 544,
       "args": [
         {
           "name": "out",
@@ -11374,7 +11778,7 @@
         {
           "name": "do_fsync",
           "type": "int",
-          "comment": "whether to do an fsync() after writing (currently ignored)"
+          "comment": "whether to do an fsync() after writing"
         },
         {
           "name": "dir_mode",
@@ -11452,14 +11856,17 @@
       "group": "oid",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_oid_fromstr-46",
-          "ex/HEAD/general.html#git_oid_fromstr-47",
           "ex/HEAD/general.html#git_oid_fromstr-48",
           "ex/HEAD/general.html#git_oid_fromstr-49",
           "ex/HEAD/general.html#git_oid_fromstr-50",
           "ex/HEAD/general.html#git_oid_fromstr-51",
           "ex/HEAD/general.html#git_oid_fromstr-52",
-          "ex/HEAD/general.html#git_oid_fromstr-53"
+          "ex/HEAD/general.html#git_oid_fromstr-53",
+          "ex/HEAD/general.html#git_oid_fromstr-54",
+          "ex/HEAD/general.html#git_oid_fromstr-55"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_oid_fromstr-23"
         ]
       }
     },
@@ -11577,12 +11984,12 @@
       "group": "oid",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_oid_fmt-54",
-          "ex/HEAD/general.html#git_oid_fmt-55",
           "ex/HEAD/general.html#git_oid_fmt-56",
           "ex/HEAD/general.html#git_oid_fmt-57",
           "ex/HEAD/general.html#git_oid_fmt-58",
-          "ex/HEAD/general.html#git_oid_fmt-59"
+          "ex/HEAD/general.html#git_oid_fmt-59",
+          "ex/HEAD/general.html#git_oid_fmt-60",
+          "ex/HEAD/general.html#git_oid_fmt-61"
         ],
         "network/fetch.c": [
           "ex/HEAD/network/fetch.html#git_oid_fmt-1",
@@ -11675,7 +12082,13 @@
       },
       "description": "<p>Format a git_oid into a statically allocated c-string.</p>\n",
       "comments": "<p>The c-string is owned by the library and should not be freed by the user. If libgit2 is built with thread support, the string will be stored in TLS (i.e. one buffer per thread) to allow for concurrent calls of the function.</p>\n",
-      "group": "oid"
+      "group": "oid",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_oid_tostr_s-24",
+          "ex/HEAD/merge.html#git_oid_tostr_s-25"
+        ]
+      }
     },
     "git_oid_tostr": {
       "type": "function",
@@ -11721,8 +12134,8 @@
           "ex/HEAD/cat-file.html#git_oid_tostr-30"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_oid_tostr-39",
-          "ex/HEAD/log.html#git_oid_tostr-40"
+          "ex/HEAD/log.html#git_oid_tostr-40",
+          "ex/HEAD/log.html#git_oid_tostr-41"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_oid_tostr-12",
@@ -12524,7 +12937,7 @@
         },
         {
           "name": "buffer",
-          "type": "const char *",
+          "type": "const void *",
           "comment": "Raw data for new side of diff, or NULL for empty"
         },
         {
@@ -12543,8 +12956,8 @@
           "comment": "Options for diff, or NULL for default options"
         }
       ],
-      "argline": "git_patch **out, const git_blob *old_blob, const char *old_as_path, const char *buffer, size_t buffer_len, const char *buffer_as_path, const git_diff_options *opts",
-      "sig": "git_patch **::const git_blob *::const char *::const char *::size_t::const char *::const git_diff_options *",
+      "argline": "git_patch **out, const git_blob *old_blob, const char *old_as_path, const void *buffer, size_t buffer_len, const char *buffer_as_path, const git_diff_options *opts",
+      "sig": "git_patch **::const git_blob *::const char *::const void *::size_t::const char *::const git_diff_options *",
       "return": {
         "type": "int",
         "comment": " 0 on success or error code \n<\n 0"
@@ -12581,7 +12994,7 @@
         },
         {
           "name": "new_buffer",
-          "type": "const char *",
+          "type": "const void *",
           "comment": "Raw data for new side of diff, or NULL for empty"
         },
         {
@@ -12600,8 +13013,8 @@
           "comment": "Options for diff, or NULL for default options"
         }
       ],
-      "argline": "git_patch **out, const void *old_buffer, size_t old_len, const char *old_as_path, const char *new_buffer, size_t new_len, const char *new_as_path, const git_diff_options *opts",
-      "sig": "git_patch **::const void *::size_t::const char *::const char *::size_t::const char *::const git_diff_options *",
+      "argline": "git_patch **out, const void *old_buffer, size_t old_len, const char *old_as_path, const void *new_buffer, size_t new_len, const char *new_as_path, const git_diff_options *opts",
+      "sig": "git_patch **::const void *::size_t::const char *::const void *::size_t::const char *::const git_diff_options *",
       "return": {
         "type": "int",
         "comment": " 0 on success or error code \n<\n 0"
@@ -12913,8 +13326,8 @@
     "git_pathspec_new": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 65,
-      "lineto": 66,
+      "line": 82,
+      "lineto": 83,
       "args": [
         {
           "name": "out",
@@ -12938,15 +13351,15 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_new-41"
+          "ex/HEAD/log.html#git_pathspec_new-42"
         ]
       }
     },
     "git_pathspec_free": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 73,
-      "lineto": 73,
+      "line": 90,
+      "lineto": 90,
       "args": [
         {
           "name": "ps",
@@ -12965,15 +13378,15 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_free-42"
+          "ex/HEAD/log.html#git_pathspec_free-43"
         ]
       }
     },
     "git_pathspec_matches_path": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 88,
-      "lineto": 89,
+      "line": 105,
+      "lineto": 106,
       "args": [
         {
           "name": "ps",
@@ -13004,8 +13417,8 @@
     "git_pathspec_match_workdir": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 113,
-      "lineto": 117,
+      "line": 130,
+      "lineto": 134,
       "args": [
         {
           "name": "out",
@@ -13041,8 +13454,8 @@
     "git_pathspec_match_index": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 142,
-      "lineto": 146,
+      "line": 159,
+      "lineto": 163,
       "args": [
         {
           "name": "out",
@@ -13078,8 +13491,8 @@
     "git_pathspec_match_tree": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 166,
-      "lineto": 170,
+      "line": 183,
+      "lineto": 187,
       "args": [
         {
           "name": "out",
@@ -13113,15 +13526,15 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_match_tree-43"
+          "ex/HEAD/log.html#git_pathspec_match_tree-44"
         ]
       }
     },
     "git_pathspec_match_diff": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 190,
-      "lineto": 194,
+      "line": 207,
+      "lineto": 211,
       "args": [
         {
           "name": "out",
@@ -13157,8 +13570,8 @@
     "git_pathspec_match_list_free": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 201,
-      "lineto": 201,
+      "line": 218,
+      "lineto": 218,
       "args": [
         {
           "name": "m",
@@ -13179,8 +13592,8 @@
     "git_pathspec_match_list_entrycount": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 209,
-      "lineto": 210,
+      "line": 226,
+      "lineto": 227,
       "args": [
         {
           "name": "m",
@@ -13201,8 +13614,8 @@
     "git_pathspec_match_list_entry": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 222,
-      "lineto": 223,
+      "line": 239,
+      "lineto": 240,
       "args": [
         {
           "name": "m",
@@ -13228,8 +13641,8 @@
     "git_pathspec_match_list_diff_entry": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 235,
-      "lineto": 236,
+      "line": 252,
+      "lineto": 253,
       "args": [
         {
           "name": "m",
@@ -13255,8 +13668,8 @@
     "git_pathspec_match_list_failed_entrycount": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 247,
-      "lineto": 248,
+      "line": 264,
+      "lineto": 265,
       "args": [
         {
           "name": "m",
@@ -13277,8 +13690,8 @@
     "git_pathspec_match_list_failed_entry": {
       "type": "function",
       "file": "pathspec.h",
-      "line": 259,
-      "lineto": 260,
+      "line": 276,
+      "lineto": 277,
       "args": [
         {
           "name": "m",
@@ -14149,7 +14562,10 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_lookup-60"
+          "ex/HEAD/general.html#git_reference_lookup-62"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_lookup-26"
         ]
       }
     },
@@ -14215,7 +14631,13 @@
       },
       "description": "<p>Lookup a reference by DWIMing its short name</p>\n",
       "comments": "<p>Apply the git precendence rules to the given shorthand to determine which reference the user is referring to.</p>\n",
-      "group": "reference"
+      "group": "reference",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_dwim-27",
+          "ex/HEAD/merge.html#git_reference_dwim-28"
+        ]
+      }
     },
     "git_reference_symbolic_create_matching": {
       "type": "function",
@@ -14361,7 +14783,12 @@
       },
       "description": "<p>Create a new direct reference.</p>\n",
       "comments": "<p>A direct reference (also called an object id reference) refers directly to a specific object id (a.k.a. OID or SHA) in the repository.  The id permanently refers to the object (although the reference itself can be moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot; refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n",
-      "group": "reference"
+      "group": "reference",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_create-29"
+        ]
+      }
     },
     "git_reference_create_matching": {
       "type": "function",
@@ -14438,7 +14865,7 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_target-61"
+          "ex/HEAD/general.html#git_reference_target-63"
         ]
       }
     },
@@ -14487,7 +14914,10 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_symbolic_target-62"
+          "ex/HEAD/general.html#git_reference_symbolic_target-64"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_symbolic_target-30"
         ]
       }
     },
@@ -14514,7 +14944,7 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_type-63"
+          "ex/HEAD/general.html#git_reference_type-65"
         ]
       }
     },
@@ -14538,7 +14968,12 @@
       },
       "description": "<p>Get the full name of a reference.</p>\n",
       "comments": "<p>See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
-      "group": "reference"
+      "group": "reference",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_name-31"
+        ]
+      }
     },
     "git_reference_resolve": {
       "type": "function",
@@ -14661,7 +15096,12 @@
       },
       "description": "<p>Conditionally create a new reference with the same name as the given reference but a\n different OID target. The reference must be a direct reference, otherwise\n this will fail.</p>\n",
       "comments": "<p>The new reference will be written to disk, overwriting the given reference.</p>\n",
-      "group": "reference"
+      "group": "reference",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_set_target-32"
+        ]
+      }
     },
     "git_reference_rename": {
       "type": "function",
@@ -14782,15 +15222,15 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_list-64"
+          "ex/HEAD/general.html#git_reference_list-66"
         ]
       }
     },
     "git_reference_foreach": {
       "type": "function",
       "file": "refs.h",
-      "line": 441,
-      "lineto": 444,
+      "line": 444,
+      "lineto": 447,
       "args": [
         {
           "name": "repo",
@@ -14815,14 +15255,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform a callback on each reference in the repository.</p>\n",
-      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the reference object and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n",
+      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the reference object and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n\n<p>Note that the callback function is responsible to call <code>git_reference_free</code> on each reference passed to it.</p>\n",
       "group": "reference"
     },
     "git_reference_foreach_name": {
       "type": "function",
       "file": "refs.h",
-      "line": 459,
-      "lineto": 462,
+      "line": 462,
+      "lineto": 465,
       "args": [
         {
           "name": "repo",
@@ -14853,8 +15293,8 @@
     "git_reference_dup": {
       "type": "function",
       "file": "refs.h",
-      "line": 473,
-      "lineto": 473,
+      "line": 476,
+      "lineto": 476,
       "args": [
         {
           "name": "dest",
@@ -14880,8 +15320,8 @@
     "git_reference_free": {
       "type": "function",
       "file": "refs.h",
-      "line": 480,
-      "lineto": 480,
+      "line": 483,
+      "lineto": 483,
       "args": [
         {
           "name": "ref",
@@ -14900,7 +15340,13 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_free-65"
+          "ex/HEAD/general.html#git_reference_free-67"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_free-33",
+          "ex/HEAD/merge.html#git_reference_free-34",
+          "ex/HEAD/merge.html#git_reference_free-35",
+          "ex/HEAD/merge.html#git_reference_free-36"
         ],
         "status.c": [
           "ex/HEAD/status.html#git_reference_free-3"
@@ -14910,8 +15356,8 @@
     "git_reference_cmp": {
       "type": "function",
       "file": "refs.h",
-      "line": 489,
-      "lineto": 491,
+      "line": 492,
+      "lineto": 494,
       "args": [
         {
           "name": "ref1",
@@ -14937,8 +15383,8 @@
     "git_reference_iterator_new": {
       "type": "function",
       "file": "refs.h",
-      "line": 500,
-      "lineto": 502,
+      "line": 503,
+      "lineto": 505,
       "args": [
         {
           "name": "out",
@@ -14964,8 +15410,8 @@
     "git_reference_iterator_glob_new": {
       "type": "function",
       "file": "refs.h",
-      "line": 513,
-      "lineto": 516,
+      "line": 516,
+      "lineto": 519,
       "args": [
         {
           "name": "out",
@@ -14996,8 +15442,8 @@
     "git_reference_next": {
       "type": "function",
       "file": "refs.h",
-      "line": 525,
-      "lineto": 525,
+      "line": 528,
+      "lineto": 528,
       "args": [
         {
           "name": "out",
@@ -15023,8 +15469,8 @@
     "git_reference_next_name": {
       "type": "function",
       "file": "refs.h",
-      "line": 538,
-      "lineto": 538,
+      "line": 541,
+      "lineto": 541,
       "args": [
         {
           "name": "out",
@@ -15050,8 +15496,8 @@
     "git_reference_iterator_free": {
       "type": "function",
       "file": "refs.h",
-      "line": 545,
-      "lineto": 545,
+      "line": 548,
+      "lineto": 548,
       "args": [
         {
           "name": "iter",
@@ -15072,8 +15518,8 @@
     "git_reference_foreach_glob": {
       "type": "function",
       "file": "refs.h",
-      "line": 565,
-      "lineto": 569,
+      "line": 568,
+      "lineto": 572,
       "args": [
         {
           "name": "repo",
@@ -15109,8 +15555,8 @@
     "git_reference_has_log": {
       "type": "function",
       "file": "refs.h",
-      "line": 579,
-      "lineto": 579,
+      "line": 582,
+      "lineto": 582,
       "args": [
         {
           "name": "repo",
@@ -15136,8 +15582,8 @@
     "git_reference_ensure_log": {
       "type": "function",
       "file": "refs.h",
-      "line": 591,
-      "lineto": 591,
+      "line": 594,
+      "lineto": 594,
       "args": [
         {
           "name": "repo",
@@ -15163,8 +15609,8 @@
     "git_reference_is_branch": {
       "type": "function",
       "file": "refs.h",
-      "line": 601,
-      "lineto": 601,
+      "line": 604,
+      "lineto": 604,
       "args": [
         {
           "name": "ref",
@@ -15185,8 +15631,8 @@
     "git_reference_is_remote": {
       "type": "function",
       "file": "refs.h",
-      "line": 611,
-      "lineto": 611,
+      "line": 614,
+      "lineto": 614,
       "args": [
         {
           "name": "ref",
@@ -15207,8 +15653,8 @@
     "git_reference_is_tag": {
       "type": "function",
       "file": "refs.h",
-      "line": 621,
-      "lineto": 621,
+      "line": 624,
+      "lineto": 624,
       "args": [
         {
           "name": "ref",
@@ -15229,8 +15675,8 @@
     "git_reference_is_note": {
       "type": "function",
       "file": "refs.h",
-      "line": 631,
-      "lineto": 631,
+      "line": 634,
+      "lineto": 634,
       "args": [
         {
           "name": "ref",
@@ -15251,8 +15697,8 @@
     "git_reference_normalize_name": {
       "type": "function",
       "file": "refs.h",
-      "line": 687,
-      "lineto": 691,
+      "line": 690,
+      "lineto": 694,
       "args": [
         {
           "name": "buffer_out",
@@ -15288,8 +15734,8 @@
     "git_reference_peel": {
       "type": "function",
       "file": "refs.h",
-      "line": 708,
-      "lineto": 711,
+      "line": 711,
+      "lineto": 714,
       "args": [
         {
           "name": "out",
@@ -15315,13 +15761,18 @@
       },
       "description": "<p>Recursively peel reference until object of the specified type is found.</p>\n",
       "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object will be peeled until a non-tag object is met.</p>\n",
-      "group": "reference"
+      "group": "reference",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_reference_peel-37"
+        ]
+      }
     },
     "git_reference_is_valid_name": {
       "type": "function",
       "file": "refs.h",
-      "line": 727,
-      "lineto": 727,
+      "line": 730,
+      "lineto": 730,
       "args": [
         {
           "name": "refname",
@@ -15342,8 +15793,8 @@
     "git_reference_shorthand": {
       "type": "function",
       "file": "refs.h",
-      "line": 741,
-      "lineto": 741,
+      "line": 744,
+      "lineto": 744,
       "args": [
         {
           "name": "ref",
@@ -15718,11 +16169,38 @@
         ]
       }
     },
+    "git_remote_create_detached": {
+      "type": "function",
+      "file": "remote.h",
+      "line": 92,
+      "lineto": 94,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_remote **",
+          "comment": "pointer to the new remote objects"
+        },
+        {
+          "name": "url",
+          "type": "const char *",
+          "comment": "the remote repository's URL"
+        }
+      ],
+      "argline": "git_remote **out, const char *url",
+      "sig": "git_remote **::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Create a remote without a connected local repo</p>\n",
+      "comments": "<p>Create a remote with the given url in-memory. You can use this when you have a URL instead of a remote&#39;s name.</p>\n\n<p>Contrasted with git_remote_create_anonymous, a detached remote will not consider any repo configuration values (such as insteadof url substitutions).</p>\n",
+      "group": "remote"
+    },
     "git_remote_lookup": {
       "type": "function",
       "file": "remote.h",
-      "line": 89,
-      "lineto": 89,
+      "line": 107,
+      "lineto": 107,
       "args": [
         {
           "name": "out",
@@ -15764,8 +16242,8 @@
     "git_remote_dup": {
       "type": "function",
       "file": "remote.h",
-      "line": 101,
-      "lineto": 101,
+      "line": 119,
+      "lineto": 119,
       "args": [
         {
           "name": "dest",
@@ -15791,8 +16269,8 @@
     "git_remote_owner": {
       "type": "function",
       "file": "remote.h",
-      "line": 109,
-      "lineto": 109,
+      "line": 127,
+      "lineto": 127,
       "args": [
         {
           "name": "remote",
@@ -15813,8 +16291,8 @@
     "git_remote_name": {
       "type": "function",
       "file": "remote.h",
-      "line": 117,
-      "lineto": 117,
+      "line": 135,
+      "lineto": 135,
       "args": [
         {
           "name": "remote",
@@ -15835,8 +16313,8 @@
     "git_remote_url": {
       "type": "function",
       "file": "remote.h",
-      "line": 128,
-      "lineto": 128,
+      "line": 146,
+      "lineto": 146,
       "args": [
         {
           "name": "remote",
@@ -15862,8 +16340,8 @@
     "git_remote_pushurl": {
       "type": "function",
       "file": "remote.h",
-      "line": 139,
-      "lineto": 139,
+      "line": 157,
+      "lineto": 157,
       "args": [
         {
           "name": "remote",
@@ -15889,8 +16367,8 @@
     "git_remote_set_url": {
       "type": "function",
       "file": "remote.h",
-      "line": 152,
-      "lineto": 152,
+      "line": 170,
+      "lineto": 170,
       "args": [
         {
           "name": "repo",
@@ -15926,8 +16404,8 @@
     "git_remote_set_pushurl": {
       "type": "function",
       "file": "remote.h",
-      "line": 165,
-      "lineto": 165,
+      "line": 183,
+      "lineto": 183,
       "args": [
         {
           "name": "repo",
@@ -15963,8 +16441,8 @@
     "git_remote_add_fetch": {
       "type": "function",
       "file": "remote.h",
-      "line": 178,
-      "lineto": 178,
+      "line": 196,
+      "lineto": 196,
       "args": [
         {
           "name": "repo",
@@ -15995,8 +16473,8 @@
     "git_remote_get_fetch_refspecs": {
       "type": "function",
       "file": "remote.h",
-      "line": 189,
-      "lineto": 189,
+      "line": 207,
+      "lineto": 207,
       "args": [
         {
           "name": "array",
@@ -16022,8 +16500,8 @@
     "git_remote_add_push": {
       "type": "function",
       "file": "remote.h",
-      "line": 202,
-      "lineto": 202,
+      "line": 220,
+      "lineto": 220,
       "args": [
         {
           "name": "repo",
@@ -16054,8 +16532,8 @@
     "git_remote_get_push_refspecs": {
       "type": "function",
       "file": "remote.h",
-      "line": 213,
-      "lineto": 213,
+      "line": 231,
+      "lineto": 231,
       "args": [
         {
           "name": "array",
@@ -16081,8 +16559,8 @@
     "git_remote_refspec_count": {
       "type": "function",
       "file": "remote.h",
-      "line": 221,
-      "lineto": 221,
+      "line": 239,
+      "lineto": 239,
       "args": [
         {
           "name": "remote",
@@ -16103,8 +16581,8 @@
     "git_remote_get_refspec": {
       "type": "function",
       "file": "remote.h",
-      "line": 230,
-      "lineto": 230,
+      "line": 248,
+      "lineto": 248,
       "args": [
         {
           "name": "remote",
@@ -16130,8 +16608,8 @@
     "git_remote_connect": {
       "type": "function",
       "file": "remote.h",
-      "line": 247,
-      "lineto": 247,
+      "line": 265,
+      "lineto": 265,
       "args": [
         {
           "name": "remote",
@@ -16177,8 +16655,8 @@
     "git_remote_ls": {
       "type": "function",
       "file": "remote.h",
-      "line": 269,
-      "lineto": 269,
+      "line": 287,
+      "lineto": 287,
       "args": [
         {
           "name": "out",
@@ -16214,8 +16692,8 @@
     "git_remote_connected": {
       "type": "function",
       "file": "remote.h",
-      "line": 280,
-      "lineto": 280,
+      "line": 298,
+      "lineto": 298,
       "args": [
         {
           "name": "remote",
@@ -16236,8 +16714,8 @@
     "git_remote_stop": {
       "type": "function",
       "file": "remote.h",
-      "line": 290,
-      "lineto": 290,
+      "line": 308,
+      "lineto": 308,
       "args": [
         {
           "name": "remote",
@@ -16258,8 +16736,8 @@
     "git_remote_disconnect": {
       "type": "function",
       "file": "remote.h",
-      "line": 299,
-      "lineto": 299,
+      "line": 317,
+      "lineto": 317,
       "args": [
         {
           "name": "remote",
@@ -16280,8 +16758,8 @@
     "git_remote_free": {
       "type": "function",
       "file": "remote.h",
-      "line": 309,
-      "lineto": 309,
+      "line": 327,
+      "lineto": 327,
       "args": [
         {
           "name": "remote",
@@ -16314,8 +16792,8 @@
     "git_remote_list": {
       "type": "function",
       "file": "remote.h",
-      "line": 320,
-      "lineto": 320,
+      "line": 338,
+      "lineto": 338,
       "args": [
         {
           "name": "out",
@@ -16346,8 +16824,8 @@
     "git_remote_init_callbacks": {
       "type": "function",
       "file": "remote.h",
-      "line": 473,
-      "lineto": 475,
+      "line": 503,
+      "lineto": 505,
       "args": [
         {
           "name": "opts",
@@ -16373,8 +16851,8 @@
     "git_fetch_init_options": {
       "type": "function",
       "file": "remote.h",
-      "line": 577,
-      "lineto": 579,
+      "line": 607,
+      "lineto": 609,
       "args": [
         {
           "name": "opts",
@@ -16400,8 +16878,8 @@
     "git_push_init_options": {
       "type": "function",
       "file": "remote.h",
-      "line": 626,
-      "lineto": 628,
+      "line": 656,
+      "lineto": 658,
       "args": [
         {
           "name": "opts",
@@ -16427,8 +16905,8 @@
     "git_remote_download": {
       "type": "function",
       "file": "remote.h",
-      "line": 646,
-      "lineto": 646,
+      "line": 676,
+      "lineto": 676,
       "args": [
         {
           "name": "remote",
@@ -16459,8 +16937,8 @@
     "git_remote_upload": {
       "type": "function",
       "file": "remote.h",
-      "line": 660,
-      "lineto": 660,
+      "line": 690,
+      "lineto": 690,
       "args": [
         {
           "name": "remote",
@@ -16491,8 +16969,8 @@
     "git_remote_update_tips": {
       "type": "function",
       "file": "remote.h",
-      "line": 676,
-      "lineto": 681,
+      "line": 706,
+      "lineto": 711,
       "args": [
         {
           "name": "remote",
@@ -16533,8 +17011,8 @@
     "git_remote_fetch": {
       "type": "function",
       "file": "remote.h",
-      "line": 697,
-      "lineto": 701,
+      "line": 727,
+      "lineto": 731,
       "args": [
         {
           "name": "remote",
@@ -16575,8 +17053,8 @@
     "git_remote_prune": {
       "type": "function",
       "file": "remote.h",
-      "line": 710,
-      "lineto": 710,
+      "line": 740,
+      "lineto": 740,
       "args": [
         {
           "name": "remote",
@@ -16602,8 +17080,8 @@
     "git_remote_push": {
       "type": "function",
       "file": "remote.h",
-      "line": 722,
-      "lineto": 724,
+      "line": 752,
+      "lineto": 754,
       "args": [
         {
           "name": "remote",
@@ -16613,7 +17091,7 @@
         {
           "name": "refspecs",
           "type": "const git_strarray *",
-          "comment": "the refspecs to use for pushing. If none are\n passed, the configured refspecs will be used"
+          "comment": "the refspecs to use for pushing. If NULL or an empty\n                 array, the configured refspecs will be used"
         },
         {
           "name": "opts",
@@ -16634,8 +17112,8 @@
     "git_remote_stats": {
       "type": "function",
       "file": "remote.h",
-      "line": 729,
-      "lineto": 729,
+      "line": 759,
+      "lineto": 759,
       "args": [
         {
           "name": "remote",
@@ -16661,8 +17139,8 @@
     "git_remote_autotag": {
       "type": "function",
       "file": "remote.h",
-      "line": 737,
-      "lineto": 737,
+      "line": 767,
+      "lineto": 767,
       "args": [
         {
           "name": "remote",
@@ -16683,8 +17161,8 @@
     "git_remote_set_autotag": {
       "type": "function",
       "file": "remote.h",
-      "line": 749,
-      "lineto": 749,
+      "line": 779,
+      "lineto": 779,
       "args": [
         {
           "name": "repo",
@@ -16715,8 +17193,8 @@
     "git_remote_prune_refs": {
       "type": "function",
       "file": "remote.h",
-      "line": 756,
-      "lineto": 756,
+      "line": 786,
+      "lineto": 786,
       "args": [
         {
           "name": "remote",
@@ -16737,8 +17215,8 @@
     "git_remote_rename": {
       "type": "function",
       "file": "remote.h",
-      "line": 778,
-      "lineto": 782,
+      "line": 808,
+      "lineto": 812,
       "args": [
         {
           "name": "problems",
@@ -16779,8 +17257,8 @@
     "git_remote_is_valid_name": {
       "type": "function",
       "file": "remote.h",
-      "line": 790,
-      "lineto": 790,
+      "line": 820,
+      "lineto": 820,
       "args": [
         {
           "name": "remote_name",
@@ -16801,8 +17279,8 @@
     "git_remote_delete": {
       "type": "function",
       "file": "remote.h",
-      "line": 802,
-      "lineto": 802,
+      "line": 832,
+      "lineto": 832,
       "args": [
         {
           "name": "repo",
@@ -16812,7 +17290,7 @@
         {
           "name": "name",
           "type": "const char *",
-          "comment": "the name of the remove to delete"
+          "comment": "the name of the remote to delete"
         }
       ],
       "argline": "git_repository *repo, const char *name",
@@ -16833,8 +17311,8 @@
     "git_remote_default_branch": {
       "type": "function",
       "file": "remote.h",
-      "line": 820,
-      "lineto": 820,
+      "line": 850,
+      "lineto": 850,
       "args": [
         {
           "name": "out",
@@ -16885,21 +17363,45 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_open-66"
-        ],
-        "network/git2.c": [
-          "ex/HEAD/network/git2.html#git_repository_open-5"
+          "ex/HEAD/general.html#git_repository_open-68"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_repository_open-14"
         ]
       }
     },
+    "git_repository_open_from_worktree": {
+      "type": "function",
+      "file": "repository.h",
+      "line": 48,
+      "lineto": 48,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_repository **",
+          "comment": "Output pointer containing opened repository"
+        },
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": "Working tree to open"
+        }
+      ],
+      "argline": "git_repository **out, git_worktree *wt",
+      "sig": "git_repository **::git_worktree *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Open working tree as a repository</p>\n",
+      "comments": "<p>Open the working directory of the working tree as a normal repository that can then be worked on.</p>\n",
+      "group": "repository"
+    },
     "git_repository_wrap_odb": {
       "type": "function",
       "file": "repository.h",
-      "line": 50,
-      "lineto": 50,
+      "line": 61,
+      "lineto": 61,
       "args": [
         {
           "name": "out",
@@ -16925,8 +17427,8 @@
     "git_repository_discover": {
       "type": "function",
       "file": "repository.h",
-      "line": 78,
-      "lineto": 82,
+      "line": 89,
+      "lineto": 93,
       "args": [
         {
           "name": "out",
@@ -16967,8 +17469,8 @@
     "git_repository_open_ext": {
       "type": "function",
       "file": "repository.h",
-      "line": 141,
-      "lineto": 145,
+      "line": 152,
+      "lineto": 156,
       "args": [
         {
           "name": "out",
@@ -17014,8 +17516,11 @@
           "ex/HEAD/diff.html#git_repository_open_ext-15"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_repository_open_ext-44",
-          "ex/HEAD/log.html#git_repository_open_ext-45"
+          "ex/HEAD/log.html#git_repository_open_ext-45",
+          "ex/HEAD/log.html#git_repository_open_ext-46"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_open_ext-38"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_repository_open_ext-16"
@@ -17031,8 +17536,8 @@
     "git_repository_open_bare": {
       "type": "function",
       "file": "repository.h",
-      "line": 158,
-      "lineto": 158,
+      "line": 169,
+      "lineto": 169,
       "args": [
         {
           "name": "out",
@@ -17058,8 +17563,8 @@
     "git_repository_free": {
       "type": "function",
       "file": "repository.h",
-      "line": 171,
-      "lineto": 171,
+      "line": 182,
+      "lineto": 182,
       "args": [
         {
           "name": "repo",
@@ -17090,19 +17595,19 @@
           "ex/HEAD/diff.html#git_repository_free-16"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_repository_free-67"
+          "ex/HEAD/general.html#git_repository_free-69"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_repository_free-6"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_repository_free-46"
+          "ex/HEAD/log.html#git_repository_free-47"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_free-39"
         ],
         "network/clone.c": [
           "ex/HEAD/network/clone.html#git_repository_free-3"
-        ],
-        "network/git2.c": [
-          "ex/HEAD/network/git2.html#git_repository_free-6"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_repository_free-17"
@@ -17118,8 +17623,8 @@
     "git_repository_init": {
       "type": "function",
       "file": "repository.h",
-      "line": 188,
-      "lineto": 191,
+      "line": 199,
+      "lineto": 202,
       "args": [
         {
           "name": "out",
@@ -17155,8 +17660,8 @@
     "git_repository_init_init_options": {
       "type": "function",
       "file": "repository.h",
-      "line": 300,
-      "lineto": 302,
+      "line": 311,
+      "lineto": 313,
       "args": [
         {
           "name": "opts",
@@ -17182,8 +17687,8 @@
     "git_repository_init_ext": {
       "type": "function",
       "file": "repository.h",
-      "line": 317,
-      "lineto": 320,
+      "line": 328,
+      "lineto": 331,
       "args": [
         {
           "name": "out",
@@ -17219,8 +17724,8 @@
     "git_repository_head": {
       "type": "function",
       "file": "repository.h",
-      "line": 335,
-      "lineto": 335,
+      "line": 346,
+      "lineto": 346,
       "args": [
         {
           "name": "out",
@@ -17243,16 +17748,52 @@
       "comments": "<p>The returned <code>git_reference</code> will be owned by caller and <code>git_reference_free()</code> must be called when done with it to release the allocated memory and prevent a leak.</p>\n",
       "group": "repository",
       "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_head-40",
+          "ex/HEAD/merge.html#git_repository_head-41"
+        ],
         "status.c": [
           "ex/HEAD/status.html#git_repository_head-7"
         ]
       }
     },
+    "git_repository_head_for_worktree": {
+      "type": "function",
+      "file": "repository.h",
+      "line": 356,
+      "lineto": 357,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_reference **",
+          "comment": "pointer to the reference which will be retrieved"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "a repository object"
+        },
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "name of the worktree to retrieve HEAD for"
+        }
+      ],
+      "argline": "git_reference **out, git_repository *repo, const char *name",
+      "sig": "git_reference **::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 when successful, error-code otherwise"
+      },
+      "description": "<p>Retrieve the referenced HEAD for the worktree</p>\n",
+      "comments": "",
+      "group": "repository"
+    },
     "git_repository_head_detached": {
       "type": "function",
       "file": "repository.h",
-      "line": 347,
-      "lineto": 347,
+      "line": 369,
+      "lineto": 369,
       "args": [
         {
           "name": "repo",
@@ -17273,8 +17814,8 @@
     "git_repository_head_unborn": {
       "type": "function",
       "file": "repository.h",
-      "line": 359,
-      "lineto": 359,
+      "line": 395,
+      "lineto": 395,
       "args": [
         {
           "name": "repo",
@@ -17295,8 +17836,8 @@
     "git_repository_is_empty": {
       "type": "function",
       "file": "repository.h",
-      "line": 371,
-      "lineto": 371,
+      "line": 407,
+      "lineto": 407,
       "args": [
         {
           "name": "repo",
@@ -17314,20 +17855,52 @@
       "comments": "<p>An empty repository has just been initialized and contains no references apart from HEAD, which must be pointing to the unborn master branch.</p>\n",
       "group": "repository"
     },
+    "git_repository_item_path": {
+      "type": "function",
+      "file": "repository.h",
+      "line": 443,
+      "lineto": 443,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_buf *",
+          "comment": "Buffer to store the path at"
+        },
+        {
+          "name": "repo",
+          "type": "const git_repository *",
+          "comment": "Repository to get path for"
+        },
+        {
+          "name": "item",
+          "type": "git_repository_item_t",
+          "comment": "The repository item for which to retrieve the path"
+        }
+      ],
+      "argline": "git_buf *out, const git_repository *repo, git_repository_item_t item",
+      "sig": "git_buf *::const git_repository *::git_repository_item_t",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND if the path cannot exist or an error code"
+      },
+      "description": "<p>Get the location of a specific repository file or directory</p>\n",
+      "comments": "<p>This function will retrieve the path of a specific repository item. It will thereby honor things like the repository&#39;s common directory, gitdir, etc. In case a file path cannot exist for a given item (e.g. the working directory of a bare repository), GIT_ENOTFOUND is returned.</p>\n",
+      "group": "repository"
+    },
     "git_repository_path": {
       "type": "function",
       "file": "repository.h",
-      "line": 382,
-      "lineto": 382,
+      "line": 454,
+      "lineto": 454,
       "args": [
         {
           "name": "repo",
-          "type": "git_repository *",
+          "type": "const git_repository *",
           "comment": "A repository object"
         }
       ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
+      "argline": "const git_repository *repo",
+      "sig": "const git_repository *",
       "return": {
         "type": "const char *",
         "comment": " the path to the repository"
@@ -17347,17 +17920,17 @@
     "git_repository_workdir": {
       "type": "function",
       "file": "repository.h",
-      "line": 393,
-      "lineto": 393,
+      "line": 465,
+      "lineto": 465,
       "args": [
         {
           "name": "repo",
-          "type": "git_repository *",
+          "type": "const git_repository *",
           "comment": "A repository object"
         }
       ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
+      "argline": "const git_repository *repo",
+      "sig": "const git_repository *",
       "return": {
         "type": "const char *",
         "comment": " the path to the working dir, if it exists"
@@ -17371,11 +17944,33 @@
         ]
       }
     },
+    "git_repository_commondir": {
+      "type": "function",
+      "file": "repository.h",
+      "line": 476,
+      "lineto": 476,
+      "args": [
+        {
+          "name": "repo",
+          "type": "const git_repository *",
+          "comment": "A repository object"
+        }
+      ],
+      "argline": "const git_repository *repo",
+      "sig": "const git_repository *",
+      "return": {
+        "type": "const char *",
+        "comment": " the path to the common dir"
+      },
+      "description": "<p>Get the path of the shared common directory for this repository</p>\n",
+      "comments": "<p>If the repository is bare is not a worktree, the git directory path is returned.</p>\n",
+      "group": "repository"
+    },
     "git_repository_set_workdir": {
       "type": "function",
       "file": "repository.h",
-      "line": 412,
-      "lineto": 413,
+      "line": 495,
+      "lineto": 496,
       "args": [
         {
           "name": "repo",
@@ -17406,17 +18001,17 @@
     "git_repository_is_bare": {
       "type": "function",
       "file": "repository.h",
-      "line": 421,
-      "lineto": 421,
+      "line": 504,
+      "lineto": 504,
       "args": [
         {
           "name": "repo",
-          "type": "git_repository *",
+          "type": "const git_repository *",
           "comment": "Repo to test"
         }
       ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
+      "argline": "const git_repository *repo",
+      "sig": "const git_repository *",
       "return": {
         "type": "int",
         "comment": " 1 if the repository is bare, 0 otherwise."
@@ -17430,11 +18025,33 @@
         ]
       }
     },
+    "git_repository_is_worktree": {
+      "type": "function",
+      "file": "repository.h",
+      "line": 512,
+      "lineto": 512,
+      "args": [
+        {
+          "name": "repo",
+          "type": "const git_repository *",
+          "comment": "Repo to test"
+        }
+      ],
+      "argline": "const git_repository *repo",
+      "sig": "const git_repository *",
+      "return": {
+        "type": "int",
+        "comment": " 1 if the repository is a linked work tree, 0 otherwise."
+      },
+      "description": "<p>Check if a repository is a linked work tree</p>\n",
+      "comments": "",
+      "group": "repository"
+    },
     "git_repository_config": {
       "type": "function",
       "file": "repository.h",
-      "line": 437,
-      "lineto": 437,
+      "line": 528,
+      "lineto": 528,
       "args": [
         {
           "name": "out",
@@ -17460,8 +18077,8 @@
     "git_repository_config_snapshot": {
       "type": "function",
       "file": "repository.h",
-      "line": 453,
-      "lineto": 453,
+      "line": 544,
+      "lineto": 544,
       "args": [
         {
           "name": "out",
@@ -17485,15 +18102,16 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_config_snapshot-68"
+          "ex/HEAD/general.html#git_repository_config_snapshot-70",
+          "ex/HEAD/general.html#git_repository_config_snapshot-71"
         ]
       }
     },
     "git_repository_odb": {
       "type": "function",
       "file": "repository.h",
-      "line": 469,
-      "lineto": 469,
+      "line": 560,
+      "lineto": 560,
       "args": [
         {
           "name": "out",
@@ -17520,15 +18138,15 @@
           "ex/HEAD/cat-file.html#git_repository_odb-33"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_repository_odb-69"
+          "ex/HEAD/general.html#git_repository_odb-72"
         ]
       }
     },
     "git_repository_refdb": {
       "type": "function",
       "file": "repository.h",
-      "line": 485,
-      "lineto": 485,
+      "line": 576,
+      "lineto": 576,
       "args": [
         {
           "name": "out",
@@ -17554,8 +18172,8 @@
     "git_repository_index": {
       "type": "function",
       "file": "repository.h",
-      "line": 501,
-      "lineto": 501,
+      "line": 592,
+      "lineto": 592,
       "args": [
         {
           "name": "out",
@@ -17579,18 +18197,21 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_index-70"
+          "ex/HEAD/general.html#git_repository_index-73"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_repository_index-11"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_index-42"
         ]
       }
     },
     "git_repository_message": {
       "type": "function",
       "file": "repository.h",
-      "line": 519,
-      "lineto": 519,
+      "line": 610,
+      "lineto": 610,
       "args": [
         {
           "name": "out",
@@ -17616,8 +18237,8 @@
     "git_repository_message_remove": {
       "type": "function",
       "file": "repository.h",
-      "line": 526,
-      "lineto": 526,
+      "line": 617,
+      "lineto": 617,
       "args": [
         {
           "name": "repo",
@@ -17638,8 +18259,8 @@
     "git_repository_state_cleanup": {
       "type": "function",
       "file": "repository.h",
-      "line": 535,
-      "lineto": 535,
+      "line": 626,
+      "lineto": 626,
       "args": [
         {
           "name": "repo",
@@ -17655,13 +18276,18 @@
       },
       "description": "<p>Remove all the metadata associated with an ongoing command like merge,\n revert, cherry-pick, etc.  For example: MERGE_HEAD, MERGE_MSG, etc.</p>\n",
       "comments": "",
-      "group": "repository"
+      "group": "repository",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_state_cleanup-43"
+        ]
+      }
     },
     "git_repository_fetchhead_foreach": {
       "type": "function",
       "file": "repository.h",
-      "line": 554,
-      "lineto": 557,
+      "line": 645,
+      "lineto": 648,
       "args": [
         {
           "name": "repo",
@@ -17692,8 +18318,8 @@
     "git_repository_mergehead_foreach": {
       "type": "function",
       "file": "repository.h",
-      "line": 574,
-      "lineto": 577,
+      "line": 665,
+      "lineto": 668,
       "args": [
         {
           "name": "repo",
@@ -17724,8 +18350,8 @@
     "git_repository_hashfile": {
       "type": "function",
       "file": "repository.h",
-      "line": 602,
-      "lineto": 607,
+      "line": 693,
+      "lineto": 698,
       "args": [
         {
           "name": "out",
@@ -17766,8 +18392,8 @@
     "git_repository_set_head": {
       "type": "function",
       "file": "repository.h",
-      "line": 627,
-      "lineto": 629,
+      "line": 718,
+      "lineto": 720,
       "args": [
         {
           "name": "repo",
@@ -17793,8 +18419,8 @@
     "git_repository_set_head_detached": {
       "type": "function",
       "file": "repository.h",
-      "line": 647,
-      "lineto": 649,
+      "line": 738,
+      "lineto": 740,
       "args": [
         {
           "name": "repo",
@@ -17820,8 +18446,8 @@
     "git_repository_set_head_detached_from_annotated": {
       "type": "function",
       "file": "repository.h",
-      "line": 663,
-      "lineto": 665,
+      "line": 754,
+      "lineto": 756,
       "args": [
         {
           "name": "repo",
@@ -17847,8 +18473,8 @@
     "git_repository_detach_head": {
       "type": "function",
       "file": "repository.h",
-      "line": 684,
-      "lineto": 685,
+      "line": 775,
+      "lineto": 776,
       "args": [
         {
           "name": "repo",
@@ -17869,8 +18495,8 @@
     "git_repository_state": {
       "type": "function",
       "file": "repository.h",
-      "line": 715,
-      "lineto": 715,
+      "line": 806,
+      "lineto": 806,
       "args": [
         {
           "name": "repo",
@@ -17886,13 +18512,18 @@
       },
       "description": "<p>Determines the status of a git repository - ie, whether an operation\n (merge, cherry-pick, etc) is in progress.</p>\n",
       "comments": "",
-      "group": "repository"
+      "group": "repository",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_state-44"
+        ]
+      }
     },
     "git_repository_set_namespace": {
       "type": "function",
       "file": "repository.h",
-      "line": 729,
-      "lineto": 729,
+      "line": 820,
+      "lineto": 820,
       "args": [
         {
           "name": "repo",
@@ -17918,8 +18549,8 @@
     "git_repository_get_namespace": {
       "type": "function",
       "file": "repository.h",
-      "line": 737,
-      "lineto": 737,
+      "line": 828,
+      "lineto": 828,
       "args": [
         {
           "name": "repo",
@@ -17940,8 +18571,8 @@
     "git_repository_is_shallow": {
       "type": "function",
       "file": "repository.h",
-      "line": 746,
-      "lineto": 746,
+      "line": 837,
+      "lineto": 837,
       "args": [
         {
           "name": "repo",
@@ -17962,8 +18593,8 @@
     "git_repository_ident": {
       "type": "function",
       "file": "repository.h",
-      "line": 758,
-      "lineto": 758,
+      "line": 849,
+      "lineto": 849,
       "args": [
         {
           "name": "name",
@@ -17994,8 +18625,8 @@
     "git_repository_set_ident": {
       "type": "function",
       "file": "repository.h",
-      "line": 771,
-      "lineto": 771,
+      "line": 862,
+      "lineto": 862,
       "args": [
         {
           "name": "repo",
@@ -18036,7 +18667,7 @@
         },
         {
           "name": "target",
-          "type": "git_object *",
+          "type": "const git_object *",
           "comment": "Committish to which the Head should be moved to. This object\n must belong to the given `repo` and can either be a git_commit or a\n git_tag. When a git_tag is being passed, it should be dereferencable\n to a git_commit which oid will be used as the target of the branch."
         },
         {
@@ -18050,8 +18681,8 @@
           "comment": "Optional checkout options to be used for a HARD reset.\n The checkout_strategy field will be overridden (based on reset_type).\n This parameter can be used to propagate notify and progress callbacks."
         }
       ],
-      "argline": "git_repository *repo, git_object *target, git_reset_t reset_type, const git_checkout_options *checkout_opts",
-      "sig": "git_repository *::git_object *::git_reset_t::const git_checkout_options *",
+      "argline": "git_repository *repo, const git_object *target, git_reset_t reset_type, const git_checkout_options *checkout_opts",
+      "sig": "git_repository *::const git_object *::git_reset_t::const git_checkout_options *",
       "return": {
         "type": "int",
         "comment": " 0 on success or an error code"
@@ -18073,7 +18704,7 @@
         },
         {
           "name": "commit",
-          "type": "git_annotated_commit *",
+          "type": "const git_annotated_commit *",
           "comment": null
         },
         {
@@ -18087,8 +18718,8 @@
           "comment": null
         }
       ],
-      "argline": "git_repository *repo, git_annotated_commit *commit, git_reset_t reset_type, const git_checkout_options *checkout_opts",
-      "sig": "git_repository *::git_annotated_commit *::git_reset_t::const git_checkout_options *",
+      "argline": "git_repository *repo, const git_annotated_commit *commit, git_reset_t reset_type, const git_checkout_options *checkout_opts",
+      "sig": "git_repository *::const git_annotated_commit *::git_reset_t::const git_checkout_options *",
       "return": {
         "type": "int",
         "comment": null
@@ -18110,17 +18741,17 @@
         },
         {
           "name": "target",
-          "type": "git_object *",
+          "type": "const git_object *",
           "comment": "The committish which content will be used to reset the content\n of the index."
         },
         {
           "name": "pathspecs",
-          "type": "git_strarray *",
+          "type": "const git_strarray *",
           "comment": "List of pathspecs to operate on."
         }
       ],
-      "argline": "git_repository *repo, git_object *target, git_strarray *pathspecs",
-      "sig": "git_repository *::git_object *::git_strarray *",
+      "argline": "git_repository *repo, const git_object *target, const git_strarray *pathspecs",
+      "sig": "git_repository *::const git_object *::const git_strarray *",
       "return": {
         "type": "int",
         "comment": " 0 on success or an error code \n<\n 0"
@@ -18277,7 +18908,7 @@
           "ex/HEAD/describe.html#git_revparse_single-8"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revparse_single-47"
+          "ex/HEAD/log.html#git_revparse_single-48"
         ],
         "tag.c": [
           "ex/HEAD/tag.html#git_revparse_single-13",
@@ -18360,7 +18991,7 @@
           "ex/HEAD/blame.html#git_revparse-27"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revparse-48"
+          "ex/HEAD/log.html#git_revparse-49"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_revparse-18",
@@ -18396,11 +19027,11 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_new-71"
+          "ex/HEAD/general.html#git_revwalk_new-74"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_new-49",
-          "ex/HEAD/log.html#git_revwalk_new-50"
+          "ex/HEAD/log.html#git_revwalk_new-50",
+          "ex/HEAD/log.html#git_revwalk_new-51"
         ]
       }
     },
@@ -18454,10 +19085,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_push-72"
+          "ex/HEAD/general.html#git_revwalk_push-75"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_push-51"
+          "ex/HEAD/log.html#git_revwalk_push-52"
         ]
       }
     },
@@ -18511,7 +19142,7 @@
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_push_head-52"
+          "ex/HEAD/log.html#git_revwalk_push_head-53"
         ]
       }
     },
@@ -18543,7 +19174,7 @@
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_hide-53"
+          "ex/HEAD/log.html#git_revwalk_hide-54"
         ]
       }
     },
@@ -18678,10 +19309,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_next-73"
+          "ex/HEAD/general.html#git_revwalk_next-76"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_next-54"
+          "ex/HEAD/log.html#git_revwalk_next-55"
         ]
       }
     },
@@ -18713,11 +19344,11 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_sorting-74"
+          "ex/HEAD/general.html#git_revwalk_sorting-77"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_sorting-55",
-          "ex/HEAD/log.html#git_revwalk_sorting-56"
+          "ex/HEAD/log.html#git_revwalk_sorting-56",
+          "ex/HEAD/log.html#git_revwalk_sorting-57"
         ]
       }
     },
@@ -18793,10 +19424,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_free-75"
+          "ex/HEAD/general.html#git_revwalk_free-78"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_free-57"
+          "ex/HEAD/log.html#git_revwalk_free-58"
         ]
       }
     },
@@ -18897,8 +19528,8 @@
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_signature_new-76",
-          "ex/HEAD/general.html#git_signature_new-77"
+          "ex/HEAD/general.html#git_signature_new-79",
+          "ex/HEAD/general.html#git_signature_new-80"
         ]
       }
     },
@@ -18932,7 +19563,12 @@
       },
       "description": "<p>Create a new action signature with a timestamp of &#39;now&#39;.</p>\n",
       "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n",
-      "group": "signature"
+      "group": "signature",
+      "examples": {
+        "merge.c": [
+          "ex/HEAD/merge.html#git_signature_now-45"
+        ]
+      }
     },
     "git_signature_default": {
       "type": "function",
@@ -19046,8 +19682,8 @@
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_signature_free-78",
-          "ex/HEAD/general.html#git_signature_free-79"
+          "ex/HEAD/general.html#git_signature_free-81",
+          "ex/HEAD/general.html#git_signature_free-82"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_signature_free-13"
@@ -19103,7 +19739,7 @@
         {
           "name": "options",
           "type": "const git_stash_apply_options *",
-          "comment": "Options to control how stashes are applied."
+          "comment": "Optional options to control how stashes are applied."
         }
       ],
       "argline": "git_repository *repo, size_t index, const git_stash_apply_options *options",
@@ -19194,7 +19830,7 @@
         {
           "name": "options",
           "type": "const git_stash_apply_options *",
-          "comment": "Options to control how stashes are applied."
+          "comment": "Optional options to control how stashes are applied."
         }
       ],
       "argline": "git_repository *repo, size_t index, const git_stash_apply_options *options",
@@ -19210,8 +19846,8 @@
     "git_status_init_options": {
       "type": "function",
       "file": "status.h",
-      "line": 195,
-      "lineto": 197,
+      "line": 199,
+      "lineto": 201,
       "args": [
         {
           "name": "opts",
@@ -19237,8 +19873,8 @@
     "git_status_foreach": {
       "type": "function",
       "file": "status.h",
-      "line": 235,
-      "lineto": 238,
+      "line": 239,
+      "lineto": 242,
       "args": [
         {
           "name": "repo",
@@ -19274,8 +19910,8 @@
     "git_status_foreach_ext": {
       "type": "function",
       "file": "status.h",
-      "line": 259,
-      "lineto": 263,
+      "line": 263,
+      "lineto": 267,
       "args": [
         {
           "name": "repo",
@@ -19316,8 +19952,8 @@
     "git_status_file": {
       "type": "function",
       "file": "status.h",
-      "line": 291,
-      "lineto": 294,
+      "line": 295,
+      "lineto": 298,
       "args": [
         {
           "name": "status_flags",
@@ -19348,8 +19984,8 @@
     "git_status_list_new": {
       "type": "function",
       "file": "status.h",
-      "line": 309,
-      "lineto": 312,
+      "line": 313,
+      "lineto": 316,
       "args": [
         {
           "name": "out",
@@ -19386,8 +20022,8 @@
     "git_status_list_entrycount": {
       "type": "function",
       "file": "status.h",
-      "line": 323,
-      "lineto": 324,
+      "line": 327,
+      "lineto": 328,
       "args": [
         {
           "name": "statuslist",
@@ -19414,8 +20050,8 @@
     "git_status_byindex": {
       "type": "function",
       "file": "status.h",
-      "line": 335,
-      "lineto": 337,
+      "line": 339,
+      "lineto": 341,
       "args": [
         {
           "name": "statuslist",
@@ -19451,8 +20087,8 @@
     "git_status_list_free": {
       "type": "function",
       "file": "status.h",
-      "line": 344,
-      "lineto": 345,
+      "line": 348,
+      "lineto": 349,
       "args": [
         {
           "name": "statuslist",
@@ -19478,8 +20114,8 @@
     "git_status_should_ignore": {
       "type": "function",
       "file": "status.h",
-      "line": 363,
-      "lineto": 366,
+      "line": 367,
+      "lineto": 370,
       "args": [
         {
           "name": "ignored",
@@ -19530,7 +20166,7 @@
       "group": "strarray",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_strarray_free-80"
+          "ex/HEAD/general.html#git_strarray_free-83"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_strarray_free-16",
@@ -20621,8 +21257,8 @@
     "git_config_add_backend": {
       "type": "function",
       "file": "sys/config.h",
-      "line": 119,
-      "lineto": 123,
+      "line": 121,
+      "lineto": 126,
       "args": [
         {
           "name": "cfg",
@@ -20640,13 +21276,18 @@
           "comment": "the priority level of the backend"
         },
         {
+          "name": "repo",
+          "type": "const git_repository *",
+          "comment": "optional repository to allow parsing of\n  conditional includes"
+        },
+        {
           "name": "force",
           "type": "int",
           "comment": "if a config file already exists for the given\n  priority level, replace it"
         }
       ],
-      "argline": "git_config *cfg, git_config_backend *file, git_config_level_t level, int force",
-      "sig": "git_config *::git_config_backend *::git_config_level_t::int",
+      "argline": "git_config *cfg, git_config_backend *file, git_config_level_t level, const git_repository *repo, int force",
+      "sig": "git_config *::git_config_backend *::git_config_level_t::const git_repository *::int",
       "return": {
         "type": "int",
         "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0), or error code"
@@ -21028,11 +21669,38 @@
       "comments": "",
       "group": "filter"
     },
+    "git_filter_init": {
+      "type": "function",
+      "file": "sys/filter.h",
+      "line": 284,
+      "lineto": 284,
+      "args": [
+        {
+          "name": "filter",
+          "type": "git_filter *",
+          "comment": "the `git_filter` struct to initialize."
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "Version the struct; pass `GIT_FILTER_VERSION`"
+        }
+      ],
+      "argline": "git_filter *filter, unsigned int version",
+      "sig": "git_filter *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initializes a <code>git_filter</code> with default values. Equivalent to\n creating an instance with GIT_FILTER_INIT.</p>\n",
+      "comments": "",
+      "group": "filter"
+    },
     "git_filter_register": {
       "type": "function",
       "file": "sys/filter.h",
-      "line": 301,
-      "lineto": 302,
+      "line": 312,
+      "lineto": 313,
       "args": [
         {
           "name": "name",
@@ -21063,8 +21731,8 @@
     "git_filter_unregister": {
       "type": "function",
       "file": "sys/filter.h",
-      "line": 317,
-      "lineto": 317,
+      "line": 328,
+      "lineto": 328,
       "args": [
         {
           "name": "name",
@@ -21203,13 +21871,13 @@
     "git_mempack_new": {
       "type": "function",
       "file": "sys/mempack.h",
-      "line": 44,
-      "lineto": 44,
+      "line": 45,
+      "lineto": 45,
       "args": [
         {
           "name": "out",
           "type": "git_odb_backend **",
-          "comment": "Poiter where to store the ODB backend"
+          "comment": "Pointer where to store the ODB backend"
         }
       ],
       "argline": "git_odb_backend **out",
@@ -21222,11 +21890,43 @@
       "comments": "<pre><code>The backend must be added to an existing ODB with the highest   priority.\n\n    git_mempack_new(&amp;mempacker);        git_repository_odb(&amp;odb, repository);       git_odb_add_backend(odb, mempacker, 999);\n\nOnce the backend has been loaded, all writes to the ODB will    instead be queued in memory, and can be finalized with  `git_mempack_dump`.\n\nSubsequent reads will also be served from the in-memory store   to ensure consistency, until the memory store is dumped.\n</code></pre>\n",
       "group": "mempack"
     },
+    "git_mempack_dump": {
+      "type": "function",
+      "file": "sys/mempack.h",
+      "line": 68,
+      "lineto": 68,
+      "args": [
+        {
+          "name": "pack",
+          "type": "git_buf *",
+          "comment": "Buffer where to store the raw packfile"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "The active repository where the backend is loaded"
+        },
+        {
+          "name": "backend",
+          "type": "git_odb_backend *",
+          "comment": "The mempack backend"
+        }
+      ],
+      "argline": "git_buf *pack, git_repository *repo, git_odb_backend *backend",
+      "sig": "git_buf *::git_repository *::git_odb_backend *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success; error code otherwise"
+      },
+      "description": "<pre><code>Dump all the queued in-memory writes to a packfile.\n</code></pre>\n",
+      "comments": "<pre><code>The contents of the packfile will be stored in the given buffer.    It is the caller&#39;s responsibility to ensure that the generated  packfile is available to the repository (e.g. by writing it to disk, or doing something crazy like distributing it across   several copies of the repository over a network).\n\nOnce the generated packfile is available to the repository, call `git_mempack_reset` to cleanup the memory store.\n\nCalling `git_mempack_reset` before the packfile has been    written to disk will result in an inconsistent repository   (the objects in the memory store won&#39;t be accessible).\n</code></pre>\n",
+      "group": "mempack"
+    },
     "git_mempack_reset": {
       "type": "function",
       "file": "sys/mempack.h",
-      "line": 81,
-      "lineto": 81,
+      "line": 82,
+      "lineto": 82,
       "args": [
         {
           "name": "backend",
@@ -21247,8 +21947,8 @@
     "git_odb_init_backend": {
       "type": "function",
       "file": "sys/odb_backend.h",
-      "line": 115,
-      "lineto": 117,
+      "line": 116,
+      "lineto": 118,
       "args": [
         {
           "name": "backend",
@@ -21801,6 +22501,38 @@
       "comments": "<p>This is a factory function suitable for setting as the transport callback in a remote (or for a clone in the options).</p>\n\n<p>The payload argument must be a strarray pointer with the paths for the <code>git-upload-pack</code> and <code>git-receive-pack</code> at index 0 and 1.</p>\n",
       "group": "transport"
     },
+    "git_transport_register": {
+      "type": "function",
+      "file": "sys/transport.h",
+      "line": 164,
+      "lineto": 167,
+      "args": [
+        {
+          "name": "prefix",
+          "type": "const char *",
+          "comment": "The scheme (ending in \"://\") to match, i.e. \"git://\""
+        },
+        {
+          "name": "cb",
+          "type": "git_transport_cb",
+          "comment": "The callback used to create an instance of the transport"
+        },
+        {
+          "name": "param",
+          "type": "void *",
+          "comment": "A fixed parameter to pass to cb at creation time"
+        }
+      ],
+      "argline": "const char *prefix, git_transport_cb cb, void *param",
+      "sig": "const char *::git_transport_cb::void *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Add a custom transport definition, to be used in addition to the built-in\n set of transports that come with libgit2.</p>\n",
+      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register and git_transport_unregister with other calls to the library that instantiate transports.</p>\n",
+      "group": "transport"
+    },
     "git_transport_unregister": {
       "type": "function",
       "file": "sys/transport.h",
@@ -21956,11 +22688,75 @@
       "comments": "",
       "group": "transport"
     },
+    "git_transport_smart_credentials": {
+      "type": "function",
+      "file": "sys/transport.h",
+      "line": 242,
+      "lineto": 242,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_cred **",
+          "comment": "the pointer where the creds are to be stored"
+        },
+        {
+          "name": "transport",
+          "type": "git_transport *",
+          "comment": "a smart transport"
+        },
+        {
+          "name": "user",
+          "type": "const char *",
+          "comment": "the user we saw on the url (if any)"
+        },
+        {
+          "name": "methods",
+          "type": "int",
+          "comment": "available methods for authentication"
+        }
+      ],
+      "argline": "git_cred **out, git_transport *transport, const char *user, int methods",
+      "sig": "git_cred **::git_transport *::const char *::int",
+      "return": {
+        "type": "int",
+        "comment": " the return value of the callback"
+      },
+      "description": "<p>Call the credentials callback for this transport</p>\n",
+      "comments": "",
+      "group": "transport"
+    },
+    "git_transport_smart_proxy_options": {
+      "type": "function",
+      "file": "sys/transport.h",
+      "line": 252,
+      "lineto": 252,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_proxy_options *",
+          "comment": "options struct to fill"
+        },
+        {
+          "name": "transport",
+          "type": "git_transport *",
+          "comment": "the transport to extract the data from."
+        }
+      ],
+      "argline": "git_proxy_options *out, git_transport *transport",
+      "sig": "git_proxy_options *::git_transport *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Get a copy of the proxy options</p>\n",
+      "comments": "<p>The url is copied and must be freed by the caller.</p>\n",
+      "group": "transport"
+    },
     "git_smart_subtransport_http": {
       "type": "function",
       "file": "sys/transport.h",
-      "line": 352,
-      "lineto": 355,
+      "line": 362,
+      "lineto": 365,
       "args": [
         {
           "name": "out",
@@ -21991,8 +22787,8 @@
     "git_smart_subtransport_git": {
       "type": "function",
       "file": "sys/transport.h",
-      "line": 364,
-      "lineto": 367,
+      "line": 374,
+      "lineto": 377,
       "args": [
         {
           "name": "out",
@@ -22023,8 +22819,8 @@
     "git_smart_subtransport_ssh": {
       "type": "function",
       "file": "sys/transport.h",
-      "line": 376,
-      "lineto": 379,
+      "line": 386,
+      "lineto": 389,
       "args": [
         {
           "name": "out",
@@ -22085,7 +22881,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_lookup-81"
+          "ex/HEAD/general.html#git_tag_lookup-84"
         ]
       }
     },
@@ -22149,7 +22945,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_free-82"
+          "ex/HEAD/general.html#git_tag_free-85"
         ]
       }
     },
@@ -22225,7 +23021,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_target-83"
+          "ex/HEAD/general.html#git_tag_target-86"
         ]
       }
     },
@@ -22282,7 +23078,7 @@
           "ex/HEAD/cat-file.html#git_tag_target_type-36"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_target_type-84"
+          "ex/HEAD/general.html#git_tag_target_type-87"
         ]
       }
     },
@@ -22312,7 +23108,7 @@
           "ex/HEAD/cat-file.html#git_tag_name-37"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_name-85"
+          "ex/HEAD/general.html#git_tag_name-88"
         ],
         "tag.c": [
           "ex/HEAD/tag.html#git_tag_name-20"
@@ -22373,7 +23169,7 @@
           "ex/HEAD/cat-file.html#git_tag_message-40"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_message-86"
+          "ex/HEAD/general.html#git_tag_message-89"
         ],
         "tag.c": [
           "ex/HEAD/tag.html#git_tag_message-21"
@@ -23130,11 +23926,14 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_lookup-87",
-          "ex/HEAD/general.html#git_tree_lookup-88"
+          "ex/HEAD/general.html#git_tree_lookup-90",
+          "ex/HEAD/general.html#git_tree_lookup-91"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_tree_lookup-14"
+        ],
+        "merge.c": [
+          "ex/HEAD/merge.html#git_tree_lookup-46"
         ]
       }
     },
@@ -23202,18 +24001,18 @@
           "ex/HEAD/diff.html#git_tree_free-18"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_free-89",
-          "ex/HEAD/general.html#git_tree_free-90"
+          "ex/HEAD/general.html#git_tree_free-92",
+          "ex/HEAD/general.html#git_tree_free-93"
         ],
         "init.c": [
           "ex/HEAD/init.html#git_tree_free-15"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_tree_free-58",
           "ex/HEAD/log.html#git_tree_free-59",
           "ex/HEAD/log.html#git_tree_free-60",
           "ex/HEAD/log.html#git_tree_free-61",
-          "ex/HEAD/log.html#git_tree_free-62"
+          "ex/HEAD/log.html#git_tree_free-62",
+          "ex/HEAD/log.html#git_tree_free-63"
         ]
       }
     },
@@ -23287,7 +24086,7 @@
           "ex/HEAD/cat-file.html#git_tree_entrycount-41"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entrycount-91"
+          "ex/HEAD/general.html#git_tree_entrycount-94"
         ]
       }
     },
@@ -23319,7 +24118,7 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_byname-92"
+          "ex/HEAD/general.html#git_tree_entry_byname-95"
         ]
       }
     },
@@ -23354,7 +24153,7 @@
           "ex/HEAD/cat-file.html#git_tree_entry_byindex-42"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_byindex-93"
+          "ex/HEAD/general.html#git_tree_entry_byindex-96"
         ]
       }
     },
@@ -23492,8 +24291,8 @@
           "ex/HEAD/cat-file.html#git_tree_entry_name-43"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_name-94",
-          "ex/HEAD/general.html#git_tree_entry_name-95"
+          "ex/HEAD/general.html#git_tree_entry_name-97",
+          "ex/HEAD/general.html#git_tree_entry_name-98"
         ]
       }
     },
@@ -23660,7 +24459,7 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_to_object-96"
+          "ex/HEAD/general.html#git_tree_entry_to_object-99"
         ]
       }
     },
@@ -23792,8 +24591,8 @@
     "git_treebuilder_insert": {
       "type": "function",
       "file": "tree.h",
-      "line": 323,
-      "lineto": 328,
+      "line": 324,
+      "lineto": 329,
       "args": [
         {
           "name": "out",
@@ -23828,14 +24627,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an entry to the builder</p>\n",
-      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the newly created/updated entry.  Pass NULL if you do not need it. The pointer may not be valid past the next operation in this builder. Duplicate the entry if you want to keep it.</p>\n\n<p>No attempt is being made to ensure that the provided oid points to an existing git object in the object database, nor that the attributes make sense regarding the type of the pointed at object.</p>\n",
+      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the newly created/updated entry.  Pass NULL if you do not need it. The pointer may not be valid past the next operation in this builder. Duplicate the entry if you want to keep it.</p>\n\n<p>By default the entry that you are inserting will be checked for validity; that it exists in the object database and is of the correct type.  If you do not want this behavior, set the <code>GIT_OPT_ENABLE_STRICT_OBJECT_CREATION</code> library option to false.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_remove": {
       "type": "function",
       "file": "tree.h",
-      "line": 336,
-      "lineto": 337,
+      "line": 337,
+      "lineto": 338,
       "args": [
         {
           "name": "bld",
@@ -23861,8 +24660,8 @@
     "git_treebuilder_filter": {
       "type": "function",
       "file": "tree.h",
-      "line": 360,
-      "lineto": 363,
+      "line": 361,
+      "lineto": 364,
       "args": [
         {
           "name": "bld",
@@ -23893,8 +24692,8 @@
     "git_treebuilder_write": {
       "type": "function",
       "file": "tree.h",
-      "line": 375,
-      "lineto": 376,
+      "line": 376,
+      "lineto": 377,
       "args": [
         {
           "name": "id",
@@ -23920,8 +24719,8 @@
     "git_treebuilder_write_with_buffer": {
       "type": "function",
       "file": "tree.h",
-      "line": 389,
-      "lineto": 390,
+      "line": 390,
+      "lineto": 391,
       "args": [
         {
           "name": "oid",
@@ -23952,8 +24751,8 @@
     "git_tree_walk": {
       "type": "function",
       "file": "tree.h",
-      "line": 419,
-      "lineto": 423,
+      "line": 420,
+      "lineto": 424,
       "args": [
         {
           "name": "tree",
@@ -23989,8 +24788,8 @@
     "git_tree_dup": {
       "type": "function",
       "file": "tree.h",
-      "line": 432,
-      "lineto": 432,
+      "line": 433,
+      "lineto": 433,
       "args": [
         {
           "name": "out",
@@ -24016,8 +24815,8 @@
     "git_tree_create_updated": {
       "type": "function",
       "file": "tree.h",
-      "line": 478,
-      "lineto": 478,
+      "line": 479,
+      "lineto": 479,
       "args": [
         {
           "name": "out",
@@ -24054,6 +24853,362 @@
       "description": "<p>Create a tree based on another one with the specified modifications</p>\n",
       "comments": "<p>Given the <code>baseline</code> perform the changes described in the list of <code>updates</code> and create a new tree.</p>\n\n<p>This function is optimized for common file/directory addition, removal and replacement in trees. It is much more efficient than reading the tree into a <code>git_index</code> and modifying that, but in exchange it is not as flexible.</p>\n\n<p>Deleting and adding the same entry is undefined behaviour, changing a tree to a blob or viceversa is not supported.</p>\n",
       "group": "tree"
+    },
+    "git_worktree_list": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 34,
+      "lineto": 34,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_strarray *",
+          "comment": "pointer to the array of working tree names"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repo to use when listing working trees"
+        }
+      ],
+      "argline": "git_strarray *out, git_repository *repo",
+      "sig": "git_strarray *::git_repository *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>List names of linked working trees</p>\n",
+      "comments": "<p>The returned list should be released with <code>git_strarray_free</code> when no longer needed.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_lookup": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 44,
+      "lineto": 44,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_worktree **",
+          "comment": "Output pointer to looked up worktree or `NULL`"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "The repository containing worktrees"
+        },
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "Name of the working tree to look up"
+        }
+      ],
+      "argline": "git_worktree **out, git_repository *repo, const char *name",
+      "sig": "git_worktree **::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Lookup a working tree by its name for a given repository</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_open_from_repository": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 56,
+      "lineto": 56,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_worktree **",
+          "comment": "Out-pointer for the newly allocated worktree"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "Repository to look up worktree for"
+        }
+      ],
+      "argline": "git_worktree **out, git_repository *repo",
+      "sig": "git_worktree **::git_repository *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Open a worktree of a given repository</p>\n",
+      "comments": "<p>If a repository is not the main tree but a worktree, this function will look up the worktree inside the parent repository and create a new <code>git_worktree</code> structure.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_free": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 63,
+      "lineto": 63,
+      "args": [
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": "worktree handle to close. If NULL nothing occurs."
+        }
+      ],
+      "argline": "git_worktree *wt",
+      "sig": "git_worktree *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free a previously allocated worktree</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_validate": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 75,
+      "lineto": 75,
+      "args": [
+        {
+          "name": "wt",
+          "type": "const git_worktree *",
+          "comment": "Worktree to check"
+        }
+      ],
+      "argline": "const git_worktree *wt",
+      "sig": "const git_worktree *",
+      "return": {
+        "type": "int",
+        "comment": " 0 when worktree is valid, error-code otherwise"
+      },
+      "description": "<p>Check if worktree is valid</p>\n",
+      "comments": "<p>A valid worktree requires both the git data structures inside the linked parent repository and the linked working copy to be present.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_add_init_options": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 95,
+      "lineto": 96,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_worktree_add_options *",
+          "comment": "the struct to initialize"
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "Verison of struct; pass `GIT_WORKTREE_ADD_OPTIONS_VERSION`"
+        }
+      ],
+      "argline": "git_worktree_add_options *opts, unsigned int version",
+      "sig": "git_worktree_add_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initializes a <code>git_worktree_add_options</code> with default vaules.\n Equivalent to creating an instance with\n GIT_WORKTREE_ADD_OPTIONS_INIT.</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_add": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 112,
+      "lineto": 114,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_worktree **",
+          "comment": "Output pointer containing new working tree"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "Repository to create working tree for"
+        },
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "Name of the working tree"
+        },
+        {
+          "name": "path",
+          "type": "const char *",
+          "comment": "Path to create working tree at"
+        },
+        {
+          "name": "opts",
+          "type": "const git_worktree_add_options *",
+          "comment": "Options to modify default behavior. May be NULL"
+        }
+      ],
+      "argline": "git_worktree **out, git_repository *repo, const char *name, const char *path, const git_worktree_add_options *opts",
+      "sig": "git_worktree **::git_repository *::const char *::const char *::const git_worktree_add_options *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Add a new working tree</p>\n",
+      "comments": "<p>Add a new working tree for the repository, that is create the required data structures inside the repository and check out the current HEAD at <code>path</code></p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_lock": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 126,
+      "lineto": 126,
+      "args": [
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": "Worktree to lock"
+        },
+        {
+          "name": "reason",
+          "type": "const char *",
+          "comment": "Reason why the working tree is being locked"
+        }
+      ],
+      "argline": "git_worktree *wt, const char *reason",
+      "sig": "git_worktree *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, non-zero otherwise"
+      },
+      "description": "<p>Lock worktree if not already locked</p>\n",
+      "comments": "<p>Lock a worktree, optionally specifying a reason why the linked working tree is being locked.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_unlock": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 135,
+      "lineto": 135,
+      "args": [
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": "Worktree to unlock"
+        }
+      ],
+      "argline": "git_worktree *wt",
+      "sig": "git_worktree *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, 1 if worktree was not locked, error-code\n  otherwise"
+      },
+      "description": "<p>Unlock a locked worktree</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_is_locked": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 149,
+      "lineto": 149,
+      "args": [
+        {
+          "name": "reason",
+          "type": "git_buf *",
+          "comment": "Buffer to store reason in. If NULL no reason is stored."
+        },
+        {
+          "name": "wt",
+          "type": "const git_worktree *",
+          "comment": "Worktree to check"
+        }
+      ],
+      "argline": "git_buf *reason, const git_worktree *wt",
+      "sig": "git_buf *::const git_worktree *",
+      "return": {
+        "type": "int",
+        "comment": " 0 when the working tree not locked, a value greater\n  than zero if it is locked, less than zero if there was an\n  error"
+      },
+      "description": "<p>Check if worktree is locked</p>\n",
+      "comments": "<p>A worktree may be locked if the linked working tree is stored on a portable device which is not available.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_prune_init_options": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 182,
+      "lineto": 184,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_worktree_prune_options *",
+          "comment": "the struct to initialize"
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "Verison of struct; pass `GIT_WORKTREE_PRUNE_OPTIONS_VERSION`"
+        }
+      ],
+      "argline": "git_worktree_prune_options *opts, unsigned int version",
+      "sig": "git_worktree_prune_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initializes a <code>git_worktree_prune_options</code> with default vaules.\n Equivalent to creating an instance with\n GIT_WORKTREE_PRUNE_OPTIONS_INIT.</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_is_prunable": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 200,
+      "lineto": 201,
+      "args": [
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": null
+        },
+        {
+          "name": "opts",
+          "type": "git_worktree_prune_options *",
+          "comment": null
+        }
+      ],
+      "argline": "git_worktree *wt, git_worktree_prune_options *opts",
+      "sig": "git_worktree *::git_worktree_prune_options *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Is the worktree prunable with the given options?</p>\n",
+      "comments": "<p>A worktree is not prunable in the following scenarios:</p>\n\n<ul>\n<li>the worktree is linking to a valid on-disk worktree. The   <code>valid</code> member will cause this check to be ignored. - the worktree is locked. The <code>locked</code> flag will cause this   check to be ignored.</li>\n</ul>\n\n<p>If the worktree is not valid and not locked or if the above flags have been passed in, this function will return a positive value.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_prune": {
+      "type": "function",
+      "file": "worktree.h",
+      "line": 215,
+      "lineto": 216,
+      "args": [
+        {
+          "name": "wt",
+          "type": "git_worktree *",
+          "comment": "Worktree to prune"
+        },
+        {
+          "name": "opts",
+          "type": "git_worktree_prune_options *",
+          "comment": "Specifies which checks to override. See\n        `git_worktree_is_prunable`. May be NULL"
+        }
+      ],
+      "argline": "git_worktree *wt, git_worktree_prune_options *opts",
+      "sig": "git_worktree *::git_worktree_prune_options *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Prune working tree</p>\n",
+      "comments": "<p>Prune the working tree, that is remove the git data structures on disk. The repository will only be pruned of <code>git_worktree_is_prunable</code> succeeds.</p>\n",
+      "group": "worktree"
     }
   },
   "callbacks": {
@@ -24245,8 +25400,8 @@
     "git_diff_notify_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 353,
-      "lineto": 357,
+      "line": 359,
+      "lineto": 363,
       "args": [
         {
           "name": "diff_so_far",
@@ -24281,8 +25436,8 @@
     "git_diff_progress_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 369,
-      "lineto": 373,
+      "line": 375,
+      "lineto": 379,
       "args": [
         {
           "name": "diff_so_far",
@@ -24317,8 +25472,8 @@
     "git_diff_file_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 452,
-      "lineto": 455,
+      "line": 458,
+      "lineto": 461,
       "args": [
         {
           "name": "delta",
@@ -24348,8 +25503,8 @@
     "git_diff_binary_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 509,
-      "lineto": 512,
+      "line": 515,
+      "lineto": 518,
       "args": [
         {
           "name": "delta",
@@ -24379,8 +25534,8 @@
     "git_diff_hunk_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 529,
-      "lineto": 532,
+      "line": 535,
+      "lineto": 538,
       "args": [
         {
           "name": "delta",
@@ -24410,8 +25565,8 @@
     "git_diff_line_cb": {
       "type": "callback",
       "file": "diff.h",
-      "line": 582,
-      "lineto": 586,
+      "line": 588,
+      "lineto": 592,
       "args": [
         {
           "name": "delta",
@@ -24596,8 +25751,8 @@
     "git_push_transfer_progress": {
       "type": "callback",
       "file": "remote.h",
-      "line": 333,
-      "lineto": 337,
+      "line": 351,
+      "lineto": 355,
       "args": [
         {
           "name": "current",
@@ -24632,8 +25787,8 @@
     "git_push_negotiation": {
       "type": "callback",
       "file": "remote.h",
-      "line": 368,
-      "lineto": 368,
+      "line": 386,
+      "lineto": 386,
       "args": [
         {
           "name": "updates",
@@ -24659,6 +25814,37 @@
       },
       "description": "<p>Callback used to inform of upcoming updates.</p>\n",
       "comments": ""
+    },
+    "git_push_update_reference_cb": {
+      "type": "callback",
+      "file": "remote.h",
+      "line": 400,
+      "lineto": 400,
+      "args": [
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "refname specifying to the remote ref"
+        },
+        {
+          "name": "status",
+          "type": "const char *",
+          "comment": "status message sent from the remote"
+        },
+        {
+          "name": "data",
+          "type": "void *",
+          "comment": "data provided by the caller"
+        }
+      ],
+      "argline": "const char *refname, const char *status, void *data",
+      "sig": "const char *::const char *::void *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, otherwise an error"
+      },
+      "description": "<p>Callback used to inform of the update status from the remote.</p>\n",
+      "comments": "<p>Called for each updated reference on push. If <code>status</code> is not <code>NULL</code>, the update was rejected by the remote server and <code>status</code> contains the reason given.</p>\n"
     },
     "git_revwalk_hide_cb": {
       "type": "callback",
@@ -25109,43 +26295,43 @@
         {
           "name": "cred",
           "type": "git_cred **",
-          "comment": null
+          "comment": "The newly created credential object."
         },
         {
           "name": "url",
           "type": "const char *",
-          "comment": null
+          "comment": "The resource for which we are demanding a credential."
         },
         {
           "name": "username_from_url",
           "type": "const char *",
-          "comment": null
+          "comment": "The username that was embedded in a \"user\n@\nhost\"\n                          remote url, or NULL if not included."
         },
         {
           "name": "allowed_types",
           "type": "unsigned int",
-          "comment": null
+          "comment": "A bitmask stating which cred types are OK to return."
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "The payload provided when specifying this callback."
         }
       ],
       "argline": "git_cred **cred, const char *url, const char *username_from_url, unsigned int allowed_types, void *payload",
       "sig": "git_cred **::const char *::const char *::unsigned int::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 for success, \n<\n 0 to indicate an error, > 0 to indicate\n       no credential was acquired"
       },
       "description": "<p>Signature of a function which acquires a credential object.</p>\n",
-      "comments": "<ul>\n<li>cred: The newly created credential object. - url: The resource for which we are demanding a credential. - username_from_url: The username that was embedded in a &quot;user@host&quot;                          remote url, or NULL if not included. - allowed_types: A bitmask stating which cred types are OK to return. - payload: The payload provided when specifying this callback. - returns 0 for success, &lt; 0 to indicate an error, &gt; 0 to indicate       no credential was acquired</li>\n</ul>\n"
+      "comments": ""
     },
     "git_treebuilder_filter_cb": {
       "type": "callback",
       "file": "tree.h",
-      "line": 346,
-      "lineto": 347,
+      "line": 347,
+      "lineto": 348,
       "args": [
         {
           "name": "entry",
@@ -25170,8 +26356,8 @@
     "git_treewalk_cb": {
       "type": "callback",
       "file": "tree.h",
-      "line": 393,
-      "lineto": 394,
+      "line": 394,
+      "lineto": 395,
       "args": [
         {
           "name": "root",
@@ -25201,8 +26387,8 @@
     "git_transfer_progress_cb": {
       "type": "callback",
       "file": "types.h",
-      "line": 270,
-      "lineto": 270,
+      "line": 274,
+      "lineto": 274,
       "args": [
         {
           "name": "stats",
@@ -25227,8 +26413,8 @@
     "git_transport_message_cb": {
       "type": "callback",
       "file": "types.h",
-      "line": 280,
-      "lineto": 280,
+      "line": 284,
+      "lineto": 284,
       "args": [
         {
           "name": "str",
@@ -25258,8 +26444,8 @@
     "git_transport_certificate_check_cb": {
       "type": "callback",
       "file": "types.h",
-      "line": 330,
-      "lineto": 330,
+      "line": 334,
+      "lineto": 334,
       "args": [
         {
           "name": "cert",
@@ -25301,8 +26487,8 @@
         "type": "struct",
         "value": "git_annotated_commit",
         "file": "types.h",
-        "line": 178,
-        "lineto": 178,
+        "line": 182,
+        "lineto": 182,
         "tdef": "typedef",
         "description": " Annotated commits, the input to merge and rebase. ",
         "comments": "",
@@ -25592,8 +26778,8 @@
         "type": "struct",
         "value": "git_blob",
         "file": "types.h",
-        "line": 117,
-        "lineto": 117,
+        "line": 120,
+        "lineto": 120,
         "tdef": "typedef",
         "description": " In-memory representation of a blob object. ",
         "comments": "",
@@ -25653,8 +26839,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 198,
-        "lineto": 202,
+        "line": 202,
+        "lineto": 206,
         "block": "GIT_BRANCH_LOCAL\nGIT_BRANCH_REMOTE\nGIT_BRANCH_ALL",
         "tdef": "typedef",
         "description": " Basic type of any Git branch. ",
@@ -25752,6 +26938,7 @@
             "git_filter_list_apply_to_data",
             "git_filter_list_apply_to_file",
             "git_filter_list_stream_data",
+            "git_mempack_dump",
             "git_message_prettify",
             "git_object_short_id",
             "git_patch_to_buf",
@@ -25759,9 +26946,11 @@
             "git_refspec_transform",
             "git_remote_default_branch",
             "git_repository_discover",
+            "git_repository_item_path",
             "git_repository_message",
             "git_submodule_resolve_url",
-            "git_treebuilder_write_with_buffer"
+            "git_treebuilder_write_with_buffer",
+            "git_worktree_is_locked"
           ]
         }
       }
@@ -25775,8 +26964,8 @@
         "type": "struct",
         "value": "git_cert",
         "file": "types.h",
-        "line": 314,
-        "lineto": 319,
+        "line": 318,
+        "lineto": 323,
         "block": "git_cert_t cert_type",
         "tdef": "typedef",
         "description": " Parent type for `git_cert_hostkey` and `git_cert_x509`.",
@@ -25889,8 +27078,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 286,
-        "lineto": 309,
+        "line": 290,
+        "lineto": 313,
         "block": "GIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY\nGIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY",
         "tdef": "typedef",
         "description": " Type of host certificate structure that is passed to the check callback",
@@ -26554,8 +27743,8 @@
         "type": "struct",
         "value": "git_commit",
         "file": "types.h",
-        "line": 120,
-        "lineto": 120,
+        "line": 123,
+        "lineto": 123,
         "tdef": "typedef",
         "description": " Parsed representation of a commit object. ",
         "comments": "",
@@ -26594,6 +27783,10 @@
             "git_commit_tree_id",
             "git_diff_commit_as_email",
             "git_merge_commits",
+            "git_note_commit_create",
+            "git_note_commit_iterator_new",
+            "git_note_commit_read",
+            "git_note_commit_remove",
             "git_revert",
             "git_revert_commit"
           ]
@@ -26607,8 +27800,8 @@
         "type": "struct",
         "value": "git_config",
         "file": "types.h",
-        "line": 138,
-        "lineto": 138,
+        "line": 141,
+        "lineto": 141,
         "tdef": "typedef",
         "description": " Memory representation of a set of config files ",
         "comments": "",
@@ -26665,9 +27858,9 @@
         "type": "struct",
         "value": "git_config_backend",
         "file": "types.h",
-        "line": 141,
-        "lineto": 141,
-        "block": "unsigned int version\nint readonly\nstruct git_config * cfg\nint (*)(struct git_config_backend *, git_config_level_t) open\nint (*)(struct git_config_backend *, const char *, git_config_entry **) get\nint (*)(struct git_config_backend *, const char *, const char *) set\nint (*)(git_config_backend *, const char *, const char *, const char *) set_multivar\nint (*)(struct git_config_backend *, const char *) del\nint (*)(struct git_config_backend *, const char *, const char *) del_multivar\nint (*)(git_config_iterator **, struct git_config_backend *) iterator\nint (*)(struct git_config_backend **, struct git_config_backend *) snapshot\nint (*)(struct git_config_backend *) lock\nint (*)(struct git_config_backend *, int) unlock\nvoid (*)(struct git_config_backend *) free",
+        "line": 144,
+        "lineto": 144,
+        "block": "unsigned int version\nint readonly\nstruct git_config * cfg\nint (*)(struct git_config_backend *, git_config_level_t, const git_repository *) open\nint (*)(struct git_config_backend *, const char *, git_config_entry **) get\nint (*)(struct git_config_backend *, const char *, const char *) set\nint (*)(git_config_backend *, const char *, const char *, const char *) set_multivar\nint (*)(struct git_config_backend *, const char *) del\nint (*)(struct git_config_backend *, const char *, const char *) del_multivar\nint (*)(git_config_iterator **, struct git_config_backend *) iterator\nint (*)(struct git_config_backend **, struct git_config_backend *) snapshot\nint (*)(struct git_config_backend *) lock\nint (*)(struct git_config_backend *, int) unlock\nvoid (*)(struct git_config_backend *) free",
         "tdef": "typedef",
         "description": " Interface to access a configuration file ",
         "comments": "",
@@ -26688,7 +27881,7 @@
             "comments": ""
           },
           {
-            "type": "int (*)(struct git_config_backend *, git_config_level_t)",
+            "type": "int (*)(struct git_config_backend *, git_config_level_t, const git_repository *)",
             "name": "open",
             "comments": ""
           },
@@ -27399,8 +28592,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 246,
-        "lineto": 258,
+        "line": 252,
+        "lineto": 264,
         "block": "GIT_DELTA_UNMODIFIED\nGIT_DELTA_ADDED\nGIT_DELTA_DELETED\nGIT_DELTA_MODIFIED\nGIT_DELTA_RENAMED\nGIT_DELTA_COPIED\nGIT_DELTA_IGNORED\nGIT_DELTA_UNTRACKED\nGIT_DELTA_TYPECHANGE\nGIT_DELTA_UNREADABLE\nGIT_DELTA_CONFLICTED",
         "tdef": "typedef",
         "description": " What type of change is described by a git_diff_delta?",
@@ -27629,7 +28822,7 @@
         "block": "GIT_DESCRIBE_DEFAULT\nGIT_DESCRIBE_TAGS\nGIT_DESCRIBE_ALL",
         "tdef": "typedef",
         "description": " Reference lookup strategy",
-        "comments": "<p>These behave like the --tags and --all optios to git-describe, namely they say to look for any reference in either refs/tags/ or refs/ respectively.</p>\n",
+        "comments": "<p>These behave like the --tags and --all options to git-describe, namely they say to look for any reference in either refs/tags/ or refs/ respectively.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -27663,8 +28856,8 @@
         "type": "struct",
         "value": "git_diff",
         "file": "diff.h",
-        "line": 219,
-        "lineto": 219,
+        "line": 225,
+        "lineto": 225,
         "tdef": "typedef",
         "description": " The diff object that contains all individual file deltas.",
         "comments": "<p>This is an opaque structure which will be allocated by one of the diff generator functions below (such as <code>git_diff_tree_to_tree</code>).  You are responsible for releasing the object memory when done, using the <code>git_diff_free()</code> function.</p>\n",
@@ -27702,6 +28895,8 @@
             "git_diff_notify_cb",
             "git_diff_num_deltas",
             "git_diff_num_deltas_of_type",
+            "git_diff_patchid",
+            "git_diff_patchid_init_options",
             "git_diff_print",
             "git_diff_print_callback__to_buf",
             "git_diff_print_callback__to_file_handle",
@@ -27740,8 +28935,8 @@
         "type": "struct",
         "value": "git_diff_binary",
         "file": "diff.h",
-        "line": 492,
-        "lineto": 503,
+        "line": 498,
+        "lineto": 509,
         "block": "unsigned int contains_data\ngit_diff_binary_file old_file\ngit_diff_binary_file new_file",
         "tdef": "typedef",
         "description": " Structure describing the binary contents of a diff. ",
@@ -27787,8 +28982,8 @@
         "type": "struct",
         "value": "git_diff_binary_file",
         "file": "diff.h",
-        "line": 477,
-        "lineto": 489,
+        "line": 483,
+        "lineto": 495,
         "block": "git_diff_binary_t type\nconst char * data\nsize_t datalen\nsize_t inflatedlen",
         "tdef": "typedef",
         "description": " The contents of one of the files in a binary diff. ",
@@ -27831,8 +29026,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 465,
-        "lineto": 474,
+        "line": 471,
+        "lineto": 480,
         "block": "GIT_DIFF_BINARY_NONE\nGIT_DIFF_BINARY_LITERAL\nGIT_DIFF_BINARY_DELTA",
         "tdef": "typedef",
         "description": " When producing a binary diff, the binary data returned will be\n either the deflated full (\"literal\") contents of the file, or\n the deflated binary delta between the two sides (whichever is\n smaller).",
@@ -27877,8 +29072,8 @@
         "type": "struct",
         "value": "git_diff_delta",
         "file": "diff.h",
-        "line": 331,
-        "lineto": 338,
+        "line": 337,
+        "lineto": 344,
         "block": "git_delta_t status\nuint32_t flags\nuint16_t similarity\nuint16_t nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
         "tdef": "typedef",
         "description": " Description of changes to one entry.",
@@ -27947,8 +29142,8 @@
         "type": "struct",
         "value": "git_diff_file",
         "file": "diff.h",
-        "line": 286,
-        "lineto": 293,
+        "line": 292,
+        "lineto": 299,
         "block": "git_oid id\nconst char * path\ngit_off_t size\nuint32_t flags\nuint16_t mode\nuint16_t id_abbrev",
         "tdef": "typedef",
         "description": " Description of one side of a delta.",
@@ -28013,8 +29208,8 @@
         "type": "struct",
         "value": "git_diff_find_options",
         "file": "diff.h",
-        "line": 697,
-        "lineto": 723,
+        "line": 703,
+        "lineto": 729,
         "block": "unsigned int version\nuint32_t flags\nuint16_t rename_threshold\nuint16_t rename_from_rewrite_threshold\nuint16_t copy_threshold\nuint16_t break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
         "tdef": "typedef",
         "description": " Control behavior of rename and copy detection",
@@ -28093,8 +29288,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 591,
-        "lineto": 660,
+        "line": 597,
+        "lineto": 666,
         "block": "GIT_DIFF_FIND_BY_CONFIG\nGIT_DIFF_FIND_RENAMES\nGIT_DIFF_FIND_RENAMES_FROM_REWRITES\nGIT_DIFF_FIND_COPIES\nGIT_DIFF_FIND_COPIES_FROM_UNMODIFIED\nGIT_DIFF_FIND_REWRITES\nGIT_DIFF_BREAK_REWRITES\nGIT_DIFF_FIND_AND_BREAK_REWRITES\nGIT_DIFF_FIND_FOR_UNTRACKED\nGIT_DIFF_FIND_ALL\nGIT_DIFF_FIND_IGNORE_LEADING_WHITESPACE\nGIT_DIFF_FIND_IGNORE_WHITESPACE\nGIT_DIFF_FIND_DONT_IGNORE_WHITESPACE\nGIT_DIFF_FIND_EXACT_MATCH_ONLY\nGIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY\nGIT_DIFF_FIND_REMOVE_UNMODIFIED",
         "tdef": "typedef",
         "description": " Flags to control the behavior of diff rename/copy detection.",
@@ -28214,8 +29409,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 229,
-        "lineto": 234,
+        "line": 235,
+        "lineto": 240,
         "block": "GIT_DIFF_FLAG_BINARY\nGIT_DIFF_FLAG_NOT_BINARY\nGIT_DIFF_FLAG_VALID_ID\nGIT_DIFF_FLAG_EXISTS",
         "tdef": "typedef",
         "description": " Flags for the delta object and the file objects on each side.",
@@ -28261,8 +29456,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 1315,
-        "lineto": 1322,
+        "line": 1321,
+        "lineto": 1328,
         "block": "GIT_DIFF_FORMAT_EMAIL_NONE\nGIT_DIFF_FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER",
         "tdef": "typedef",
         "description": " Formatting options for diff e-mail generation",
@@ -28305,8 +29500,8 @@
         "type": "struct",
         "value": "git_diff_format_email_options",
         "file": "diff.h",
-        "line": 1327,
-        "lineto": 1349,
+        "line": 1333,
+        "lineto": 1355,
         "block": "unsigned int version\ngit_diff_format_email_flags_t flags\nsize_t patch_no\nsize_t total_patches\nconst git_oid * id\nconst char * summary\nconst char * body\nconst git_signature * author",
         "tdef": "typedef",
         "description": " Options for controlling the formatting of the generated e-mail.",
@@ -28374,8 +29569,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 1039,
-        "lineto": 1045,
+        "line": 1045,
+        "lineto": 1051,
         "block": "GIT_DIFF_FORMAT_PATCH\nGIT_DIFF_FORMAT_PATCH_HEADER\nGIT_DIFF_FORMAT_RAW\nGIT_DIFF_FORMAT_NAME_ONLY\nGIT_DIFF_FORMAT_NAME_STATUS",
         "tdef": "typedef",
         "description": " Possible output formats for diff data",
@@ -28435,8 +29630,8 @@
         "type": "struct",
         "value": "git_diff_hunk",
         "file": "diff.h",
-        "line": 517,
-        "lineto": 524,
+        "line": 523,
+        "lineto": 530,
         "block": "int old_start\nint old_lines\nint new_start\nint new_lines\nsize_t header_len\nchar [128] header",
         "tdef": "typedef",
         "description": " Structure describing a hunk of a diff.",
@@ -28445,32 +29640,32 @@
           {
             "type": "int",
             "name": "old_start",
-            "comments": ""
-          },
-          {
-            "type": "int",
-            "name": "old_lines",
             "comments": " Starting line number in old_file "
           },
           {
             "type": "int",
-            "name": "new_start",
+            "name": "old_lines",
             "comments": " Number of lines in old_file "
           },
           {
             "type": "int",
-            "name": "new_lines",
+            "name": "new_start",
             "comments": " Starting line number in new_file "
+          },
+          {
+            "type": "int",
+            "name": "new_lines",
+            "comments": " Number of lines in new_file "
           },
           {
             "type": "size_t",
             "name": "header_len",
-            "comments": " Number of lines in new_file "
+            "comments": " Number of bytes in header text "
           },
           {
             "type": "char [128]",
             "name": "header",
-            "comments": " Number of bytes in header text "
+            "comments": " Header text, NUL-byte terminated "
           }
         ],
         "used": {
@@ -28504,8 +29699,8 @@
         "type": "struct",
         "value": "git_diff_line",
         "file": "diff.h",
-        "line": 564,
-        "lineto": 572,
+        "line": 570,
+        "lineto": 578,
         "block": "char origin\nint old_lineno\nint new_lineno\nint num_lines\nsize_t content_len\ngit_off_t content_offset\nconst char * content",
         "tdef": "typedef",
         "description": " Structure describing a line (or data span) of a diff.",
@@ -28580,8 +29775,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 543,
-        "lineto": 559,
+        "line": 549,
+        "lineto": 565,
         "block": "GIT_DIFF_LINE_CONTEXT\nGIT_DIFF_LINE_ADDITION\nGIT_DIFF_LINE_DELETION\nGIT_DIFF_LINE_CONTEXT_EOFNL\nGIT_DIFF_LINE_ADD_EOFNL\nGIT_DIFF_LINE_DEL_EOFNL\nGIT_DIFF_LINE_FILE_HDR\nGIT_DIFF_LINE_HUNK_HDR\nGIT_DIFF_LINE_BINARY",
         "tdef": "typedef",
         "description": " Line origin constants.",
@@ -28680,13 +29875,14 @@
           "GIT_DIFF_SHOW_UNMODIFIED",
           "GIT_DIFF_PATIENCE",
           "GIT_DIFF_MINIMAL",
-          "GIT_DIFF_SHOW_BINARY"
+          "GIT_DIFF_SHOW_BINARY",
+          "GIT_DIFF_INDENT_HEURISTIC"
         ],
         "type": "enum",
         "file": "diff.h",
         "line": 72,
-        "lineto": 209,
-        "block": "GIT_DIFF_NORMAL\nGIT_DIFF_REVERSE\nGIT_DIFF_INCLUDE_IGNORED\nGIT_DIFF_RECURSE_IGNORED_DIRS\nGIT_DIFF_INCLUDE_UNTRACKED\nGIT_DIFF_RECURSE_UNTRACKED_DIRS\nGIT_DIFF_INCLUDE_UNMODIFIED\nGIT_DIFF_INCLUDE_TYPECHANGE\nGIT_DIFF_INCLUDE_TYPECHANGE_TREES\nGIT_DIFF_IGNORE_FILEMODE\nGIT_DIFF_IGNORE_SUBMODULES\nGIT_DIFF_IGNORE_CASE\nGIT_DIFF_INCLUDE_CASECHANGE\nGIT_DIFF_DISABLE_PATHSPEC_MATCH\nGIT_DIFF_SKIP_BINARY_CHECK\nGIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS\nGIT_DIFF_UPDATE_INDEX\nGIT_DIFF_INCLUDE_UNREADABLE\nGIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED\nGIT_DIFF_FORCE_TEXT\nGIT_DIFF_FORCE_BINARY\nGIT_DIFF_IGNORE_WHITESPACE\nGIT_DIFF_IGNORE_WHITESPACE_CHANGE\nGIT_DIFF_IGNORE_WHITESPACE_EOL\nGIT_DIFF_SHOW_UNTRACKED_CONTENT\nGIT_DIFF_SHOW_UNMODIFIED\nGIT_DIFF_PATIENCE\nGIT_DIFF_MINIMAL\nGIT_DIFF_SHOW_BINARY",
+        "lineto": 215,
+        "block": "GIT_DIFF_NORMAL\nGIT_DIFF_REVERSE\nGIT_DIFF_INCLUDE_IGNORED\nGIT_DIFF_RECURSE_IGNORED_DIRS\nGIT_DIFF_INCLUDE_UNTRACKED\nGIT_DIFF_RECURSE_UNTRACKED_DIRS\nGIT_DIFF_INCLUDE_UNMODIFIED\nGIT_DIFF_INCLUDE_TYPECHANGE\nGIT_DIFF_INCLUDE_TYPECHANGE_TREES\nGIT_DIFF_IGNORE_FILEMODE\nGIT_DIFF_IGNORE_SUBMODULES\nGIT_DIFF_IGNORE_CASE\nGIT_DIFF_INCLUDE_CASECHANGE\nGIT_DIFF_DISABLE_PATHSPEC_MATCH\nGIT_DIFF_SKIP_BINARY_CHECK\nGIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS\nGIT_DIFF_UPDATE_INDEX\nGIT_DIFF_INCLUDE_UNREADABLE\nGIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED\nGIT_DIFF_FORCE_TEXT\nGIT_DIFF_FORCE_BINARY\nGIT_DIFF_IGNORE_WHITESPACE\nGIT_DIFF_IGNORE_WHITESPACE_CHANGE\nGIT_DIFF_IGNORE_WHITESPACE_EOL\nGIT_DIFF_SHOW_UNTRACKED_CONTENT\nGIT_DIFF_SHOW_UNMODIFIED\nGIT_DIFF_PATIENCE\nGIT_DIFF_MINIMAL\nGIT_DIFF_SHOW_BINARY\nGIT_DIFF_INDENT_HEURISTIC",
         "tdef": "typedef",
         "description": " Flags for diff options.  A combination of these flags can be passed\n in via the `flags` value in the `git_diff_options`.",
         "comments": "",
@@ -28864,6 +30060,12 @@
             "name": "GIT_DIFF_SHOW_BINARY",
             "comments": "<p>Include the necessary deflate / delta information so that <code>git-apply</code>\n  can apply given diff information to binary files.</p>\n",
             "value": 1073741824
+          },
+          {
+            "type": "unsigned int",
+            "name": "GIT_DIFF_INDENT_HEURISTIC",
+            "comments": "<p>Use a heuristic that takes indentation and whitespace into account\n which generally can produce better diffs when dealing with ambiguous\n diff hunks.</p>\n",
+            "value": -2147483648
           }
         ],
         "used": {
@@ -28893,8 +30095,8 @@
         "type": "struct",
         "value": "git_diff_options",
         "file": "diff.h",
-        "line": 402,
-        "lineto": 422,
+        "line": 408,
+        "lineto": 428,
         "block": "unsigned int version\nuint32_t flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nuint32_t context_lines\nuint32_t interhunk_lines\nuint16_t id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
         "tdef": "typedef",
         "description": " Structure describing options about how the diff should be executed.",
@@ -28988,6 +30190,37 @@
       }
     ],
     [
+      "git_diff_patchid_options",
+      {
+        "decl": [
+          "unsigned int version"
+        ],
+        "type": "struct",
+        "value": "git_diff_patchid_options",
+        "file": "diff.h",
+        "line": 1415,
+        "lineto": 1417,
+        "block": "unsigned int version",
+        "tdef": "typedef",
+        "description": " Patch ID options structure",
+        "comments": "<p>Initialize with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code> macro to correctly set the default values and version.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_diff_patchid",
+            "git_diff_patchid_init_options"
+          ]
+        }
+      }
+    ],
+    [
       "git_diff_perfdata",
       {
         "decl": [
@@ -29043,8 +30276,8 @@
         "type": "struct",
         "value": "git_diff_similarity_metric",
         "file": "diff.h",
-        "line": 665,
-        "lineto": 675,
+        "line": 671,
+        "lineto": 681,
         "block": "int (*)(void **, const git_diff_file *, const char *, void *) file_signature\nint (*)(void **, const git_diff_file *, const char *, size_t, void *) buffer_signature\nvoid (*)(void *, void *) free_signature\nint (*)(int *, void *, void *, void *) similarity\nvoid * payload",
         "tdef": "typedef",
         "description": " Pluggable similarity metric",
@@ -29089,8 +30322,8 @@
         "type": "struct",
         "value": "git_diff_stats",
         "file": "diff.h",
-        "line": 1229,
-        "lineto": 1229,
+        "line": 1235,
+        "lineto": 1235,
         "tdef": "typedef",
         "description": " This is an opaque structure which is allocated by `git_diff_get_stats`.\n You are responsible for releasing the object memory when done, using the\n `git_diff_stats_free()` function.",
         "comments": "",
@@ -29119,8 +30352,8 @@
         ],
         "type": "enum",
         "file": "diff.h",
-        "line": 1234,
-        "lineto": 1249,
+        "line": 1240,
+        "lineto": 1255,
         "block": "GIT_DIFF_STATS_NONE\nGIT_DIFF_STATS_FULL\nGIT_DIFF_STATS_SHORT\nGIT_DIFF_STATS_NUMBER\nGIT_DIFF_STATS_INCLUDE_SUMMARY",
         "tdef": "typedef",
         "description": " Formatting options for diff stats",
@@ -29214,8 +30447,8 @@
         "type": "struct",
         "value": "git_error",
         "file": "errors.h",
-        "line": 64,
-        "lineto": 67,
+        "line": 66,
+        "lineto": 69,
         "block": "char * message\nint klass",
         "tdef": "typedef",
         "description": " Structure to store extra details of the last error that occurred.",
@@ -29269,13 +30502,15 @@
           "GIT_EDIRECTORY",
           "GIT_EMERGECONFLICT",
           "GIT_PASSTHROUGH",
-          "GIT_ITEROVER"
+          "GIT_ITEROVER",
+          "GIT_RETRY",
+          "GIT_EMISMATCH"
         ],
         "type": "enum",
         "file": "errors.h",
         "line": 21,
-        "lineto": 56,
-        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER",
+        "lineto": 58,
+        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER\nGIT_RETRY\nGIT_EMISMATCH",
         "tdef": "typedef",
         "description": " Generic return codes ",
         "comments": "",
@@ -29435,6 +30670,18 @@
             "name": "GIT_ITEROVER",
             "comments": "<p>Signals end of iteration with iterator </p>\n",
             "value": -31
+          },
+          {
+            "type": "int",
+            "name": "GIT_RETRY",
+            "comments": "<p>Internal only </p>\n",
+            "value": -32
+          },
+          {
+            "type": "int",
+            "name": "GIT_EMISMATCH",
+            "comments": "<p>Hashsum mismatch in object </p>\n",
+            "value": -33
           }
         ],
         "used": {
@@ -29478,13 +30725,15 @@
           "GITERR_DESCRIBE",
           "GITERR_REBASE",
           "GITERR_FILESYSTEM",
-          "GITERR_PATCH"
+          "GITERR_PATCH",
+          "GITERR_WORKTREE",
+          "GITERR_SHA1"
         ],
         "type": "enum",
         "file": "errors.h",
-        "line": 70,
-        "lineto": 103,
-        "block": "GITERR_NONE\nGITERR_NOMEMORY\nGITERR_OS\nGITERR_INVALID\nGITERR_REFERENCE\nGITERR_ZLIB\nGITERR_REPOSITORY\nGITERR_CONFIG\nGITERR_REGEX\nGITERR_ODB\nGITERR_INDEX\nGITERR_OBJECT\nGITERR_NET\nGITERR_TAG\nGITERR_TREE\nGITERR_INDEXER\nGITERR_SSL\nGITERR_SUBMODULE\nGITERR_THREAD\nGITERR_STASH\nGITERR_CHECKOUT\nGITERR_FETCHHEAD\nGITERR_MERGE\nGITERR_SSH\nGITERR_FILTER\nGITERR_REVERT\nGITERR_CALLBACK\nGITERR_CHERRYPICK\nGITERR_DESCRIBE\nGITERR_REBASE\nGITERR_FILESYSTEM\nGITERR_PATCH",
+        "line": 72,
+        "lineto": 107,
+        "block": "GITERR_NONE\nGITERR_NOMEMORY\nGITERR_OS\nGITERR_INVALID\nGITERR_REFERENCE\nGITERR_ZLIB\nGITERR_REPOSITORY\nGITERR_CONFIG\nGITERR_REGEX\nGITERR_ODB\nGITERR_INDEX\nGITERR_OBJECT\nGITERR_NET\nGITERR_TAG\nGITERR_TREE\nGITERR_INDEXER\nGITERR_SSL\nGITERR_SUBMODULE\nGITERR_THREAD\nGITERR_STASH\nGITERR_CHECKOUT\nGITERR_FETCHHEAD\nGITERR_MERGE\nGITERR_SSH\nGITERR_FILTER\nGITERR_REVERT\nGITERR_CALLBACK\nGITERR_CHERRYPICK\nGITERR_DESCRIBE\nGITERR_REBASE\nGITERR_FILESYSTEM\nGITERR_PATCH\nGITERR_WORKTREE\nGITERR_SHA1",
         "tdef": "typedef",
         "description": " Error classes ",
         "comments": "",
@@ -29680,6 +30929,18 @@
             "name": "GITERR_PATCH",
             "comments": "",
             "value": 31
+          },
+          {
+            "type": "int",
+            "name": "GITERR_WORKTREE",
+            "comments": "",
+            "value": 32
+          },
+          {
+            "type": "int",
+            "name": "GITERR_SHA1",
+            "comments": "",
+            "value": 33
           }
         ],
         "used": {
@@ -29752,8 +31013,8 @@
         "type": "struct",
         "value": "git_fetch_options",
         "file": "remote.h",
-        "line": 525,
-        "lineto": 562,
+        "line": 555,
+        "lineto": 592,
         "block": "int version\ngit_remote_callbacks callbacks\ngit_fetch_prune_t prune\nint update_fetchhead\ngit_remote_autotag_option_t download_tags\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Fetch options structure.",
@@ -29818,8 +31079,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 205,
-        "lineto": 212,
+        "line": 209,
+        "lineto": 216,
         "block": "GIT_FILEMODE_UNREADABLE\nGIT_FILEMODE_TREE\nGIT_FILEMODE_BLOB\nGIT_FILEMODE_BLOB_EXECUTABLE\nGIT_FILEMODE_LINK\nGIT_FILEMODE_COMMIT",
         "tdef": "typedef",
         "description": " Valid modes for index and tree entries. ",
@@ -29946,6 +31207,7 @@
             "git_filter_apply_fn",
             "git_filter_check_fn",
             "git_filter_cleanup_fn",
+            "git_filter_init",
             "git_filter_init_fn",
             "git_filter_list_apply_to_blob",
             "git_filter_list_apply_to_data",
@@ -30319,8 +31581,8 @@
         "type": "struct",
         "value": "git_index",
         "file": "types.h",
-        "line": 132,
-        "lineto": 132,
+        "line": 135,
+        "lineto": 135,
         "tdef": "typedef",
         "description": " Memory representation of an index file. ",
         "comments": "",
@@ -30448,8 +31710,8 @@
         "type": "struct",
         "value": "git_index_conflict_iterator",
         "file": "types.h",
-        "line": 135,
-        "lineto": 135,
+        "line": 138,
+        "lineto": 138,
         "tdef": "typedef",
         "description": " An iterator for conflicts in the index. ",
         "comments": "",
@@ -30708,13 +31970,18 @@
           "GIT_OPT_ENABLE_STRICT_OBJECT_CREATION",
           "GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION",
           "GIT_OPT_SET_SSL_CIPHERS",
-          "GIT_OPT_GET_USER_AGENT"
+          "GIT_OPT_GET_USER_AGENT",
+          "GIT_OPT_ENABLE_OFS_DELTA",
+          "GIT_OPT_ENABLE_FSYNC_GITDIR",
+          "GIT_OPT_GET_WINDOWS_SHAREMODE",
+          "GIT_OPT_SET_WINDOWS_SHAREMODE",
+          "GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION"
         ],
         "type": "enum",
         "file": "common.h",
         "line": 162,
-        "lineto": 181,
-        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT",
+        "lineto": 186,
+        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION",
         "tdef": "typedef",
         "description": " Global library options",
         "comments": "<p>These are used to select which global option to set or get and are used in <code>git_libgit2_opts()</code>.</p>\n",
@@ -30826,6 +32093,36 @@
             "name": "GIT_OPT_GET_USER_AGENT",
             "comments": "",
             "value": 17
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_ENABLE_OFS_DELTA",
+            "comments": "",
+            "value": 18
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_ENABLE_FSYNC_GITDIR",
+            "comments": "",
+            "value": 19
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_GET_WINDOWS_SHAREMODE",
+            "comments": "",
+            "value": 20
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_SET_WINDOWS_SHAREMODE",
+            "comments": "",
+            "value": 21
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION",
+            "comments": "",
+            "value": 22
           }
         ],
         "used": {
@@ -30846,8 +32143,8 @@
         ],
         "type": "enum",
         "file": "merge.h",
-        "line": 312,
-        "lineto": 341,
+        "line": 318,
+        "lineto": 347,
         "block": "GIT_MERGE_ANALYSIS_NONE\nGIT_MERGE_ANALYSIS_NORMAL\nGIT_MERGE_ANALYSIS_UP_TO_DATE\nGIT_MERGE_ANALYSIS_FASTFORWARD\nGIT_MERGE_ANALYSIS_UNBORN",
         "tdef": "typedef",
         "description": " The results of `git_merge_analysis` indicate the merge opportunities.",
@@ -31157,14 +32454,15 @@
           "const char * our_label",
           "const char * their_label",
           "git_merge_file_favor_t favor",
-          "git_merge_file_flag_t flags"
+          "git_merge_file_flag_t flags",
+          "unsigned short marker_size"
         ],
         "type": "struct",
         "value": "git_merge_file_options",
         "file": "merge.h",
-        "line": 168,
-        "lineto": 194,
-        "block": "unsigned int version\nconst char * ancestor_label\nconst char * our_label\nconst char * their_label\ngit_merge_file_favor_t favor\ngit_merge_file_flag_t flags",
+        "line": 170,
+        "lineto": 200,
+        "block": "unsigned int version\nconst char * ancestor_label\nconst char * our_label\nconst char * their_label\ngit_merge_file_favor_t favor\ngit_merge_file_flag_t flags\nunsigned short marker_size",
         "tdef": "typedef",
         "description": " Options for merging a file",
         "comments": "",
@@ -31198,6 +32496,11 @@
             "type": "git_merge_file_flag_t",
             "name": "flags",
             "comments": " see `git_merge_file_flag_t` above "
+          },
+          {
+            "type": "unsigned short",
+            "name": "marker_size",
+            "comments": " The size of conflict markers (eg, \"\n<\n<\n<\n<\n<\n<\n<\n\").  Default is\n GIT_MERGE_CONFLICT_MARKER_SIZE. "
           }
         ],
         "used": {
@@ -31223,8 +32526,8 @@
         "type": "struct",
         "value": "git_merge_file_result",
         "file": "merge.h",
-        "line": 215,
-        "lineto": 236,
+        "line": 221,
+        "lineto": 242,
         "block": "unsigned int automergeable\nconst char * path\nunsigned int mode\nconst char * ptr\nsize_t len",
         "tdef": "typedef",
         "description": " Information about file-level merging",
@@ -31332,8 +32635,8 @@
         "type": "struct",
         "value": "git_merge_options",
         "file": "merge.h",
-        "line": 241,
-        "lineto": 290,
+        "line": 247,
+        "lineto": 296,
         "block": "unsigned int version\ngit_merge_flag_t flags\nunsigned int rename_threshold\nunsigned int target_limit\ngit_diff_similarity_metric * metric\nunsigned int recursion_limit\nconst char * default_driver\ngit_merge_file_favor_t file_favor\ngit_merge_file_flag_t file_flags",
         "tdef": "typedef",
         "description": " Merging options",
@@ -31408,8 +32711,8 @@
         ],
         "type": "enum",
         "file": "merge.h",
-        "line": 346,
-        "lineto": 364,
+        "line": 352,
+        "lineto": 370,
         "block": "GIT_MERGE_PREFERENCE_NONE\nGIT_MERGE_PREFERENCE_NO_FASTFORWARD\nGIT_MERGE_PREFERENCE_FASTFORWARD_ONLY",
         "tdef": "typedef",
         "description": " The user's stated preference for merges.",
@@ -31449,8 +32752,8 @@
         "type": "struct",
         "value": "git_merge_result",
         "file": "types.h",
-        "line": 181,
-        "lineto": 181,
+        "line": 185,
+        "lineto": 185,
         "tdef": "typedef",
         "description": " Merge result ",
         "comments": "",
@@ -31461,14 +32764,94 @@
       }
     ],
     [
+      "git_message_trailer",
+      {
+        "decl": [
+          "const char * key",
+          "const char * value"
+        ],
+        "type": "struct",
+        "value": "git_message_trailer",
+        "file": "message.h",
+        "line": 43,
+        "lineto": 46,
+        "block": "const char * key\nconst char * value",
+        "tdef": "typedef",
+        "description": " Represents a single git message trailer.",
+        "comments": "",
+        "fields": [
+          {
+            "type": "const char *",
+            "name": "key",
+            "comments": ""
+          },
+          {
+            "type": "const char *",
+            "name": "value",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_message_trailer_array_free",
+            "git_message_trailers"
+          ]
+        }
+      }
+    ],
+    [
+      "git_message_trailer_array",
+      {
+        "decl": [
+          "git_message_trailer * trailers",
+          "size_t count",
+          "char * _trailer_block"
+        ],
+        "type": "struct",
+        "value": "git_message_trailer_array",
+        "file": "message.h",
+        "line": 54,
+        "lineto": 60,
+        "block": "git_message_trailer * trailers\nsize_t count\nchar * _trailer_block",
+        "tdef": "typedef",
+        "description": " Represents an array of git message trailers.",
+        "comments": "<p>Struct members under the private comment are private, subject to change and should not be used by callers.</p>\n",
+        "fields": [
+          {
+            "type": "git_message_trailer *",
+            "name": "trailers",
+            "comments": ""
+          },
+          {
+            "type": "size_t",
+            "name": "count",
+            "comments": ""
+          },
+          {
+            "type": "char *",
+            "name": "_trailer_block",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_message_trailer_array_free",
+            "git_message_trailers"
+          ]
+        }
+      }
+    ],
+    [
       "git_note",
       {
         "decl": "git_note",
         "type": "struct",
         "value": "git_note",
         "file": "types.h",
-        "line": 150,
-        "lineto": 150,
+        "line": 153,
+        "lineto": 153,
         "tdef": "typedef",
         "description": " Representation of a git note ",
         "comments": "",
@@ -31476,6 +32859,8 @@
           "returns": [],
           "needs": [
             "git_note_author",
+            "git_note_commit_iterator_new",
+            "git_note_commit_read",
             "git_note_committer",
             "git_note_foreach",
             "git_note_free",
@@ -31504,6 +32889,7 @@
         "used": {
           "returns": [],
           "needs": [
+            "git_note_commit_iterator_new",
             "git_note_iterator_free",
             "git_note_iterator_new",
             "git_note_next"
@@ -31518,8 +32904,8 @@
         "type": "struct",
         "value": "git_object",
         "file": "types.h",
-        "line": 108,
-        "lineto": 108,
+        "line": 111,
+        "lineto": 111,
         "tdef": "typedef",
         "description": " Representation of a generic object in a repository ",
         "comments": "",
@@ -31569,6 +32955,7 @@
           "returns": [],
           "needs": [
             "git_indexer_new",
+            "git_mempack_dump",
             "git_mempack_new",
             "git_mempack_reset",
             "git_odb_add_alternate",
@@ -31621,7 +33008,7 @@
         "file": "types.h",
         "line": 84,
         "lineto": 84,
-        "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_otype *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_otype *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_otype *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_otype) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_otype) writestream\nint (*)(git_odb_stream **, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
+        "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_otype *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_otype *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_otype *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_otype) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_otype) writestream\nint (*)(git_odb_stream **, size_t *, git_otype *, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
         "tdef": "typedef",
         "description": " A custom backend in an ODB ",
         "comments": "",
@@ -31662,7 +33049,7 @@
             "comments": ""
           },
           {
-            "type": "int (*)(git_odb_stream **, git_odb_backend *, const git_oid *)",
+            "type": "int (*)(git_odb_stream **, size_t *, git_otype *, git_odb_backend *, const git_oid *)",
             "name": "readstream",
             "comments": ""
           },
@@ -31705,6 +33092,7 @@
         "used": {
           "returns": [],
           "needs": [
+            "git_mempack_dump",
             "git_mempack_new",
             "git_mempack_reset",
             "git_odb_add_alternate",
@@ -32012,6 +33400,7 @@
             "git_commit_extract_signature",
             "git_commit_lookup",
             "git_commit_lookup_prefix",
+            "git_diff_patchid",
             "git_graph_ahead_behind",
             "git_graph_descendant_of",
             "git_index_write_tree",
@@ -32021,6 +33410,9 @@
             "git_merge_base_octopus",
             "git_merge_bases",
             "git_merge_bases_many",
+            "git_note_commit_create",
+            "git_note_commit_read",
+            "git_note_commit_remove",
             "git_note_create",
             "git_note_foreach_cb",
             "git_note_next",
@@ -32256,6 +33648,7 @@
             "git_object_typeisloose",
             "git_odb_hash",
             "git_odb_hashfile",
+            "git_odb_open_rstream",
             "git_odb_open_wstream",
             "git_odb_read_header",
             "git_odb_write",
@@ -32272,8 +33665,8 @@
         "type": "struct",
         "value": "git_packbuilder",
         "file": "types.h",
-        "line": 153,
-        "lineto": 153,
+        "line": 156,
+        "lineto": 156,
         "tdef": "typedef",
         "description": " Representation of a git packbuilder ",
         "comments": "",
@@ -32412,12 +33805,12 @@
         ],
         "type": "enum",
         "file": "pathspec.h",
-        "line": 48,
-        "lineto": 56,
+        "line": 30,
+        "lineto": 73,
         "block": "GIT_PATHSPEC_DEFAULT\nGIT_PATHSPEC_IGNORE_CASE\nGIT_PATHSPEC_USE_CASE\nGIT_PATHSPEC_NO_GLOB\nGIT_PATHSPEC_NO_MATCH_ERROR\nGIT_PATHSPEC_FIND_FAILURES\nGIT_PATHSPEC_FAILURES_ONLY",
         "tdef": "typedef",
         "description": " Options controlling how pathspec match should be executed",
-        "comments": "<ul>\n<li>GIT_PATHSPEC_IGNORE_CASE forces match to ignore case; otherwise   match will use native case sensitivity of platform filesystem - GIT_PATHSPEC_USE_CASE forces case sensitive match; otherwise   match will use native case sensitivity of platform filesystem - GIT_PATHSPEC_NO_GLOB disables glob patterns and just uses simple   string comparison for matching - GIT_PATHSPEC_NO_MATCH_ERROR means the match functions return error   code GIT_ENOTFOUND if no matches are found; otherwise no matches is   still success (return 0) but <code>git_pathspec_match_list_entrycount</code>   will indicate 0 matches. - GIT_PATHSPEC_FIND_FAILURES means that the <code>git_pathspec_match_list</code>   should track which patterns matched which files so that at the end of   the match we can identify patterns that did not match any files. - GIT_PATHSPEC_FAILURES_ONLY means that the <code>git_pathspec_match_list</code>   does not need to keep the actual matching filenames.  Use this to   just test if there were any matches at all or in combination with   GIT_PATHSPEC_FIND_FAILURES to validate a pathspec.</li>\n</ul>\n",
+        "comments": "",
         "fields": [
           {
             "type": "int",
@@ -32428,37 +33821,37 @@
           {
             "type": "int",
             "name": "GIT_PATHSPEC_IGNORE_CASE",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_IGNORE_CASE forces match to ignore case; otherwise\n match will use native case sensitivity of platform filesystem</p>\n",
             "value": 1
           },
           {
             "type": "int",
             "name": "GIT_PATHSPEC_USE_CASE",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_USE_CASE forces case sensitive match; otherwise\n match will use native case sensitivity of platform filesystem</p>\n",
             "value": 2
           },
           {
             "type": "int",
             "name": "GIT_PATHSPEC_NO_GLOB",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_NO_GLOB disables glob patterns and just uses simple\n string comparison for matching</p>\n",
             "value": 4
           },
           {
             "type": "int",
             "name": "GIT_PATHSPEC_NO_MATCH_ERROR",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_NO_MATCH_ERROR means the match functions return error\n code GIT_ENOTFOUND if no matches are found; otherwise no matches is\n still success (return 0) but <code>git_pathspec_match_list_entrycount</code>\n will indicate 0 matches.</p>\n",
             "value": 8
           },
           {
             "type": "int",
             "name": "GIT_PATHSPEC_FIND_FAILURES",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_FIND_FAILURES means that the <code>git_pathspec_match_list</code>\n should track which patterns matched which files so that at the end of\n the match we can identify patterns that did not match any files.</p>\n",
             "value": 16
           },
           {
             "type": "int",
             "name": "GIT_PATHSPEC_FAILURES_ONLY",
-            "comments": "",
+            "comments": "<p>GIT_PATHSPEC_FAILURES_ONLY means that the <code>git_pathspec_match_list</code>\n does not need to keep the actual matching filenames.  Use this to\n just test if there were any matches at all or in combination with\n GIT_PATHSPEC_FIND_FAILURES to validate a pathspec.</p>\n",
             "value": 32
           }
         ],
@@ -32553,7 +33946,8 @@
           "returns": [],
           "needs": [
             "git_proxy_init_options",
-            "git_remote_connect"
+            "git_remote_connect",
+            "git_transport_smart_proxy_options"
           ]
         }
       }
@@ -32607,8 +34001,8 @@
         "type": "struct",
         "value": "git_push",
         "file": "types.h",
-        "line": 236,
-        "lineto": 236,
+        "line": 240,
+        "lineto": 240,
         "tdef": "typedef",
         "description": " Preparation for a push operation. Can be used to configure what to\n push and the level of parallelism of the packfile builder.",
         "comments": "",
@@ -32636,8 +34030,8 @@
         "type": "struct",
         "value": "git_push_options",
         "file": "remote.h",
-        "line": 585,
-        "lineto": 612,
+        "line": 615,
+        "lineto": 642,
         "block": "unsigned int version\nunsigned int pb_parallelism\ngit_remote_callbacks callbacks\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Controls the behavior of a git_push object.",
@@ -32691,8 +34085,8 @@
         "type": "struct",
         "value": "git_push_update",
         "file": "remote.h",
-        "line": 341,
-        "lineto": 358,
+        "line": 359,
+        "lineto": 376,
         "block": "char * src_refname\nchar * dst_refname\ngit_oid src\ngit_oid dst",
         "tdef": "typedef",
         "description": " Represents an update which will be performed on the remote during push",
@@ -32734,8 +34128,8 @@
         "type": "struct",
         "value": "git_rebase",
         "file": "types.h",
-        "line": 187,
-        "lineto": 187,
+        "line": 191,
+        "lineto": 191,
         "tdef": "typedef",
         "description": " Representation of a rebase ",
         "comments": "",
@@ -32878,8 +34272,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 190,
-        "lineto": 195,
+        "line": 194,
+        "lineto": 199,
         "block": "GIT_REF_INVALID\nGIT_REF_OID\nGIT_REF_SYMBOLIC\nGIT_REF_LISTALL",
         "tdef": "typedef",
         "description": " Basic type of any Git reference. ",
@@ -33063,8 +34457,8 @@
         "type": "struct",
         "value": "git_reference",
         "file": "types.h",
-        "line": 169,
-        "lineto": 169,
+        "line": 173,
+        "lineto": 173,
         "tdef": "typedef",
         "description": " In-memory representation of a reference. ",
         "comments": "",
@@ -33078,6 +34472,7 @@
             "git_branch_create",
             "git_branch_create_from_annotated",
             "git_branch_delete",
+            "git_branch_is_checked_out",
             "git_branch_is_head",
             "git_branch_lookup",
             "git_branch_move",
@@ -33120,6 +34515,7 @@
             "git_reference_target_peel",
             "git_reference_type",
             "git_repository_head",
+            "git_repository_head_for_worktree",
             "git_revparse_ext"
           ]
         }
@@ -33132,8 +34528,8 @@
         "type": "struct",
         "value": "git_reference_iterator",
         "file": "types.h",
-        "line": 172,
-        "lineto": 172,
+        "line": 176,
+        "lineto": 176,
         "block": "git_refdb * db\nint (*)(git_reference **, git_reference_iterator *) next\nint (*)(const char **, git_reference_iterator *) next_name\nvoid (*)(git_reference_iterator *) free",
         "tdef": "typedef",
         "description": " Iterator for references ",
@@ -33183,8 +34579,8 @@
         ],
         "type": "enum",
         "file": "refs.h",
-        "line": 636,
-        "lineto": 665,
+        "line": 639,
+        "lineto": 668,
         "block": "GIT_REF_FORMAT_NORMAL\nGIT_REF_FORMAT_ALLOW_ONELEVEL\nGIT_REF_FORMAT_REFSPEC_PATTERN\nGIT_REF_FORMAT_REFSPEC_SHORTHAND",
         "tdef": "typedef",
         "description": " Normalization options for reference lookup",
@@ -33228,8 +34624,8 @@
         "type": "struct",
         "value": "git_reflog",
         "file": "types.h",
-        "line": 147,
-        "lineto": 147,
+        "line": 150,
+        "lineto": 150,
         "tdef": "typedef",
         "description": " Representation of a reference log ",
         "comments": "",
@@ -33260,8 +34656,8 @@
         "type": "struct",
         "value": "git_reflog_entry",
         "file": "types.h",
-        "line": 144,
-        "lineto": 144,
+        "line": 147,
+        "lineto": 147,
         "tdef": "typedef",
         "description": " Representation of a reference log entry ",
         "comments": "",
@@ -33285,8 +34681,8 @@
         "type": "struct",
         "value": "git_remote",
         "file": "types.h",
-        "line": 224,
-        "lineto": 224,
+        "line": 228,
+        "lineto": 228,
         "tdef": "typedef",
         "description": " Git's idea of a remote repository. A remote can be anonymous (in\n which case it does not have backing configuration entires).",
         "comments": "",
@@ -33302,6 +34698,7 @@
             "git_remote_create",
             "git_remote_create_anonymous",
             "git_remote_create_cb",
+            "git_remote_create_detached",
             "git_remote_create_with_fetchspec",
             "git_remote_default_branch",
             "git_remote_disconnect",
@@ -33349,8 +34746,8 @@
         ],
         "type": "enum",
         "file": "remote.h",
-        "line": 497,
-        "lineto": 515,
+        "line": 527,
+        "lineto": 545,
         "block": "GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED\nGIT_REMOTE_DOWNLOAD_TAGS_AUTO\nGIT_REMOTE_DOWNLOAD_TAGS_NONE\nGIT_REMOTE_DOWNLOAD_TAGS_ALL",
         "tdef": "typedef",
         "description": " Automatic tag following option",
@@ -33405,7 +34802,7 @@
           "int (*)(const char *, const git_oid *, const git_oid *, void *) update_tips",
           "git_packbuilder_progress pack_progress",
           "git_push_transfer_progress push_transfer_progress",
-          "int (*)(const char *, const char *, void *) push_update_reference",
+          "git_push_update_reference_cb push_update_reference",
           "git_push_negotiation push_negotiation",
           "git_transport_cb transport",
           "void * payload"
@@ -33413,9 +34810,9 @@
         "type": "struct",
         "value": "git_remote_callbacks",
         "file": "remote.h",
-        "line": 376,
-        "lineto": 460,
-        "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_type, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_transfer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress push_transfer_progress\nint (*)(const char *, const char *, void *) push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload",
+        "line": 408,
+        "lineto": 490,
+        "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_type, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_transfer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress push_transfer_progress\ngit_push_update_reference_cb push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload",
         "tdef": null,
         "description": " The callback settings structure",
         "comments": "<p>Set the callbacks to be called by the remote when informing the user about the progress of the network operations.</p>\n",
@@ -33466,9 +34863,9 @@
             "comments": " Function to call with progress information during the\n upload portion of a push. Be aware that this is called\n inline with pack building operations, so performance may be\n affected."
           },
           {
-            "type": "int (*)(const char *, const char *, void *)",
+            "type": "git_push_update_reference_cb",
             "name": "push_update_reference",
-            "comments": " Called for each updated reference on push. If `status` is\n not `NULL`, the update was rejected by the remote server\n and `status` contains the reason given."
+            "comments": " See documentation of git_push_update_reference_cb"
           },
           {
             "type": "git_push_negotiation",
@@ -33507,8 +34904,8 @@
         ],
         "type": "enum",
         "file": "remote.h",
-        "line": 326,
-        "lineto": 330,
+        "line": 344,
+        "lineto": 348,
         "block": "GIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR\nGIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR",
         "tdef": "typedef",
         "description": " Argument to the completion callback which tells it which operation\n finished.",
@@ -33656,6 +35053,8 @@
             "git_commit_extract_signature",
             "git_commit_lookup",
             "git_commit_lookup_prefix",
+            "git_config_add_backend",
+            "git_config_add_file_ondisk",
             "git_describe_workdir",
             "git_diff_commit_as_email",
             "git_diff_index_to_index",
@@ -33674,6 +35073,7 @@
             "git_ignore_clear_internal_rules",
             "git_ignore_path_is_ignored",
             "git_index_write_tree_to",
+            "git_mempack_dump",
             "git_merge",
             "git_merge_analysis",
             "git_merge_base",
@@ -33684,6 +35084,9 @@
             "git_merge_commits",
             "git_merge_file_from_index",
             "git_merge_trees",
+            "git_note_commit_create",
+            "git_note_commit_read",
+            "git_note_commit_remove",
             "git_note_create",
             "git_note_foreach",
             "git_note_iterator_new",
@@ -33731,6 +35134,7 @@
             "git_remote_set_pushurl",
             "git_remote_set_url",
             "git_repository__cleanup",
+            "git_repository_commondir",
             "git_repository_config",
             "git_repository_config_snapshot",
             "git_repository_create_cb",
@@ -33741,6 +35145,7 @@
             "git_repository_hashfile",
             "git_repository_head",
             "git_repository_head_detached",
+            "git_repository_head_for_worktree",
             "git_repository_head_unborn",
             "git_repository_ident",
             "git_repository_index",
@@ -33750,6 +35155,8 @@
             "git_repository_is_bare",
             "git_repository_is_empty",
             "git_repository_is_shallow",
+            "git_repository_is_worktree",
+            "git_repository_item_path",
             "git_repository_mergehead_foreach",
             "git_repository_message",
             "git_repository_message_remove",
@@ -33758,6 +35165,7 @@
             "git_repository_open",
             "git_repository_open_bare",
             "git_repository_open_ext",
+            "git_repository_open_from_worktree",
             "git_repository_path",
             "git_repository_refdb",
             "git_repository_reinit_filesystem",
@@ -33823,7 +35231,11 @@
             "git_tree_entry_to_object",
             "git_tree_lookup",
             "git_tree_lookup_prefix",
-            "git_treebuilder_new"
+            "git_treebuilder_new",
+            "git_worktree_add",
+            "git_worktree_list",
+            "git_worktree_lookup",
+            "git_worktree_open_from_repository"
           ]
         }
       }
@@ -33842,8 +35254,8 @@
         ],
         "type": "enum",
         "file": "repository.h",
-        "line": 221,
-        "lineto": 229,
+        "line": 232,
+        "lineto": 240,
         "block": "GIT_REPOSITORY_INIT_BARE\nGIT_REPOSITORY_INIT_NO_REINIT\nGIT_REPOSITORY_INIT_NO_DOTGIT_DIR\nGIT_REPOSITORY_INIT_MKDIR\nGIT_REPOSITORY_INIT_MKPATH\nGIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE\nGIT_REPOSITORY_INIT_RELATIVE_GITLINK",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_init_ext`.",
@@ -33908,8 +35320,8 @@
         ],
         "type": "enum",
         "file": "repository.h",
-        "line": 244,
-        "lineto": 248,
+        "line": 255,
+        "lineto": 259,
         "block": "GIT_REPOSITORY_INIT_SHARED_UMASK\nGIT_REPOSITORY_INIT_SHARED_GROUP\nGIT_REPOSITORY_INIT_SHARED_ALL",
         "tdef": "typedef",
         "description": " Mode options for `git_repository_init_ext`.",
@@ -33956,8 +35368,8 @@
         "type": "struct",
         "value": "git_repository_init_options",
         "file": "repository.h",
-        "line": 278,
-        "lineto": 287,
+        "line": 289,
+        "lineto": 298,
         "block": "unsigned int version\nuint32_t flags\nuint32_t mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
         "tdef": "typedef",
         "description": " Extended options structure for `git_repository_init_ext`.",
@@ -34014,6 +35426,127 @@
       }
     ],
     [
+      "git_repository_item_t",
+      {
+        "decl": [
+          "GIT_REPOSITORY_ITEM_GITDIR",
+          "GIT_REPOSITORY_ITEM_WORKDIR",
+          "GIT_REPOSITORY_ITEM_COMMONDIR",
+          "GIT_REPOSITORY_ITEM_INDEX",
+          "GIT_REPOSITORY_ITEM_OBJECTS",
+          "GIT_REPOSITORY_ITEM_REFS",
+          "GIT_REPOSITORY_ITEM_PACKED_REFS",
+          "GIT_REPOSITORY_ITEM_REMOTES",
+          "GIT_REPOSITORY_ITEM_CONFIG",
+          "GIT_REPOSITORY_ITEM_INFO",
+          "GIT_REPOSITORY_ITEM_HOOKS",
+          "GIT_REPOSITORY_ITEM_LOGS",
+          "GIT_REPOSITORY_ITEM_MODULES",
+          "GIT_REPOSITORY_ITEM_WORKTREES"
+        ],
+        "type": "enum",
+        "file": "repository.h",
+        "line": 412,
+        "lineto": 427,
+        "block": "GIT_REPOSITORY_ITEM_GITDIR\nGIT_REPOSITORY_ITEM_WORKDIR\nGIT_REPOSITORY_ITEM_COMMONDIR\nGIT_REPOSITORY_ITEM_INDEX\nGIT_REPOSITORY_ITEM_OBJECTS\nGIT_REPOSITORY_ITEM_REFS\nGIT_REPOSITORY_ITEM_PACKED_REFS\nGIT_REPOSITORY_ITEM_REMOTES\nGIT_REPOSITORY_ITEM_CONFIG\nGIT_REPOSITORY_ITEM_INFO\nGIT_REPOSITORY_ITEM_HOOKS\nGIT_REPOSITORY_ITEM_LOGS\nGIT_REPOSITORY_ITEM_MODULES\nGIT_REPOSITORY_ITEM_WORKTREES",
+        "tdef": "typedef",
+        "description": " List of items which belong to the git repository layout",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_GITDIR",
+            "comments": "",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_WORKDIR",
+            "comments": "",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_COMMONDIR",
+            "comments": "",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_INDEX",
+            "comments": "",
+            "value": 3
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_OBJECTS",
+            "comments": "",
+            "value": 4
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_REFS",
+            "comments": "",
+            "value": 5
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_PACKED_REFS",
+            "comments": "",
+            "value": 6
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_REMOTES",
+            "comments": "",
+            "value": 7
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_CONFIG",
+            "comments": "",
+            "value": 8
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_INFO",
+            "comments": "",
+            "value": 9
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_HOOKS",
+            "comments": "",
+            "value": 10
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_LOGS",
+            "comments": "",
+            "value": 11
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_MODULES",
+            "comments": "",
+            "value": 12
+          },
+          {
+            "type": "int",
+            "name": "GIT_REPOSITORY_ITEM_WORKTREES",
+            "comments": "",
+            "value": 13
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_repository_item_path"
+          ]
+        }
+      }
+    ],
+    [
       "git_repository_open_flag_t",
       {
         "decl": [
@@ -34025,8 +35558,8 @@
         ],
         "type": "enum",
         "file": "repository.h",
-        "line": 115,
-        "lineto": 121,
+        "line": 126,
+        "lineto": 132,
         "block": "GIT_REPOSITORY_OPEN_NO_SEARCH\nGIT_REPOSITORY_OPEN_CROSS_FS\nGIT_REPOSITORY_OPEN_BARE\nGIT_REPOSITORY_OPEN_NO_DOTGIT\nGIT_REPOSITORY_OPEN_FROM_ENV",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_open_ext`.",
@@ -34088,8 +35621,8 @@
         ],
         "type": "enum",
         "file": "repository.h",
-        "line": 693,
-        "lineto": 706,
+        "line": 784,
+        "lineto": 797,
         "block": "GIT_REPOSITORY_STATE_NONE\nGIT_REPOSITORY_STATE_MERGE\nGIT_REPOSITORY_STATE_REVERT\nGIT_REPOSITORY_STATE_REVERT_SEQUENCE\nGIT_REPOSITORY_STATE_CHERRYPICK\nGIT_REPOSITORY_STATE_CHERRYPICK_SEQUENCE\nGIT_REPOSITORY_STATE_BISECT\nGIT_REPOSITORY_STATE_REBASE\nGIT_REPOSITORY_STATE_REBASE_INTERACTIVE\nGIT_REPOSITORY_STATE_REBASE_MERGE\nGIT_REPOSITORY_STATE_APPLY_MAILBOX\nGIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE",
         "tdef": "typedef",
         "description": " Repository state",
@@ -34359,8 +35892,8 @@
         "type": "struct",
         "value": "git_revwalk",
         "file": "types.h",
-        "line": 111,
-        "lineto": 111,
+        "line": 114,
+        "lineto": 114,
         "tdef": "typedef",
         "description": " Representation of an in-progress walk through the commits in a repo ",
         "comments": "",
@@ -34400,8 +35933,8 @@
         "type": "struct",
         "value": "git_signature",
         "file": "types.h",
-        "line": 162,
-        "lineto": 166,
+        "line": 166,
+        "lineto": 170,
         "block": "char * name\nchar * email\ngit_time when",
         "tdef": "typedef",
         "description": " An action signature (e.g. for committers, taggers, etc) ",
@@ -34439,6 +35972,8 @@
             "git_commit_create_from_callback",
             "git_commit_create_from_ids",
             "git_commit_create_v",
+            "git_note_commit_create",
+            "git_note_commit_remove",
             "git_note_create",
             "git_note_remove",
             "git_rebase_commit",
@@ -34467,8 +36002,8 @@
         "type": "struct",
         "value": "git_smart_subtransport_definition",
         "file": "sys/transport.h",
-        "line": 326,
-        "lineto": 339,
+        "line": 336,
+        "lineto": 349,
         "block": "git_smart_subtransport_cb callback\nunsigned int rpc\nvoid * param",
         "tdef": "typedef",
         "description": " Definition for a \"subtransport\"",
@@ -34636,8 +36171,8 @@
         "type": "struct",
         "value": "git_status_list",
         "file": "types.h",
-        "line": 184,
-        "lineto": 184,
+        "line": 188,
+        "lineto": 188,
         "tdef": "typedef",
         "description": " Representation of a status collection ",
         "comments": "",
@@ -34996,7 +36531,8 @@
             "git_strarray_copy",
             "git_strarray_free",
             "git_tag_list",
-            "git_tag_list_match"
+            "git_tag_list_match",
+            "git_worktree_list"
           ]
         }
       }
@@ -35010,7 +36546,7 @@
           "int proxy_support",
           "int (*)(struct git_stream *) connect",
           "int (*)(git_cert **, struct git_stream *) certificate",
-          "int (*)(struct git_stream *, const int *) set_proxy",
+          "int (*)(struct git_stream *, const git_proxy_options *) set_proxy",
           "ssize_t (*)(struct git_stream *, void *, size_t) read",
           "ssize_t (*)(struct git_stream *, const char *, size_t, int) write",
           "int (*)(struct git_stream *) close",
@@ -35021,7 +36557,7 @@
         "file": "sys/stream.h",
         "line": 29,
         "lineto": 41,
-        "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const int *) set_proxy\nssize_t (*)(struct git_stream *, void *, size_t) read\nssize_t (*)(struct git_stream *, const char *, size_t, int) write\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
+        "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const git_proxy_options *) set_proxy\nssize_t (*)(struct git_stream *, void *, size_t) read\nssize_t (*)(struct git_stream *, const char *, size_t, int) write\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
         "tdef": "typedef",
         "description": " Every stream must have this struct as its first element, so the\n API can talk to it. You'd define your stream as",
         "comments": "<pre><code> struct my_stream {             git_stream parent;             ...     }\n</code></pre>\n\n<p>and fill the functions</p>\n",
@@ -35052,7 +36588,7 @@
             "comments": ""
           },
           {
-            "type": "int (*)(struct git_stream *, const int *)",
+            "type": "int (*)(struct git_stream *, const git_proxy_options *)",
             "name": "set_proxy",
             "comments": ""
           },
@@ -35092,8 +36628,8 @@
         "type": "struct",
         "value": "git_submodule",
         "file": "types.h",
-        "line": 335,
-        "lineto": 335,
+        "line": 339,
+        "lineto": 339,
         "tdef": "typedef",
         "description": " Opaque structure representing a submodule.",
         "comments": "",
@@ -35150,8 +36686,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 399,
-        "lineto": 406,
+        "line": 403,
+        "lineto": 410,
         "block": "GIT_SUBMODULE_IGNORE_UNSPECIFIED\nGIT_SUBMODULE_IGNORE_NONE\nGIT_SUBMODULE_IGNORE_UNTRACKED\nGIT_SUBMODULE_IGNORE_DIRTY\nGIT_SUBMODULE_IGNORE_ALL",
         "tdef": "typedef",
         "description": " Submodule ignore values",
@@ -35209,8 +36745,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 418,
-        "lineto": 422,
+        "line": 422,
+        "lineto": 426,
         "block": "GIT_SUBMODULE_RECURSE_NO\nGIT_SUBMODULE_RECURSE_YES\nGIT_SUBMODULE_RECURSE_ONDEMAND",
         "tdef": "typedef",
         "description": " Options for submodule recurse.",
@@ -35425,8 +36961,8 @@
         ],
         "type": "enum",
         "file": "types.h",
-        "line": 363,
-        "lineto": 370,
+        "line": 367,
+        "lineto": 374,
         "block": "GIT_SUBMODULE_UPDATE_CHECKOUT\nGIT_SUBMODULE_UPDATE_REBASE\nGIT_SUBMODULE_UPDATE_MERGE\nGIT_SUBMODULE_UPDATE_NONE\nGIT_SUBMODULE_UPDATE_DEFAULT",
         "tdef": "typedef",
         "description": " Submodule update values",
@@ -35480,8 +37016,8 @@
         "type": "struct",
         "value": "git_tag",
         "file": "types.h",
-        "line": 114,
-        "lineto": 114,
+        "line": 117,
+        "lineto": 117,
         "tdef": "typedef",
         "description": " Parsed representation of a tag object. ",
         "comments": "",
@@ -35511,14 +37047,15 @@
       {
         "decl": [
           "git_time_t time",
-          "int offset"
+          "int offset",
+          "char sign"
         ],
         "type": "struct",
         "value": "git_time",
         "file": "types.h",
-        "line": 156,
-        "lineto": 159,
-        "block": "git_time_t time\nint offset",
+        "line": 159,
+        "lineto": 163,
+        "block": "git_time_t time\nint offset\nchar sign",
         "tdef": "typedef",
         "description": " Time in a signature ",
         "comments": "",
@@ -35532,6 +37069,11 @@
             "type": "int",
             "name": "offset",
             "comments": " timezone offset, in minutes "
+          },
+          {
+            "type": "char",
+            "name": "sign",
+            "comments": " indicator for questionable '-0000' offsets in signature "
           }
         ],
         "used": {
@@ -35624,8 +37166,8 @@
         "type": "struct",
         "value": "git_transaction",
         "file": "types.h",
-        "line": 175,
-        "lineto": 175,
+        "line": 179,
+        "lineto": 179,
         "tdef": "typedef",
         "description": " Transactional interface to references ",
         "comments": "",
@@ -35652,8 +37194,8 @@
         "type": "struct",
         "value": "git_transfer_progress",
         "file": "types.h",
-        "line": 253,
-        "lineto": 261,
+        "line": 257,
+        "lineto": 265,
         "block": "unsigned int total_objects\nunsigned int indexed_objects\nunsigned int received_objects\nunsigned int local_objects\nunsigned int total_deltas\nunsigned int indexed_deltas\nsize_t received_bytes",
         "tdef": "typedef",
         "description": " This is passed as the first argument to the callback to allow the\n user to see the progress.",
@@ -35717,8 +37259,8 @@
         "type": "struct",
         "value": "git_transport",
         "file": "types.h",
-        "line": 230,
-        "lineto": 230,
+        "line": 234,
+        "lineto": 234,
         "tdef": "typedef",
         "description": " Interface which represents a transport to communicate with a\n remote.",
         "comments": "",
@@ -35733,8 +37275,11 @@
             "git_transport_init",
             "git_transport_local",
             "git_transport_new",
+            "git_transport_register",
             "git_transport_smart",
             "git_transport_smart_certificate_check",
+            "git_transport_smart_credentials",
+            "git_transport_smart_proxy_options",
             "git_transport_ssh_with_paths"
           ]
         }
@@ -35775,8 +37320,8 @@
         "type": "struct",
         "value": "git_tree",
         "file": "types.h",
-        "line": 126,
-        "lineto": 126,
+        "line": 129,
+        "lineto": 129,
         "tdef": "typedef",
         "description": " Representation of a tree object. ",
         "comments": "",
@@ -35845,8 +37390,8 @@
         "type": "struct",
         "value": "git_tree_entry",
         "file": "types.h",
-        "line": 123,
-        "lineto": 123,
+        "line": 126,
+        "lineto": 126,
         "tdef": "typedef",
         "description": " Representation of each one of the entries in a tree object. ",
         "comments": "",
@@ -35887,8 +37432,8 @@
         "type": "struct",
         "value": "git_tree_update",
         "file": "tree.h",
-        "line": 447,
-        "lineto": 456,
+        "line": 448,
+        "lineto": 457,
         "block": "git_tree_update_t action\ngit_oid id\ngit_filemode_t filemode\nconst char * path",
         "tdef": "typedef",
         "description": " An action to perform during the update of a tree",
@@ -35932,8 +37477,8 @@
         ],
         "type": "enum",
         "file": "tree.h",
-        "line": 437,
-        "lineto": 442,
+        "line": 438,
+        "lineto": 443,
         "block": "GIT_TREE_UPDATE_UPSERT\nGIT_TREE_UPDATE_REMOVE",
         "tdef": "typedef",
         "description": " The kind of update to perform",
@@ -35965,8 +37510,8 @@
         "type": "struct",
         "value": "git_treebuilder",
         "file": "types.h",
-        "line": 129,
-        "lineto": 129,
+        "line": 132,
+        "lineto": 132,
         "tdef": "typedef",
         "description": " Constructor for in-memory trees ",
         "comments": "",
@@ -35996,8 +37541,8 @@
         ],
         "type": "enum",
         "file": "tree.h",
-        "line": 397,
-        "lineto": 400,
+        "line": 398,
+        "lineto": 401,
         "block": "GIT_TREEWALK_PRE\nGIT_TREEWALK_POST",
         "tdef": "typedef",
         "description": " Tree traversal modes ",
@@ -36025,14 +37570,88 @@
       }
     ],
     [
+      "git_worktree",
+      {
+        "decl": "git_worktree",
+        "type": "struct",
+        "value": "git_worktree",
+        "file": "types.h",
+        "line": 108,
+        "lineto": 108,
+        "tdef": "typedef",
+        "description": " Representation of a working tree ",
+        "comments": "",
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_repository_open_from_worktree",
+            "git_worktree_add",
+            "git_worktree_add_init_options",
+            "git_worktree_free",
+            "git_worktree_is_locked",
+            "git_worktree_is_prunable",
+            "git_worktree_lock",
+            "git_worktree_lookup",
+            "git_worktree_open_from_repository",
+            "git_worktree_prune",
+            "git_worktree_prune_init_options",
+            "git_worktree_unlock",
+            "git_worktree_validate"
+          ]
+        }
+      }
+    ],
+    [
+      "git_worktree_prune_t",
+      {
+        "decl": [
+          "GIT_WORKTREE_PRUNE_VALID",
+          "GIT_WORKTREE_PRUNE_LOCKED",
+          "GIT_WORKTREE_PRUNE_WORKING_TREE"
+        ],
+        "type": "enum",
+        "file": "worktree.h",
+        "line": 155,
+        "lineto": 162,
+        "block": "GIT_WORKTREE_PRUNE_VALID\nGIT_WORKTREE_PRUNE_LOCKED\nGIT_WORKTREE_PRUNE_WORKING_TREE",
+        "tdef": "typedef",
+        "description": " Flags which can be passed to git_worktree_prune to alter its\n behavior.",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_WORKTREE_PRUNE_VALID",
+            "comments": "",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_WORKTREE_PRUNE_LOCKED",
+            "comments": "",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_WORKTREE_PRUNE_WORKING_TREE",
+            "comments": "",
+            "value": 4
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_writestream",
       {
         "decl": "git_writestream",
         "type": "struct",
         "value": "git_writestream",
         "file": "types.h",
-        "line": 425,
-        "lineto": 425,
+        "line": 429,
+        "lineto": 429,
         "tdef": "typedef",
         "description": " A type to write in a streaming fashion, for example, for filters. ",
         "comments": "",
@@ -36111,6 +37730,7 @@
         "git_branch_create",
         "git_branch_create_from_annotated",
         "git_branch_delete",
+        "git_branch_is_checked_out",
         "git_branch_is_head",
         "git_branch_iterator_free",
         "git_branch_iterator_new",
@@ -36119,7 +37739,6 @@
         "git_branch_name",
         "git_branch_next",
         "git_branch_set_upstream",
-        "git_branch_remote_name",
         "git_branch_upstream"
       ]
     ],
@@ -36292,6 +37911,8 @@
         "git_diff_merge",
         "git_diff_num_deltas",
         "git_diff_num_deltas_of_type",
+        "git_diff_patchid",
+        "git_diff_patchid_init_options",
         "git_diff_print",
         "git_diff_print_callback__to_buf",
         "git_diff_print_callback__to_file_handle",
@@ -36317,6 +37938,7 @@
     [
       "filter",
       [
+        "git_filter_init",
         "git_filter_list_apply_to_blob",
         "git_filter_list_apply_to_data",
         "git_filter_list_apply_to_file",
@@ -36441,6 +38063,7 @@
     [
       "mempack",
       [
+        "git_mempack_dump",
         "git_mempack_new",
         "git_mempack_reset"
       ]
@@ -36468,13 +38091,19 @@
     [
       "message",
       [
-        "git_message_prettify"
+        "git_message_prettify",
+        "git_message_trailer_array_free",
+        "git_message_trailers"
       ]
     ],
     [
       "note",
       [
         "git_note_author",
+        "git_note_commit_create",
+        "git_note_commit_iterator_new",
+        "git_note_commit_read",
+        "git_note_commit_remove",
         "git_note_committer",
         "git_note_create",
         "git_note_foreach",
@@ -36771,6 +38400,7 @@
         "git_remote_connected",
         "git_remote_create",
         "git_remote_create_anonymous",
+        "git_remote_create_detached",
         "git_remote_create_with_fetchspec",
         "git_remote_default_branch",
         "git_remote_delete",
@@ -36809,6 +38439,7 @@
       "repository",
       [
         "git_repository__cleanup",
+        "git_repository_commondir",
         "git_repository_config",
         "git_repository_config_snapshot",
         "git_repository_detach_head",
@@ -36819,6 +38450,7 @@
         "git_repository_hashfile",
         "git_repository_head",
         "git_repository_head_detached",
+        "git_repository_head_for_worktree",
         "git_repository_head_unborn",
         "git_repository_ident",
         "git_repository_index",
@@ -36828,6 +38460,8 @@
         "git_repository_is_bare",
         "git_repository_is_empty",
         "git_repository_is_shallow",
+        "git_repository_is_worktree",
+        "git_repository_item_path",
         "git_repository_mergehead_foreach",
         "git_repository_message",
         "git_repository_message_remove",
@@ -36836,6 +38470,7 @@
         "git_repository_open",
         "git_repository_open_bare",
         "git_repository_open_ext",
+        "git_repository_open_from_worktree",
         "git_repository_path",
         "git_repository_refdb",
         "git_repository_reinit_filesystem",
@@ -37043,8 +38678,11 @@
         "git_transport_init",
         "git_transport_local",
         "git_transport_new",
+        "git_transport_register",
         "git_transport_smart",
         "git_transport_smart_certificate_check",
+        "git_transport_smart_credentials",
+        "git_transport_smart_proxy_options",
         "git_transport_ssh_with_paths",
         "git_transport_unregister"
       ]
@@ -37090,6 +38728,24 @@
         "git_treebuilder_write",
         "git_treebuilder_write_with_buffer"
       ]
+    ],
+    [
+      "worktree",
+      [
+        "git_worktree_add",
+        "git_worktree_add_init_options",
+        "git_worktree_free",
+        "git_worktree_is_locked",
+        "git_worktree_is_prunable",
+        "git_worktree_list",
+        "git_worktree_lock",
+        "git_worktree_lookup",
+        "git_worktree_open_from_repository",
+        "git_worktree_prune",
+        "git_worktree_prune_init_options",
+        "git_worktree_unlock",
+        "git_worktree_validate"
+      ]
     ]
   ],
   "examples": [
@@ -37132,6 +38788,10 @@
     [
       "log.c",
       "ex/HEAD/log.html"
+    ],
+    [
+      "merge.c",
+      "ex/HEAD/merge.html"
     ],
     [
       "network/clone.c",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -86,6 +86,30 @@
   },
   "new" : {
     "functions": {
+      "git_branch_remote_name": {
+        "type": "function",
+        "file": "branch.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_buf *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          },
+          {
+            "name": "canonical_branch_name",
+            "type": "const char *"
+          }
+        ],
+        "isAsync": true,
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        },
+        "group": "branch"
+      },
       "git_commit_extract_signature": {
         "args": [
           {
@@ -804,6 +828,61 @@
             ]
           }
         }
+      ],
+      [
+        "git_worktree_add_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "int",
+              "name": "lock"
+            }
+          ]
+        }
+      ],
+      [
+        "git_worktree_prune_t",
+        {
+          "type": "enum",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "git_worktree_prune_valid",
+              "value": 1
+            },
+            {
+              "type": "unsigned int",
+              "name": "git_worktree_prune_locked",
+              "value": 2
+            },
+            {
+              "type": "unsigned int",
+              "name": "git_worktree_prune_working_tree",
+              "value": 4
+            }
+          ]
+        }
+      ],
+      [
+        "git_worktree_prune_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "uint32_t",
+              "name": "flags"
+            }
+          ]
+        }
       ]
     ]
   },
@@ -840,6 +919,11 @@
         "git_merge_head_from_id",
         "git_merge_head_from_ref",
         "git_merge_head_id"
+      ]
+    },
+    "message": {
+      "functions": [
+        "git_message_trailer_array_free"
       ]
     },
     "odb": {
@@ -881,6 +965,9 @@
     }
   },
   "groups": {
+    "branch": [
+      "git_branch_remote_name"
+    ],
     "stash": [
       "git_stash_save"
     ]

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -1,5 +1,6 @@
 const fse = require("fs-extra");
 const walk = require("walk");
+const _ = require('lodash');
 
 const fs = require("fs");
 const path = require("path");
@@ -62,13 +63,7 @@ var util = {
     }).join("");
   },
 
-  camelCase: function(str) {
-    return str.split(/_|\//).map(function(val, index) {
-      return (index >= 1
-        ? val[0].toUpperCase() + val.slice(1)
-        : val[0].toLowerCase() + val.slice(1));
-    }).join("");
-  },
+  camelCase: _.camelCase,
 
   getFilePathsRelativeToDir: function(dir) {
     const files = [];

--- a/generate/templates/manual/commit/extract_signature.cc
+++ b/generate/templates/manual/commit/extract_signature.cc
@@ -115,14 +115,14 @@ void GitCommit::ExtractSignatureWorker::HandleOKCallback()
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
   }
   else if (baton->error)
   {
     Local<v8::Value> argv[1] = {
       Nan::Error(baton->error->message)
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
     {
       free((void *)baton->error->message);
@@ -138,11 +138,11 @@ void GitCommit::ExtractSignatureWorker::HandleOKCallback()
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
   }
   else
   {
-    callback->Call(0, NULL);
+    callback->Call(0, NULL, async_resource);
   }
 
   git_buf_free(&baton->signature);

--- a/generate/templates/manual/patches/convenient_patches.cc
+++ b/generate/templates/manual/patches/convenient_patches.cc
@@ -89,7 +89,7 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
 
     return;
   }
@@ -106,7 +106,7 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
     {
       free((void *)baton->error->message);
@@ -124,7 +124,7 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
 
     return;
   }

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -68,14 +68,14 @@ void GitRemote::ReferenceListWorker::HandleOKCallback()
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
   }
   else if (baton->error)
   {
     Local<v8::Value> argv[1] = {
       Nan::Error(baton->error->message)
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
     {
       free((void *)baton->error->message);
@@ -91,10 +91,10 @@ void GitRemote::ReferenceListWorker::HandleOKCallback()
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
   }
   else
   {
-    callback->Call(0, NULL);
+    callback->Call(0, NULL, async_resource);
   }
 }

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -12,7 +12,7 @@ NAN_METHOD(GitRevwalk::FastWalk)
 
   baton->error_code = GIT_OK;
   baton->error = NULL;
-  baton->max_count = (unsigned int)info[0]->ToNumber()->Value();
+  baton->max_count = Nan::To<unsigned int>(info[0]).FromJust();
   baton->out = new std::vector<git_oid*>;
   baton->out->reserve(baton->max_count);
   baton->walk = Nan::ObjectWrap::Unwrap<GitRevwalk>(info.This())->GetValue();
@@ -82,7 +82,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
   }
   else
   {
@@ -99,7 +99,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
       Local<v8::Value> argv[1] = {
         err
       };
-      callback->Call(1, argv);
+      callback->Call(1, argv, async_resource);
       if (baton->error->message)
       {
         free((void *)baton->error->message);
@@ -139,7 +139,7 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
           Local<v8::Value> argv[1] = {
             checkValue->ToObject()
           };
-          callback->Call(1, argv);
+          callback->Call(1, argv, async_resource);
           callbackFired = true;
           break;
         }
@@ -164,12 +164,12 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
         Local<v8::Value> argv[1] = {
           err
         };
-        callback->Call(1, argv);
+        callback->Call(1, argv, async_resource);
       }
     }
     else
     {
-      callback->Call(0, NULL);
+      callback->Call(0, NULL, async_resource);
     }
   }
 }

--- a/generate/templates/manual/revwalk/file_history_walk.cc
+++ b/generate/templates/manual/revwalk/file_history_walk.cc
@@ -18,7 +18,7 @@ NAN_METHOD(GitRevwalk::FileHistoryWalk)
   baton->error = NULL;
   String::Utf8Value from_js_file_path(info[0]->ToString());
   baton->file_path = strdup(*from_js_file_path);
-  baton->max_count = (unsigned int)info[1]->ToNumber()->Value();
+  baton->max_count = Nan::To<unsigned int>(info[1]).FromJust();
   baton->out = new std::vector< std::pair<git_commit *, std::pair<char *, git_delta_t> > *>;
   baton->out->reserve(baton->max_count);
   baton->walk = Nan::ObjectWrap::Unwrap<GitRevwalk>(info.This())->GetValue();
@@ -282,7 +282,7 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
 
     delete baton->out;
     return;
@@ -300,7 +300,7 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
     {
       free((void *)baton->error->message);
@@ -317,9 +317,9 @@ void GitRevwalk::FileHistoryWalkWorker::HandleOKCallback()
     Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     return;
   }
 
-  callback->Call(0, NULL);
+  callback->Call(0, NULL, async_resource);
 }

--- a/generate/templates/manual/src/convenient_hunk.cc
+++ b/generate/templates/manual/src/convenient_hunk.cc
@@ -135,7 +135,7 @@ void ConvenientHunk::LinesWorker::HandleOKCallback() {
     Nan::Null(),
     result
   };
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }
 
 NAN_METHOD(ConvenientHunk::OldStart) {

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -268,7 +268,7 @@ void ConvenientPatch::HunksWorker::HandleOKCallback() {
     Nan::Null(),
     result
   };
-  callback->Call(2, argv);
+  callback->Call(2, argv, async_resource);
 }
 
 NAN_METHOD(ConvenientPatch::LineStats) {

--- a/generate/templates/manual/src/filter_registry.cc
+++ b/generate/templates/manual/src/filter_registry.cc
@@ -28,7 +28,7 @@ void GitFilterRegistry::InitializeComponent(v8::Local<v8::Object> target) {
 
   Nan::SetMethod(object, "register", GitFilterRegister);
   Nan::SetMethod(object, "unregister", GitFilterUnregister);
-  
+
   Nan::Set(target, Nan::New<String>("FilterRegistry").ToLocalChecked(), object);
   GitFilterRegistry::persistentHandle.Reset(object);
 }
@@ -56,14 +56,14 @@ NAN_METHOD(GitFilterRegistry::GitFilterRegister) {
 
   baton->filter = Nan::ObjectWrap::Unwrap<GitFilter>(info[1]->ToObject())->GetValue();
   String::Utf8Value name(info[0]->ToString());
-  
+
   baton->filter_name = (char *)malloc(name.length() + 1);
   memcpy((void *)baton->filter_name, *name, name.length());
   memset((void *)(((char *)baton->filter_name) + name.length()), 0, 1);
 
   baton->error_code = GIT_OK;
-  baton->filter_priority = (int)info[2]->ToNumber()->Value();
-  
+  baton->filter_priority = Nan::To<int>(info[2]).FromJust();
+
   Nan::New(GitFilterRegistry::persistentHandle)->Set(info[0]->ToString(), info[1]->ToObject());
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[3]));
@@ -97,8 +97,8 @@ void GitFilterRegistry::RegisterWorker::HandleOKCallback() {
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
-  } 
+    callback->Call(2, argv, async_resource);
+  }
   else if (baton->error) {
     v8::Local<v8::Object> err;
     if (baton->error->message) {
@@ -111,7 +111,7 @@ void GitFilterRegistry::RegisterWorker::HandleOKCallback() {
     v8::Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
       free((void *)baton->error->message);
     free((void *)baton->error);
@@ -123,10 +123,10 @@ void GitFilterRegistry::RegisterWorker::HandleOKCallback() {
     v8::Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
   }
   else {
-    callback->Call(0, NULL);
+    callback->Call(0, NULL, async_resource);
   }
   delete baton;
   return;
@@ -183,8 +183,8 @@ void GitFilterRegistry::UnregisterWorker::HandleOKCallback() {
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
-  } 
+    callback->Call(2, argv, async_resource);
+  }
   else if (baton->error) {
     v8::Local<v8::Object> err;
     if (baton->error->message) {
@@ -197,7 +197,7 @@ void GitFilterRegistry::UnregisterWorker::HandleOKCallback() {
     v8::Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
     if (baton->error->message)
       free((void *)baton->error->message);
     free((void *)baton->error);
@@ -209,10 +209,10 @@ void GitFilterRegistry::UnregisterWorker::HandleOKCallback() {
     v8::Local<v8::Value> argv[1] = {
       err
     };
-    callback->Call(1, argv);
+    callback->Call(1, argv, async_resource);
   }
   else {
-    callback->Call(0, NULL);
+    callback->Call(0, NULL, async_resource);
   }
   delete baton;
   return;

--- a/generate/templates/manual/src/promise_completion.cc
+++ b/generate/templates/manual/src/promise_completion.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "../include/promise_completion.h"
 
 Nan::Persistent<v8::Function> PromiseCompletion::newFn;
@@ -19,7 +20,7 @@ bool PromiseCompletion::ForwardIfPromise(v8::Local<v8::Value> result, AsyncBaton
   Nan::HandleScope scope;
 
   // check if the result is a promise
-  if (result->IsObject()) {
+  if (!result.IsEmpty() && result->IsObject()) {
     Nan::MaybeLocal<v8::Value> maybeThenProp = Nan::Get(result->ToObject(), Nan::New("then").ToLocalChecked());
     if (!maybeThenProp.IsEmpty()) {
       v8::Local<v8::Value> thenProp = maybeThenProp.ToLocalChecked();

--- a/generate/templates/manual/src/wrapper.cc
+++ b/generate/templates/manual/src/wrapper.cc
@@ -63,7 +63,7 @@ NAN_METHOD(Wrapper::ToBuffer) {
     return Nan::ThrowError("Number is required.");
   }
 
-  int len = info[0]->ToNumber()->Value();
+  int len = Nan::To<int>(info[0]).FromJust();
 
   Local<Function> bufferConstructor = Local<Function>::Cast(
     Nan::Get(Nan::GetCurrentContext()->Global(), Nan::New("Buffer").ToLocalChecked()).ToLocalChecked());

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -52,7 +52,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
         {%endif%}
       {%endif%}
     {%elsif arg.shouldAlloc %}
-      baton->{{arg.name}} = ({{ arg.cType }})malloc(sizeof({{ arg.cType|replace '*' '' }}));  
+      baton->{{arg.name}} = ({{ arg.cType }})malloc(sizeof({{ arg.cType|replace '*' '' }}));
       {%if arg.cppClassName == "GitBuf" %}
         baton->{{arg.name}}->ptr = NULL;
         baton->{{arg.name}}->size = baton->{{arg.name}}->asize = 0;
@@ -151,7 +151,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       Nan::Null(),
       result
     };
-    callback->Call(2, argv);
+    callback->Call(2, argv, async_resource);
   } else {
     if (baton->error) {
       v8::Local<v8::Object> err;
@@ -165,7 +165,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       v8::Local<v8::Value> argv[1] = {
         err
       };
-      callback->Call(1, argv);
+      callback->Call(1, argv, async_resource);
       if (baton->error->message)
         free((void *)baton->error->message);
       free((void *)baton->error);
@@ -205,7 +205,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
           v8::Local<v8::Value> argv[1] = {
             checkValue->ToObject()
           };
-          callback->Call(1, argv);
+          callback->Call(1, argv, async_resource);
           callbackFired = true;
           break;
         }
@@ -227,10 +227,10 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
         v8::Local<v8::Value> argv[1] = {
           err
         };
-        callback->Call(1, argv);
+        callback->Call(1, argv, async_resource);
       }
     } else {
-      callback->Call(0, NULL);
+      callback->Call(0, NULL, async_resource);
     }
 
     {%each args|argsInfo as arg %}

--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -62,9 +62,9 @@
   {%elsif cppClassName|isV8Value %}
 
     {%if cType|isPointer %}
-  *from_{{ name }} = ({{ cType|unPointer }}) {{ cast }} {%if isEnum %}(int){%endif%} info[{{ jsArg }}]->To{{ cppClassName }}()->Value();
+      *from_{{ name }} = ({{ cType|unPointer }}) {{ cast }} {%if isEnum %}(int){%endif%} info[{{ jsArg }}].As<v8::{{ cppClassName }}>()->Value();
     {%else%}
-  from_{{ name }} = ({{ cType }}) {{ cast }} {%if isEnum %}(int){%endif%} info[{{ jsArg }}]->To{{ cppClassName }}()->Value();
+      from_{{ name }} = ({{ cType }}) {{ cast }} {%if isEnum %}(int){%endif%} info[{{ jsArg }}].As<v8::{{ cppClassName }}>()->Value();
     {%endif%}
   {%elsif cppClassName == 'GitOid'%}
   if (info[{{ jsArg }}]->IsString()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2630,9 +2630,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
-      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw=="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "natives": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "fs-extra": "~0.27.0",
     "lodash": "^4.13.1",
-    "nan": "^2.9.2",
+    "nan": "^2.10.0",
     "node-gyp": "^3.6.2",
     "node-pre-gyp": "~0.6.39",
     "promisify-node": "~0.3.0"

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -24,10 +24,11 @@ describe("Tag", function() {
     assert.equal(tag.targetType(), Obj.TYPE.COMMIT);
     assert.equal(tag.message(), tagMessage);
 
-    var target = tag.target();
-
-    assert.ok(target.isCommit());
-    assert.equal(target.id().toString(), commitPointedTo);
+    return tag.target()
+      .then(function(target) {
+        assert.ok(target.isCommit());
+        assert.equal(target.id().toString(), commitPointedTo);
+      });
   }
 
   beforeEach(function() {
@@ -42,21 +43,21 @@ describe("Tag", function() {
   it("can get a tag from a repo via the tag name", function() {
     return this.repository.getTagByName(tagName)
       .then(function(tag) {
-        testTag(tag);
+        return testTag(tag);
       });
   });
 
   it("can get a tag from a repo via the long tag name", function() {
     return this.repository.getTagByName(tagFullName)
       .then(function(tag) {
-        testTag(tag);
+        return testTag(tag);
       });
   });
 
   it("can get a tag from a repo via the tag's OID as a string", function() {
     return this.repository.getTag(tagOid)
       .then(function(tag) {
-        testTag(tag);
+        return testTag(tag);
       });
   });
 
@@ -65,7 +66,7 @@ describe("Tag", function() {
 
     return this.repository.getTag(oid)
       .then(function(tag) {
-        testTag(tag);
+        return testTag(tag);
       });
   });
 
@@ -87,7 +88,7 @@ describe("Tag", function() {
 
     return repository.createTag(oid, name, tagMessage)
       .then(function(tag) {
-        testTag(tag, name);
+        return testTag(tag, name);
       })
       .then(function() {
         return repository.createTag(oid, name, tagMessage);
@@ -167,8 +168,8 @@ describe("Tag", function() {
         return repository.getTag(oid);
       })
       .then(function(tag) {
-        testTag(tag, name);
         assert(tag.tagger(), signature);
+        return testTag(tag, name);
       })
       .then(function() {
         // overwriting is okay

--- a/test/tests/treebuilder.js
+++ b/test/tests/treebuilder.js
@@ -65,11 +65,13 @@ describe("TreeBuilder", function(){
       .then(function(rootTreeBuilder){
         //new dir builder
         return Git.Treebuilder.create(test.repo, null)
-        .then(function(newTreeBuilder){
-          //insert new dir
+        .then(function(newTreeBuilder) {
+          return newTreeBuilder.write();
+        })
+        .then(function(oid) {
           return rootTreeBuilder.insert(
             "mynewfolder",
-            newTreeBuilder.write(),
+            oid,
             Git.TreeEntry.FILEMODE.TREE
           );
         });

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -74,11 +74,13 @@
         "libgit2/src/config_cache.c",
         "libgit2/src/config_file.c",
         "libgit2/src/config_file.h",
+        "libgit2/src/config_parse.c",
+        "libgit2/src/config_parse.h",
         "libgit2/src/config.c",
         "libgit2/src/config.h",
         "libgit2/src/crlf.c",
-        "libgit2/src/curl_stream.c",
-        "libgit2/src/curl_stream.h",
+        "libgit2/src/streams/curl.c",
+        "libgit2/src/streams/curl.h",
         "libgit2/src/date.c",
         "libgit2/src/delta.c",
         "libgit2/src/delta.h",
@@ -162,12 +164,14 @@
         "libgit2/src/oidarray.h",
         "libgit2/src/oidmap.c",
         "libgit2/src/oidmap.h",
-        "libgit2/src/openssl_stream.c",
-        "libgit2/src/openssl_stream.h",
+        "libgit2/src/streams/openssl.c",
+        "libgit2/src/streams/openssl.h",
         "libgit2/src/pack-objects.c",
         "libgit2/src/pack-objects.h",
         "libgit2/src/pack.c",
         "libgit2/src/pack.h",
+        "libgit2/src/parse.c",
+        "libgit2/src/parse.h",
         "libgit2/src/patch_generate.c",
         "libgit2/src/patch_generate.h",
         "libgit2/src/patch_parse.c",
@@ -213,8 +217,8 @@
         "libgit2/src/sha1_lookup.h",
         "libgit2/src/signature.c",
         "libgit2/src/signature.h",
-        "libgit2/src/socket_stream.c",
-        "libgit2/src/socket_stream.h",
+        "libgit2/src/streams/socket.c",
+        "libgit2/src/streams/socket.h",
         "libgit2/src/sortedcache.c",
         "libgit2/src/sortedcache.h",
         "libgit2/src/stash.c",
@@ -233,6 +237,7 @@
         "libgit2/src/thread-utils.h",
         "libgit2/src/trace.c",
         "libgit2/src/trace.h",
+        "libgit2/src/trailer.c",
         "libgit2/src/transaction.c",
         "libgit2/src/transport.c",
         "libgit2/src/transports/auth.c",
@@ -286,8 +291,8 @@
                 "GIT_USE_STAT_MTIMESPEC"
             ],
             "sources": [
-                "libgit2/src/stransport_stream.c",
-                "libgit2/src/stransport_stream.h"
+                "libgit2/src/streams/stransport.c",
+                "libgit2/src/streams/stransport.h"
             ],
             "link_settings": {
                 "xcode_settings": {
@@ -308,8 +313,8 @@
           ],
           "sources": [
             "libgit2/src/hash/hash_openssl.h",
-            "libgit2/src/tls_stream.c",
-            "libgit2/src/tls_stream.h"
+            "libgit2/src/streams/tls.c",
+            "libgit2/src/streams/tls.h"
           ]
         }],
         ["OS=='linux' or OS.endswith('bsd')" , {


### PR DESCRIPTION
# Functions that are now returning error codes to javascript from libgit2
- `NodeGit.Attr.prototype.get`
- `NodeGit.Blob.createFrombuffer`
- `NodeGit.Blob.createFromworkdir`
- `NodeGit.Reference.list`
- `NodeGit.Remote.prototype.getFetchRefspecs`
- `NodeGit.Remote.prototype.getPushRefspecs`

# Functions that are now async
- `NodeGit.Attr.prototype.getMany`
- `NodeGit.Tag.prototype.target`
- `NodeGit.Treebuilder.prototype.Write`

# WorkTree is now exposed
## Static methods
- `add`
- `list`
- `lookup`
- `openFromRepository`
## Instance methods
- `isLocked`
- `isPrunable`
- `lock`
- `prune`
- `unlock`
- `validate`

# Breaking
Diffs generated from `NodeGit.Diff.treeToIndex` and `NodeGit.Diff.treeToWorkdirWithIndex` conditionally support `NodeGit.Diff.OPTION.IGNORE_CASE`. Only on repositories where the index is case insensitive will the flag be set on the output diff. The flag itself is ignored when passed to DiffOptions.