### PR TITLE
Garbage collection: Free mostly everything automatically

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -76,10 +76,34 @@
   "types":
   {
     "annotated_commit": {
+      "selfFreeing": true,
       "functions": {
+        "git_annotated_commit_free": {
+          "ignore": true
+        },
         "git_annotated_commit_id": {
           "return": {
             "ownedByThis": true
+          }
+        },
+        "git_annotated_commit_from_ref": {
+          "return": {
+            "ownedBy": "repo"
+          }
+        },
+        "git_annotated_commit_from_fetchhead": {
+          "return": {
+            "ownedBy": "repo"
+          }
+        },
+        "git_annotated_commit_lookup": {
+          "return": {
+            "ownedBy": "repo"
+          }
+        },
+        "git_annotated_commit_from_revspec": {
+          "return": {
+            "ownedBy": "repo"
           }
         }
       }
@@ -115,13 +139,37 @@
       }
     },
     "blame": {
+      "selfFreeing": true,
       "cType": "git_blame",
       "functions": {
+        "git_blame_buffer": {
+          "args": {
+            "out": {
+              "ownedBy": "reference"
+            }
+          }
+        },
         "git_blame_file": {
           "args": {
+            "out": {
+              "ownedBy": "repo"
+            },
             "options": {
               "isOptional": true
             }
+          }
+        },
+        "git_blame_free": {
+          "ignore": true
+        },
+        "git_blame_get_hunk_byindex": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_blame_get_hunk_byline": {
+          "return": {
+            "ownedByThis": true
           }
         }
       }
