### PR TITLE
Fix Electron builds on win32

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -547,6 +547,10 @@
             ["node_root_dir.split('\\\\')[-1].startswith('iojs')", {
               "include_dirs": [
                 "openssl/include"
+              ],
+              "libraries": [
+                "openssl/libssl.lib",
+                "openssl/libcrypto.lib"
               ]
             }, {
               "defines": [


### PR DESCRIPTION
It appears that the compiler on 32-bit Windows wasn't quite smart enough to figure out implicit links†.