### PR TITLE
Fix segfault in NodeGit.Revert.revert

### DIFF
--- a/lib/revert.js
+++ b/lib/revert.js
@@ -50,7 +50,7 @@ Revert.commit = function(
 /**
  * Reverts the given commit, producing changes in the index and
  * working directory.
- * 
+ *
  * @async
  * @param {Repository} repo the repository to perform the revert in
  * @param {Commit} commit the commit to revert
@@ -71,7 +71,7 @@ Revert.revert = function(repo, commit, revertOpts) {
 
   revertOpts = normalizeOptions(revertOpts, NodeGit.RevertOptions);
 
-  if (revertOpts) {
+  if (mergeOpts) {
     revertOpts.mergeOpts =
       normalizeOptions(mergeOpts, NodeGit.MergeOptions);
   }

--- a/test/tests/revert.js
+++ b/test/tests/revert.js
@@ -74,4 +74,11 @@ describe("Revert", function() {
         throw error;
       });
   });
+
+  it("RevertOptions without MergeOptions should not segfault", function() {
+    return Revert.revert(test.repository, test.firstCommit, {})
+      .catch(function(error) {
+        throw error;
+      });
+  });
 });


### PR DESCRIPTION
Seems we weren't normalizing mergeOpts correctly. Closes https://github.com/nodegit/nodegit/issues/1597