### PR TITLE
Marked Repository.createBlobFromBuffer as async

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -537,6 +537,7 @@ Repository.prototype.createBranch = function(name, commit, force) {
 /**
  * Create a blob from a buffer
  *
+ * @async
  * @param {Buffer} buffer
  * @return {Oid}
  */


### PR DESCRIPTION
It returns `Blob.createFromBuffer(...)` which calls [an async function](https://www.nodegit.org/api/blob/#createFromBuffer).