### PR TITLE
Fix return type for Reference.isHead (typed as boolean, but returns a number)

### DIFF
--- a/lib/reference.js
+++ b/lib/reference.js
@@ -37,7 +37,7 @@ Reference.prototype.isConcrete = function() {
  * @return {bool}
  */
 Reference.prototype.isHead = function() {
-  return Branch.isHead(this);
+  return Branch.isHead(this) === 1;
 };
 
 /**


### PR DESCRIPTION
Both API docs and TypeScript typings say that [Reference.isHead](http://www.nodegit.org/api/reference/#isHead) returns boolean, while in fact it's just a wrapper around Branch.isHead that returns 0 for false, 1 for true. 

This change makes the code do what published API already says it does. Branch.isHead is [correctly typed in API](http://www.nodegit.org/api/branch/#isHead) as returning number.