### PR TITLE
Fix wrong OpenSSL distribution downloaded on Windows 32-bit and bad link directory

### DIFF
--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -12,7 +12,7 @@ const extractPath = path.join(vendorPath, "openssl");
 
 const getOSName = () => {
   if (process.platform === "win32") {
-    if (process.arch === "x64" || process.env.hasOwnProperty("PROCESSOR_ARCHITEW6432")) {
+    if (process.arch === "x64") {
       return "win64";
     } else {
       return "win32";

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -549,8 +549,8 @@
                 "openssl/include"
               ],
               "libraries": [
-                "openssl/libssl.lib",
-                "openssl/libcrypto.lib"
+                "<(module_root_dir)/openssl/lib/libssl.lib",
+                "<(module_root_dir)/openssl/lib/libcrypto.lib"
               ]
             }, {
               "defines": [


### PR DESCRIPTION
Continuation of #1560