### PR TITLE
Remove ssl and crypto dependency on non-electron builds

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -189,13 +189,17 @@
         ],
         [
           "OS=='linux' or OS.endswith('bsd')", {
+            "cflags": [
+              "-std=c++11"
+            ]
+          }
+        ],
+        [
+          "OS.endswith('bsd') or (node_root_dir.split('/')[-1].startswith('iojs') and OS=='linux')", {
             "libraries": [
               "-lcrypto",
               "-lssl"
             ],
-            "cflags": [
-              "-std=c++11"
-            ]
           }
         ]
       ]


### PR DESCRIPTION
Node should actually satisfy both of these links, because it actually exposes the headers for them. This isn't the case in Electron. This should hopefully solve some prebuilt issues regarding the various linuxes.