### PR TITLE
Check parameters before performing reset

### DIFF
--- a/lib/reset.js
+++ b/lib/reset.js
@@ -45,7 +45,11 @@ Reset.default = function(repo, target, pathspecs) {
  */
 Reset.reset = function(repo, target, resetType, opts) {
   opts = normalizeOptions(opts, NodeGit.CheckoutOptions);
-
+  if (repo !== target.repo) {
+    // this is the same that is performed on libgit2's side
+    // https://github.com/nodegit/libgit2/blob/8d89e409616831b7b30a5ca7b89354957137b65e/src/reset.c#L120-L124
+    throw new Error("Repository and target commit's repository does not match");
+  }
   return _reset.call(this, repo, target, resetType, opts);
 };
 

--- a/test/tests/reset.js
+++ b/test/tests/reset.js
@@ -269,4 +269,43 @@ describe("Reset", function() {
       return Reset.reset(test.repo, test.currentCommit, Reset.TYPE.HARD);
     });
   });
+
+  it("reset fails if parameter is not a Commit object", function() {
+    var test = this;
+    var commit = test.repo.getReferenceCommit("master");
+    try {
+      Reset.reset(test.repo, commit, Reset.TYPE.HARD);
+      assert.fail(
+        "Should not be able to pass a Promise (Commit) into the function"
+      );
+    } catch (err) {
+      // ok
+      assert.equal(
+        "Repository and target commit's repository does not match",
+        err.message
+      );
+    }
+  });
+
+  it("reset fails if originating repository is not the same", function() {
+    var test = this;
+    var testCommit = null;
+    return test.repo.getReferenceCommit("master")
+    .then(function(commit) {
+      testCommit = commit;
+      return Repository.open(reposPath);
+    })
+    .then(function(repo) {
+      return Reset.reset(repo, testCommit, Reset.TYPE.HARD);
+    })
+    .then(function() {
+      assert.fail("Different source repository instance should fail");
+    })
+    .catch(function(err) {
+      assert.equal(
+        "Repository and target commit's repository does not match",
+        err.message
+      );
+    });
+  });
 });


### PR DESCRIPTION
If a promise is passed down to the native C++ layer, v8 will crash. To ensure that this does not happen, a check will be performed in the JavaScript layer to verify that the repository is the same as the repository of the commit object.

While logically the commit of one repository instance is the same as a commit of another repository instance (if they point to the same `.git` folder), programmatically they are not equivalent as a check is done
on libgit2's side to ensure that they come from the same thing. As a result, the check on the JavaScript side purely compares the pointers over some other logical piece of information (such as its path or working directory).

This is not a general fix for #1127 but is simply meant to help the case of #1596. I have not put much thought into it but perhaps the generator could be changed so that at least `Repository` and `Commit` objects could be verified?