### PR TITLE
Fixed createBranch API params

### DIFF
--- a/examples/create-branch.js
+++ b/examples/create-branch.js
@@ -9,9 +9,7 @@ nodegit.Repository.open(path.resolve(__dirname, "../.git"))
       return repo.createBranch(
         "new-branch",
         commit,
-        0,
-        repo.defaultSignature(),
-        "Created new-branch on HEAD");
+        0);
     });
   }).done(function() {
     console.log("All done!");


### PR DESCRIPTION
The 'create-branch.js' example file had outdated params for 'Repository.createBranch() when compared to the API documentation. I changed the params to match the documentation.