### PR TITLE
Fix behavior of Commit#parent

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -17,6 +17,24 @@ var _parent = Commit.prototype.parent;
 Commit.lookup = LookupWrapper(Commit);
 
 /**
+ * @async
+ * @param {Number} n
+ * @return {Commit}
+ */
+Commit.prototype.parent = function(n, callback) {
+  var repo = this.repo;
+  return _parent.call(this, n).then(p => {
+    p.repo = repo;
+
+    if (typeof callback === "function") {
+      callback(null, p);
+    }
+
+    return p;
+  }, callback);
+};
+
+/**
  * Amend a commit
  * @async
  * @param {String} update_ref

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -774,6 +774,16 @@ describe("Commit", function() {
     assert.equal(1, this.commit.parentcount());
   });
 
+  it("can fetch a single parent", function() {
+    return this.commit.parent(0).then(function(parent) {
+      assert.strictEqual(parent.sha(),
+                         "ecfd36c80a3e9081f200dfda2391acadb56dac27");
+      // This used to crash due to a missing .repo property on the retrieved
+      // parent.
+      return parent.getTree().then(tree => assert(tree));
+    });
+  });
+
   it("can retrieve and walk a commit tree", function() {
     var commitTreeEntryCount = 0;
     var expectedCommitTreeEntryCount = 198;


### PR DESCRIPTION
`Commit#parent` did not assign the `repo` property so subsequent calls which relied on this property (such as `Commit#getTree`) failed. This change works around this problem by imitating what `LookupWrapper` does for `Commit.lookup`, that is, it wraps the actual call in a new function and manually assigns the `repo` property.

This commit also adds a test case for the corrected behavior.