### PR TITLE
Update package.json engines to reflect lack of 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lib": "./lib"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">=4 <10"
   },
   "dependencies": {
     "fs-extra": "~0.27.0",


### PR DESCRIPTION
Doesnt mean much directly, except npm will warn and yarn I think will error if you try to install with node 10. Just to provide a bit of feedback to people running into that, since it seems to be coming up a lot. 