### PR TITLE
Remove unnecessary assignment of Commit#repo

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1143,8 +1143,6 @@ Repository.prototype.getCommit = function(oid, callback) {
   var repository = this;
 
   return Commit.lookup(repository, oid).then(function(commit) {
-    commit.repo = repository;
-
     if (typeof callback === "function") {
       callback(null, commit);
     }


### PR DESCRIPTION
`Repository#getCommit` uses `Commit.lookup` and then manually assigns to `Commit#repo` even though `Commit.lookup` already does that. There is no way for `Commit.lookup` to return a `Commit` without a `repo` property.