### PR TITLE
Add a test for Repository's getReferenceCommit

### DIFF
--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -109,6 +109,16 @@ describe("Repository", function() {
       });
   });
 
+  it("can get a reference commit", function() {
+    return this.repository.getReferenceCommit("master")
+      .then(function(commit) {
+        assert.equal(
+          "32789a79e71fbc9e04d3eff7425e1771eb595150",
+          commit.toString()
+        );
+      });
+  });
+
   it("can get the default signature", function() {
     var sig = this.repository.defaultSignature();
 


### PR DESCRIPTION
Surprisingly enough, `Repository`'s `getReferenceCommit` is not used anywhere in the tests.