### PR TITLE
Add `updateRef` parameter to Repository#createCommitWithSignature

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -174,6 +174,22 @@ function getPathHunks(repo, index, filePath, isStaged, additionalDiffOptions) {
     });
 }
 
+function getReflogMessageForCommit(commit) {
+  var parentCount = commit.parentcount();
+  var summary = commit.summary();
+  var commitType;
+
+  if (parentCount >= 2) {
+    commitType = " (merge)";
+  } else if (parentCount == 0) {
+    commitType = " (initial)";
+  } else {
+    commitType = "";
+  }
+
+  return `commit${commitType}: ${summary}`;
+}
+
 /**
  * Goes through a rebase's rebase operations and commits them if there are
  * no merge conflicts
@@ -626,6 +642,7 @@ Repository.prototype.createCommitBuffer = function(
  * Create a commit that is digitally signed
  *
  * @async
+ * @param {String} updateRef
  * @param {Signature} author
  * @param {Signature} committer
  * @param {String} message
@@ -636,6 +653,7 @@ Repository.prototype.createCommitBuffer = function(
  * @return {Oid} The oid of the commit
  */
 Repository.prototype.createCommitWithSignature = function(
+    updateRef,
     author,
     committer,
     message,
@@ -647,6 +665,8 @@ Repository.prototype.createCommitWithSignature = function(
   var repo = this;
   var promises = [];
   var commit_content;
+  var commit_oid;
+  var commit;
 
   parents = parents || [];
 
@@ -686,6 +706,16 @@ Repository.prototype.createCommitWithSignature = function(
       commit_content,
       signature,
       signature_field);
+  }).then(function(commit_oidResult) {
+    commit_oid = commit_oidResult;
+    return repo.getCommit(commit_oid);
+  }).then(function(commitResult) {
+    commit = commitResult;
+    return repo.getReference(updateRef);
+  }).then(function(ref) {
+    return ref.setTarget(commit_oid, getReflogMessageForCommit(commit));
+  }).then(function() {
+    return commit_oid;
   });
 };
 

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -676,7 +676,7 @@ Repository.prototype.createCommitWithSignature = function(
     promises.push(repo.getCommit(parent));
   });
 
-  return Promise.all(promises).then(function(results) {
+  const createCommitPromise = Promise.all(promises).then(function(results) {
     tree = results[0];
 
     // Get the normalized values for our input into the function
@@ -706,7 +706,13 @@ Repository.prototype.createCommitWithSignature = function(
       commit_content,
       signature,
       signature_field);
-  }).then(function(commit_oidResult) {
+  });
+
+  if (!updateRef) {
+    return createCommitPromise;
+  }
+
+  return createCommitPromise.then(function(commit_oidResult) {
     commit_oid = commit_oidResult;
     return repo.getCommit(commit_oid);
   }).then(function(commitResult) {


### PR DESCRIPTION
The recently added `Repository#createCommitWithSignature` method lacks the facilities for updating refs.  This change prepends an `updateRef` parameter the method, similar to the convention in `Repository#createCommit`.