### PR TITLE
Fix argument handling in Git.Merge.trees

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1572,6 +1572,16 @@
             }
           }
         },
+        "git_merge_trees": {
+          "args": {
+            "ancestor_tree": {
+              "isOptional": true
+            },
+            "opts": {
+              "isOptional": true
+            }
+          }
+        },
         "git_merge_file": {
           "ignore": true
         },


### PR DESCRIPTION
This change makes `ancestor_tree` and `opts` optional to match the documentation.

Closes: https://github.com/nodegit/nodegit/issues/1504