@@ -135,6 +183,10 @@
     },
     "blob": {
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_blob_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_blob_create_frombuffer": {
           "isAsync": true,
@@ -176,6 +228,9 @@
         "git_blob_create_fromchunks": {
           "ignore": true
         },
+        "git_blob_dup": {
+          "ignore": true
+        },
         "git_blob_filtered_content": {
           "isAsync": true,
           "isPrototypeMethod": false,
@@ -205,6 +260,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_blob_free": {
+          "ignore": true
         },
         "git_blob_id": {
           "return": {
@@ -314,6 +372,9 @@
     },
     "buf": {
       "functions": {
+        "git_buf_free": {
+          "ignore": true
+        },
         "git_buf_grow": {
           "cppFunctionName": "Grow",
           "jsFunctionName": "grow",
@@ -460,6 +521,10 @@
     },
     "commit": {
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_commit_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_commit_amend": {
           "isAsync": true,
@@ -555,8 +620,14 @@
         "git_commit_create_from_v": {
           "ignore": true
         },
+        "git_commit_dup": {
+          "ignore": true
+        },
         "git_commit_extract_signature": {
           "isAsync": true
+        },
+        "git_commit_free": {
+          "ignore": true
         },
         "git_commit_id": {
           "return": {
@@ -589,6 +660,7 @@
       }
     },
     "config": {
+      "selfFreeing": true,
       "functions": {
         "git_config_add_backend": {
           "ignore": true
@@ -657,7 +729,12 @@
           "ignore": true
         },
         "git_config_get_entry": {
-          "ignore": true
+          "args": {
+            "out": {
+              "isReturn": true,
+              "ownedBy": "cfg"
+            }
+          }
         },
         "git_config_get_int32": {
           "ignore": true
@@ -772,6 +849,9 @@
             "isErrorCode": true
           }
         },
+        "git_config_snapshot": {
+          "ignore": true
+        },
         "git_config_find_programdata": {
           "isAsync": true,
           "return": {
@@ -793,14 +873,21 @@
     "config_backend": {
       "ignore": true
     },
+    "config_entry": {
+      "selfFreeing": true
+    },
     "config_iterator": {
       "ignore": true
     },
     "cred": {
+      "selfFreeing": true,
       "cType": "git_cred",
       "functions": {
         "git_cred_default_new": {
           "isAsync": false
+        },
+        "git_cred_free": {
+          "ignore": true
         },
         "git_cred_ssh_custom_new": {
           "ignore": true
@@ -851,6 +938,7 @@
       "ignore": true
     },
     "diff": {
+      "selfFreeing": true,
       "cDependencies": [
         "git2/sys/diff.h"
       ],
@@ -936,8 +1024,18 @@
         "git_diff_get_stats": {
           "ignore": true
         },
+        "git_diff_index_to_index": {
+          "args": {
+            "diff": {
+              "ownedBy": "repo"
+            }
+          }
+        },
         "git_diff_index_to_workdir": {
           "args": {
+            "diff": {
+              "ownedBy": "repo"
+            },
             "index": {
               "isOptional": true
             },
@@ -1008,6 +1106,9 @@
         },
         "git_diff_tree_to_index": {
           "args": {
+            "diff": {
+              "ownedBy": "repo"
+            },
             "old_tree": {
               "isOptional": true
             },
@@ -1021,6 +1122,9 @@
         },
         "git_diff_tree_to_tree": {
           "args": {
+            "diff": {
+              "ownedBy": "repo"
+            },
             "old_tree": {
               "isOptional": true
             },
@@ -1034,6 +1138,9 @@
         },
         "git_diff_tree_to_workdir": {
           "args": {
+            "diff": {
+              "ownedBy": "repo"
+            },
             "old_tree": {
               "isOptional": true
             },
@@ -1044,6 +1151,9 @@
         },
         "git_diff_tree_to_workdir_with_index": {
           "args": {
+            "diff": {
+              "ownedBy": "repo"
+            },
             "old_tree": {
               "isOptional": true
             },
@@ -1072,6 +1182,9 @@
     },
     "diff_similarity_metric": {
       "ignore": true
+    },
+    "diff_stats": {
+      "selfFreeing": true
     },
     "error_code": {
       "values": {
@@ -1145,7 +1258,8 @@
           "args": {
             "filters": {
               "isReturn": true,
-              "cType": "git_filter_list **"
+              "cType": "git_filter_list **",
+              "ownedBy": "repo"
             },
             "repo": {
               "cType": "git_repository *"
@@ -1196,6 +1310,17 @@
         "git2/sys/filter.h"
       ]
     },
+    "filter_list": {
+      "selfFreeing": true,
+      "functions": {
+        "git_filter_list_free": {
+          "ignore": true
+        }
+      },
+      "dependencies": [
+        "../include/filter_registry.h"
+      ]
+    },
     "graph": {
       "functions": {
         "git_graph_ahead_behind": {
@@ -1223,6 +1348,12 @@
       }
     },
     "hashsig": {
+      "selfFreeing": true,
+      "functions": {
+        "git_hashsig_free": {
+          "ignore": true
+        }
+      },
       "cDependencies": [
         "git2/sys/hashsig.h"
       ]
@@ -1244,6 +1375,11 @@
       }
     },
     "index": {
+      "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_index_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_index_add": {
           "isAsync": true,
@@ -1317,13 +1453,16 @@
         "git_index_conflict_get": {
           "args": {
             "ancestor_out": {
-              "isReturn": true
+              "isReturn": true,
+              "ownedBy": "index"
             },
             "our_out": {
-              "isReturn": true
+              "isReturn": true,
+              "ownedBy": "index"
             },
             "their_out": {
-              "isReturn": true
+              "isReturn": true,
+              "ownedBy": "index"
             }
           },
           "isAsync": true,
@@ -1494,9 +1633,13 @@
       "ignoreInit": true
     },
     "indexer": {
+      "selfFreeing": true,
       "cType": "git_indexer",
       "functions": {
         "git_indexer_append": {
+          "ignore": true
+        },
+        "git_indexer_free": {
           "ignore": true
         },
         "git_indexer_hash": {
@@ -1613,6 +1756,7 @@
       }
     },
     "note": {
+      "selfFreeing": true,
       "functions": {
         "git_note_iterator_free": {
           "ignore": true
@@ -1623,6 +1767,9 @@
               "shouldAlloc": true
             }
           }
+        },
+        "git_note_free": {
+          "ignore": true
         },
         "git_note_id": {
           "return": {
@@ -1644,7 +1791,18 @@
       }
     },
     "object": {
+      "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_object_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
+        "git_object_dup": {
+          "ignore": true
+        },
+        "git_object_free": {
+          "ignore": true
+        },
         "git_object_id": {
           "return": {
             "ownedByThis": true
@@ -1660,6 +1818,7 @@
       }
     },
     "odb": {
+      "selfFreeing": true,
       "functions": {
         "git_odb_add_alternate": {
           "ignore": true
@@ -1683,6 +1842,9 @@
           "ignore": true
         },
         "git_odb_foreach": {
+          "ignore": true
+        },
+        "git_odb_free": {
           "ignore": true
         },
         "git_odb_get_backend": {
@@ -1762,6 +1924,9 @@
             "jsClassName": "Buffer"
           }
         },
+        "git_odb_object_free": {
+          "ignore": true
+        },
         "git_odb_object_id": {
           "return": {
             "ownedByThis": true
@@ -1832,14 +1997,29 @@
         }
       }
     },
+    "oid_shorten": {
+      "selfFreeing": true
+    },
+    "oidarray": {
+      "selfFreeing": true,
+      "functions": {
+        "git_oidarray_free": {
+          "ignore": true
+        }
+      }
+    },
     "openssl": {
       "cDependencies": [
         "git2/sys/openssl.h"
       ]
     },
     "packbuilder": {
+      "selfFreeing": true,
       "functions": {
         "git_packbuilder_foreach": {
+          "ignore": true
+        },
+        "git_packbuilder_free": {
           "ignore": true
         },
         "git_packbuilder_hash": {
@@ -1859,6 +2039,7 @@
       }
     },
     "patch": {
+      "selfFreeing": true,
       "dependencies": [
         "../include/convenient_patch.h"
       ],
@@ -1925,10 +2106,14 @@
       }
     },
     "pathspec": {
+      "selfFreeing": true,
       "dependencies": [
         "../include/str_array_converter.h"
       ],
       "functions": {
+        "git_pathspec_free": {
+          "ignore": true
+        },
         "git_pathspec_match_list_free": {
           "ignore": true
         },
@@ -1938,23 +2123,10 @@
       }
     },
     "push": {
-      "cType": "git_push",
-      "functions": {
-        "git_push_finish": {
-          "isAsync": true,
-          "return": {
-            "isErrorCode": true
-          }
-        },
-        "git_push_set_callbacks": {
-          "ignore": true
-        },
-        "git_push_status_foreach": {
-          "ignore": true
-        }
-      }
+      "ignore": true
     },
     "rebase": {
+      "selfFreeing": true,
       "functions": {
         "git_rebase_commit": {
           "isAsync": true,
@@ -2025,8 +2197,12 @@
       }
     },
     "refdb": {
+      "selfFreeing": true,
       "functions": {
         "git_refdb_backend_fs": {
+          "ignore": true
+        },
+        "git_refdb_free": {
           "ignore": true
         },
         "git_refdb_init_backend": {
@@ -2046,6 +2222,10 @@
     "reference": {
       "cppClassName": "GitRefs",
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_reference_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_reference__alloc": {
           "ignore": true
@@ -2123,7 +2303,16 @@
       "ignore": true
     },
     "reflog": {
+      "selfFreeing": true,
       "functions": {
+        "git_reflog_entry_byindex": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_reflog_free": {
+          "ignore": true
+        },
         "git_reflog_write": {
           "isAsync": true,
           "isSelf": true,
@@ -2168,6 +2357,10 @@
       ],
       "cType": "git_remote",
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_remote_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_remote_create": {
           "isAsync": true,
@@ -2230,6 +2423,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_remote_free": {
+          "ignore": true
         },
         "git_remote_get_fetch_refspecs": {
           "args": {
@@ -2340,10 +2536,22 @@
       "selfFreeing": true
     },
     "repository": {
+      "selfFreeing": true,
+      "isSingleton": true,
       "dependencies": [
         "git2/sys/repository.h"
       ],
       "functions": {
+        "git_repository_config": {
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          }
+        },
+        "git_repository_config_snapshot": {
+          "ignore": true
+        },
         "git_repository_discover": {
           "isAsync": true,
           "return": {
@@ -2365,6 +2573,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_repository_free": {
+          "ignore": true
         },
         "git_repository_hashfile": {
           "ignore": true
@@ -2498,6 +2709,10 @@
     },
     "revwalk": {
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_revwalk_repository",
+        "singletonCppClassName": "GitRepository"
+      },
       "dependencies": [
         "../include/commit.h",
         "../include/functions/copy.h"
@@ -2506,16 +2721,23 @@
         "git_revwalk_add_hide_cb": {
           "ignore": true
         },
+        "git_revwalk_free": {
+          "ignore": true
+        },
         "git_revwalk_new": {
           "isAsync": false
         }
       }
     },
 	  "signature": {
+      "selfFreeing": true,
       "dupFunction": "git_signature_dup",
 	    "functions": {
         "git_signature_default": {
           "isAsync": false
+        },
+        "git_signature_free": {
+          "ignore": true
         },
 	      "git_signature_new": {
 	        "isAsync": false
@@ -2618,7 +2840,11 @@
       }
     },
     "status_list": {
+      "selfFreeing": true,
       "functions": {
+        "git_status_list_free": {
+          "ignore": true
+        },
         "git_status_list_new": {
           "isAsync": true,
           "args": {
@@ -2633,6 +2859,11 @@
       }
     },
     "strarray": {
+      "functions": {
+        "git_strarray_free": {
+          "ignore": true
+        }
+      },
       "dependencies": [
         "../include/str_array_converter.h"
       ]
@@ -2644,6 +2875,11 @@
       ]
     },
     "submodule": {
+      "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_submodule_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_submodule_add_to_index": {
           "isAsync": true,
@@ -2681,6 +2917,9 @@
             "isErrorCode": true,
             "type": "int"
           }
+        },
+        "git_submodule_free": {
+          "ignore": true
         },
         "git_submodule_index_id": {
           "return": {
@@ -2788,9 +3027,21 @@
         "../include/str_array_converter.h"
       ],
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_tag_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
-        "git_tag_foreach": {
-          "ignore": true
+        "git_tag_annotation_create": {
+          "args": {
+            "oid": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          },
+          "isAsync": true
         },
         "git_tag_create": {
           "args": {
@@ -2806,11 +3057,6 @@
         "git_tag_create_frombuffer": {
           "ignore": true
         },
-        "git_tag_id": {
-          "return": {
-            "ownedByThis": true
-          }
-        },
         "git_tag_create_lightweight": {
           "args": {
             "oid": {
@@ -2822,16 +3068,16 @@
           },
           "isAsync": true
         },
-        "git_tag_annotation_create": {
-          "args": {
-            "oid": {
-              "isReturn": true
-            }
-          },
+        "git_tag_foreach": {
+          "ignore": true
+        },
+        "git_tag_free": {
+          "ignore": true
+        },
+        "git_tag_id": {
           "return": {
-            "isErrorCode": true
-          },
-          "isAsync": true
+            "ownedByThis": true
+          }
         },
         "git_tag_list": {
           "args": {
@@ -2957,6 +3203,10 @@
     },
     "tree": {
       "selfFreeing": true,
+      "ownerFn": {
+        "name": "git_tree_owner",
+        "singletonCppClassName": "GitRepository"
+      },
       "functions": {
         "git_tree_entry_byid": {
           "return": {
@@ -2981,6 +3231,9 @@
         "git_tree_entrycount": {
           "jsFunctionName": "entryCount"
         },
+        "git_tree_free": {
+          "ignore": true
+        },
         "git_tree_id": {
           "return": {
             "ownedByThis": true
@@ -2992,8 +3245,12 @@
       }
     },
     "treebuilder": {
+      "selfFreeing": true,
       "functions": {
         "git_treebuilder_filter": {
+          "ignore": true
+        },
+        "git_treebuilder_free": {
           "ignore": true
         },
         "git_treebuilder_get": {
@@ -3039,6 +3296,9 @@
       "dupFunction": "git_tree_entry_dup",
       "freeFunctionName": "git_tree_entry_free",
       "functions": {
+        "git_tree_entry_free": {
+          "ignore": true
+        },
         "git_tree_entry_id": {
           "return": {
             "ownedByThis": true

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -234,9 +234,6 @@
         "git_blob_create_fromstream_commit": {
           "ignore": true
         },
-        "git_blob_dup": {
-          "ignore": true
-        },
         "git_blob_filtered_content": {
           "isAsync": true,
           "isPrototypeMethod": false,
@@ -637,9 +634,6 @@
           "ignore": true
         },
         "git_commit_create_from_v": {
-          "ignore": true
-        },
-        "git_commit_dup": {
           "ignore": true
         },
         "git_commit_extract_signature": {
@@ -1910,9 +1904,6 @@
         "singletonCppClassName": "GitRepository"
       },
       "functions": {
-        "git_object_dup": {
-          "ignore": true
-        },
         "git_object_free": {
           "ignore": true
         },
@@ -2528,9 +2519,6 @@
         "git_reference__alloc_symbolic": {
           "ignore": true
         },
-        "git_reference_dup": {
-          "ignore": true
-        },
         "git_reference_foreach": {
           "ignore": true
         },
@@ -2739,9 +2727,6 @@
           "return": {
             "isErrorCode": true
           }
-        },
-        "git_remote_dup": {
-          "ignore": true
         },
         "git_remote_fetch": {
           "args": {
@@ -3448,9 +3433,6 @@
           },
           "isAsync": true
         },
-        "git_tag_dup": {
-          "ignore": true
-        },
         "git_tag_foreach": {
           "ignore": true
         },
@@ -3615,9 +3597,6 @@
         "singletonCppClassName": "GitRepository"
       },
       "functions": {
-        "git_tree_dup": {
-          "ignore": true
-        },
         "git_tree_entry_byid": {
           "return": {
             "ownedByThis": true

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -88,22 +88,22 @@
         },
         "git_annotated_commit_from_ref": {
           "return": {
-            "ownedBy": "repo"
+            "ownedBy": ["repo"]
           }
         },
         "git_annotated_commit_from_fetchhead": {
           "return": {
-            "ownedBy": "repo"
+            "ownedBy": ["repo"]
           }
         },
         "git_annotated_commit_lookup": {
           "return": {
-            "ownedBy": "repo"
+            "ownedBy": ["repo"]
           }
         },
         "git_annotated_commit_from_revspec": {
           "return": {
-            "ownedBy": "repo"
+            "ownedBy": ["repo"]
           }
         }
       }
@@ -145,14 +145,14 @@
         "git_blame_buffer": {
           "args": {
             "out": {
-              "ownedBy": "reference"
+              "ownedBy": ["reference"]
             }
           }
         },
         "git_blame_file": {
           "args": {
             "out": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "options": {
               "isOptional": true
@@ -171,6 +171,9 @@
           "return": {
             "ownedByThis": true
           }
+        },
+        "git_blame_init_options": {
+          "ignore": true
         }
       }
     },
@@ -225,7 +228,10 @@
             "isErrorCode": true
           }
         },
-        "git_blob_create_fromchunks": {
+        "git_blob_create_fromstream": {
+          "ignore": true
+        },
+        "git_blob_create_fromstream_commit": {
           "ignore": true
         },
         "git_blob_dup": {
@@ -283,9 +289,6 @@
     },
     "branch": {
       "functions": {
-        "git_branch_iterator_free": {
-          "ignore": true
-        },
         "git_branch_create": {
           "args": {
             "force": {
@@ -315,6 +318,12 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_branch_iterator_free": {
+          "ignore": true
+        },
+        "git_branch_iterator_new": {
+          "ignore": true
         },
         "git_branch_next": {
           "ignore": true
@@ -466,6 +475,9 @@
             "isErrorCode": true
           }
         },
+        "git_checkout_init_options": {
+          "ignore": true
+        },
         "git_checkout_tree": {
           "args": {
             "treeish": {
@@ -489,6 +501,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_cherrypick_init_options": {
+          "ignore": true
         }
       }
     },
@@ -500,6 +515,9 @@
               "isOptional": true
             }
           }
+        },
+        "git_clone_init_options": {
+          "ignore": true
         }
       }
     },
@@ -692,6 +710,19 @@
             "isErrorCode": true
           }
         },
+        "git_config_find_programdata": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          },
+          "args": {
+            "out": {
+              "isReturn": true,
+              "isSelf": false,
+              "shouldAlloc": true
+            }
+          }
+        },
         "git_config_find_system": {
           "isAsync": true,
           "args": {
@@ -732,7 +763,7 @@
           "args": {
             "out": {
               "isReturn": true,
-              "ownedBy": "cfg"
+              "ownedByThis": true
             }
           }
         },
@@ -775,6 +806,9 @@
             "isErrorCode": true
           }
         },
+        "git_config_init_backend": {
+          "ignore": true
+        },
         "git_config_iterator_free": {
           "ignore": true
         },
@@ -784,8 +818,14 @@
         "git_config_iterator_new": {
           "ignore": true
         },
-        "git_config_init_backend": {
-          "ignore": true
+        "git_config_lock": {
+          "isAsync": true,
+          "args": {
+            "tx": {
+              "isReturn": true,
+              "ownedByThis": true
+            }
+          }
         },
         "git_config_lookup_map_value": {
           "ignore": true
@@ -834,14 +874,23 @@
         "git_config_parse_path": {
           "ignore": true
         },
-        "git_config_refresh": {
-          "ignore": true
-        },
         "git_config_set_bool": {
-          "ignore": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_config_set_int32": {
-          "ignore": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_config_set_int64": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_config_set_string": {
           "isAsync": true,
@@ -851,19 +900,6 @@
         },
         "git_config_snapshot": {
           "ignore": true
-        },
-        "git_config_find_programdata": {
-          "isAsync": true,
-          "return": {
-            "isErrorCode": true
-          },
-          "args": {
-            "out": {
-              "isReturn": true,
-              "isSelf": false,
-              "shouldAlloc": true
-            }
-          }
         }
       },
       "dependencies": [
@@ -909,6 +945,9 @@
         }
       }
     },
+    "cred_default": {
+      "ignore": true
+    },
     "cred_ssh_custom": {
       "ignore": true
     },
@@ -919,23 +958,19 @@
       "ignore": true
     },
     "cred_username": {
-      "fields": {
-        "username": {
-          "cppClassName": "String",
-          "cType": "char *"
-        }
-      }
+      "ignore": true
     },
     "cred_userpass_payload": {
-      "cDependencies": [
-        "git2/cred_helpers.h"
-      ]
+      "ignore": true
     },
     "cred_userpass_plaintext": {
       "ignore": true
     },
     "describe": {
       "ignore": true
+    },
+    "describe_format_options": {
+      "hasConstructor": true
     },
     "diff": {
       "selfFreeing": true,
@@ -1021,20 +1056,47 @@
         "git_diff_free": {
           "ignore": true
         },
+        "git_diff_get_perfdata": {
+          "isAsync": false,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "shouldAlloc": true
+            },
+            "diff": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_diff_get_stats": {
-          "ignore": true
+          "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "ownedByThis": true
+            },
+            "diff": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_diff_index_to_index": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             }
           }
         },
         "git_diff_index_to_workdir": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "index": {
               "isOptional": true
@@ -1047,12 +1109,12 @@
         "git_diff_init_options": {
           "ignore": true
         },
-        "git_diff_is_sorted_icase": {
-          "ignore": true
-        },
         "git_diff_merge": {
           "isAsync": true,
           "args": {
+            "from": {
+              "ownedByThis": true
+            },
             "onto": {
               "isSelf": true
             }
@@ -1064,6 +1126,9 @@
         "git_diff_num_deltas_of_type": {
           "ignore": true
         },
+        "git_diff_patchid_init_options": {
+          "ignore": true
+        },
         "git_diff_print": {
           "ignore": true
         },
@@ -1071,21 +1136,6 @@
           "ignore": true
         },
         "git_diff_print_callback__to_file_handle": {
-          "ignore": true
-        },
-        "git_diff_stats_deletions": {
-          "ignore": true
-        },
-        "git_diff_stats_files_changed": {
-          "ignore": true
-        },
-        "git_diff_stats_free": {
-          "ignore": true
-        },
-        "git_diff_stats_insertions": {
-          "ignore": true
-        },
-        "git_diff_stats_to_buf": {
           "ignore": true
         },
         "git_diff_status_char": {
@@ -1107,7 +1157,7 @@
         "git_diff_tree_to_index": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "old_tree": {
               "isOptional": true
@@ -1123,7 +1173,7 @@
         "git_diff_tree_to_tree": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "old_tree": {
               "isOptional": true
@@ -1139,7 +1189,7 @@
         "git_diff_tree_to_workdir": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "old_tree": {
               "isOptional": true
@@ -1152,7 +1202,7 @@
         "git_diff_tree_to_workdir_with_index": {
           "args": {
             "diff": {
-              "ownedBy": "repo"
+              "ownedBy": ["repo"]
             },
             "old_tree": {
               "isOptional": true
@@ -1176,6 +1226,7 @@
       "ignore": true
     },
     "diff_perfdata": {
+      "selfFreeing": true,
       "cDependencies": [
         "git2/sys/diff.h"
       ]
@@ -1184,7 +1235,42 @@
       "ignore": true
     },
     "diff_stats": {
-      "selfFreeing": true
+      "selfFreeing": true,
+      "functions": {
+        "git_diff_stats_deletions": {
+          "args": {
+            "stats": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_diff_stats_files_changed": {
+          "args": {
+            "stats": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_diff_stats_free": {
+          "ignore": true
+        },
+        "git_diff_stats_insertions": {
+          "args": {
+            "stats": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_diff_stats_to_buf": {
+          "cppFunctionName": "DiffStatsToBuf",
+          "isAsync": true,
+          "args": {
+            "stats": {
+              "isSelf": true
+            }
+          }
+        }
+      }
     },
     "error_code": {
       "values": {
@@ -1193,108 +1279,16 @@
         }
       }
     },
+    "fetch": {
+      "functions": {
+        "git_fetch_init_options": {
+          "ignore": true
+        }
+      }
+    },
     "filter": {
       "selfFreeing": false,
       "hasConstructor": true,
-      "functions": {
-        "git_filter_list_apply_to_blob": {
-          "async": true,
-          "return": {
-            "isErrorCode": true
-          },
-          "args": {
-            "out": {
-              "isReturn": true,
-              "shouldAlloc": true
-            },
-            "filters": {
-              "isSelf": true
-            }
-          }
-        },
-        "git_filter_list_apply_to_data": {
-          "async": true,
-          "return": {
-            "isErrorCode": true
-          },
-          "args": {
-            "out": {
-              "isReturn": true,
-              "shouldAlloc": true
-            },
-            "filters": {
-              "isSelf": true
-            }
-          }
-        },
-        "git_filter_list_apply_to_file": {
-          "async": true,
-          "return": {
-            "isErrorCode": true
-          },
-          "args": {
-            "out": {
-              "isReturn": true,
-              "shouldAlloc": true
-            },
-            "filters": {
-              "isSelf": true
-            }
-          }
-        },
-        "git_filter_list_free": {
-          "async": true,
-          "args": {
-            "filters": {
-              "isSelf": true
-            }
-          }
-        },
-        "git_filter_list_load": {
-          "async": true,
-          "return": {
-            "isErrorCode": true
-          },
-          "args": {
-            "filters": {
-              "isReturn": true,
-              "cType": "git_filter_list **",
-              "ownedBy": "repo"
-            },
-            "repo": {
-              "cType": "git_repository *"
-            },
-            "blob": {
-              "isOptional": true,
-              "cType": "git_blob *"
-            }
-          }
-        },
-        "git_filter_list_push": {
-          "ignore": true
-        },
-        "git_filter_source_filemode": {
-          "ignore": true
-        },
-        "git_filter_source_flags": {
-          "ignore": true
-        },
-        "git_filter_source_id": {
-          "ignore": true
-        },
-        "git_filter_source_mode": {
-          "ignore": true
-        },
-        "git_filter_source_options": {
-          "ignore": true
-        },
-        "git_filter_source_path": {
-          "ignore": true
-        },
-        "git_filter_source_repo": {
-          "ignore": true
-        }
-      },
       "cDependencies": [
         "git2/sys/filter.h"
       ],
@@ -1305,7 +1299,59 @@
       }
     },
     "filter_source": {
-      "ignore": false,
+      "functions": {
+        "git_filter_source_filemode": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_filter_source_flags": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_filter_source_id": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_filter_source_mode": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_filter_source_path": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_filter_source_repo": {
+          "isPrototypeMethod": true,
+          "args": {
+            "src": {
+              "isSelf": true
+            }
+          }
+        }
+      },
       "cDependencies": [
         "git2/sys/filter.h"
       ]
@@ -1313,7 +1359,46 @@
     "filter_list": {
       "selfFreeing": true,
       "functions": {
+        "git_filter_list_apply_to_blob": {
+          "isPrototypeMethod": true,
+          "args": {
+            "filters": {
+              "isSelf": true
+            },
+            "out": {
+              "shouldAlloc": true
+            }
+          }
+        },
+        "git_filter_list_apply_to_data": {
+          "isPrototypeMethod": true,
+          "args": {
+            "filters": {
+              "isSelf": true
+            },
+            "out": {
+              "shouldAlloc": true
+            }
+          }
+        },
+        "git_filter_list_apply_to_file": {
+          "isPrototypeMethod": true,
+          "args": {
+            "filters": {
+              "isSelf": true
+            },
+            "out": {
+              "shouldAlloc": true
+            }
+          }
+        },
         "git_filter_list_free": {
+          "ignore": true
+        },
+        "git_filter_list_new": {
+          "ignore": true
+        },
+        "git_filter_list_push": {
           "ignore": true
         }
       },
@@ -1454,15 +1539,15 @@
           "args": {
             "ancestor_out": {
               "isReturn": true,
-              "ownedBy": "index"
+              "ownedBy": ["index"]
             },
             "our_out": {
               "isReturn": true,
-              "ownedBy": "index"
+              "ownedBy": ["index"]
             },
             "their_out": {
               "isReturn": true,
-              "ownedBy": "index"
+              "ownedBy": ["index"]
             }
           },
           "isAsync": true,
@@ -1528,8 +1613,12 @@
         "git_index_open": {
           "isAsync": true,
           "return": {
+            "selfOwned": true,
             "isErrorCode": true
           }
+        },
+        "git_index_owner": {
+          "ignore": true
         },
         "git_index_read": {
           "args": {
@@ -1583,6 +1672,12 @@
             "isErrorCode": true
           }
         },
+        "git_index_reuc_get_byindex": {
+          "ignore": true
+        },
+        "git_index_reuc_get_bypath": {
+          "ignore": true
+        },
         "git_index_update_all": {
           "args": {
             "pathspec": {
@@ -1633,37 +1728,10 @@
       "ignoreInit": true
     },
     "indexer": {
-      "selfFreeing": true,
-      "cType": "git_indexer",
-      "functions": {
-        "git_indexer_append": {
-          "ignore": true
-        },
-        "git_indexer_free": {
-          "ignore": true
-        },
-        "git_indexer_hash": {
-          "return": {
-            "ownedByThis": true
-          }
-        },
-        "git_indexer_new": {
-          "ignore": true
-        }
-      }
+      "ignore": true
     },
     "mempack": {
-      "functions": {
-        "git_mempack_dump": {
-          "ignore": true
-        },
-        "git_mempack_new": {
-          "ignore": true
-        },
-        "git_mempack_reset": {
-          "ignore": true
-        }
-      }
+      "ignore": true
     },
     "merge": {
       "functions": {
@@ -1718,16 +1786,6 @@
             }
           }
         },
-        "git_merge_trees": {
-          "args": {
-            "ancestor_tree": {
-              "isOptional": true
-            },
-            "opts": {
-              "isOptional": true
-            }
-          }
-        },
         "git_merge_file": {
           "ignore": true
         },
@@ -1737,35 +1795,86 @@
         "git_merge_file_init_options": {
           "ignore": true
         },
-        "git_merge_file_result_free": {
+        "git_merge_init_options": {
           "ignore": true
+        },
+        "git_merge_trees": {
+          "args": {
+            "ancestor_tree": {
+              "isOptional": true
+            },
+            "opts": {
+              "isOptional": true
+            }
+          }
         }
       }
     },
     "merge_driver": {
       "ignore": true
     },
+    "merge_driver_source": {
+      "ignore": true
+    },
+    "merge_file_result": {
+      "ignore": true
+    },
+    "merge_result": {
+      "ignore": true
+    },
     "message": {
-      "functions": {
-        "git_message_prettify": {
-          "ignore": true
-        },
-        "git_message_trailers": {
-          "ignore": true
-        }
-      }
+      "ignore": true
+    },
+    "message_trailer": {
+      "ignore": true
+    },
+    "message_trailer_array": {
+      "ignore": true
     },
     "note": {
       "selfFreeing": true,
       "functions": {
-        "git_note_iterator_free": {
-          "ignore": true
+        "git_note_author": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_note_commit_create": {
+          "args": {
+            "notes_commit_out": {
+              "isReturn": true,
+              "shouldAlloc": true
+            },
+            "notes_blob_out": {
+              "isReturn": true,
+              "shouldAlloc": true
+            }
+          }
+        },
+        "git_note_commit_remove": {
+          "isAsync": true,
+          "args": {
+            "notes_commit_out": {
+              "isReturn": true
+            }
+          }
+        },
+        "git_note_comitter": {
+          "return": {
+            "ownedByThis": true
+          }
         },
         "git_note_create": {
           "args": {
             "out": {
               "shouldAlloc": true
             }
+          }
+        },
+        "git_note_foreach": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_note_free": {
@@ -1776,13 +1885,16 @@
             "ownedByThis": true
           }
         },
-        "git_note_remove": {
-          "isAsync": true,
-          "return": {
-            "isErrorCode": true
-          }
+        "git_note_iterator_free": {
+          "ignore": true
         },
-        "git_note_foreach": {
+        "git_note_iterator_new": {
+          "ignore": true
+        },
+        "git_note_next": {
+          "ignore": true
+        },
+        "git_note_remove": {
           "isAsync": true,
           "return": {
             "isErrorCode": true
@@ -1826,6 +1938,9 @@
         "git_odb_add_backend": {
           "ignore": true
         },
+        "git_odb_add_disk_alternate": {
+          "ignore": true
+        },
         "git_odb_backend_loose": {
           "ignore": true
         },
@@ -1836,9 +1951,29 @@
           "ignore": true
         },
         "git_odb_exists": {
-          "ignore": true
+          "ignore": true,
+          "isAsync": true,
+          "args": {
+            "db": {
+              "isSelf": true
+            }
+          }
         },
         "git_odb_exists_prefix": {
+          "isAsync": true,
+          "args": {
+            "db": {
+              "isSelf": true
+            },
+            "out": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_odb_expand_ids": {
           "ignore": true
         },
         "git_odb_foreach": {
@@ -1854,7 +1989,15 @@
           "ignore": true
         },
         "git_odb_hashfile": {
-          "ignore": true
+          "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_odb_init_backend": {
           "ignore": true
@@ -1871,25 +2014,25 @@
         "git_odb_open_wstream": {
           "ignore": true
         },
+        "git_odb_read": {
+          "cppFunctionName": "OdbRead",
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          }
+        },
         "git_odb_read_header": {
           "ignore": true
         },
         "git_odb_read_prefix": {
-          "ignore": true
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          }
         },
         "git_odb_refresh": {
-          "ignore": true
-        },
-        "git_odb_stream_finalize_write": {
-          "ignore": true
-        },
-        "git_odb_stream_free": {
-          "ignore": true
-        },
-        "git_odb_stream_read": {
-          "ignore": true
-        },
-        "git_odb_stream_write": {
           "ignore": true
         },
         "git_odb_write": {
@@ -1916,13 +2059,20 @@
       },
       "ignore": true
     },
+    "odb_expand_id": {
+      "ignore": true
+    },
     "odb_object": {
+      "selfFreeing": true,
       "functions": {
         "git_odb_object_data": {
           "return": {
             "cppClassName": "Wrapper",
             "jsClassName": "Buffer"
           }
+        },
+        "git_odb_object_dup": {
+          "ignore": true
         },
         "git_odb_object_free": {
           "ignore": true
@@ -1978,15 +2128,6 @@
         "git_oid_pathfmt": {
           "ignore": true
         },
-        "git_oid_shorten_add": {
-          "ignore": true
-        },
-        "git_oid_shorten_free": {
-          "ignore": true
-        },
-        "git_oid_shorten_new": {
-          "ignore": true
-        },
         "git_oid_tostr": {
           "ignore": true
         }
@@ -1998,7 +2139,22 @@
       }
     },
     "oid_shorten": {
-      "selfFreeing": true
+      "selfFreeing": true,
+      "functions": {
+        "git_oid_shorten_new": {
+          "isPrototypeMethod": false
+        },
+        "git_oid_shorten_add": {
+          "args": {
+            "os": {
+              "isSelf": true
+            }
+          }
+        },
+        "git_oid_shorten_free": {
+          "ignore": true
+        }
+      }
     },
     "oidarray": {
       "selfFreeing": true,
@@ -2027,6 +2183,30 @@
             "ownedByThis": true
           }
         },
+        "git_packbuilder_insert": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_packbuilder_insert_commit": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_packbuilder_insert_recur": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_packbuilder_insert_walk": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_packbuilder_new": {
           "isAsync": false
         },
@@ -2034,6 +2214,9 @@
           "ignore": true
         },
         "git_packbuilder_write": {
+          "ignore": true
+        },
+        "git_packbuilder_write_buf": {
           "ignore": true
         }
       }
@@ -2056,13 +2239,19 @@
         "git_patch_from_diff": {
           "isAsync": true,
           "return": {
-            "isErrorCode": true
+            "ownedBy": ["diff"]
+          }
+        },
+        "git_patch_get_delta": {
+          "return": {
+            "ownedByThis": true
           }
         },
         "git_patch_get_hunk": {
           "args": {
             "out": {
-              "returnName": "hunk"
+              "returnName": "hunk",
+              "ownedByThis": true
             },
             "lines_in_hunk": {
               "shouldAlloc": true,
@@ -2077,6 +2266,11 @@
         },
         "git_patch_get_line_in_hunk": {
           "isAsync": true,
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          },
           "return": {
             "isErrorCode": true
           }
@@ -2114,11 +2308,64 @@
         "git_pathspec_free": {
           "ignore": true
         },
-        "git_pathspec_match_list_free": {
-          "ignore": true
+        "git_pathspec_match_diff": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedBy": ["diff"],
+              "ownedByThis": true
+            }
+          }
+        },
+        "git_pathspec_match_index": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedBy": ["index"],
+              "ownedByThis": true
+            }
+          }
         },
         "git_pathspec_new": {
           "isAsync": false
+        },
+        "git_pathspec_match_tree": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedBy": ["tree"],
+              "ownedByThis": true
+            }
+          }
+        },
+        "git_pathspec_match_workdir": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedBy": ["repo"],
+              "ownedByThis": true
+            }
+          }
+        }
+      }
+    },
+    "pathspec_match_list": {
+      "selfFreeing": true,
+      "functions": {
+        "git_pathspec_match_list_diff_entry": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
+        "git_pathspec_match_list_free": {
+          "ignore": true
+        }
+      }
+    },
+    "proxy": {
+      "functions": {
+        "git_proxy_init_options": {
+          "ignore": true
         }
       }
     },
@@ -2128,6 +2375,22 @@
     "rebase": {
       "selfFreeing": true,
       "functions": {
+        "git_rebase_abort": {
+          "isAsync": true,
+          "args": {
+            "rebase": {
+              "cType": "git_rebase *",
+              "cppClassName": "GitRebase",
+              "jsClassName": "Rebase",
+              "isOptional": false,
+              "isSelf": true,
+              "isReturn": false
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_rebase_commit": {
           "isAsync": true,
           "args": {
@@ -2164,6 +2427,9 @@
         },
         "git_rebase_init": {
           "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            },
             "upstream": {
               "isOptional": true
             },
@@ -2178,20 +2444,40 @@
             }
           }
         },
-        "git_rebase_abort": {
-          "isAsync": true,
+        "git_rebase_init_options": {
+          "ignore": true
+        },
+        "git_rebase_inmemory_index": {
           "args": {
-            "rebase": {
-              "cType": "git_rebase *",
-              "cppClassName": "GitRebase",
-              "jsClassName": "Rebase",
-              "isOptional": false,
-              "isSelf": true,
-              "isReturn": false
+            "out": {
+              "ownedByThis": true
             }
-          },
+          }
+        },
+        "git_rebase_next": {
+          "args": {
+            "operation": {
+              "isReturn": true,
+              "ownedByThis": true
+            }
+          }
+        },
+        "git_rebase_open": {
+          "args": {
+            "out": {
+              "isSelf": true,
+              "ownedBy": ["repo"]
+            }
+          }
+        },
+        "git_rebase_operation_byindex": {
           "return": {
-            "isErrorCode": true
+            "ownedByThis": true
+          }
+        },
+        "git_rebase_operation_current": {
+          "return": {
+            "ownedByThis": true
           }
         }
       }
@@ -2213,6 +2499,13 @@
         },
         "git_refdb_new": {
           "ignore": true
+        },
+        "git_refdb_open": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
         }
       }
     },
@@ -2231,6 +2524,9 @@
           "ignore": true
         },
         "git_reference__alloc_symbolic": {
+          "ignore": true
+        },
+        "git_reference_dup": {
           "ignore": true
         },
         "git_reference_foreach": {
@@ -2313,6 +2609,13 @@
         "git_reflog_free": {
           "ignore": true
         },
+        "git_reflog_read": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
+        },
         "git_reflog_write": {
           "isAsync": true,
           "isSelf": true,
@@ -2324,6 +2627,11 @@
     },
     "reflog_entry": {
       "functions": {
+        "git_reflog_entry_committer": {
+          "return": {
+            "ownedByThis": true
+          }
+        },
         "git_reflog_entry_id_new": {
           "return": {
             "ownedByThis": true
@@ -2337,12 +2645,24 @@
       }
     },
     "refspec": {
+      "selfFreeing": true,
       "cType": "git_refspec",
       "functions": {
-        "git_refspec_rtransform": {
+        "git_refspec_free": {
           "ignore": true
         },
-        "git_refspec_string": {
+        "git_refspec_parse": {
+          "isAsync": true,
+          "args": {
+            "refspec": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_refspec_rtransform": {
           "ignore": true
         },
         "git_refspec_transform": {
@@ -2366,6 +2686,14 @@
           "isAsync": true,
           "return": {
             "isErrorCode": true
+          }
+        },
+        "git_remote_create_detached": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "selfOwned": true
+            }
           }
         },
         "git_remote_connect": {
@@ -2409,6 +2737,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_remote_dup": {
+          "ignore": true
         },
         "git_remote_fetch": {
           "args": {
@@ -2463,6 +2794,9 @@
           "return": {
             "ownedByThis": true
           }
+        },
+        "git_remote_init_callbacks": {
+          "ignore": true
         },
         "git_remote_list": {
           "args": {
@@ -2565,9 +2899,6 @@
             }
           }
         },
-        "git_repository_init_init_options": {
-          "ignore": true
-        },
         "git_repository_fetchhead_foreach": {
           "isAsync": true,
           "return": {
@@ -2583,6 +2914,9 @@
         "git_repository_ident": {
           "ignore": true
         },
+        "git_repository_init_init_options": {
+          "ignore": true
+        },
         "git_repository_mergehead_foreach": {
           "isAsync": true,
           "return": {
@@ -2594,6 +2928,34 @@
         },
         "git_repository_new": {
           "ignore": true
+        },
+        "git_repository_odb": {
+          "isAsync": true,
+          "args": {
+            "odb": {
+              "ownedByThis": true
+            },
+            "repo": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_repository_refdb": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedByThis": true
+            },
+            "repo": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_repository_reinit_filesystem": {
           "ignore": true
@@ -2736,6 +3098,9 @@
         "git_signature_default": {
           "isAsync": false
         },
+        "git_signature_dup": {
+          "ignore": true
+        },
         "git_signature_free": {
           "ignore": true
         },
@@ -2783,6 +3148,9 @@
             "isErrorCode": true
           }
         },
+        "git_stash_apply_init_options": {
+          "ignore": true
+        },
         "git_stash_pop": {
           "isAsync": true,
           "return": {
@@ -2808,7 +3176,10 @@
       ],
       "functions": {
         "git_status_byindex": {
-          "isAsync": false
+          "isAsync": false,
+          "return": {
+            "ownedBy": ["statuslist"]
+          }
         },
         "git_status_file": {
           "isAsync": true,
@@ -2848,6 +3219,9 @@
         "git_status_list_new": {
           "isAsync": true,
           "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            },
             "opts": {
               "isOptional": true
             }
@@ -2859,6 +3233,7 @@
       }
     },
     "strarray": {
+      "selfFreeing": true,
       "functions": {
         "git_strarray_free": {
           "ignore": true
@@ -3019,6 +3394,9 @@
           "return": {
             "isErrorCode": true
           }
+        },
+        "git_submodule_update_init_options": {
+          "ignore": true
         }
       }
     },
@@ -3067,6 +3445,9 @@
             "isErrorCode": true
           },
           "isAsync": true
+        },
+        "git_tag_dup": {
+          "ignore": true
         },
         "git_tag_foreach": {
           "ignore": true
@@ -3174,6 +3555,21 @@
         }
       }
     },
+    "transaction": {
+      "selfFreeing": true,
+      "functions": {
+        "git_transaction_free": {
+          "ignore": true
+        },
+        "git_transaction_new": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
+        }
+      }
+    },
     "transfer_progress": {
       "dupFunction": "git_transfer_progress_dup"
     },
@@ -3182,6 +3578,9 @@
       "needsForwardDeclaration": false,
       "functions": {
         "git_transport_dummy": {
+          "ignore": true
+        },
+        "git_transport_init": {
           "ignore": true
         },
         "git_transport_local": {
@@ -3194,6 +3593,12 @@
           "ignore": true
         },
         "git_transport_smart": {
+          "ignore": true
+        },
+        "git_transport_ssh_with_paths": {
+          "ignore": true
+        },
+        "git_transport_unregister": {
           "ignore": true
         }
       },
@@ -3208,24 +3613,38 @@
         "singletonCppClassName": "GitRepository"
       },
       "functions": {
+        "git_tree_dup": {
+          "ignore": true
+        },
         "git_tree_entry_byid": {
           "return": {
-            "ownedByThis": true,
-            "selfFreeing": false
+            "ownedByThis": true
           }
         },
         "git_tree_entry_byindex": {
           "jsFunctionName": "_entryByIndex",
           "return": {
-            "ownedByThis": true,
-            "selfFreeing": false
+            "ownedByThis": true
           }
         },
         "git_tree_entry_byname": {
           "jsFunctionName": "_entryByName",
           "return": {
-            "ownedByThis": true,
-            "selfFreeing": false
+            "ownedByThis": true
+          }
+        },
+        "git_tree_entry_bypath": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "ownedByThis": true
+            },
+            "root": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_tree_entrycount": {
@@ -3255,7 +3674,6 @@
         },
         "git_treebuilder_get": {
           "return": {
-            "selfFreeing": false,
             "ownedByThis": true
           }
         },
@@ -3284,6 +3702,9 @@
         },
         "git_treebuilder_new": {
           "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            },
             "source": {
               "isOptional": true
             }
@@ -3296,6 +3717,9 @@
       "dupFunction": "git_tree_entry_dup",
       "freeFunctionName": "git_tree_entry_free",
       "functions": {
+        "git_tree_entry_dup": {
+          "ignore": true
+        },
         "git_tree_entry_free": {
           "ignore": true
         },
@@ -3322,11 +3746,32 @@
       "cType": "git_worktree",
       "freeFunctionName": "git_worktree_free",
       "functions": {
-        "git_worktree_free": {
-          "ignore": true
+        "git_worktree_add": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
         },
         "git_worktree_add_init_options": {
           "ignore": true
+        },
+        "git_worktree_free": {
+          "ignore": true
+        },
+        "git_worktree_lookup": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
+        },
+        "git_worktree_open_from_repository": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          }
         },
         "git_worktree_prune_init_options": {
           "ignore": true

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -277,6 +277,7 @@
         },
         "git_blob_rawcontent": {
           "return": {
+            "ownedByThis": true,
             "cppClassName": "Wrapper",
             "jsClassName": "Buffer"
           }
@@ -2067,6 +2068,7 @@
       "functions": {
         "git_odb_object_data": {
           "return": {
+            "ownedByThis": true,
             "cppClassName": "Wrapper",
             "jsClassName": "Buffer"
           }

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -346,6 +346,16 @@
         ]
       ],
       [
+        "diff_stats",
+        [
+          "git_diff_stats_files_changed",
+          "git_diff_stats_insertions",
+          "git_diff_stats_deletions",
+          "git_diff_stats_to_buf",
+          "git_diff_stats_free"
+        ]
+      ],
+      [
         "filter_list",
         [
           "git_filter_list_apply_to_blob",
@@ -367,6 +377,12 @@
         ]
       ],
       [
+        "merge_file_result",
+        [
+          "git_merge_file_result_free"
+        ]
+      ],
+      [
         "odb_object",
         [
           "git_odb_object_data",
@@ -378,9 +394,37 @@
         ]
       ],
       [
+        "odb_stream",
+        [
+          "git_odb_stream_finalize_write",
+          "git_odb_stream_free",
+          "git_odb_stream_read",
+          "git_odb_stream_write"
+        ]
+      ],
+      [
+        "oid_shorten",
+        [
+          "git_oid_shorten_add",
+          "git_oid_shorten_free",
+          "git_oid_shorten_new"
+        ]
+      ],
+      [
         "patch",
         [
           "git_patch_convenient_from_diff"
+        ]
+      ],
+      [
+        "pathspec_match_list",
+        [
+          "git_pathspec_match_list_diff_entry",
+          "git_pathspec_match_list_entry",
+          "git_pathspec_match_list_entrycount",
+          "git_pathspec_match_list_failed_entry",
+          "git_pathspec_match_list_failed_entrycount",
+          "git_pathspec_match_list_free"
         ]
       ],
       [
@@ -498,6 +542,72 @@
               "ignore": true
             }
           ]
+        }
+      ],
+      [
+        "git_describe_format_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "unsigned int",
+              "name": "abbreviated_size"
+            },
+            {
+              "type": "int",
+              "name": "always_use_long_format"
+            },
+            {
+              "type": "const char *",
+              "name": "dirty_suffix"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_describe_init_format_options"
+            ]
+          }
+        }
+      ],
+      [
+        "git_describe_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "unsigned int",
+              "name": "max_candidates_tags"
+            },
+            {
+              "type": "unsigned int",
+              "name": "describe_strategy"
+            },
+            {
+              "type": "const char *",
+              "name": "pattern"
+            },
+            {
+              "type": "int",
+              "name": "only_follow_first_parent"
+            },
+            {
+              "type": "int",
+              "name": "show_commit_oid_as_fallback"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_describe_init_options"
+            ]
+          }
         }
       ],
       [
@@ -916,23 +1026,25 @@
         "git_annotated_commit_lookup"
       ]
     },
-    "filter": {
+    "diff": {
       "functions": [
-        "git_filter_list_new",
-        "git_filter_list_push",
-        "git_filter_list_stream_blob",
-        "git_filter_list_stream_data",
-        "git_filter_list_stream_file",
-        "git_filter_source_filemode",
-        "git_filter_source_flags",
-        "git_filter_source_id",
-        "git_filter_source_mode",
-        "git_filter_source_path",
-        "git_filter_source_repo"
+        "git_diff_stats_files_changed",
+        "git_diff_stats_insertions",
+        "git_diff_stats_deletions",
+        "git_diff_stats_to_buf",
+        "git_diff_stats_free"
       ]
     },
     "merge": {
       "functions": [
+        "git_merge_driver_lookup",
+        "git_merge_driver_register",
+        "git_merge_driver_source_ancestor",
+        "git_merge_driver_source_ours",
+        "git_merge_driver_source_repo",
+        "git_merge_driver_source_theirs",
+        "git_merge_driver_unregister",
+        "git_merge_file_result_free",
         "git_merge_head_free",
         "git_merge_head_from_fetchhead",
         "git_merge_head_from_id",
@@ -952,7 +1064,28 @@
         "git_odb_object_free",
         "git_odb_object_id",
         "git_odb_object_size",
-        "git_odb_object_type"
+        "git_odb_object_type",
+        "git_odb_stream_finalize_write",
+        "git_odb_stream_free",
+        "git_odb_stream_read",
+        "git_odb_stream_write"
+      ]
+    },
+    "oid": {
+      "functions": [
+        "git_oid_shorten_add",
+        "git_oid_shorten_free",
+        "git_oid_shorten_new"
+      ]
+    },
+    "pathspec": {
+      "functions": [
+        "git_pathspec_match_list_diff_entry",
+        "git_pathspec_match_list_entry",
+        "git_pathspec_match_list_entrycount",
+        "git_pathspec_match_list_failed_entry",
+        "git_pathspec_match_list_failed_entrycount",
+        "git_pathspec_match_list_free"
       ]
     },
     "reflog": {
@@ -973,6 +1106,7 @@
     },
     "tree": {
       "functions": [
+        "git_tree_entry_dup",
         "git_tree_entry_filemode",
         "git_tree_entry_filemode_raw",
         "git_tree_entry_free",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -144,6 +144,13 @@
           "isErrorCode": true
         }
       },
+      "git_filter_list_load": {
+        "isManual": true,
+        "cFile": "generate/templates/manual/filter_list/load.cc",
+        "isAsync": true,
+        "isPrototypeMethod": false,
+        "group": "filter_list"
+      },
       "git_patch_convenient_from_diff": {
         "args": [
           {

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -110,6 +110,13 @@
         },
         "group": "branch"
       },
+      "git_clone": {
+        "isManual": true,
+        "cFile": "generate/templates/manual/clone/clone.cc",
+        "isAsync": true,
+        "isPrototypeMethod": false,
+        "group": "clone"
+      },
       "git_commit_extract_signature": {
         "args": [
           {

--- a/generate/templates/filters/fields_info.js
+++ b/generate/templates/filters/fields_info.js
@@ -9,7 +9,7 @@ module.exports = function(fields) {
     fieldInfo.parsedName = field.name || "result";
     fieldInfo.isCppClassIntType = ~["Uint32", "Int32"].indexOf(field.cppClassName);
     fieldInfo.parsedClassName = (field.cppClassName || '').toLowerCase() + "_t";
-    fieldInfo.hasOwner = !!fieldInfo.ownedByThis;
+    fieldInfo.hasOwner = !fieldInfo.selfOwned && !!fieldInfo.ownedByThis;
 
     result.push(fieldInfo);
   });

--- a/generate/templates/filters/fields_info.js
+++ b/generate/templates/filters/fields_info.js
@@ -9,6 +9,7 @@ module.exports = function(fields) {
     fieldInfo.parsedName = field.name || "result";
     fieldInfo.isCppClassIntType = ~["Uint32", "Int32"].indexOf(field.cppClassName);
     fieldInfo.parsedClassName = (field.cppClassName || '').toLowerCase() + "_t";
+    fieldInfo.hasOwner = !!fieldInfo.ownedByThis;
 
     result.push(fieldInfo);
   });

--- a/generate/templates/filters/returns_info.js
+++ b/generate/templates/filters/returns_info.js
@@ -4,6 +4,18 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
   var result = [];
   var args = fn.args || [];
 
+  // We will use this to figure out the index
+  // of arguments, because sync functions
+  // need to respect ownership to an arbitrary
+  // parameter that is labeled by name in the
+  // descriptor, and we won't have access to
+  // any sort of string to argument index
+  // in the template.
+  var nameToArgIndex = {};
+  args.forEach(function (arg, index) {
+    nameToArgIndex[arg.name] = index;
+  });
+
   args.forEach(function (arg) {
     if (!arg.isReturn) return;
 
@@ -11,6 +23,7 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
 
     return_info.__proto__ = arg;
 
+    return_info.isAsync = isAsync;
     return_info.parsedName = isAsync ? "baton->" + return_info.name : return_info.name;
     return_info.isCppClassIntType = ~['Uint32', 'Int32'].indexOf(return_info.cppClassName);
     return_info.needsDereference
@@ -21,6 +34,15 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
     return_info.returnNameOrName = return_info.returnName || return_info.name;
     return_info.jsOrCppClassName = return_info.jsClassName || return_info.cppClassName;
     return_info.isOutParam = true;
+    return_info.hasOwner = return_info.ownedBy || return_info.ownedByThis;
+    return_info.ownedByIndex = -1;
+
+    // Here we convert ownedBy, which is the name of the parameter
+    // that owns this result to the argument index.
+    // sync functions will need to know this.
+    if (!isAsync && return_info.ownedBy) {
+      return_info.ownedByIndex = nameToArgIndex[return_info.ownedBy];
+    }
 
     result.push(return_info);
   });
@@ -33,6 +55,8 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
     var return_info = {};
 
     return_info.__proto__ = fn.return;
+
+    return_info.isAsync = isAsync;
     return_info.parsedName = return_info.name && isAsync ? "baton->" + return_info.name : "result";
     return_info.isCppClassIntType = ~['Uint32', 'Int32'].indexOf(return_info.cppClassName);
     return_info.parsedClassName = (return_info.cppClassName || '').toLowerCase() + "_t";

--- a/generate/templates/filters/returns_info.js
+++ b/generate/templates/filters/returns_info.js
@@ -34,7 +34,7 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
     return_info.returnNameOrName = return_info.returnName || return_info.name;
     return_info.jsOrCppClassName = return_info.jsClassName || return_info.cppClassName;
     return_info.isOutParam = true;
-    return_info.hasOwner = return_info.ownedBy || return_info.ownedByThis;
+    return_info.hasOwner = !!(return_info.ownedBy || return_info.ownedByThis);
     return_info.ownedByIndex = -1;
 
     // Here we convert ownedBy, which is the name of the parameter
@@ -57,6 +57,8 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
     return_info.__proto__ = fn.return;
 
     return_info.isAsync = isAsync;
+    return_info.hasOwner = !!return_info.ownedByThis;
+    return_info.ownedByIndex = -1;
     return_info.parsedName = return_info.name && isAsync ? "baton->" + return_info.name : "result";
     return_info.isCppClassIntType = ~['Uint32', 'Int32'].indexOf(return_info.cppClassName);
     return_info.parsedClassName = (return_info.cppClassName || '').toLowerCase() + "_t";

--- a/generate/templates/manual/clone/clone.cc
+++ b/generate/templates/manual/clone/clone.cc
@@ -1,0 +1,211 @@
+// NOTE you may need to occasionally rebuild this method by calling the generators
+// if major changes are made to the templates / generator.
+
+// Due to some file locking issues, we have the need to free a repository after it's cloned.
+// We do not expose free functions to javascript, and so, we've moved the implementation of
+// cloning, freeing the repo, and opening the repo into a custom template.
+
+/*
+ * @param String url
+ * @param String local_path
+ * @param CloneOptions options
+ * @param Repository callback
+ */
+NAN_METHOD(GitClone::Clone) {
+
+  if (info.Length() == 0 || !info[0]->IsString()) {
+    return Nan::ThrowError("String url is required.");
+  }
+
+  if (info.Length() == 1 || !info[1]->IsString()) {
+    return Nan::ThrowError("String local_path is required.");
+  }
+
+  if (info.Length() == 3 || !info[3]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  CloneBaton *baton = new CloneBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+
+  // start convert_from_v8 block
+  const char *from_url = NULL;
+
+  String::Utf8Value url(info[0]->ToString());
+  // malloc with one extra byte so we can add the terminating null character
+  // C-strings expect:
+  from_url = (const char *)malloc(url.length() + 1);
+  // copy the characters from the nodejs string into our C-string (used instead
+  // of strdup or strcpy because nulls in the middle of strings are valid coming
+  // from nodejs):
+  memcpy((void *)from_url, *url, url.length());
+  // ensure the final byte of our new string is null, extra casts added to
+  // ensure compatibility with various C types used in the nodejs binding
+  // generation:
+  memset((void *)(((char *)from_url) + url.length()), 0, 1);
+  // end convert_from_v8 block
+  baton->url = from_url;
+  // start convert_from_v8 block
+  const char *from_local_path = NULL;
+
+  String::Utf8Value local_path(info[1]->ToString());
+  // malloc with one extra byte so we can add the terminating null character
+  // C-strings expect:
+  from_local_path = (const char *)malloc(local_path.length() + 1);
+  // copy the characters from the nodejs string into our C-string (used instead
+  // of strdup or strcpy because nulls in the middle of strings are valid coming
+  // from nodejs):
+  memcpy((void *)from_local_path, *local_path, local_path.length());
+  // ensure the final byte of our new string is null, extra casts added to
+  // ensure compatibility with various C types used in the nodejs binding
+  // generation:
+  memset((void *)(((char *)from_local_path) + local_path.length()), 0, 1);
+  // end convert_from_v8 block
+  baton->local_path = from_local_path;
+  // start convert_from_v8 block
+  const git_clone_options *from_options = NULL;
+  if (info[2]->IsObject()) {
+    from_options = Nan::ObjectWrap::Unwrap<GitCloneOptions>(info[2]->ToObject())
+                       ->GetValue();
+  } else {
+    from_options = 0;
+  }
+  // end convert_from_v8 block
+  baton->options = from_options;
+
+  Nan::Callback *callback =
+      new Nan::Callback(v8::Local<Function>::Cast(info[3]));
+  CloneWorker *worker = new CloneWorker(baton, callback);
+
+  if (!info[0]->IsUndefined() && !info[0]->IsNull())
+    worker->SaveToPersistent("url", info[0]->ToObject());
+  if (!info[1]->IsUndefined() && !info[1]->IsNull())
+    worker->SaveToPersistent("local_path", info[1]->ToObject());
+  if (!info[2]->IsUndefined() && !info[2]->IsNull())
+    worker->SaveToPersistent("options", info[2]->ToObject());
+
+  AsyncLibgit2QueueWorker(worker);
+  return;
+}
+
+void GitClone::CloneWorker::Execute() {
+  giterr_clear();
+
+  {
+    LockMaster lockMaster(
+        /*asyncAction: */ true, baton->url, baton->local_path, baton->options);
+
+    git_repository *repo;
+    int result =
+        git_clone(&repo, baton->url, baton->local_path, baton->options);
+
+    if (result == GIT_OK) {
+      // This is required to clean up after the clone to avoid file locking
+      // issues in Windows and potentially other issues we don't know about.
+      git_repository_free(repo);
+
+      // We want to provide a valid repository object, so reopen the repository
+      // after clone and cleanup.
+      result = git_repository_open(&baton->out, baton->local_path);
+    }
+
+    baton->error_code = result;
+
+    if (result != GIT_OK && giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+  }
+}
+
+void GitClone::CloneWorker::HandleOKCallback() {
+  if (baton->error_code == GIT_OK) {
+    v8::Local<v8::Value> to;
+    // start convert_to_v8 block
+
+    if (baton->out != NULL) {
+      // GitRepository baton->out
+      to = GitRepository::New(baton->out, true);
+    } else {
+      to = Nan::Null();
+    }
+
+    // end convert_to_v8 block
+    v8::Local<v8::Value> result = to;
+
+    v8::Local<v8::Value> argv[2] = {Nan::Null(), result};
+    callback->Call(2, argv, async_resource);
+  } else {
+    if (baton->error) {
+      v8::Local<v8::Object> err;
+      if (baton->error->message) {
+        err = Nan::Error(baton->error->message)->ToObject();
+      } else {
+        err = Nan::Error("Method clone has thrown an error.")->ToObject();
+      }
+      err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(),
+               Nan::New("Clone.clone").ToLocalChecked());
+      v8::Local<v8::Value> argv[1] = {err};
+      callback->Call(1, argv, async_resource);
+      if (baton->error->message)
+        free((void *)baton->error->message);
+      free((void *)baton->error);
+    } else if (baton->error_code < 0) {
+      std::queue<v8::Local<v8::Value>> workerArguments;
+      workerArguments.push(GetFromPersistent("url"));
+      workerArguments.push(GetFromPersistent("local_path"));
+      workerArguments.push(GetFromPersistent("options"));
+      bool callbackFired = false;
+      while (!workerArguments.empty()) {
+        v8::Local<v8::Value> node = workerArguments.front();
+        workerArguments.pop();
+
+        if (!node->IsObject() || node->IsArray() || node->IsBooleanObject() ||
+            node->IsDate() || node->IsFunction() || node->IsNumberObject() ||
+            node->IsRegExp() || node->IsStringObject()) {
+          continue;
+        }
+
+        v8::Local<v8::Object> nodeObj = node->ToObject();
+        v8::Local<v8::Value> checkValue = GetPrivate(
+            nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
+
+        if (!checkValue.IsEmpty() && !checkValue->IsNull() &&
+            !checkValue->IsUndefined()) {
+          v8::Local<v8::Value> argv[1] = {checkValue->ToObject()};
+          callback->Call(1, argv, async_resource);
+          callbackFired = true;
+          break;
+        }
+
+        v8::Local<v8::Array> properties = nodeObj->GetPropertyNames();
+        for (unsigned int propIndex = 0; propIndex < properties->Length();
+             ++propIndex) {
+          v8::Local<v8::String> propName =
+              properties->Get(propIndex)->ToString();
+          v8::Local<v8::Value> nodeToQueue = nodeObj->Get(propName);
+          if (!nodeToQueue->IsUndefined()) {
+            workerArguments.push(nodeToQueue);
+          }
+        }
+      }
+
+      if (!callbackFired) {
+        v8::Local<v8::Object> err =
+            Nan::Error("Method clone has thrown an error.")->ToObject();
+        err->Set(Nan::New("errno").ToLocalChecked(),
+                 Nan::New(baton->error_code));
+        err->Set(Nan::New("errorFunction").ToLocalChecked(),
+                 Nan::New("Clone.clone").ToLocalChecked());
+        v8::Local<v8::Value> argv[1] = {err};
+        callback->Call(1, argv, async_resource);
+      }
+    } else {
+      callback->Call(0, NULL, async_resource);
+    }
+  }
+
+  delete baton;
+}

--- a/generate/templates/manual/filter_list/load.cc
+++ b/generate/templates/manual/filter_list/load.cc
@@ -1,3 +1,15 @@
+// NOTE you may need to occasionally rebuild this method by calling the generators
+// if major changes are made to the templates / generator.
+
+// git_filter_list_load has a more complex ownership pattern than is currently available
+// in the generator. This is because it not only has to get the repo as an owner,
+// but it also needs to discover which custom filters, a git_filter, it is bound to, if any.
+// We must enforce that the custom filters are not freed before a git_filter_list is freed,
+// but a git_filter_list also has pointers to the repo in it.
+
+// TODO In the future, it would be awesome if we could instead of writing a manual method like this, provide
+// custom ownership methods that can be injected into the HandleOKCallback.
+
 /*
  * @param Repository repo
  * @param Blob blob

--- a/generate/templates/manual/filter_list/load.cc
+++ b/generate/templates/manual/filter_list/load.cc
@@ -1,0 +1,233 @@
+/*
+ * @param Repository repo
+ * @param Blob blob
+ * @param String path
+ * @param Number mode
+ * @param Number flags
+ * @param FilterList callback
+ */
+NAN_METHOD(GitFilterList::Load) {
+  if (info.Length() == 0 || !info[0]->IsObject()) {
+    return Nan::ThrowError("Repository repo is required.");
+  }
+
+  if (info.Length() == 2 || !info[2]->IsString()) {
+    return Nan::ThrowError("String path is required.");
+  }
+
+  if (info.Length() == 3 || !info[3]->IsNumber()) {
+    return Nan::ThrowError("Number mode is required.");
+  }
+
+  if (info.Length() == 4 || !info[4]->IsNumber()) {
+    return Nan::ThrowError("Number flags is required.");
+  }
+
+  if (info.Length() == 5 || !info[5]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  LoadBaton *baton = new LoadBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+
+  // start convert_from_v8 block
+  git_repository *from_repo = NULL;
+  from_repo =
+      Nan::ObjectWrap::Unwrap<GitRepository>(info[0]->ToObject())->GetValue();
+  // end convert_from_v8 block
+  baton->repo = from_repo;
+  // start convert_from_v8 block
+  git_blob *from_blob = NULL;
+  if (info[1]->IsObject()) {
+    from_blob =
+        Nan::ObjectWrap::Unwrap<GitBlob>(info[1]->ToObject())->GetValue();
+  } else {
+    from_blob = 0;
+  }
+  // end convert_from_v8 block
+  baton->blob = from_blob;
+  // start convert_from_v8 block
+  const char *from_path = NULL;
+
+  String::Utf8Value path(info[2]->ToString());
+  // malloc with one extra byte so we can add the terminating null character
+  // C-strings expect:
+  from_path = (const char *)malloc(path.length() + 1);
+  // copy the characters from the nodejs string into our C-string (used instead
+  // of strdup or strcpy because nulls in the middle of strings are valid coming
+  // from nodejs):
+  memcpy((void *)from_path, *path, path.length());
+  // ensure the final byte of our new string is null, extra casts added to
+  // ensure compatibility with various C types used in the nodejs binding
+  // generation:
+  memset((void *)(((char *)from_path) + path.length()), 0, 1);
+  // end convert_from_v8 block
+  baton->path = from_path;
+  // start convert_from_v8 block
+  git_filter_mode_t from_mode;
+  from_mode = (git_filter_mode_t)(int)info[3].As<v8::Number>()->Value();
+  // end convert_from_v8 block
+  baton->mode = from_mode;
+  // start convert_from_v8 block
+  uint32_t from_flags;
+  from_flags = (uint32_t)info[4].As<v8::Number>()->Value();
+  // end convert_from_v8 block
+  baton->flags = from_flags;
+
+  Nan::Callback *callback =
+      new Nan::Callback(v8::Local<Function>::Cast(info[5]));
+  LoadWorker *worker = new LoadWorker(baton, callback);
+
+  if (!info[0]->IsUndefined() && !info[0]->IsNull())
+    worker->SaveToPersistent("repo", info[0]->ToObject());
+  if (!info[1]->IsUndefined() && !info[1]->IsNull())
+    worker->SaveToPersistent("blob", info[1]->ToObject());
+  if (!info[2]->IsUndefined() && !info[2]->IsNull())
+    worker->SaveToPersistent("path", info[2]->ToObject());
+  if (!info[3]->IsUndefined() && !info[3]->IsNull())
+    worker->SaveToPersistent("mode", info[3]->ToObject());
+  if (!info[4]->IsUndefined() && !info[4]->IsNull())
+    worker->SaveToPersistent("flags", info[4]->ToObject());
+
+  AsyncLibgit2QueueWorker(worker);
+  return;
+}
+
+void GitFilterList::LoadWorker::Execute() {
+  giterr_clear();
+
+  {
+    LockMaster lockMaster(
+        /*asyncAction: */ true, baton->repo, baton->blob, baton->path);
+
+    int result = git_filter_list_load(&baton->filters, baton->repo, baton->blob,
+                                      baton->path, baton->mode, baton->flags);
+
+    baton->error_code = result;
+
+    if (result != GIT_OK && giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+  }
+}
+
+void GitFilterList::LoadWorker::HandleOKCallback() {
+  if (baton->error_code == GIT_OK) {
+    v8::Local<v8::Value> to;
+    // start convert_to_v8 block
+
+    if (baton->filters != NULL) {
+      // GitFilterList baton->filters
+      v8::Local<v8::Array> owners = Nan::New<Array>(0);
+      v8::Local<v8::Object> filterRegistry = Nan::New(GitFilterRegistry::persistentHandle);
+      v8::Local<v8::Array> propertyNames = filterRegistry->GetPropertyNames();
+
+      Nan::Set(
+        owners,
+        Nan::New<Number>(0),
+        this->GetFromPersistent("repo")->ToObject()
+      );
+
+      for (uint32_t index = 0; index < propertyNames->Length(); ++index) {
+        v8::Local<v8::String> propertyName = propertyNames->Get(index)->ToString();
+        String::Utf8Value propertyNameAsUtf8Value(propertyName);
+        const char *propertyNameAsCString = *propertyNameAsUtf8Value;
+
+        bool isNotMethodOnRegistry = strcmp("register", propertyNameAsCString)
+          && strcmp("unregister", propertyNameAsCString);
+        if (isNotMethodOnRegistry && git_filter_list_contains(baton->filters, propertyNameAsCString)) {
+          Nan::Set(
+            owners,
+            Nan::New<Number>(owners->Length()),
+            filterRegistry->Get(propertyName)
+          );
+        }
+      }
+
+      to = GitFilterList::New(baton->filters, true, owners->ToObject());
+    } else {
+      to = Nan::Null();
+    }
+
+    // end convert_to_v8 block
+    v8::Local<v8::Value> result = to;
+
+    v8::Local<v8::Value> argv[2] = {Nan::Null(), result};
+    callback->Call(2, argv, async_resource);
+  } else {
+    if (baton->error) {
+      v8::Local<v8::Object> err;
+      if (baton->error->message) {
+        err = Nan::Error(baton->error->message)->ToObject();
+      } else {
+        err = Nan::Error("Method load has thrown an error.")->ToObject();
+      }
+      err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(),
+               Nan::New("FilterList.load").ToLocalChecked());
+      v8::Local<v8::Value> argv[1] = {err};
+      callback->Call(1, argv, async_resource);
+      if (baton->error->message)
+        free((void *)baton->error->message);
+      free((void *)baton->error);
+    } else if (baton->error_code < 0) {
+      std::queue<v8::Local<v8::Value>> workerArguments;
+      workerArguments.push(GetFromPersistent("repo"));
+      workerArguments.push(GetFromPersistent("blob"));
+      workerArguments.push(GetFromPersistent("path"));
+      workerArguments.push(GetFromPersistent("mode"));
+      workerArguments.push(GetFromPersistent("flags"));
+      bool callbackFired = false;
+      while (!workerArguments.empty()) {
+        v8::Local<v8::Value> node = workerArguments.front();
+        workerArguments.pop();
+
+        if (!node->IsObject() || node->IsArray() || node->IsBooleanObject() ||
+            node->IsDate() || node->IsFunction() || node->IsNumberObject() ||
+            node->IsRegExp() || node->IsStringObject()) {
+          continue;
+        }
+
+        v8::Local<v8::Object> nodeObj = node->ToObject();
+        v8::Local<v8::Value> checkValue = GetPrivate(
+            nodeObj, Nan::New("NodeGitPromiseError").ToLocalChecked());
+
+        if (!checkValue.IsEmpty() && !checkValue->IsNull() &&
+            !checkValue->IsUndefined()) {
+          v8::Local<v8::Value> argv[1] = {checkValue->ToObject()};
+          callback->Call(1, argv, async_resource);
+          callbackFired = true;
+          break;
+        }
+
+        v8::Local<v8::Array> properties = nodeObj->GetPropertyNames();
+        for (unsigned int propIndex = 0; propIndex < properties->Length();
+             ++propIndex) {
+          v8::Local<v8::String> propName =
+              properties->Get(propIndex)->ToString();
+          v8::Local<v8::Value> nodeToQueue = nodeObj->Get(propName);
+          if (!nodeToQueue->IsUndefined()) {
+            workerArguments.push(nodeToQueue);
+          }
+        }
+      }
+
+      if (!callbackFired) {
+        v8::Local<v8::Object> err =
+            Nan::Error("Method load has thrown an error.")->ToObject();
+        err->Set(Nan::New("errno").ToLocalChecked(),
+                 Nan::New(baton->error_code));
+        err->Set(Nan::New("errorFunction").ToLocalChecked(),
+                 Nan::New("FilterList.load").ToLocalChecked());
+        v8::Local<v8::Value> argv[1] = {err};
+        callback->Call(1, argv, async_resource);
+      }
+    } else {
+      callback->Call(0, NULL, async_resource);
+    }
+  }
+
+  delete baton;
+}

--- a/generate/templates/manual/include/nodegit_wrapper.h
+++ b/generate/templates/manual/include/nodegit_wrapper.h
@@ -2,6 +2,7 @@
 #define NODEGIT_WRAPPER_H
 
 #include <nan.h>
+#include <unordered_map>
 
 // the Traits template parameter supplies:
 //  typename cppClass - the C++ type of the NodeGit wrapper (e.g. GitRepository)

--- a/generate/templates/manual/include/reference_counter.h
+++ b/generate/templates/manual/include/reference_counter.h
@@ -1,0 +1,30 @@
+#ifndef REFERENCE_COUNTER_H
+#define REFERENCE_COUNTER_H
+
+#include <unordered_map>
+
+#include "lock_master.h"
+
+// There are certain instances in libgit2 which can be retrieved from multiple sources
+// We need to make sure that we're counting how many times we've seen that pointer
+// so that when we are performing free behavior, we don't free it until it is no longer
+// referenced. The main example of this behavior is the repository instance, where
+// after git_repository_open open (first instance) we can git_commit_lookup, followed by
+// git_commit_owner (second instance).
+//
+// I was hoping that we could construct a Persistent handle, but that would interfere with
+// GC. We want it to attmept to GC, and if this handle exists, the final repo will not
+// free itself :(.
+//
+// Make sure to utilize LockMaster when incrementing or decrementing a reference count.
+class ReferenceCounter {
+public:
+  static void incrementCountForPointer(void *ptr);
+
+  static unsigned long decrementCountForPointer(void *ptr);
+
+private:
+  static std::unordered_map<void *, unsigned long> referenceCountByPointer;
+};
+
+#endif

--- a/generate/templates/manual/src/reference_counter.cc
+++ b/generate/templates/manual/src/reference_counter.cc
@@ -1,0 +1,24 @@
+#include "../include/reference_counter.h"
+
+void ReferenceCounter::incrementCountForPointer(void *ptr) {
+  LockMaster(true, &referenceCountByPointer);
+  if (referenceCountByPointer.find(ptr) == referenceCountByPointer.end()) {
+    referenceCountByPointer[ptr] = 1;
+  } else {
+    referenceCountByPointer[ptr] = referenceCountByPointer[ptr] + 1;
+  }
+}
+
+unsigned long ReferenceCounter::decrementCountForPointer(void *ptr) {
+  LockMaster(true, &referenceCountByPointer);
+  unsigned long referenceCount = referenceCountByPointer[ptr];
+  if (referenceCount == 1) {
+    referenceCountByPointer.erase(ptr);
+    return 0;
+  } else {
+    referenceCountByPointer[ptr] = referenceCount - 1;
+    return referenceCountByPointer[ptr];
+  }
+}
+
+std::unordered_map<void *, unsigned long> ReferenceCounter::referenceCountByPointer;

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -13,41 +13,41 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 
   {%each args|argsInfo as arg %}
     {%if arg.globalPayload %}
-  {{ cppFunctionName }}_globalPayload* globalPayload = new {{ cppFunctionName }}_globalPayload;
+      {{ cppFunctionName }}_globalPayload* globalPayload = new {{ cppFunctionName }}_globalPayload;
     {%endif%}
   {%endeach%}
 
   {%each args|argsInfo as arg %}
     {%if not arg.isReturn %}
       {%if arg.isSelf %}
-  baton->{{ arg.name }} = Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue();
+        baton->{{ arg.name }} = Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue();
       {%elsif arg.isCallbackFunction %}
-  if (!info[{{ arg.jsArg }}]->IsFunction()) {
-    baton->{{ arg.name }} = NULL;
+        if (!info[{{ arg.jsArg }}]->IsFunction()) {
+          baton->{{ arg.name }} = NULL;
         {%if arg.payload.globalPayload %}
-    globalPayload->{{ arg.name }} = NULL;
+          globalPayload->{{ arg.name }} = NULL;
         {%else%}
-    baton->{{ arg.payload.name }} = NULL;
+          baton->{{ arg.payload.name }} = NULL;
         {%endif%}
-  }
-  else {
-    baton->{{ arg.name}} = {{ cppFunctionName }}_{{ arg.name }}_cppCallback;
-        {%if arg.payload.globalPayload %}
-    globalPayload->{{ arg.name }} = new Nan::Callback(info[{{ arg.jsArg }}].As<Function>());
-        {%else%}
-    baton->{{ arg.payload.name }} = new Nan::Callback(info[{{ arg.jsArg }}].As<Function>());
-        {%endif%}
-  }
+        }
+        else {
+          baton->{{ arg.name}} = {{ cppFunctionName }}_{{ arg.name }}_cppCallback;
+          {%if arg.payload.globalPayload %}
+            globalPayload->{{ arg.name }} = new Nan::Callback(info[{{ arg.jsArg }}].As<Function>());
+          {%else%}
+            baton->{{ arg.payload.name }} = new Nan::Callback(info[{{ arg.jsArg }}].As<Function>());
+          {%endif%}
+        }
       {%elsif arg.payloadFor %}
         {%if arg.globalPayload %}
-  baton->{{ arg.name }} = globalPayload;
+          baton->{{ arg.name }} = globalPayload;
         {%endif%}
       {%elsif arg.name %}
-  {%partial convertFromV8 arg%}
+        {%partial convertFromV8 arg%}
         {%if not arg.payloadFor %}
-  baton->{{ arg.name }} = from_{{ arg.name }};
+          baton->{{ arg.name }} = from_{{ arg.name }};
           {%if arg | isOid %}
-  baton->{{ arg.name }}NeedsFree = info[{{ arg.jsArg }}]->IsString();
+            baton->{{ arg.name }}NeedsFree = info[{{ arg.jsArg }}]->IsString();
           {%endif%}
         {%endif%}
       {%endif%}
@@ -62,13 +62,14 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 
   Nan::Callback *callback = new Nan::Callback(v8::Local<Function>::Cast(info[{{args|jsArgsCount}}]));
   {{ cppFunctionName }}Worker *worker = new {{ cppFunctionName }}Worker(baton, callback);
+
   {%each args|argsInfo as arg %}
     {%if not arg.isReturn %}
       {%if arg.isSelf %}
-  worker->SaveToPersistent("{{ arg.name }}", info.This());
+        worker->SaveToPersistent("{{ arg.name }}", info.This());
       {%elsif not arg.isCallbackFunction %}
-  if (!info[{{ arg.jsArg }}]->IsUndefined() && !info[{{ arg.jsArg }}]->IsNull())
-    worker->SaveToPersistent("{{ arg.name }}", info[{{ arg.jsArg }}]->ToObject());
+        if (!info[{{ arg.jsArg }}]->IsUndefined() && !info[{{ arg.jsArg }}]->IsNull())
+          worker->SaveToPersistent("{{ arg.name }}", info[{{ arg.jsArg }}]->ToObject());
       {%endif%}
     {%endif%}
   {%endeach%}
@@ -81,41 +82,45 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
   giterr_clear();
 
   {
-    LockMaster lockMaster(/*asyncAction: */true{%each args|argsInfo as arg %}
-      {%if arg.cType|isPointer%}{%if not arg.cType|isDoublePointer%}
-        ,baton->{{ arg.name }}
-      {%endif%}{%endif%}
-    {%endeach%});
+    LockMaster lockMaster(
+      /*asyncAction: */true
+      {%each args|argsInfo as arg %}
+        {%if arg.cType|isPointer%}
+          {%if not arg.cType|isDoublePointer%}
+            ,baton->{{ arg.name }}
+          {%endif%}
+        {%endif%}
+      {%endeach%}
+    );
 
   {%if .|hasReturnType %}
-  {{ return.cType }} result = {{ cFunctionName }}(
+    {{ return.cType }} result = {{ cFunctionName }}(
   {%else%}
-  {{ cFunctionName }}(
+    {{ cFunctionName }}(
   {%endif%}
     {%-- Insert Function Arguments --%}
     {%each args|argsInfo as arg %}
       {%-- turn the pointer into a ref --%}
-    {%if arg.isReturn|and arg.cType|isDoublePointer %}&{%endif%}baton->{{ arg.name }}{%if not arg.lastArg %},{%endif%}
-
+      {%if arg.isReturn|and arg.cType|isDoublePointer %}&{%endif%}baton->{{ arg.name }}{%if not arg.lastArg %},{%endif%}
     {%endeach%}
-    );
+  );
 
     {%if return.isResultOrError %}
-    baton->error_code = result;
-    if (result < GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
-    }
+      baton->error_code = result;
+      if (result < GIT_OK && giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
 
     {%elsif return.isErrorCode %}
-    baton->error_code = result;
+      baton->error_code = result;
 
-    if (result != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
-    }
+      if (result != GIT_OK && giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
 
     {%elsif not return.cType == 'void' %}
 
-    baton->result = result;
+      baton->result = result;
 
     {%endif%}
   }
@@ -123,30 +128,32 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
 
 void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
   {%if return.isResultOrError %}
-  if (baton->error_code >= GIT_OK) {
+    if (baton->error_code >= GIT_OK) {
   {%else%}
-  if (baton->error_code == GIT_OK) {
+    if (baton->error_code == GIT_OK) {
   {%endif%}
-    {%if return.isResultOrError %}
+
+  {%if return.isResultOrError %}
     v8::Local<v8::Value> result = Nan::New<v8::Number>(baton->error_code);
 
-    {%elsif not .|returnsCount %}
+  {%elsif not .|returnsCount %}
     v8::Local<v8::Value> result = Nan::Undefined();
-    {%else%}
+  {%else%}
     v8::Local<v8::Value> to;
-      {%if .|returnsCount > 1 %}
-    v8::Local<Object> result = Nan::New<Object>();
-      {%endif%}
-      {%each .|returnsInfo 0 1 as _return %}
-        {%partial convertToV8 _return %}
-        {%if .|returnsCount > 1 %}
-    Nan::Set(result, Nan::New("{{ _return.returnNameOrName }}").ToLocalChecked(), to);
-        {%endif%}
-      {%endeach%}
-      {%if .|returnsCount == 1 %}
-    v8::Local<v8::Value> result = to;
-      {%endif%}
+    {%if .|returnsCount > 1 %}
+      v8::Local<Object> result = Nan::New<Object>();
     {%endif%}
+    {%each .|returnsInfo 0 1 as _return %}
+      {%partial convertToV8 _return %}
+      {%if .|returnsCount > 1 %}
+        Nan::Set(result, Nan::New("{{ _return.returnNameOrName }}").ToLocalChecked(), to);
+      {%endif%}
+    {%endeach%}
+    {%if .|returnsCount == 1 %}
+      v8::Local<v8::Value> result = to;
+    {%endif%}
+  {%endif%}
+
     v8::Local<v8::Value> argv[2] = {
       Nan::Null(),
       result
@@ -171,15 +178,15 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       free((void *)baton->error);
     } else if (baton->error_code < 0) {
       std::queue< v8::Local<v8::Value> > workerArguments;
-{%each args|argsInfo as arg %}
-  {%if not arg.isReturn %}
-    {%if not arg.isSelf %}
-      {%if not arg.isCallbackFunction %}
-      workerArguments.push(GetFromPersistent("{{ arg.name }}"));
-      {%endif%}
-    {%endif%}
-  {%endif%}
-{%endeach%}
+      {%each args|argsInfo as arg %}
+        {%if not arg.isReturn %}
+          {%if not arg.isSelf %}
+            {%if not arg.isCallbackFunction %}
+              workerArguments.push(GetFromPersistent("{{ arg.name }}"));
+            {%endif%}
+          {%endif%}
+        {%endif%}
+      {%endeach%}
       bool callbackFired = false;
       while(!workerArguments.empty()) {
         v8::Local<v8::Value> node = workerArguments.front();
@@ -237,18 +244,18 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
       {%if arg.shouldAlloc %}
         {%if not arg.isCppClassStringOrArray %}
         {%elsif arg | isOid %}
-    if (baton->{{ arg.name}}NeedsFree) {
-      baton->{{ arg.name}}NeedsFree = false;
-      free((void*)baton->{{ arg.name }});
-    }
+          if (baton->{{ arg.name}}NeedsFree) {
+            baton->{{ arg.name}}NeedsFree = false;
+            free((void*)baton->{{ arg.name }});
+          }
         {%elsif arg.isCallbackFunction %}
           {%if not arg.payload.globalPayload %}
-    delete baton->{{ arg.payload.name }};
+            delete baton->{{ arg.payload.name }};
           {%endif%}
         {%elsif arg.globalPayload %}
-    delete ({{ cppFunctionName}}_globalPayload*)baton->{{ arg.name }};
+          delete ({{ cppFunctionName}}_globalPayload*)baton->{{ arg.name }};
         {%else%}
-    free((void*)baton->{{ arg.name }});
+          free((void*)baton->{{ arg.name }});
         {%endif%}
       {%endif%}
     {%endeach%}
@@ -257,21 +264,21 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
   {%each args|argsInfo as arg %}
     {%if arg.isCppClassStringOrArray %}
       {%if arg.freeFunctionName %}
-  {{ arg.freeFunctionName }}(baton->{{ arg.name }});
+        {{ arg.freeFunctionName }}(baton->{{ arg.name }});
       {%elsif not arg.isConst%}
-  free((void *)baton->{{ arg.name }});
+        free((void *)baton->{{ arg.name }});
       {%endif%}
     {%elsif arg | isOid %}
-  if (baton->{{ arg.name}}NeedsFree) {
-    baton->{{ arg.name}}NeedsFree = false;
-    free((void *)baton->{{ arg.name }});
-  }
+      if (baton->{{ arg.name}}NeedsFree) {
+        baton->{{ arg.name}}NeedsFree = false;
+        free((void *)baton->{{ arg.name }});
+      }
     {%elsif arg.isCallbackFunction %}
       {%if not arg.payload.globalPayload %}
-  delete baton->{{ arg.payload.name }};
+        delete baton->{{ arg.payload.name }};
       {%endif%}
     {%elsif arg.globalPayload %}
-  delete ({{ cppFunctionName}}_globalPayload*)baton->{{ arg.name }};
+      delete ({{ cppFunctionName}}_globalPayload*)baton->{{ arg.name }};
     {%endif%}
     {%if arg.cppClassName == "GitBuf" %}
       {%if cppFunctionName == "Set" %}

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -65,7 +65,20 @@
     {% if cppClassName == 'Wrapper' %}
       to = {{ cppClassName }}::New({{= parsedName =}});
     {% else %}
-      to = {{ cppClassName }}::New({{= parsedName =}}, {{ selfFreeing|toBool }} {% if ownedByThis %}, info.This(){% endif %});
+      to = {{ cppClassName }}::New(
+        {{= parsedName =}},
+        {{ selfFreeing|toBool }}
+        {% if hasOwner %}
+          ,
+          {% if ownedByThis %}
+            info.This()
+          {% elsif isAsync %}
+            this->GetFromPersistent("{{= ownedBy =}}")
+          {% else %}
+            info[{{= ownedByIndex =}}]->ToObject()
+          {% endif %}
+        {% endif %}
+      );
     {% endif %}
   }
   else {

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -70,10 +70,15 @@
         {{ selfFreeing|toBool }}
         {% if hasOwner %}
           ,
-          {% if ownedByThis %}
-            info.This()
+          {% if ownerFn | toBool %}
+            {{= ownerFn.singletonCppClassName =}}::New(
+              {{= ownerFn.name =}}({{= parsedName =}}),
+              true
+            )->ToObject()
           {% elsif isAsync %}
-            this->GetFromPersistent("{{= ownedBy =}}")
+            this->GetFromPersistent("{{= ownedBy =}}")->ToObject()
+          {% elsif ownedByThis %}
+            info.This()
           {% else %}
             info[{{= ownedByIndex =}}]->ToObject()
           {% endif %}

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -6,9 +6,9 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 
   {%each .|returnsInfo 'true' as _return %}
     {%if _return.shouldAlloc %}
-  {{ _return.cType }}{{ _return.name }} = ({{ _return.cType }})malloc(sizeof({{ _return.cType|unPointer }}));
+      {{ _return.cType }}{{ _return.name }} = ({{ _return.cType }})malloc(sizeof({{ _return.cType|unPointer }}));
     {%else%}
-  {{ _return.cType|unPointer }} {{ _return.name }} = {{ _return.cType|unPointer|defaultValue }};
+      {{ _return.cType|unPointer }} {{ _return.name }} = {{ _return.cType|unPointer|defaultValue }};
     {%endif%}
   {%endeach%}
 
@@ -17,112 +17,115 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
       {%if not arg.isReturn %}
         {%partial convertFromV8 arg %}
         {%if arg.saveArg %}
-  v8::Local<Object> {{ arg.name }}(info[{{ arg.jsArg }}]->ToObject());
-  {{ cppClassName }} *thisObj = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This());
+          v8::Local<Object> {{ arg.name }}(info[{{ arg.jsArg }}]->ToObject());
+          {{ cppClassName }} *thisObj = Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This());
 
-  thisObj->{{ cppFunctionName }}_{{ arg.name }}.Reset({{ arg.name }});
+          thisObj->{{ cppFunctionName }}_{{ arg.name }}.Reset({{ arg.name }});
         {%endif%}
       {%endif%}
     {%endif%}
   {%endeach%}
 
-{%each args|argsInfo as arg %}
-{%endeach%}
-
-{%-- Inside a free call, if the value is already free'd don't do it again.--%}
-{% if cppFunctionName == "Free" %}
-if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL) {
-{% endif %}
+  {%-- Inside a free call, if the value is already free'd don't do it again.--%}
+  {%if cppFunctionName == "Free" %}
+    if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL) {
+  {%endif%}
 
   giterr_clear();
 
-  {
-    LockMaster lockMaster(/*asyncAction: */false{%each args|argsInfo as arg %}
-      {%if arg.cType|isPointer%}{%if not arg.isReturn%}
-        ,{%if arg.isSelf %}
-    Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue()
-        {%else%}
-    from_{{ arg.name }}
-      {%endif%}
-      {%endif%}{%endif%}
-    {%endeach%});
-
-  {%if .|hasReturnValue %}
-    {{ return.cType }} result = {%endif%}{{ cFunctionName }}(
-    {%each args|argsInfo as arg %}
-      {%if arg.isReturn %}
-        {%if not arg.shouldAlloc %}&{%endif%}
-      {%endif%}
-      {%if arg.isSelf %}
-  Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue()
-      {%elsif arg.isReturn %}
-  {{ arg.name }}
-      {%else%}
-  from_{{ arg.name }}
-      {%endif%}
-      {%if not arg.lastArg %},{%endif%}
-    {%endeach%}
+  { // lock master scope start
+    LockMaster lockMaster(
+      /*asyncAction: */false
+      {%each args|argsInfo as arg %}
+        {%if arg.cType|isPointer%}
+          {%if not arg.isReturn%}
+            ,
+            {%if arg.isSelf %}
+              Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue()
+            {%else%}
+              from_{{ arg.name }}
+            {%endif%}
+          {%endif%}
+        {%endif%}
+      {%endeach%}
     );
 
-  {%if .|hasReturnValue |and return.isErrorCode %}
-    if (result != GIT_OK) {
+    {%if .|hasReturnValue %} {{ return.cType }} result = {%endif%}
+    {{ cFunctionName }}(
+      {%each args|argsInfo as arg %}
+        {%if arg.isReturn %}
+          {%if not arg.shouldAlloc %}&{%endif%}
+        {%endif%}
+        {%if arg.isSelf %}
+          Nan::ObjectWrap::Unwrap<{{ arg.cppClassName }}>(info.This())->GetValue()
+        {%elsif arg.isReturn %}
+          {{ arg.name }}
+        {%else%}
+          from_{{ arg.name }}
+        {%endif%}
+        {%if not arg.lastArg %},{%endif%}
+      {%endeach%}
+    );
+
+    {%if .|hasReturnValue |and return.isErrorCode %}
+      if (result != GIT_OK) {
+      {%each args|argsInfo as arg %}
+        {%if arg.shouldAlloc %}
+          free({{ arg.name }});
+        {%elsif arg | isOid %}
+          if (info[{{ arg.jsArg }}]->IsString()) {
+            free({{ arg.name }});
+          }
+        {%endif%}
+      {%endeach%}
+
+        if (giterr_last()) {
+          return Nan::ThrowError(giterr_last()->message);
+        } else {
+          return Nan::ThrowError("Unknown Error");
+        }
+      } // lock master scope end
+    {%endif%}
+
+    {%if cppFunctionName == "Free" %}
+        Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->ClearValue();
+      } // lock master scope end
+    {%endif%}
+
+
     {%each args|argsInfo as arg %}
-      {%if arg.shouldAlloc %}
-      free({{ arg.name }});
-      {%elsif arg | isOid %}
+      {%if arg | isOid %}
       if (info[{{ arg.jsArg }}]->IsString()) {
-        free({{ arg.name }});
+        free((void *)from_{{ arg.name }});
       }
       {%endif%}
     {%endeach%}
 
-      if (giterr_last()) {
-        return Nan::ThrowError(giterr_last()->message);
-      } else {
-        return Nan::ThrowError("Unknown Error");
-      }
-    }
-  {%endif%}
-
-  {% if cppFunctionName == "Free" %}
-    Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->ClearValue();
-  }
-  {% endif %}
-
-
-  {%each args|argsInfo as arg %}
-    {%if arg | isOid %}
-    if (info[{{ arg.jsArg }}]->IsString()) {
-      free((void *)from_{{ arg.name }});
-    }
-    {%endif%}
-  {%endeach%}
-
-  {%if not .|returnsCount %}
-    return info.GetReturnValue().Set(scope.Escape(Nan::Undefined()));
-  {%else%}
-    {%if return.cType | isPointer %}
-    // null checks on pointers
-    if (!result) {
+    {%if not .|returnsCount %}
       return info.GetReturnValue().Set(scope.Escape(Nan::Undefined()));
-    }
-    {%endif%}
-
-    v8::Local<v8::Value> to;
-    {%if .|returnsCount > 1 %}
-    v8::Local<Object> toReturn = Nan::New<Object>();
-    {%endif%}
-    {%each .|returnsInfo as _return %}
-      {%partial convertToV8 _return %}
-      {%if .|returnsCount > 1 %}
-    Nan::Set(toReturn, Nan::New("{{ _return.returnNameOrName }}").ToLocalChecked(), to);
-      {%endif%}
-    {%endeach%}
-    {%if .|returnsCount == 1 %}
-    return info.GetReturnValue().Set(scope.Escape(to));
     {%else%}
-    return info.GetReturnValue().Set(scope.Escape(toReturn));
+      {%if return.cType | isPointer %}
+        // null checks on pointers
+        if (!result) {
+          return info.GetReturnValue().Set(scope.Escape(Nan::Undefined()));
+        }
+      {%endif%}
+
+      v8::Local<v8::Value> to;
+      {%if .|returnsCount > 1 %}
+        v8::Local<Object> toReturn = Nan::New<Object>();
+      {%endif%}
+      {%each .|returnsInfo as _return %}
+        {%partial convertToV8 _return %}
+        {%if .|returnsCount > 1 %}
+          Nan::Set(toReturn, Nan::New("{{ _return.returnNameOrName }}").ToLocalChecked(), to);
+        {%endif%}
+      {%endeach%}
+      {%if .|returnsCount == 1 %}
+        return info.GetReturnValue().Set(scope.Escape(to));
+      {%else%}
+        return info.GetReturnValue().Set(scope.Escape(toReturn));
+      {%endif%}
     {%endif%}
-  {%endif%}
   }
 }

--- a/generate/templates/partials/traits.h
+++ b/generate/templates/partials/traits.h
@@ -17,10 +17,17 @@ struct {{ cppClassName }}Traits {
   {% endif %}
   }
 
+  static const bool isSingleton = {{ isSingleton | toBool }};
   static const bool isFreeable = {{ freeFunctionName | toBool}};
   static void free({{ cType }} *raw) {
   {% if freeFunctionName %}
-    ::{{ freeFunctionName }}(raw); // :: to avoid calling this free recursively
+    unsigned long referenceCount = 0;
+    {% if isSingleton %}
+    referenceCount = ReferenceCounter::decrementCountForPointer((void *)raw);
+    {% endif %}
+    if (referenceCount == 0) {
+      ::{{ freeFunctionName }}(raw); // :: to avoid calling this free recursively
+    }
   {% else %}
     Nan::ThrowError("free called on {{ cppClassName }} which cannot be freed");
   {% endif %}

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -75,6 +75,7 @@
       "sources": [
         "src/async_baton.cc",
         "src/lock_master.cc",
+        "src/reference_counter.cc",
         "src/nodegit.cc",
         "src/init_ssh2.cc",
         "src/promise_completion.cc",

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -134,7 +134,9 @@
             ],
             "xcode_settings": {
               "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
-              "MACOSX_DEPLOYMENT_TARGET": "10.7",
+              "MACOSX_DEPLOYMENT_TARGET": "10.9",
+              'CLANG_CXX_LIBRARY': 'libc++',
+              'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
 
               "WARNING_CFLAGS": [
                 "-Wno-unused-variable",

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -4,10 +4,12 @@
 #include <string>
 #include <queue>
 #include <utility>
+#include <unordered_map>
 
 #include "async_baton.h"
 #include "nodegit_wrapper.h"
 #include "promise_completion.h"
+#include "reference_counter.h"
 
 extern "C" {
 #include <git2.h>

--- a/generate/templates/templates/struct_header.h
+++ b/generate/templates/templates/struct_header.h
@@ -4,9 +4,11 @@
 #include <string>
 #include <queue>
 #include <utility>
+#include <unordered_map>
 
 #include "async_baton.h"
 #include "callback_wrapper.h"
+#include "reference_counter.h"
 #include "nodegit_wrapper.h"
 
 extern "C" {

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -29,19 +29,5 @@ Clone.clone = function(url, local_path, options) {
     options.fetchOpts = fetchOpts;
   }
 
-  // This is required to clean up after the clone to avoid file locking
-  // issues in Windows and potentially other issues we don't know about.
-  var freeRepository = function(repository) {
-    repository.free();
-  };
-
-  // We want to provide a valid repository object, so reopen the repository
-  // after clone and cleanup.
-  var openRepository = function() {
-    return NodeGit.Repository.open(local_path);
-  };
-
-  return _clone.call(this, url, local_path, options)
-    .then(freeRepository)
-    .then(openRepository);
+  return _clone.call(this, url, local_path, options);
 };

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -803,11 +803,6 @@ Repository.prototype.discardLines =
     })
     .then(function(content) {
       originalContent = content;
-      if (filterList) {
-        filterList.free();
-        filterList = null;
-      }
-
       return getPathHunks(repo, index, filePath, false, additionalDiffOptions);
     })
     .then(function(hunks) {
@@ -837,11 +832,6 @@ Repository.prototype.discardLines =
         });
     })
     .then(function(filteredContent) {
-      if (filterList) {
-        filterList.free();
-        filterList = null;
-      }
-
       return fse.writeFile(fullFilePath, filteredContent);
     });
 };

--- a/test/tests/annotated_commit.js
+++ b/test/tests/annotated_commit.js
@@ -32,25 +32,6 @@ describe("AnnotatedCommit", function() {
       });
   });
 
-  it("can free an AnnotatedCommit after creating it", function() {
-    var test = this;
-
-    return Branch.lookup(test.repository, branchName, Branch.BRANCH.LOCAL)
-      .then(function(ref) {
-        return AnnotatedCommit.fromRef(test.repository, ref);
-      })
-      .then(function(annotatedCommit) {
-        // Annotated commit should exist
-        assert(annotatedCommit.id());
-
-        // Free the annotated commit
-        annotatedCommit.free();
-
-        // Getting the id should now throw because the commit was freed
-        assert.throws(annotatedCommit.id);
-      });
-  });
-
   it("can lookup an AnnotatedCommit after creating it", function() {
     var test = this;
     var id;

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -990,7 +990,6 @@ describe("Filter", function() {
         })
         .then(function(content) {
           assert.equal(content, message);
-          list.free();
         });
     });
 
@@ -1036,7 +1035,6 @@ describe("Filter", function() {
         })
         .then(function(content) {
           assert.equal(content, message);
-          list.free();
         });
     });
 
@@ -1093,7 +1091,6 @@ describe("Filter", function() {
         })
         .then(function(content) {
           assert.equal(content, message);
-          list.free();
         });
     });
   });

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -61,6 +61,4 @@ describe("Patch", function() {
       });
 
   });
-
-
 });

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -326,4 +326,9 @@ describe("Repository", function() {
         assert.equal(numMergeHeads, 1);
       });
   });
+
+  it("can GC", function() {
+    global.gc();
+    assert.equal(true, true);
+  });
 });

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -326,9 +326,4 @@ describe("Repository", function() {
         assert.equal(numMergeHeads, 1);
       });
   });
-
-  it("can GC", function() {
-    global.gc();
-    assert.equal(true, true);
-  });
 });


### PR DESCRIPTION
# Garbage Collection in LibGit2
So this is as much as I could glean.

## Memory models

### Reference counted
Most objects that exist in the repository ODB or that extend from object are cached and reference counted. In order to ensure we are cleaning up memory for reference counted libgit2 objects, we should always call the provided libgit2 free method on the pointers when v8 garbage collects them. A lot of these reference counted objects have an underlying memory dependency with the repository, so the repository pointer will need to be kept around until the last call to the last object related to the repository has been freed. This means that most reference counted objects are owned by the repository. This class of objects will always call the free function, even if they have an owner.

### Borrowed pointers
Borrowed pointers are like fields on a struct. They should never be freed. Instead, we should build an owner dependency on the v8 object that contains the struct that this borrowed pointer came from. This ownership dependency will keep the memory alive for as long as the borrowed pointer is alive. 

### Borrowed, duplicable pointers
Certain borrowed pointers (git_oid, git_signature...) are easily duplicable and may have provided duplication functions from libgit2. They may also be easily copied using memcpy. If a pointer is borrowed, but duplicable, no ownership relationship should be established. Instead, we should duplicate the memory and always free when v8 garbage collects us.

### Non reference counted, non duplicable, mega owners
This mostly applies to the repository. The repository has a huge network of underlying relationships between the moment you git_repository_open. Almost every reference counted object has an underlying relationship with the repository via an odb cache or just plain having a field pointing back to the repository. Most reference counted objects will form an owned relationship with the repository. Unfortunately, there are several ways to get back to the same repository pointer that you got when you performed git_repository_open. That means that we need to keep track of how many times we've seen the repository. We now have an external reference counting mechanism to keep track of pointers like the repository. As new v8 objects get created that wrap the repository pointer, we reference count. When every v8 object that wraps the repository has been garbage collected, the last one to be collected will also perform the free method on the repository.
I've currently flagged these as isSingleton and refer to them as such, but that is a silly name and I am open to suggestions (if I don't find a better name myself :smile:).

## Additional behavior

### OwnerFn
I've added a new field to the ownerFn in the descriptor.json. An example of the ownerFn is `git_commit_owner`. You pass it a commit pointer and it will give you the repository pointer that it is bound to. We now utilize these functions to generate a persistent handle to the repository. When a new commit is created, we bind it to the repository via git_commit_owner. As mentioned above, we will create a new v8 object wrapper around the repository handle and reference count it. This will at least guarantee that even though it's a different v8 object wrapper that we persist, it's still persisting the important underlying libgit2 pointer.

### ownedBy
You can now specify ownedBy fields in arguments to instruct the descriptor that a particular argument from JS is the owner of a return result. This extends ownedByThis behavior by being more open to other ownership configurations than a this relationship.


## Need to do still
- [x] Walk through documentation and ensure ownedBy is set on arguments at the appropriate place
- [ ] Callback memory management is still set to never free callback parameters. We will need to find out how to fish ownership details via the async payload. I am not sure if I want to complete this in this PR or push it into the future, as I imagine callbacks are a much smaller memory foot print than being able to free the repository.
- [ ] Write additional segfault tests like the ones seen in revwalk for the config, which is borderline similar to the repository, but not quite as complex.
- [ ] Write additional segfault tests in general utilizing the GC.

## Future work
- Maybe callback memory managent, depends on if we can get something simple done in this PR.
- Complex owner scenarios like git_filter. It would be nice if instead of having to write a full template, we would be capable of patching the HandleOKCallback with a custom owner resolver.
- It would be nice if we also had an overwrite block specifically targeting function calls in AsyncWorker::Execute. For an example of what I am referring to, check out generate/templates/manual/clone/clone.cc.