### PR TITLE
Fixed cannot read property 'name' of null error

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nan": "^2.10.0",
     "node-gyp": "^3.6.2",
     "node-pre-gyp": "~0.6.39",
-    "promisify-node": "~0.3.0"
+    "promisify-node": "~0.5.0"
   },
   "devDependencies": {
     "aws-sdk": "^2.3.19",


### PR DESCRIPTION
In `promisify-node~0.3.0`, function `processExports` in `index.js` don't add `null` checking for `exports` argument.It got fixed in `promisify-node~0.5.0`.

Details in [https://github.com/nodegit/promisify-node/issues/24](https://github.com/nodegit/promisify-node/issues/24)