### PR TITLE
add github issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,13 @@
+## System information
+  - node version:
+  - npm or yarn version:
+  - OS/version/architechture:
+  - Applicable nodegit version:
+
+```
+node -v
+npm -v # (or yarn -v)
+node -e "console.log(process.platform)"
+node -e "console.log(require('os').release())"
+node -e "console.log(console.log(process.arch))"
+```


### PR DESCRIPTION
Just asks for people to list their OS/arch/node/npm/yarn info when they're creating an issue since we get a lot of people omitting that, and even omitting the parts of the error logs that would expose that. 