### PR TITLE
Define error codes to fix compiler warnings about unused variables

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1236,7 +1236,10 @@
               "isReturn": true
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },
@@ -2850,7 +2853,10 @@
               "key": "strings"
             }
           },
-          "isAsync": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_tag_tagger": {
           "return": {


### PR DESCRIPTION
The `result` field for `git_ignore_path_is_ignored` and `git_tag_list_match` isn't being used so the compiler is generating warnings for the unused variable. I have fixed up `descriptor.json` so that they will be used.
```
../src/ignore.cc
:
192
:
7
:

warning
:
unused variable 'result' [-Wunused-variable]

int result = git_ignore_path_is_ignored(

^

CXX(target) Release/obj.target/nodegit/src/index_entry.o
1
warning
generated.
CXX(target) Release/obj.target/nodegit/src/index_time.o
CXX(target) Release/obj.target/nodegit/src/indexer.o
```
```
../src/tag.cc
:
1332
:
7
:

warning
:
unused variable 'result' [-Wunused-variable]

int result = git_tag_list_match(

^

4 warnings generated.
CXX(target) Release/obj.target/nodegit/src/time.o
CXX(target) Release/obj.target/nodegit/src/trace.o
```