### PR TITLE
Use curl-config to find curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ In Ubuntu:
 sudo apt-get install libssl-dev
 ```
 
+Additionally, you need `curl-config` on your system. You need one of these packages:
+  * libcurl4-gnutls-dev
+  * libcurl4-nss-dev
+  * libcurl4-openssl-dev 
+
 If you are still encountering problems while installing, you should try the
 [Building from source](http://www.nodegit.org/guides/install/from-source/)
 instructions.

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -92,9 +92,9 @@
           }
         ],
         [
-          "OS=='linux' or OS=='mac'", {
+          "OS=='linux' or OS=='mac' or OS.endswith('bsd')", {
             "libraries": [
-              "-lcurl"
+              "<!(curl-config --libs)"
             ]
           }
         ],

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -305,7 +305,8 @@
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd')", {
           "cflags": [
-            "-DGIT_CURL"
+            "-DGIT_CURL",
+            "<!(curl-config --cflags)"
           ],
           "defines": [
             "GIT_CURL",


### PR DESCRIPTION
On BSDs headers will be in /usr/local/include which
is not added to the include path automatically.

This is a rebased version of #1237 
Closes #1237 