### PR TITLE
 Enable git_push_transfer_progress - Help wanted

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -798,6 +798,33 @@
       "throttle": 100
     }
   },
+  "git_push_transfer_progress": {
+    "args": [
+      {
+        "name": "current",
+        "type": "unsigned int"
+      },
+      {
+        "name": "total",
+        "type": "unsigned int"
+      },
+      {
+        "name": "bytes",
+        "type": "size_t"
+      },
+      {
+        "name": "payload",
+        "type": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 0,
+      "success": 0,
+      "error": -1,
+      "throttle": 100
+    }
+  },
   "git_transport_cb": {
     "args": [
       {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2915,6 +2915,9 @@
     "transfer_progress": {
       "dupFunction": "git_transfer_progress_dup"
     },
+    "push_transfer_progress": {
+      "dupFunction": "git_transfer_progress_dup"
+    },
     "transport": {
       "cType": "git_transport",
       "needsForwardDeclaration": false,

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2311,9 +2311,6 @@
         "push_negotiation": {
           "ignore": true
         },
-        "push_transfer_progress": {
-          "ignore": true
-        },
         "sideband_progress": {
           "ignore": true
         },
@@ -2916,6 +2913,9 @@
       }
     },
     "transfer_progress": {
+      "dupFunction": "git_transfer_progress_dup"
+    },
+    "push_transfer_progress": {
       "dupFunction": "git_transfer_progress_dup"
     },
     "transport": {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2915,9 +2915,6 @@
     "transfer_progress": {
       "dupFunction": "git_transfer_progress_dup"
     },
-    "push_transfer_progress": {
-      "dupFunction": "git_transfer_progress_dup"
-    },
     "transport": {
       "cType": "git_transport",
       "needsForwardDeclaration": false,

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -699,7 +699,7 @@
               "name": "transfer_progress"
             },
             {
-              "type": "git_push_transfer_progress",
+              "type": "git_push_transfer_progress_cb",
               "name": "push_transfer_progress"
             },
             {

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -699,6 +699,10 @@
               "name": "transfer_progress"
             },
             {
+              "type": "git_push_transfer_progress",
+              "name": "push_transfer_progress"
+            },
+            {
               "type": "git_transport_cb",
               "name": "transport",
               "ignore": true

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -699,8 +699,9 @@
               "name": "transfer_progress"
             },
             {
-              "type": "git_push_transfer_progress_cb",
-              "name": "push_transfer_progress"
+              "type": "git_push_transfer_progress",
+              "name": "push_transfer_progress",
+              "isCallback": true
             },
             {
               "type": "git_transport_cb",

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -85,7 +85,8 @@ var Helpers = {
   },
 
   isCallbackFunction: function(cType) {
-    // TODO: Fix this
+    // NOTE: Added this just to get it working, I'm not sure how else to get
+    // around this, as the fieldOverrides are applied after this.
     if (cType === 'git_push_transfer_progress') {
       return true;
     }

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -85,6 +85,11 @@ var Helpers = {
   },
 
   isCallbackFunction: function(cType) {
+    // TODO: Fix this
+    if (cType === 'git_push_transfer_progress') {
+      return true;
+    }
+
     return callbackTypePattern.test(cType);
   },
 

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -85,12 +85,6 @@ var Helpers = {
   },
 
   isCallbackFunction: function(cType) {
-    // NOTE: Added this just to get it working, I'm not sure how else to get
-    // around this, as the fieldOverrides are applied after this.
-    if (cType === 'git_push_transfer_progress') {
-      return true;
-    }
-
     return callbackTypePattern.test(cType);
   },
 

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -84,8 +84,8 @@ var Helpers = {
       });
   },
 
-  isCallbackFunction: function(cType) {
-    return callbackTypePattern.test(cType);
+  isCallbackFunction: function(cType, isCallback) {
+    return isCallback === true || callbackTypePattern.test(cType);
   },
 
   isPayloadFor: function(cbField, payloadName) {
@@ -228,7 +228,7 @@ var Helpers = {
     field.jsClassName = utils.titleCase(Helpers.cTypeToJsName(field.type));
     field.ownedByThis = true;
 
-    if (Helpers.isCallbackFunction(field.cType)) {
+    if (Helpers.isCallbackFunction(field.cType, field.isCallback)) {
       Helpers.processCallback(field);
 
       var argOverrides = fieldOverrides.args || {};

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -129,6 +129,37 @@ describe("Remote", function() {
       });
   });
 
+  it("can monitor transfer progress while pushing", function() {
+    var repo = this.repository;
+    var wasCalled = false;
+
+    return Remote.create(repo, "test2", url2)
+      .then(function(remote) {
+        var fetchOpts = {
+          callbacks: {
+            credentials: function(url, userName) {
+              return NodeGit.Cred.sshKeyFromAgent(userName);
+            },
+            certificateCheck: function() {
+              return 1;
+            },
+            pushTransferProgress: function() {
+              wasCalled = true;
+            }
+          }
+        };
+
+        var ref = "refs/heads/master";
+        var refs = [ref + ":" + ref];
+        return remote.push(refs, fetchOpts);
+      })
+      .then(function() {
+        assert.ok(wasCalled);
+
+        return Remote.delete(repo, "test2");
+      });
+  });
+
   it("can monitor transfer progress while downloading", function() {
     // Set a reasonable timeout here now that our repository has grown.
     this.timeout(600000);

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -142,8 +142,7 @@ describe("Remote", function() {
       .then(function(remote) {
         var fetchOpts = {
           callbacks: {
-            pushTransferProgress: function(a, b, c) {
-              console.log("CALL", a, b, c);
+            pushTransferProgress: function() {
               wasCalled = true;
             }
           }
@@ -159,7 +158,7 @@ describe("Remote", function() {
       });
   });
 
-  it.only("can monitor transfer progress while pushing with throttling",
+  it("can monitor transfer progress while pushing with throttling",
     function() {
       var repo = this.repository;
       var wasCalled = false;
@@ -170,7 +169,7 @@ describe("Remote", function() {
             callbacks: {
               pushTransferProgress: {
                 throttle: 200,
-                callback: function(a, b, c) {
+                callback: function() {
                   wasCalled = true;
                 },
               }

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -133,6 +133,9 @@ describe("Remote", function() {
     var repo = this.repository;
     var wasCalled = false;
 
+    // NOTE: This doesn't work, the credentials callback fails.
+    // Did manage to get it working by setting up a local bare repo and pushing to it.
+
     return Remote.create(repo, "test2", url2)
       .then(function(remote) {
         var fetchOpts = {

--- a/test/utils/repository_setup.js
+++ b/test/utils/repository_setup.js
@@ -49,14 +49,15 @@ var RepositorySetup = {
 	},
 
 	createRepository:
-	function createRepository(repoPath){
+	function createRepository(repoPath, isBare){
 		// Create a new repository in a clean directory
 		return fse.remove(repoPath)
 		.then(function() {
 			return fse.ensureDir(repoPath);
 		})
 		.then(function() {
-			return NodeGit.Repository.init(repoPath, 0);
+			var bare = typeof isBare !== "undefined" ? isBare : 0;
+			return NodeGit.Repository.init(repoPath, bare);
 		});
 	},
 


### PR DESCRIPTION
Have enabled the `pushTransferProgress` callback for `RemoteCallbacks`, which is used in `Remote.push`.

The [docs](http://www.nodegit.org/api/push_options/) for `PushOptions` says it accepts callbacks as `RemoteCallbacks` which is correct, but `transferProgress` is only for downloads, libgit has separate [API](https://libgit2.github.com/libgit2/#HEAD/type/git_remote_callbacks) for uploads.

I've been able to get the callback (`pushTransferProgress`) working, similar to `transferProgress` (with throttling). I just need help finishing it off.

**Current Issues**

Generate - The generate callback function uses a regex pattern (`/\s*_(cb|fn)/`) against the function name which isn't satisfied by libgit function name `git_push_transfer_progress`. For now, I've just put in a strict check to bypass.

Testing - I'm unable to get the test case working... I keep getting credentials errors. I was able to get it working by setting up a local bare repo and have the test push to that.

Docs - May need to update the docs to reflect the changes.

It would be great to get some help finishing this off.

Cheers!