### PR TITLE
Bump libgit2 to a preview of v0.28

### DIFF
--- a/examples/clone.js
+++ b/examples/clone.js
@@ -14,7 +14,7 @@ fse.remove(path).then(function() {
           certificateCheck: function() {
             // github will fail cert check on some OSX machines
             // this overrides that check
-            return 1;
+            return 0;
           }
         }
       }

--- a/examples/cloneFromGithubWith2Factor.js
+++ b/examples/cloneFromGithubWith2Factor.js
@@ -20,7 +20,7 @@ var opts = {
         return nodegit.Cred.userpassPlaintextNew(token, "x-oauth-basic");
       },
       certificateCheck: function() {
-        return 1;
+        return 0;
       }
     }
   }

--- a/examples/pull.js
+++ b/examples/pull.js
@@ -16,7 +16,7 @@ nodegit.Repository.open(path.resolve(__dirname, repoDir))
           return nodegit.Cred.sshKeyFromAgent(userName);
         },
         certificateCheck: function() {
-          return 1;
+          return 0;
         }
       }
     });

--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -118,6 +118,32 @@
       "error": -1
     }
   },
+  "git_commit_signing_cb": {
+    "args": [
+      {
+        "name": "signature",
+        "cType": "git_buf *"
+      },
+      {
+        "name": "signature_field",
+        "cType": "git_buf *"
+      },
+      {
+        "name": "commit_content",
+        "cType": "const char *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": -30,
+      "success": 0,
+      "error": -1
+    }
+  },
   "git_config_foreach_cb": {
     "args": [
       {
@@ -311,101 +337,101 @@
       "error": -1
     }
   },
-  "git_filter_apply_fn": { 
-    "args": [ 
-      { 
-        "name": "self", 
-        "cType": "git_filter *" 
-      }, 
-      { 
-        "name": "payload", 
-        "cType": "void **" 
-      }, 
-      { 
-        "name": "to", 
-        "cType": "git_buf *" 
-      }, 
-      { 
-        "name": "from", 
-        "cType": "const git_buf *" 
-      }, 
-      { 
-        "name": "src", 
-        "cType": "const git_filter_source *" 
-      } 
-    ], 
-    "return": { 
-      "type": "int", 
-      "noResults": -30, 
-      "success": 0, 
-      "error": -1 
-    } 
-  }, 
-  "git_filter_check_fn": { 
-    "args": [ 
-      { 
-        "name": "self", 
-        "cType": "git_filter *" 
-      }, 
-      { 
+  "git_filter_apply_fn": {
+    "args": [
+      {
+        "name": "self",
+        "cType": "git_filter *"
+      },
+      {
         "name": "payload",
         "cType": "void **"
-      }, 
-      { 
+      },
+      {
+        "name": "to",
+        "cType": "git_buf *"
+      },
+      {
+        "name": "from",
+        "cType": "const git_buf *"
+      },
+      {
         "name": "src",
         "cType": "const git_filter_source *"
-      }, 
-      { 
-        "name": "attr_values", 
-        "cType": "const char **" 
-      } 
-    ], 
-    "return": { 
-      "type": "int", 
-      "noResults": -30, 
-      "success": 0, 
-      "error": -1 
-    } 
-  }, 
-  "git_filter_cleanup_fn": { 
-    "args": [ 
-      { 
-        "name": "self", 
-        "cType": "git_filter *" 
-      }, 
-      { 
-        "name": "payload", 
-        "cType": "void *" 
-      } 
-    ], 
-    "return": { 
-      "type": "void" 
-    } 
-  }, 
-  "git_filter_init_fn": { 
-    "args": [ 
-      { 
-        "name": "self", 
-        "cType": "git_filter *" 
-      } 
-    ], 
-    "return": { 
-      "type": "int", 
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": -30,
+      "success": 0,
+      "error": -1
+    }
+  },
+  "git_filter_check_fn": {
+    "args": [
+      {
+        "name": "self",
+        "cType": "git_filter *"
+      },
+      {
+        "name": "payload",
+        "cType": "void **"
+      },
+      {
+        "name": "src",
+        "cType": "const git_filter_source *"
+      },
+      {
+        "name": "attr_values",
+        "cType": "const char **"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": -30,
+      "success": 0,
+      "error": -1
+    }
+  },
+  "git_filter_cleanup_fn": {
+    "args": [
+      {
+        "name": "self",
+        "cType": "git_filter *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "void"
+    }
+  },
+  "git_filter_init_fn": {
+    "args": [
+      {
+        "name": "self",
+        "cType": "git_filter *"
+      }
+    ],
+    "return": {
+      "type": "int",
       "noResults": 0,
-      "success": 0, 
-      "error": -1 
-    } 
-  }, 
-  "git_filter_shutdown_fn": { 
-    "args": [ 
-      { 
-        "name": "self", 
-        "cType": "git_filter *" 
-      } 
-    ], 
-    "return": { 
-      "type": "void" 
-    } 
+      "success": 0,
+      "error": -1
+    }
+  },
+  "git_filter_shutdown_fn": {
+    "args": [
+      {
+        "name": "self",
+        "cType": "git_filter *"
+      }
+    ],
+    "return": {
+      "type": "void"
+    }
   },
   "git_index_matched_path_cb": {
     "args": [

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -75,6 +75,9 @@
   },
   "types":
   {
+    "allocator": {
+      "ignore": true
+    },
     "annotated_commit": {
       "selfFreeing": true,
       "functions": {
@@ -378,6 +381,7 @@
       ]
     },
     "buf": {
+      "freeFunctionName": "git_buf_dispose",
       "functions": {
         "git_buf_free": {
           "ignore": true
@@ -820,6 +824,9 @@
               "isReturn": true,
               "ownedByThis": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_config_lookup_map_value": {
@@ -911,8 +918,14 @@
       "ignore": true
     },
     "cred": {
+      "needsForwardDeclaration": false,
       "selfFreeing": true,
       "cType": "git_cred",
+      "fields": {
+        "free": {
+          "ignore": true
+        }
+      },
       "functions": {
         "git_cred_default_new": {
           "isAsync": false
@@ -1401,6 +1414,9 @@
         "../include/filter_registry.h"
       ]
     },
+    "giterr": {
+      "ignore": true
+    },
     "graph": {
       "functions": {
         "git_graph_ahead_behind": {
@@ -1453,6 +1469,12 @@
           }
         }
       }
+    },
+    "imaxdiv": {
+      "ignore": true
+    },
+    "imaxdiv_t": {
+      "ignore": true
     },
     "index": {
       "selfFreeing": true,
@@ -1667,12 +1689,6 @@
             "isErrorCode": true
           }
         },
-        "git_index_reuc_get_byindex": {
-          "ignore": true
-        },
-        "git_index_reuc_get_bypath": {
-          "ignore": true
-        },
         "git_index_update_all": {
           "args": {
             "pathspec": {
@@ -1722,8 +1738,163 @@
       "hasConstructor": true,
       "ignoreInit": true
     },
+    "index_name_entry": {
+      "functions": {
+        "git_index_name_add": {
+          "cppFunctionName": "Add",
+          "jsFunctionName": "add",
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_index_name_clear": {
+          "cppFunctionName": "Clear",
+          "jsFunctionName": "clear",
+          "isAsync": true
+        },
+        "git_index_name_entrycount": {
+          "cppFunctionName": "Entrycount",
+          "jsFunctionName": "entryCount"
+        },
+        "git_index_name_get_byindex": {
+          "cppFunctionName": "GetByIndex",
+          "jsFunctionName": "getByIndex",
+          "isPrototypeMethod": false
+        }
+      },
+      "cDependencies": [
+        "git2/sys/index.h"
+      ]
+    },
+    "index_reuc_entry": {
+      "functions": {
+        "git_index_reuc_add": {
+          "cppFunctionName": "Add",
+          "jsFunctionName": "add",
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_index_reuc_clear": {
+          "cppFunctionName": "Clear",
+          "jsFunctionName": "clear",
+          "isAsync": true
+        },
+        "git_index_reuc_entrycount": {
+          "cppFunctionName": "Entrycount",
+          "jsFunctionName": "entryCount"
+        },
+        "git_index_reuc_find": {
+          "args": {
+            "at_pos": {
+              "isReturn": true,
+              "shouldAlloc": true
+            }
+          },
+          "cppFunctionName": "Find",
+          "jsFunctionName": "find",
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_index_reuc_get_byindex": {
+          "cppFunctionName": "GetByIndex",
+          "jsFunctionName": "getByIndex",
+          "isPrototypeMethod": false
+        },
+        "git_index_reuc_get_bypath": {
+          "cppFunctionName": "GetByPath",
+          "jsFunctionName": "getByPath",
+          "isPrototypeMethod": false
+        },
+        "git_index_reuc_remove": {
+          "cppFunctionName": "Remove",
+          "jsFunctionName": "remove",
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        }
+      },
+      "cDependencies": [
+        "git2/sys/index.h"
+      ]
+    },
     "indexer": {
       "ignore": true
+    },
+    "indexer_options": {
+      "ignore": true
+    },
+    "LIBSSH2_SESSION": {
+      "ignore": true
+    },
+    "LIBSSH2_USERAUTH_KBDINT_PROMPT": {
+      "ignore": true
+    },
+    "LIBSSH2_USERAUTH_KBDINT_RESPONSE": {
+      "ignore": true
+    },
+    "_LIBSSH2_SESSION": {
+      "ignore": true
+    },
+    "_LIBSSH2_USERAUTH_KBDINT_PROMPT": {
+      "ignore": true
+    },
+    "_LIBSSH2_USERAUTH_KBDINT_RESPONSE": {
+      "ignore": true
+    },
+    "mailmap": {
+      "selfFreeing": true,
+      "freeFunctionName": "git_mailmap_free",
+      "functions": {
+        "git_mailmap_add_entry": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_mailmap_free": {
+          "ignore": true
+        },
+        "git_mailmap_from_buffer": {
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_mailmap_from_repository": {
+          "args": {
+            "out": {
+              "ownedBy": ["repo"]
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_mailmap_resolve": {
+          "args": {
+            "real_name": {
+              "isReturn": true
+            },
+            "real_email": {
+              "isReturn": true
+            }
+          },
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_mailmap_resolve_signature": {
+          "return": {
+            "isErrorCode": true
+          }
+        }
+      }
     },
     "mempack": {
       "ignore": true
@@ -1931,15 +2102,6 @@
           "ignore": true
         },
         "git_odb_add_disk_alternate": {
-          "ignore": true
-        },
-        "git_odb_backend_loose": {
-          "ignore": true
-        },
-        "git_odb_backend_one_pack": {
-          "ignore": true
-        },
-        "git_odb_backend_pack": {
           "ignore": true
         },
         "git_odb_exists": {
@@ -2291,6 +2453,11 @@
           "ignore": true
         }
       }
+    },
+    "path": {
+      "cDependencies": [
+        "git2/sys/path.h"
+      ]
     },
     "pathspec": {
       "selfFreeing": true,
@@ -2779,6 +2946,7 @@
         },
         "git_remote_get_refspec": {
           "return": {
+            "selfFreeing": false,
             "ownedByThis": true
           }
         },
@@ -3112,7 +3280,13 @@
         }
       }
     },
+    "smart_subtransport": {
+      "ignore": true
+    },
     "smart_subtransport_definition": {
+      "ignore": true
+    },
+    "smart_subtransport_stream": {
       "ignore": true
     },
     "stash": {
@@ -3156,6 +3330,9 @@
           }
         }
       }
+    },
+    "stdalloc": {
+      "ignore": true
     },
     "status": {
       "cDependencies": [
@@ -3560,6 +3737,47 @@
     "transport": {
       "cType": "git_transport",
       "needsForwardDeclaration": false,
+      "fields": {
+        "cancel": {
+          "ignore": true
+        },
+        "close": {
+          "ignore": true
+        },
+        "connect": {
+          "ignore": true
+        },
+        "download_pack": {
+          "ignore": true
+        },
+        "free": {
+          "ignore": true
+        },
+        "is_connected": {
+          "ignore": true
+        },
+        "ls": {
+          "ignore": true
+        },
+        "negotiate_fetch": {
+          "ignore": true
+        },
+        "push": {
+          "ignore": true
+        },
+        "read_flags": {
+          "ignore": true
+        },
+        "set_callbacks": {
+          "ignore": true
+        },
+        "set_custom_headers": {
+          "ignore": true
+        },
+        "version": {
+          "ignore": true
+        }
+      },
       "functions": {
         "git_transport_dummy": {
           "ignore": true
@@ -3722,6 +3940,9 @@
         }
       }
     },
+    "win32": {
+      "ignore": true
+    },
     "worktree": {
       "selfFreeing": true,
       "cType": "git_worktree",
@@ -3761,7 +3982,18 @@
     },
     "writestream": {
       "cType": "git_writestream",
-      "needsForwardDeclaration": false
+      "needsForwardDeclaration": false,
+      "fields": {
+        "close": {
+          "ignore": true
+        },
+        "free": {
+          "ignore": true
+        },
+        "write": {
+          "ignore": true
+        }
+      }
     }
   }
 }

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -401,7 +401,7 @@
             "jsClassName": "Number",
             "isErrorCode": true
           },
-          "isAsync": true
+          "isAsync": false
         },
         "git_buf_set": {
           "cppFunctionName": "Set",
@@ -422,7 +422,7 @@
             "jsClassName": "Number",
             "isErrorCode": true
           },
-          "isAsync": true
+          "isAsync": false
         }
       },
       "dependencies": [

--- a/generate/input/libgit2-docs.json
+++ b/generate/input/libgit2-docs.json
@@ -1,33 +1,35 @@
 {
   "files": [
     {
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "functions": [
         "git_annotated_commit_from_ref",
         "git_annotated_commit_from_fetchhead",
         "git_annotated_commit_lookup",
         "git_annotated_commit_from_revspec",
         "git_annotated_commit_id",
+        "git_annotated_commit_ref",
         "git_annotated_commit_free"
       ],
       "meta": {},
-      "lines": 112
+      "lines": 121
     },
     {
-      "file": "attr.h",
+      "file": "git2/attr.h",
       "functions": [
         "git_attr_value",
         "git_attr_get",
         "git_attr_get_many",
+        "git_attr_foreach_cb",
         "git_attr_foreach",
         "git_attr_cache_flush",
         "git_attr_add_macro"
       ],
       "meta": {},
-      "lines": 240
+      "lines": 251
     },
     {
-      "file": "blame.h",
+      "file": "git2/blame.h",
       "functions": [
         "git_blame_init_options",
         "git_blame_get_hunk_count",
@@ -38,10 +40,10 @@
         "git_blame_free"
       ],
       "meta": {},
-      "lines": 207
+      "lines": 224
     },
     {
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "functions": [
         "git_blob_lookup",
         "git_blob_lookup_prefix",
@@ -63,7 +65,7 @@
       "lines": 228
     },
     {
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "functions": [
         "git_branch_create",
         "git_branch_create_from_annotated",
@@ -76,15 +78,19 @@
         "git_branch_name",
         "git_branch_upstream",
         "git_branch_set_upstream",
+        "git_branch_upstream_name",
         "git_branch_is_head",
-        "git_branch_is_checked_out"
+        "git_branch_is_checked_out",
+        "git_branch_remote_name",
+        "git_branch_upstream_remote"
       ],
       "meta": {},
-      "lines": 258
+      "lines": 288
     },
     {
-      "file": "buffer.h",
+      "file": "git2/buffer.h",
       "functions": [
+        "git_buf_dispose",
         "git_buf_free",
         "git_buf_grow",
         "git_buf_set",
@@ -92,10 +98,10 @@
         "git_buf_contains_nul"
       ],
       "meta": {},
-      "lines": 122
+      "lines": 134
     },
     {
-      "file": "checkout.h",
+      "file": "git2/checkout.h",
       "functions": [
         "git_checkout_notify_cb",
         "git_checkout_progress_cb",
@@ -106,20 +112,20 @@
         "git_checkout_tree"
       ],
       "meta": {},
-      "lines": 361
+      "lines": 362
     },
     {
-      "file": "cherrypick.h",
+      "file": "git2/cherrypick.h",
       "functions": [
         "git_cherrypick_init_options",
         "git_cherrypick_commit",
         "git_cherrypick"
       ],
       "meta": {},
-      "lines": 84
+      "lines": 86
     },
     {
-      "file": "clone.h",
+      "file": "git2/clone.h",
       "functions": [
         "git_remote_create_cb",
         "git_repository_create_cb",
@@ -127,10 +133,10 @@
         "git_clone"
       ],
       "meta": {},
-      "lines": 203
+      "lines": 205
     },
     {
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "functions": [
         "git_commit_lookup",
         "git_commit_lookup_prefix",
@@ -146,6 +152,8 @@
         "git_commit_time_offset",
         "git_commit_committer",
         "git_commit_author",
+        "git_commit_committer_with_mailmap",
+        "git_commit_author_with_mailmap",
         "git_commit_raw_header",
         "git_commit_tree",
         "git_commit_tree_id",
@@ -163,22 +171,23 @@
         "git_commit_dup"
       ],
       "meta": {},
-      "lines": 474
+      "lines": 502
     },
     {
-      "file": "common.h",
+      "file": "git2/common.h",
       "functions": [
         "git_libgit2_version",
         "git_libgit2_features",
         "git_libgit2_opts"
       ],
       "meta": {},
-      "lines": 352
+      "lines": 393
     },
     {
-      "file": "config.h",
+      "file": "git2/config.h",
       "functions": [
         "git_config_entry_free",
+        "git_config_foreach_cb",
         "git_config_find_global",
         "git_config_find_xdg",
         "git_config_find_system",
@@ -223,10 +232,10 @@
         "git_config_lock"
       ],
       "meta": {},
-      "lines": 751
+      "lines": 762
     },
     {
-      "file": "cred_helpers.h",
+      "file": "git2/cred_helpers.h",
       "functions": [
         "git_cred_userpass"
       ],
@@ -234,18 +243,20 @@
       "lines": 48
     },
     {
-      "file": "describe.h",
+      "file": "git2/describe.h",
       "functions": [
+        "git_describe_init_options",
+        "git_describe_init_format_options",
         "git_describe_commit",
         "git_describe_workdir",
         "git_describe_format",
         "git_describe_result_free"
       ],
       "meta": {},
-      "lines": 161
+      "lines": 184
     },
     {
-      "file": "diff.h",
+      "file": "git2/diff.h",
       "functions": [
         "git_diff_notify_cb",
         "git_diff_progress_cb",
@@ -289,10 +300,10 @@
         "git_diff_patchid"
       ],
       "meta": {},
-      "lines": 1452
+      "lines": 1502
     },
     {
-      "file": "errors.h",
+      "file": "git2/errors.h",
       "functions": [
         "giterr_last",
         "giterr_clear",
@@ -300,10 +311,10 @@
         "giterr_set_oom"
       ],
       "meta": {},
-      "lines": 149
+      "lines": 156
     },
     {
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "functions": [
         "git_filter_list_load",
         "git_filter_list_contains",
@@ -319,7 +330,7 @@
       "lines": 210
     },
     {
-      "file": "global.h",
+      "file": "git2/global.h",
       "functions": [
         "git_libgit2_init",
         "git_libgit2_shutdown"
@@ -328,7 +339,7 @@
       "lines": 39
     },
     {
-      "file": "graph.h",
+      "file": "git2/graph.h",
       "functions": [
         "git_graph_ahead_behind",
         "git_graph_descendant_of"
@@ -337,7 +348,7 @@
       "lines": 54
     },
     {
-      "file": "ignore.h",
+      "file": "git2/ignore.h",
       "functions": [
         "git_ignore_add_rule",
         "git_ignore_clear_internal_rules",
@@ -347,7 +358,7 @@
       "lines": 74
     },
     {
-      "file": "index.h",
+      "file": "git2/index.h",
       "functions": [
         "git_index_matched_path_cb",
         "git_index_open",
@@ -395,8 +406,9 @@
       "lines": 806
     },
     {
-      "file": "indexer.h",
+      "file": "git2/indexer.h",
       "functions": [
+        "git_indexer_init_options",
         "git_indexer_new",
         "git_indexer_append",
         "git_indexer_commit",
@@ -404,10 +416,32 @@
         "git_indexer_free"
       ],
       "meta": {},
-      "lines": 72
+      "lines": 98
     },
     {
-      "file": "merge.h",
+      "file": "git2/inttypes.h",
+      "functions": [
+        "imaxdiv"
+      ],
+      "meta": {},
+      "lines": 298
+    },
+    {
+      "file": "git2/mailmap.h",
+      "functions": [
+        "git_mailmap_new",
+        "git_mailmap_free",
+        "git_mailmap_add_entry",
+        "git_mailmap_from_buffer",
+        "git_mailmap_from_repository",
+        "git_mailmap_resolve",
+        "git_mailmap_resolve_signature"
+      ],
+      "meta": {},
+      "lines": 111
+    },
+    {
+      "file": "git2/merge.h",
       "functions": [
         "git_merge_file_init_input",
         "git_merge_file_init_options",
@@ -426,10 +460,10 @@
         "git_merge"
       ],
       "meta": {},
-      "lines": 585
+      "lines": 587
     },
     {
-      "file": "message.h",
+      "file": "git2/message.h",
       "functions": [
         "git_message_prettify",
         "git_message_trailers",
@@ -439,7 +473,7 @@
       "lines": 79
     },
     {
-      "file": "net.h",
+      "file": "git2/net.h",
       "functions": [
         "git_headlist_cb"
       ],
@@ -447,7 +481,7 @@
       "lines": 55
     },
     {
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "functions": [
         "git_note_foreach_cb",
         "git_note_iterator_new",
@@ -465,13 +499,14 @@
         "git_note_remove",
         "git_note_commit_remove",
         "git_note_free",
+        "git_note_default_ref",
         "git_note_foreach"
       ],
       "meta": {},
       "lines": 302
     },
     {
-      "file": "object.h",
+      "file": "git2/object.h",
       "functions": [
         "git_object_lookup",
         "git_object_lookup_prefix",
@@ -492,7 +527,7 @@
       "lines": 237
     },
     {
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "functions": [
         "git_odb_foreach_cb",
         "git_odb_new",
@@ -532,7 +567,7 @@
       "lines": 544
     },
     {
-      "file": "odb_backend.h",
+      "file": "git2/odb_backend.h",
       "functions": [
         "git_odb_backend_pack",
         "git_odb_backend_loose",
@@ -542,7 +577,7 @@
       "lines": 130
     },
     {
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "functions": [
         "git_oid_fromstr",
         "git_oid_fromstrp",
@@ -568,7 +603,7 @@
       "lines": 264
     },
     {
-      "file": "oidarray.h",
+      "file": "git2/oidarray.h",
       "functions": [
         "git_oidarray_free"
       ],
@@ -576,7 +611,7 @@
       "lines": 34
     },
     {
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "functions": [
         "git_packbuilder_new",
         "git_packbuilder_set_threads",
@@ -585,8 +620,10 @@
         "git_packbuilder_insert_commit",
         "git_packbuilder_insert_walk",
         "git_packbuilder_insert_recur",
+        "git_packbuilder_write_buf",
         "git_packbuilder_write",
         "git_packbuilder_hash",
+        "git_packbuilder_foreach_cb",
         "git_packbuilder_foreach",
         "git_packbuilder_object_count",
         "git_packbuilder_written",
@@ -598,7 +635,7 @@
       "lines": 236
     },
     {
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "functions": [
         "git_patch_from_diff",
         "git_patch_from_blobs",
@@ -619,7 +656,7 @@
       "lines": 268
     },
     {
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "functions": [
         "git_pathspec_new",
         "git_pathspec_free",
@@ -639,15 +676,15 @@
       "lines": 277
     },
     {
-      "file": "proxy.h",
+      "file": "git2/proxy.h",
       "functions": [
         "git_proxy_init_options"
       ],
       "meta": {},
-      "lines": 88
+      "lines": 92
     },
     {
-      "file": "rebase.h",
+      "file": "git2/rebase.h",
       "functions": [
         "git_rebase_init_options",
         "git_rebase_init",
@@ -663,10 +700,10 @@
         "git_rebase_free"
       ],
       "meta": {},
-      "lines": 316
+      "lines": 319
     },
     {
-      "file": "refdb.h",
+      "file": "git2/refdb.h",
       "functions": [
         "git_refdb_new",
         "git_refdb_open",
@@ -677,7 +714,7 @@
       "lines": 63
     },
     {
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "functions": [
         "git_reflog_read",
         "git_reflog_write",
@@ -697,7 +734,7 @@
       "lines": 166
     },
     {
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "functions": [
         "git_reference_lookup",
         "git_reference_name_to_id",
@@ -719,6 +756,8 @@
         "git_reference_delete",
         "git_reference_remove",
         "git_reference_list",
+        "git_reference_foreach_cb",
+        "git_reference_foreach_name_cb",
         "git_reference_foreach",
         "git_reference_foreach_name",
         "git_reference_dup",
@@ -745,8 +784,10 @@
       "lines": 744
     },
     {
-      "file": "refspec.h",
+      "file": "git2/refspec.h",
       "functions": [
+        "git_refspec_parse",
+        "git_refspec_free",
         "git_refspec_src",
         "git_refspec_dst",
         "git_refspec_string",
@@ -758,10 +799,10 @@
         "git_refspec_rtransform"
       ],
       "meta": {},
-      "lines": 100
+      "lines": 117
     },
     {
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "functions": [
         "git_remote_create",
         "git_remote_create_with_fetchspec",
@@ -810,10 +851,10 @@
         "git_remote_default_branch"
       ],
       "meta": {},
-      "lines": 850
+      "lines": 852
     },
     {
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "functions": [
         "git_repository_open",
         "git_repository_open_from_worktree",
@@ -828,6 +869,7 @@
         "git_repository_head",
         "git_repository_head_for_worktree",
         "git_repository_head_detached",
+        "git_repository_head_detached_for_worktree",
         "git_repository_head_unborn",
         "git_repository_is_empty",
         "git_repository_item_path",
@@ -845,7 +887,9 @@
         "git_repository_message",
         "git_repository_message_remove",
         "git_repository_state_cleanup",
+        "git_repository_fetchhead_foreach_cb",
         "git_repository_fetchhead_foreach",
+        "git_repository_mergehead_foreach_cb",
         "git_repository_mergehead_foreach",
         "git_repository_hashfile",
         "git_repository_set_head",
@@ -860,10 +904,10 @@
         "git_repository_set_ident"
       ],
       "meta": {},
-      "lines": 862
+      "lines": 864
     },
     {
-      "file": "reset.h",
+      "file": "git2/reset.h",
       "functions": [
         "git_reset",
         "git_reset_from_annotated",
@@ -873,17 +917,17 @@
       "lines": 107
     },
     {
-      "file": "revert.h",
+      "file": "git2/revert.h",
       "functions": [
         "git_revert_init_options",
         "git_revert_commit",
         "git_revert"
       ],
       "meta": {},
-      "lines": 84
+      "lines": 86
     },
     {
-      "file": "revparse.h",
+      "file": "git2/revparse.h",
       "functions": [
         "git_revparse_single",
         "git_revparse_ext",
@@ -893,7 +937,7 @@
       "lines": 108
     },
     {
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "functions": [
         "git_revwalk_new",
         "git_revwalk_reset",
@@ -918,7 +962,7 @@
       "lines": 291
     },
     {
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "functions": [
         "git_signature_new",
         "git_signature_now",
@@ -931,8 +975,9 @@
       "lines": 99
     },
     {
-      "file": "stash.h",
+      "file": "git2/stash.h",
       "functions": [
+        "git_stash_save",
         "git_stash_apply_progress_cb",
         "git_stash_apply_init_options",
         "git_stash_apply",
@@ -942,10 +987,10 @@
         "git_stash_pop"
       ],
       "meta": {},
-      "lines": 253
+      "lines": 256
     },
     {
-      "file": "status.h",
+      "file": "git2/status.h",
       "functions": [
         "git_status_cb",
         "git_status_init_options",
@@ -959,10 +1004,16 @@
         "git_status_should_ignore"
       ],
       "meta": {},
-      "lines": 370
+      "lines": 374
     },
     {
-      "file": "strarray.h",
+      "file": "git2/stdint.h",
+      "functions": [],
+      "meta": {},
+      "lines": 124
+    },
+    {
+      "file": "git2/strarray.h",
       "functions": [
         "git_strarray_free",
         "git_strarray_copy"
@@ -971,7 +1022,7 @@
       "lines": 53
     },
     {
-      "file": "submodule.h",
+      "file": "git2/submodule.h",
       "functions": [
         "git_submodule_cb",
         "git_submodule_update_init_options",
@@ -1008,10 +1059,19 @@
         "git_submodule_location"
       ],
       "meta": {},
-      "lines": 632
+      "lines": 633
     },
     {
-      "file": "sys/commit.h",
+      "file": "git2/sys/alloc.h",
+      "functions": [
+        "git_stdalloc_init_allocator",
+        "git_win32_crtdbg_init_allocator"
+      ],
+      "meta": {},
+      "lines": 97
+    },
+    {
+      "file": "git2/sys/commit.h",
       "functions": [
         "git_commit_create_from_ids",
         "git_commit_create_from_callback"
@@ -1020,7 +1080,7 @@
       "lines": 76
     },
     {
-      "file": "sys/config.h",
+      "file": "git2/sys/config.h",
       "functions": [
         "git_config_init_backend",
         "git_config_add_backend"
@@ -1029,7 +1089,7 @@
       "lines": 126
     },
     {
-      "file": "sys/diff.h",
+      "file": "git2/sys/diff.h",
       "functions": [
         "git_diff_print_callback__to_buf",
         "git_diff_print_callback__to_file_handle",
@@ -1040,7 +1100,7 @@
       "lines": 90
     },
     {
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "functions": [
         "git_filter_lookup",
         "git_filter_list_new",
@@ -1056,6 +1116,7 @@
         "git_filter_shutdown_fn",
         "git_filter_check_fn",
         "git_filter_apply_fn",
+        "git_filter_stream_fn",
         "git_filter_cleanup_fn",
         "git_filter_init",
         "git_filter_register",
@@ -1065,7 +1126,7 @@
       "lines": 328
     },
     {
-      "file": "sys/hashsig.h",
+      "file": "git2/sys/hashsig.h",
       "functions": [
         "git_hashsig_create",
         "git_hashsig_create_fromfile",
@@ -1076,7 +1137,25 @@
       "lines": 102
     },
     {
-      "file": "sys/mempack.h",
+      "file": "git2/sys/index.h",
+      "functions": [
+        "git_index_name_entrycount",
+        "git_index_name_get_byindex",
+        "git_index_name_add",
+        "git_index_name_clear",
+        "git_index_reuc_entrycount",
+        "git_index_reuc_find",
+        "git_index_reuc_get_bypath",
+        "git_index_reuc_get_byindex",
+        "git_index_reuc_add",
+        "git_index_reuc_remove",
+        "git_index_reuc_clear"
+      ],
+      "meta": {},
+      "lines": 174
+    },
+    {
+      "file": "git2/sys/mempack.h",
       "functions": [
         "git_mempack_new",
         "git_mempack_dump",
@@ -1086,25 +1165,34 @@
       "lines": 82
     },
     {
-      "file": "sys/merge.h",
+      "file": "git2/sys/merge.h",
       "functions": [
+        "git_merge_driver_lookup",
+        "git_merge_driver_source_repo",
+        "git_merge_driver_source_ancestor",
+        "git_merge_driver_source_ours",
+        "git_merge_driver_source_theirs",
+        "git_merge_driver_source_file_options",
         "git_merge_driver_init_fn",
         "git_merge_driver_shutdown_fn",
-        "git_merge_driver_apply_fn"
+        "git_merge_driver_apply_fn",
+        "git_merge_driver_register",
+        "git_merge_driver_unregister"
       ],
       "meta": {},
-      "lines": 135
+      "lines": 178
     },
     {
-      "file": "sys/odb_backend.h",
+      "file": "git2/sys/odb_backend.h",
       "functions": [
-        "git_odb_init_backend"
+        "git_odb_init_backend",
+        "git_odb_backend_malloc"
       ],
       "meta": {},
-      "lines": 118
+      "lines": 120
     },
     {
-      "file": "sys/openssl.h",
+      "file": "git2/sys/openssl.h",
       "functions": [
         "git_openssl_set_locking"
       ],
@@ -1112,7 +1200,15 @@
       "lines": 34
     },
     {
-      "file": "sys/refdb_backend.h",
+      "file": "git2/sys/path.h",
+      "functions": [
+        "git_path_is_gitfile"
+      ],
+      "meta": {},
+      "lines": 60
+    },
+    {
+      "file": "git2/sys/refdb_backend.h",
       "functions": [
         "git_refdb_init_backend",
         "git_refdb_backend_fs",
@@ -1122,7 +1218,16 @@
       "lines": 214
     },
     {
-      "file": "sys/refs.h",
+      "file": "git2/sys/reflog.h",
+      "functions": [
+        "git_reflog_entry__alloc",
+        "git_reflog_entry__free"
+      ],
+      "meta": {},
+      "lines": 17
+    },
+    {
+      "file": "git2/sys/refs.h",
       "functions": [
         "git_reference__alloc",
         "git_reference__alloc_symbolic"
@@ -1131,7 +1236,7 @@
       "lines": 45
     },
     {
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "functions": [
         "git_repository_new",
         "git_repository__cleanup",
@@ -1148,15 +1253,16 @@
       "lines": 165
     },
     {
-      "file": "sys/stream.h",
+      "file": "git2/sys/stream.h",
       "functions": [
+        "git_stream_cb",
         "git_stream_register_tls"
       ],
       "meta": {},
       "lines": 54
     },
     {
-      "file": "sys/time.h",
+      "file": "git2/sys/time.h",
       "functions": [
         "git_time_monotonic"
       ],
@@ -1164,7 +1270,7 @@
       "lines": 27
     },
     {
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "functions": [
         "git_transport_init",
         "git_transport_new",
@@ -1177,6 +1283,7 @@
         "git_transport_smart_certificate_check",
         "git_transport_smart_credentials",
         "git_transport_smart_proxy_options",
+        "git_smart_subtransport_cb",
         "git_smart_subtransport_http",
         "git_smart_subtransport_git",
         "git_smart_subtransport_ssh"
@@ -1185,7 +1292,7 @@
       "lines": 389
     },
     {
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "functions": [
         "git_tag_lookup",
         "git_tag_lookup_prefix",
@@ -1205,6 +1312,7 @@
         "git_tag_delete",
         "git_tag_list",
         "git_tag_list_match",
+        "git_tag_foreach_cb",
         "git_tag_foreach",
         "git_tag_peel",
         "git_tag_dup"
@@ -1213,7 +1321,7 @@
       "lines": 357
     },
     {
-      "file": "trace.h",
+      "file": "git2/trace.h",
       "functions": [
         "git_trace_callback",
         "git_trace_set"
@@ -1222,9 +1330,26 @@
       "lines": 63
     },
     {
-      "file": "transport.h",
+      "file": "git2/transaction.h",
+      "functions": [
+        "git_transaction_new",
+        "git_transaction_lock_ref",
+        "git_transaction_set_target",
+        "git_transaction_set_symbolic_target",
+        "git_transaction_set_reflog",
+        "git_transaction_remove",
+        "git_transaction_commit",
+        "git_transaction_free"
+      ],
+      "meta": {},
+      "lines": 117
+    },
+    {
+      "file": "git2/transport.h",
       "functions": [
         "git_transport_cb",
+        "git_cred_sign_callback",
+        "git_cred_ssh_interactive_callback",
         "git_cred_has_username",
         "git_cred_userpass_plaintext_new",
         "git_cred_ssh_key_new",
@@ -1238,10 +1363,10 @@
         "git_cred_acquire_cb"
       ],
       "meta": {},
-      "lines": 338
+      "lines": 367
     },
     {
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "functions": [
         "git_tree_lookup",
         "git_tree_lookup_prefix",
@@ -1282,17 +1407,17 @@
       "lines": 479
     },
     {
-      "file": "types.h",
+      "file": "git2/types.h",
       "functions": [
         "git_transfer_progress_cb",
         "git_transport_message_cb",
         "git_transport_certificate_check_cb"
       ],
       "meta": {},
-      "lines": 429
+      "lines": 438
     },
     {
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "functions": [
         "git_worktree_list",
         "git_worktree_lookup",
@@ -1304,18 +1429,20 @@
         "git_worktree_lock",
         "git_worktree_unlock",
         "git_worktree_is_locked",
+        "git_worktree_name",
+        "git_worktree_path",
         "git_worktree_prune_init_options",
         "git_worktree_is_prunable",
         "git_worktree_prune"
       ],
       "meta": {},
-      "lines": 216
+      "lines": 251
     }
   ],
   "functions": {
     "git_annotated_commit_from_ref": {
       "type": "function",
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "line": 33,
       "lineto": 36,
       "args": [
@@ -1343,16 +1470,11 @@
       },
       "description": "<p>Creates a <code>git_annotated_commit</code> from the given reference.\n The resulting git_annotated_commit must be freed with\n <code>git_annotated_commit_free</code>.</p>\n",
       "comments": "",
-      "group": "annotated",
-      "examples": {
-        "merge.c": [
-          "ex/HEAD/merge.html#git_annotated_commit_from_ref-1"
-        ]
-      }
+      "group": "annotated"
     },
     "git_annotated_commit_from_fetchhead": {
       "type": "function",
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "line": 50,
       "lineto": 55,
       "args": [
@@ -1394,7 +1516,7 @@
     },
     "git_annotated_commit_lookup": {
       "type": "function",
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "line": 75,
       "lineto": 78,
       "args": [
@@ -1421,17 +1543,12 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Creates a <code>git_annotated_commit</code> from the given commit id.\n The resulting git_annotated_commit must be freed with\n <code>git_annotated_commit_free</code>.</p>\n",
-      "comments": "<p>An annotated commit contains information about how it was looked up, which may be useful for functions like merge or rebase to provide context to the operation.  For example, conflict files will include the name of the source or target branches being merged.  It is therefore preferable to use the most specific function (eg <code>git_annotated_commit_from_ref</code>) instead of this one when that data is known.</p>\n",
-      "group": "annotated",
-      "examples": {
-        "merge.c": [
-          "ex/HEAD/merge.html#git_annotated_commit_lookup-2"
-        ]
-      }
+      "comments": "<p>An annotated commit contains information about how it was\n looked up, which may be useful for functions like merge or\n rebase to provide context to the operation.  For example,\n conflict files will include the name of the source or target\n branches being merged.  It is therefore preferable to use the\n most specific function (eg <code>git_annotated_commit_from_ref</code>)\n instead of this one when that data is known.</p>\n",
+      "group": "annotated"
     },
     "git_annotated_commit_from_revspec": {
       "type": "function",
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "line": 92,
       "lineto": 95,
       "args": [
@@ -1458,12 +1575,12 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Creates a <code>git_annotated_comit</code> from a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n",
       "group": "annotated"
     },
     "git_annotated_commit_id": {
       "type": "function",
-      "file": "annotated_commit.h",
+      "file": "git2/annotated_commit.h",
       "line": 103,
       "lineto": 104,
       "args": [
@@ -1483,18 +1600,49 @@
       "comments": "",
       "group": "annotated",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_annotated_commit_id-1"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_annotated_commit_id-3",
-          "ex/HEAD/merge.html#git_annotated_commit_id-4",
-          "ex/HEAD/merge.html#git_annotated_commit_id-5"
+          "ex/HEAD/merge.html#git_annotated_commit_id-1",
+          "ex/HEAD/merge.html#git_annotated_commit_id-2",
+          "ex/HEAD/merge.html#git_annotated_commit_id-3"
+        ]
+      }
+    },
+    "git_annotated_commit_ref": {
+      "type": "function",
+      "file": "git2/annotated_commit.h",
+      "line": 112,
+      "lineto": 113,
+      "args": [
+        {
+          "name": "commit",
+          "type": "const git_annotated_commit *",
+          "comment": "the given annotated commit"
+        }
+      ],
+      "argline": "const git_annotated_commit *commit",
+      "sig": "const git_annotated_commit *",
+      "return": {
+        "type": "const char *",
+        "comment": " ref name."
+      },
+      "description": "<p>Get the refname that the given <code>git_annotated_commit</code> refers to.</p>\n",
+      "comments": "",
+      "group": "annotated",
+      "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_annotated_commit_ref-2",
+          "ex/HEAD/checkout.html#git_annotated_commit_ref-3"
         ]
       }
     },
     "git_annotated_commit_free": {
       "type": "function",
-      "file": "annotated_commit.h",
-      "line": 111,
-      "lineto": 112,
+      "file": "git2/annotated_commit.h",
+      "line": 120,
+      "lineto": 121,
       "args": [
         {
           "name": "commit",
@@ -1510,11 +1658,16 @@
       },
       "description": "<p>Frees a <code>git_annotated_commit</code>.</p>\n",
       "comments": "",
-      "group": "annotated"
+      "group": "annotated",
+      "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_annotated_commit_free-4"
+        ]
+      }
     },
     "git_attr_value": {
       "type": "function",
-      "file": "attr.h",
+      "file": "git2/attr.h",
       "line": 102,
       "lineto": 102,
       "args": [
@@ -1531,12 +1684,12 @@
         "comment": " the value type for the attribute"
       },
       "description": "<p>Return the value type for a given attribute.</p>\n",
-      "comments": "<p>This can be either <code>TRUE</code>, <code>FALSE</code>, <code>UNSPECIFIED</code> (if the attribute was not set at all), or <code>VALUE</code>, if the attribute was set to an actual string.</p>\n\n<p>If the attribute has a <code>VALUE</code> string, it can be accessed normally as a NULL-terminated C string.</p>\n",
+      "comments": "<p>This can be either <code>TRUE</code>, <code>FALSE</code>, <code>UNSPECIFIED</code> (if the attribute\n was not set at all), or <code>VALUE</code>, if the attribute was set to an\n actual string.</p>\n\n<p>If the attribute has a <code>VALUE</code> string, it can be accessed normally\n as a NULL-terminated C string.</p>\n",
       "group": "attr"
     },
     "git_attr_get": {
       "type": "function",
-      "file": "attr.h",
+      "file": "git2/attr.h",
       "line": 145,
       "lineto": 150,
       "args": [
@@ -1578,7 +1731,7 @@
     },
     "git_attr_get_many": {
       "type": "function",
-      "file": "attr.h",
+      "file": "git2/attr.h",
       "line": 181,
       "lineto": 187,
       "args": [
@@ -1620,14 +1773,14 @@
         "comment": null
       },
       "description": "<p>Look up a list of git attributes for path.</p>\n",
-      "comments": "<p>Use this if you have a known list of attributes that you want to look up in a single call.  This is somewhat more efficient than calling <code>git_attr_get()</code> multiple times.</p>\n\n<p>For example, you might write:</p>\n\n<pre><code> const char *attrs[] = { &quot;crlf&quot;, &quot;diff&quot;, &quot;foo&quot; };     const char **values[3];     git_attr_get_many(values, repo, 0, &quot;my/fun/file.c&quot;, 3, attrs);\n</code></pre>\n\n<p>Then you could loop through the 3 values to get the settings for the three attributes you asked about.</p>\n",
+      "comments": "<p>Use this if you have a known list of attributes that you want to\n look up in a single call.  This is somewhat more efficient than\n calling <code>git_attr_get()</code> multiple times.</p>\n\n<p>For example, you might write:</p>\n\n<pre><code> const char *attrs[] = { &quot;crlf&quot;, &quot;diff&quot;, &quot;foo&quot; };\n const char **values[3];\n git_attr_get_many(values, repo, 0, &quot;my/fun/file.c&quot;, 3, attrs);\n</code></pre>\n\n<p>Then you could loop through the 3 values to get the settings for\n the three attributes you asked about.</p>\n",
       "group": "attr"
     },
     "git_attr_foreach": {
       "type": "function",
-      "file": "attr.h",
-      "line": 209,
-      "lineto": 214,
+      "file": "git2/attr.h",
+      "line": 220,
+      "lineto": 225,
       "args": [
         {
           "name": "repo",
@@ -1647,7 +1800,7 @@
         {
           "name": "callback",
           "type": "git_attr_foreach_cb",
-          "comment": "Function to invoke on each attribute name and value.  The\n             value may be NULL is the attribute is explicitly set to\n             UNSPECIFIED using the '!' sign.  Callback will be invoked\n             only once per attribute name, even if there are multiple\n             rules for a given file.  The highest priority rule will be\n             used.  Return a non-zero value from this to stop looping.\n             The value will be returned from `git_attr_foreach`."
+          "comment": "Function to invoke on each attribute name and value.\n                 See git_attr_foreach_cb."
         },
         {
           "name": "payload",
@@ -1667,9 +1820,9 @@
     },
     "git_attr_cache_flush": {
       "type": "function",
-      "file": "attr.h",
-      "line": 224,
-      "lineto": 225,
+      "file": "git2/attr.h",
+      "line": 235,
+      "lineto": 236,
       "args": [
         {
           "name": "repo",
@@ -1684,14 +1837,14 @@
         "comment": null
       },
       "description": "<p>Flush the gitattributes cache.</p>\n",
-      "comments": "<p>Call this if you have reason to believe that the attributes files on disk no longer match the cached contents of memory.  This will cause the attributes files to be reloaded the next time that an attribute access function is called.</p>\n",
+      "comments": "<p>Call this if you have reason to believe that the attributes files on\n disk no longer match the cached contents of memory.  This will cause\n the attributes files to be reloaded the next time that an attribute\n access function is called.</p>\n",
       "group": "attr"
     },
     "git_attr_add_macro": {
       "type": "function",
-      "file": "attr.h",
-      "line": 237,
-      "lineto": 240,
+      "file": "git2/attr.h",
+      "line": 248,
+      "lineto": 251,
       "args": [
         {
           "name": "repo",
@@ -1716,24 +1869,24 @@
         "comment": null
       },
       "description": "<p>Add a macro definition.</p>\n",
-      "comments": "<p>Macros will automatically be loaded from the top level <code>.gitattributes</code> file of the repository (plus the build-in &quot;binary&quot; macro).  This function allows you to add others.  For example, to add the default macro, you would call:</p>\n\n<pre><code> git_attr_add_macro(repo, &quot;binary&quot;, &quot;-diff -crlf&quot;);\n</code></pre>\n",
+      "comments": "<p>Macros will automatically be loaded from the top level <code>.gitattributes</code>\n file of the repository (plus the build-in &quot;binary&quot; macro).  This\n function allows you to add others.  For example, to add the default\n macro, you would call:</p>\n\n<pre><code> git_attr_add_macro(repo, &quot;binary&quot;, &quot;-diff -crlf&quot;);\n</code></pre>\n",
       "group": "attr"
     },
     "git_blame_init_options": {
       "type": "function",
-      "file": "blame.h",
-      "line": 92,
-      "lineto": 94,
+      "file": "git2/blame.h",
+      "line": 103,
+      "lineto": 105,
       "args": [
         {
           "name": "opts",
           "type": "git_blame_options *",
-          "comment": "The `git_blame_options` struct to initialize"
+          "comment": "The `git_blame_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_BLAME_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_BLAME_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_blame_options *opts, unsigned int version",
@@ -1742,15 +1895,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_blame_options</code> with default values. Equivalent to\n creating an instance with GIT_BLAME_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_blame_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_blame_options</code> with default values. Equivalent to creating\n an instance with GIT_BLAME_OPTIONS_INIT.</p>\n",
       "group": "blame"
     },
     "git_blame_get_hunk_count": {
       "type": "function",
-      "file": "blame.h",
-      "line": 137,
-      "lineto": 137,
+      "file": "git2/blame.h",
+      "line": 154,
+      "lineto": 154,
       "args": [
         {
           "name": "blame",
@@ -1770,9 +1923,9 @@
     },
     "git_blame_get_hunk_byindex": {
       "type": "function",
-      "file": "blame.h",
-      "line": 146,
-      "lineto": 148,
+      "file": "git2/blame.h",
+      "line": 163,
+      "lineto": 165,
       "args": [
         {
           "name": "blame",
@@ -1797,9 +1950,9 @@
     },
     "git_blame_get_hunk_byline": {
       "type": "function",
-      "file": "blame.h",
-      "line": 157,
-      "lineto": 159,
+      "file": "git2/blame.h",
+      "line": 174,
+      "lineto": 176,
       "args": [
         {
           "name": "blame",
@@ -1829,9 +1982,9 @@
     },
     "git_blame_file": {
       "type": "function",
-      "file": "blame.h",
-      "line": 172,
-      "lineto": 176,
+      "file": "git2/blame.h",
+      "line": 189,
+      "lineto": 193,
       "args": [
         {
           "name": "out",
@@ -1871,9 +2024,9 @@
     },
     "git_blame_buffer": {
       "type": "function",
-      "file": "blame.h",
-      "line": 196,
-      "lineto": 200,
+      "file": "git2/blame.h",
+      "line": 213,
+      "lineto": 217,
       "args": [
         {
           "name": "out",
@@ -1903,14 +2056,14 @@
         "comment": " 0 on success, or an error code. (use giterr_last for information\n         about the error)"
       },
       "description": "<p>Get blame data for a file that has been modified in memory. The <code>reference</code>\n parameter is a pre-calculated blame for the in-odb history of the file. This\n means that once a file blame is completed (which can be expensive), updating\n the buffer blame is very fast.</p>\n",
-      "comments": "<p>Lines that differ between the buffer and the committed version are marked as having a zero OID for their final_commit_id.</p>\n",
+      "comments": "<p>Lines that differ between the buffer and the committed version are marked as\n having a zero OID for their final_commit_id.</p>\n",
       "group": "blame"
     },
     "git_blame_free": {
       "type": "function",
-      "file": "blame.h",
-      "line": 207,
-      "lineto": 207,
+      "file": "git2/blame.h",
+      "line": 224,
+      "lineto": 224,
       "args": [
         {
           "name": "blame",
@@ -1935,7 +2088,7 @@
     },
     "git_blob_lookup": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 33,
       "lineto": 33,
       "args": [
@@ -1975,7 +2128,7 @@
     },
     "git_blob_lookup_prefix": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 47,
       "lineto": 47,
       "args": [
@@ -2012,7 +2165,7 @@
     },
     "git_blob_free": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 60,
       "lineto": 60,
       "args": [
@@ -2029,7 +2182,7 @@
         "comment": null
       },
       "description": "<p>Close an open blob</p>\n",
-      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using a blob. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop\n using a blob. Failure to do so will cause a memory leak.</p>\n",
       "group": "blob",
       "examples": {
         "blame.c": [
@@ -2042,7 +2195,7 @@
     },
     "git_blob_id": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 68,
       "lineto": 68,
       "args": [
@@ -2064,7 +2217,7 @@
     },
     "git_blob_owner": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 76,
       "lineto": 76,
       "args": [
@@ -2086,7 +2239,7 @@
     },
     "git_blob_rawcontent": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 89,
       "lineto": 89,
       "args": [
@@ -2103,7 +2256,7 @@
         "comment": " the pointer"
       },
       "description": "<p>Get a read-only buffer with the raw content of a blob.</p>\n",
-      "comments": "<p>A pointer to the raw content of a blob is returned; this pointer is owned internally by the object and shall not be free&#39;d. The pointer may be invalidated at a later time.</p>\n",
+      "comments": "<p>A pointer to the raw content of a blob is returned;\n this pointer is owned internally by the object and shall\n not be free&#39;d. The pointer may be invalidated at a later\n time.</p>\n",
       "group": "blob",
       "examples": {
         "blame.c": [
@@ -2119,7 +2272,7 @@
     },
     "git_blob_rawsize": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 97,
       "lineto": 97,
       "args": [
@@ -2153,7 +2306,7 @@
     },
     "git_blob_filtered_content": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 122,
       "lineto": 126,
       "args": [
@@ -2185,12 +2338,12 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Get a buffer with the filtered content of a blob.</p>\n",
-      "comments": "<p>This applies filters as if the blob was being checked out to the working directory under the specified filename.  This may apply CRLF filtering or other types of changes depending on the file attributes set for the blob and the content detected in it.</p>\n\n<p>The output is written into a <code>git_buf</code> which the caller must free when done (via <code>git_buf_free</code>).</p>\n\n<p>If no filters need to be applied, then the <code>out</code> buffer will just be populated with a pointer to the raw content of the blob.  In that case, be careful to <em>not</em> free the blob until done with the buffer or copy it into memory you own.</p>\n",
+      "comments": "<p>This applies filters as if the blob was being checked out to the\n working directory under the specified filename.  This may apply\n CRLF filtering or other types of changes depending on the file\n attributes set for the blob and the content detected in it.</p>\n\n<p>The output is written into a <code>git_buf</code> which the caller must free\n when done (via <code>git_buf_dispose</code>).</p>\n\n<p>If no filters need to be applied, then the <code>out</code> buffer will just\n be populated with a pointer to the raw content of the blob.  In\n that case, be careful to <em>not</em> free the blob until done with the\n buffer or copy it into memory you own.</p>\n",
       "group": "blob"
     },
     "git_blob_create_fromworkdir": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 139,
       "lineto": 139,
       "args": [
@@ -2222,7 +2375,7 @@
     },
     "git_blob_create_fromdisk": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 151,
       "lineto": 151,
       "args": [
@@ -2254,7 +2407,7 @@
     },
     "git_blob_create_fromstream": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 178,
       "lineto": 181,
       "args": [
@@ -2281,12 +2434,12 @@
         "comment": " 0 or error code"
       },
       "description": "<p>Create a stream to write a new blob into the object db</p>\n",
-      "comments": "<p>This function may need to buffer the data on disk and will in general not be the right choice if you know the size of the data to write. If you have data in memory, use <code>git_blob_create_frombuffer()</code>. If you do not, but know the size of the contents (and don&#39;t want/need to perform filtering), use <code>git_odb_open_wstream()</code>.</p>\n\n<p>Don&#39;t close this stream yourself but pass it to <code>git_blob_create_fromstream_commit()</code> to commit the write to the object db and get the object id.</p>\n\n<p>If the <code>hintpath</code> parameter is filled, it will be used to determine what git filters should be applied to the object before it is written to the object database.</p>\n",
+      "comments": "<p>This function may need to buffer the data on disk and will in\n general not be the right choice if you know the size of the data\n to write. If you have data in memory, use\n <code>git_blob_create_frombuffer()</code>. If you do not, but know the size of\n the contents (and don&#39;t want/need to perform filtering), use\n <code>git_odb_open_wstream()</code>.</p>\n\n<p>Don&#39;t close this stream yourself but pass it to\n <code>git_blob_create_fromstream_commit()</code> to commit the write to the\n object db and get the object id.</p>\n\n<p>If the <code>hintpath</code> parameter is filled, it will be used to determine\n what git filters should be applied to the object before it is written\n to the object database.</p>\n",
       "group": "blob"
     },
     "git_blob_create_fromstream_commit": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 192,
       "lineto": 194,
       "args": [
@@ -2313,7 +2466,7 @@
     },
     "git_blob_create_frombuffer": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 205,
       "lineto": 206,
       "args": [
@@ -2350,7 +2503,7 @@
     },
     "git_blob_is_binary": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 219,
       "lineto": 219,
       "args": [
@@ -2367,12 +2520,12 @@
         "comment": " 1 if the content of the blob is detected\n as binary; 0 otherwise."
       },
       "description": "<p>Determine if the blob content is most certainly binary or not.</p>\n",
-      "comments": "<p>The heuristic used to guess if a file is binary is taken from core git: Searching for NUL bytes and looking for a reasonable ratio of printable to non-printable characters among the first 8000 bytes.</p>\n",
+      "comments": "<p>The heuristic used to guess if a file is binary is taken from core git:\n Searching for NUL bytes and looking for a reasonable ratio of printable\n to non-printable characters among the first 8000 bytes.</p>\n",
       "group": "blob"
     },
     "git_blob_dup": {
       "type": "function",
-      "file": "blob.h",
+      "file": "git2/blob.h",
       "line": 228,
       "lineto": 228,
       "args": [
@@ -2399,7 +2552,7 @@
     },
     "git_branch_create": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 50,
       "lineto": 55,
       "args": [
@@ -2436,12 +2589,12 @@
         "comment": " 0, GIT_EINVALIDSPEC or an error code.\n A proper reference is written in the refs/heads namespace\n pointing to the provided target commit."
       },
       "description": "<p>Create a new branch pointing at a target commit</p>\n",
-      "comments": "<p>A new direct reference will be created pointing to this target commit. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The returned reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>A new direct reference will be created pointing to\n this target commit. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The returned reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_create_from_annotated": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 68,
       "lineto": 73,
       "args": [
@@ -2478,12 +2631,12 @@
         "comment": null
       },
       "description": "<p>Create a new branch pointing at a target commit</p>\n",
-      "comments": "<p>This behaves like <code>git_branch_create()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_branch_create()</code>.</p>\n",
+      "comments": "<p>This behaves like <code>git_branch_create()</code> but takes an annotated\n commit, which lets you specify which extended sha syntax string was\n specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_branch_create()</code>.</p>\n",
       "group": "branch"
     },
     "git_branch_delete": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 85,
       "lineto": 85,
       "args": [
@@ -2500,12 +2653,12 @@
         "comment": " 0 on success, or an error code."
       },
       "description": "<p>Delete an existing branch reference.</p>\n",
-      "comments": "<p>If the branch is successfully deleted, the passed reference object will be invalidated. The reference must be freed manually by the user.</p>\n",
+      "comments": "<p>If the branch is successfully deleted, the passed reference\n object will be invalidated. The reference must be freed manually\n by the user.</p>\n",
       "group": "branch"
     },
     "git_branch_iterator_new": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 101,
       "lineto": 104,
       "args": [
@@ -2537,7 +2690,7 @@
     },
     "git_branch_next": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 114,
       "lineto": 114,
       "args": [
@@ -2569,7 +2722,7 @@
     },
     "git_branch_iterator_free": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 121,
       "lineto": 121,
       "args": [
@@ -2591,7 +2744,7 @@
     },
     "git_branch_move": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 138,
       "lineto": 142,
       "args": [
@@ -2623,12 +2776,12 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Move/rename an existing local branch reference.</p>\n",
-      "comments": "<p>The new branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The new branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_lookup": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 165,
       "lineto": 169,
       "args": [
@@ -2660,12 +2813,12 @@
         "comment": " 0 on success; GIT_ENOTFOUND when no matching branch\n exists, GIT_EINVALIDSPEC, otherwise an error code."
       },
       "description": "<p>Lookup a branch by its name in a repository.</p>\n",
-      "comments": "<p>The generated reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The generated reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_name": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 186,
       "lineto": 188,
       "args": [
@@ -2687,17 +2840,17 @@
         "comment": " 0 on success; otherwise an error code (e.g., if the\n  ref is no local or remote branch)."
       },
       "description": "<p>Return the name of the given local or remote branch.</p>\n",
-      "comments": "<p>The name of the branch matches the definition of the name for git_branch_lookup. That is, if the returned name is given to git_branch_lookup() then the reference is returned that was given to this function.</p>\n",
+      "comments": "<p>The name of the branch matches the definition of the name\n for git_branch_lookup. That is, if the returned name is given\n to git_branch_lookup() then the reference is returned that\n was given to this function.</p>\n",
       "group": "branch",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_branch_name-6"
+          "ex/HEAD/merge.html#git_branch_name-4"
         ]
       }
     },
     "git_branch_upstream": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 202,
       "lineto": 204,
       "args": [
@@ -2724,7 +2877,7 @@
     },
     "git_branch_set_upstream": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 216,
       "lineto": 216,
       "args": [
@@ -2749,9 +2902,41 @@
       "comments": "",
       "group": "branch"
     },
+    "git_branch_upstream_name": {
+      "type": "function",
+      "file": "git2/branch.h",
+      "line": 232,
+      "lineto": 235,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_buf *",
+          "comment": "Pointer to the user-allocated git_buf which will be\n filled with the name of the reference."
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository where the branches live"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "reference name of the local branch."
+        }
+      ],
+      "argline": "git_buf *out, git_repository *repo, const char *refname",
+      "sig": "git_buf *::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND when no remote tracking reference exists,\n     otherwise an error code."
+      },
+      "description": "<p>Return the name of the reference supporting the remote tracking branch,\n given the name of a local branch reference.</p>\n",
+      "comments": "",
+      "group": "branch"
+    },
     "git_branch_is_head": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 245,
       "lineto": 246,
       "args": [
@@ -2773,7 +2958,7 @@
     },
     "git_branch_is_checked_out": {
       "type": "function",
-      "file": "branch.h",
+      "file": "git2/branch.h",
       "line": 257,
       "lineto": 258,
       "args": [
@@ -2793,9 +2978,73 @@
       "comments": "",
       "group": "branch"
     },
-    "git_buf_free": {
+    "git_branch_remote_name": {
       "type": "function",
-      "file": "buffer.h",
+      "file": "git2/branch.h",
+      "line": 274,
+      "lineto": 277,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_buf *",
+          "comment": "Pointer to the user-allocated git_buf which will be filled with the name of the remote."
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "The repository where the branch lives."
+        },
+        {
+          "name": "canonical_branch_name",
+          "type": "const char *",
+          "comment": "name of the remote tracking branch."
+        }
+      ],
+      "argline": "git_buf *out, git_repository *repo, const char *canonical_branch_name",
+      "sig": "git_buf *::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND\n     when no remote matching remote was found,\n     GIT_EAMBIGUOUS when the branch maps to several remotes,\n     otherwise an error code."
+      },
+      "description": "<p>Return the name of remote that the remote tracking branch belongs to.</p>\n",
+      "comments": "",
+      "group": "branch"
+    },
+    "git_branch_upstream_remote": {
+      "type": "function",
+      "file": "git2/branch.h",
+      "line": 288,
+      "lineto": 288,
+      "args": [
+        {
+          "name": "buf",
+          "type": "git_buf *",
+          "comment": "the buffer into which to write the name"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository in which to look"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "the full name of the branch"
+        }
+      ],
+      "argline": "git_buf *buf, git_repository *repo, const char *refname",
+      "sig": "git_buf *::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Retrieve the name of the upstream remote of a local branch</p>\n",
+      "comments": "",
+      "group": "branch"
+    },
+    "git_buf_dispose": {
+      "type": "function",
+      "file": "git2/buffer.h",
       "line": 72,
       "lineto": 72,
       "args": [
@@ -2812,25 +3061,47 @@
         "comment": null
       },
       "description": "<p>Free the memory referred to by the git_buf.</p>\n",
-      "comments": "<p>Note that this does not free the <code>git_buf</code> itself, just the memory pointed to by <code>buffer-&gt;ptr</code>.  This will not free the memory if it looks like it was not allocated internally, but it will clear the buffer back to the empty state.</p>\n",
+      "comments": "<p>Note that this does not free the <code>git_buf</code> itself, just the memory\n pointed to by <code>buffer-&gt;ptr</code>.  This will not free the memory if it looks\n like it was not allocated internally, but it will clear the buffer back\n to the empty state.</p>\n",
       "group": "buf",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_buf_free-1"
+          "ex/HEAD/diff.html#git_buf_dispose-1"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_buf_free-1"
+          "ex/HEAD/remote.html#git_buf_dispose-1"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_buf_free-1"
+          "ex/HEAD/tag.html#git_buf_dispose-1"
         ]
       }
     },
+    "git_buf_free": {
+      "type": "function",
+      "file": "git2/buffer.h",
+      "line": 84,
+      "lineto": 84,
+      "args": [
+        {
+          "name": "buffer",
+          "type": "git_buf *",
+          "comment": null
+        }
+      ],
+      "argline": "git_buf *buffer",
+      "sig": "git_buf *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "",
+      "comments": "",
+      "group": "buf"
+    },
     "git_buf_grow": {
       "type": "function",
-      "file": "buffer.h",
-      "line": 95,
-      "lineto": 95,
+      "file": "git2/buffer.h",
+      "line": 107,
+      "lineto": 107,
       "args": [
         {
           "name": "buffer",
@@ -2850,14 +3121,14 @@
         "comment": " 0 on success, -1 on allocation failure"
       },
       "description": "<p>Resize the buffer allocation to make more space.</p>\n",
-      "comments": "<p>This will attempt to grow the buffer to accommodate the target size.</p>\n\n<p>If the buffer refers to memory that was not allocated by libgit2 (i.e. the <code>asize</code> field is zero), then <code>ptr</code> will be replaced with a newly allocated block of data.  Be careful so that memory allocated by the caller is not lost.  As a special variant, if you pass <code>target_size</code> as 0 and the memory is not allocated by libgit2, this will allocate a new buffer of size <code>size</code> and copy the external data into it.</p>\n\n<p>Currently, this will never shrink a buffer, only expand it.</p>\n\n<p>If the allocation fails, this will return an error and the buffer will be marked as invalid for future operations, invaliding the contents.</p>\n",
+      "comments": "<p>This will attempt to grow the buffer to accommodate the target size.</p>\n\n<p>If the buffer refers to memory that was not allocated by libgit2 (i.e.\n the <code>asize</code> field is zero), then <code>ptr</code> will be replaced with a newly\n allocated block of data.  Be careful so that memory allocated by the\n caller is not lost.  As a special variant, if you pass <code>target_size</code> as\n 0 and the memory is not allocated by libgit2, this will allocate a new\n buffer of size <code>size</code> and copy the external data into it.</p>\n\n<p>Currently, this will never shrink a buffer, only expand it.</p>\n\n<p>If the allocation fails, this will return an error and the buffer will be\n marked as invalid for future operations, invaliding the contents.</p>\n",
       "group": "buf"
     },
     "git_buf_set": {
       "type": "function",
-      "file": "buffer.h",
-      "line": 105,
-      "lineto": 106,
+      "file": "git2/buffer.h",
+      "line": 117,
+      "lineto": 118,
       "args": [
         {
           "name": "buffer",
@@ -2887,9 +3158,9 @@
     },
     "git_buf_is_binary": {
       "type": "function",
-      "file": "buffer.h",
-      "line": 114,
-      "lineto": 114,
+      "file": "git2/buffer.h",
+      "line": 126,
+      "lineto": 126,
       "args": [
         {
           "name": "buf",
@@ -2909,9 +3180,9 @@
     },
     "git_buf_contains_nul": {
       "type": "function",
-      "file": "buffer.h",
-      "line": 122,
-      "lineto": 122,
+      "file": "git2/buffer.h",
+      "line": 134,
+      "lineto": 134,
       "args": [
         {
           "name": "buf",
@@ -2931,19 +3202,19 @@
     },
     "git_checkout_init_options": {
       "type": "function",
-      "file": "checkout.h",
-      "line": 308,
-      "lineto": 310,
+      "file": "git2/checkout.h",
+      "line": 309,
+      "lineto": 311,
       "args": [
         {
           "name": "opts",
           "type": "git_checkout_options *",
-          "comment": "the `git_checkout_options` struct to initialize."
+          "comment": "The `git_checkout_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_CHECKOUT_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_CHECKOUT_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_checkout_options *opts, unsigned int version",
@@ -2952,15 +3223,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_checkout_options</code> with default values. Equivalent to\n creating an instance with GIT_CHECKOUT_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_checkout_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_checkout_options</code> with default values. Equivalent to creating\n an instance with GIT_CHECKOUT_OPTIONS_INIT.</p>\n",
       "group": "checkout"
     },
     "git_checkout_head": {
       "type": "function",
-      "file": "checkout.h",
-      "line": 329,
-      "lineto": 331,
+      "file": "git2/checkout.h",
+      "line": 330,
+      "lineto": 332,
       "args": [
         {
           "name": "repo",
@@ -2980,14 +3251,14 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH if HEAD points to a non\n         existing branch, non-zero value returned by `notify_cb`, or\n         other error code \n<\n 0 (use giterr_last for error details)"
       },
       "description": "<p>Updates files in the index and the working tree to match the content of\n the commit pointed at by HEAD.</p>\n",
-      "comments": "<p>Note that this is <em>not</em> the correct mechanism used to switch branches; do not change your <code>HEAD</code> and then call this method, that would leave you with checkout conflicts since your working directory would then appear to be dirty.  Instead, checkout the target of the branch and then update <code>HEAD</code> using <code>git_repository_set_head</code> to point to the branch you checked out.</p>\n",
+      "comments": "<p>Note that this is <em>not</em> the correct mechanism used to switch branches;\n do not change your <code>HEAD</code> and then call this method, that would leave\n you with checkout conflicts since your working directory would then\n appear to be dirty.  Instead, checkout the target of the branch and\n then update <code>HEAD</code> using <code>git_repository_set_head</code> to point to the\n branch you checked out.</p>\n",
       "group": "checkout"
     },
     "git_checkout_index": {
       "type": "function",
-      "file": "checkout.h",
-      "line": 342,
-      "lineto": 345,
+      "file": "git2/checkout.h",
+      "line": 343,
+      "lineto": 346,
       "args": [
         {
           "name": "repo",
@@ -3017,9 +3288,9 @@
     },
     "git_checkout_tree": {
       "type": "function",
-      "file": "checkout.h",
-      "line": 358,
-      "lineto": 361,
+      "file": "git2/checkout.h",
+      "line": 359,
+      "lineto": 362,
       "args": [
         {
           "name": "repo",
@@ -3047,26 +3318,29 @@
       "comments": "",
       "group": "checkout",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_checkout_tree-5"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_checkout_tree-7"
+          "ex/HEAD/merge.html#git_checkout_tree-5"
         ]
       }
     },
     "git_cherrypick_init_options": {
       "type": "function",
-      "file": "cherrypick.h",
-      "line": 47,
-      "lineto": 49,
+      "file": "git2/cherrypick.h",
+      "line": 49,
+      "lineto": 51,
       "args": [
         {
           "name": "opts",
           "type": "git_cherrypick_options *",
-          "comment": "the `git_cherrypick_options` struct to initialize"
+          "comment": "The `git_cherrypick_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_CHERRYPICK_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_CHERRYPICK_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_cherrypick_options *opts, unsigned int version",
@@ -3075,15 +3349,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_cherrypick_options</code> with default values. Equivalent to\n creating an instance with GIT_CHERRYPICK_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_cherrypick_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_cherrypick_options</code> with default values. Equivalent to creating\n an instance with GIT_CHERRYPICK_OPTIONS_INIT.</p>\n",
       "group": "cherrypick"
     },
     "git_cherrypick_commit": {
       "type": "function",
-      "file": "cherrypick.h",
-      "line": 65,
-      "lineto": 71,
+      "file": "git2/cherrypick.h",
+      "line": 67,
+      "lineto": 73,
       "args": [
         {
           "name": "out",
@@ -3128,9 +3402,9 @@
     },
     "git_cherrypick": {
       "type": "function",
-      "file": "cherrypick.h",
-      "line": 81,
-      "lineto": 84,
+      "file": "git2/cherrypick.h",
+      "line": 83,
+      "lineto": 86,
       "args": [
         {
           "name": "repo",
@@ -3160,19 +3434,19 @@
     },
     "git_clone_init_options": {
       "type": "function",
-      "file": "clone.h",
-      "line": 179,
-      "lineto": 181,
+      "file": "git2/clone.h",
+      "line": 181,
+      "lineto": 183,
       "args": [
         {
           "name": "opts",
           "type": "git_clone_options *",
-          "comment": "The `git_clone_options` struct to initialize"
+          "comment": "The `git_clone_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_CLONE_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_CLONE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_clone_options *opts, unsigned int version",
@@ -3181,15 +3455,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_clone_options</code> with default values. Equivalent to\n creating an instance with GIT_CLONE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_clone_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_clone_options</code> with default values. Equivalent to creating\n an instance with GIT_CLONE_OPTIONS_INIT.</p>\n",
       "group": "clone"
     },
     "git_clone": {
       "type": "function",
-      "file": "clone.h",
-      "line": 199,
-      "lineto": 203,
+      "file": "git2/clone.h",
+      "line": 201,
+      "lineto": 205,
       "args": [
         {
           "name": "out",
@@ -3219,17 +3493,12 @@
         "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `giterr_last` for a detailed error message)"
       },
       "description": "<p>Clone a remote repository.</p>\n",
-      "comments": "<p>By default this creates its repository and initial remote to match git&#39;s defaults. You can use the options in the callback to customize how these are created.</p>\n",
-      "group": "clone",
-      "examples": {
-        "network/clone.c": [
-          "ex/HEAD/network/clone.html#git_clone-1"
-        ]
-      }
+      "comments": "<p>By default this creates its repository and initial remote to match\n git&#39;s defaults. You can use the options in the callback to\n customize how these are created.</p>\n",
+      "group": "clone"
     },
     "git_commit_lookup": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 36,
       "lineto": 37,
       "args": [
@@ -3256,9 +3525,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a commit object from a repository.</p>\n",
-      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no longer needed.</p>\n",
+      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no\n longer needed.</p>\n",
       "group": "commit",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_commit_lookup-6"
+        ],
         "general.c": [
           "ex/HEAD/general.html#git_commit_lookup-6",
           "ex/HEAD/general.html#git_commit_lookup-7",
@@ -3268,13 +3540,13 @@
           "ex/HEAD/log.html#git_commit_lookup-1"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_commit_lookup-8"
+          "ex/HEAD/merge.html#git_commit_lookup-6"
         ]
       }
     },
     "git_commit_lookup_prefix": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 55,
       "lineto": 56,
       "args": [
@@ -3306,12 +3578,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a commit object from a repository, given a prefix of its\n identifier (short id).</p>\n",
-      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no longer needed.</p>\n",
+      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no\n longer needed.</p>\n",
       "group": "commit"
     },
     "git_commit_free": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 70,
       "lineto": 70,
       "args": [
@@ -3328,9 +3600,12 @@
         "comment": null
       },
       "description": "<p>Close an open commit</p>\n",
-      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using a commit. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop\n using a commit. Failure to do so will cause a memory leak.</p>\n",
       "group": "commit",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_commit_free-7"
+        ],
         "general.c": [
           "ex/HEAD/general.html#git_commit_free-9",
           "ex/HEAD/general.html#git_commit_free-10",
@@ -3348,7 +3623,7 @@
     },
     "git_commit_id": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 78,
       "lineto": 78,
       "args": [
@@ -3378,7 +3653,7 @@
     },
     "git_commit_owner": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 86,
       "lineto": 86,
       "args": [
@@ -3406,7 +3681,7 @@
     },
     "git_commit_message_encoding": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 98,
       "lineto": 98,
       "args": [
@@ -3423,12 +3698,12 @@
         "comment": " NULL, or the encoding"
       },
       "description": "<p>Get the encoding for the message of a commit,\n as a string representing a standard encoding name.</p>\n",
-      "comments": "<p>The encoding may be NULL if the <code>encoding</code> header in the commit is missing; in that case UTF-8 is assumed.</p>\n",
+      "comments": "<p>The encoding may be NULL if the <code>encoding</code> header\n in the commit is missing; in that case UTF-8 is assumed.</p>\n",
       "group": "commit"
     },
     "git_commit_message": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 109,
       "lineto": 109,
       "args": [
@@ -3445,7 +3720,7 @@
         "comment": " the message of a commit"
       },
       "description": "<p>Get the full message of a commit.</p>\n",
-      "comments": "<p>The returned message will be slightly prettified by removing any potential leading newlines.</p>\n",
+      "comments": "<p>The returned message will be slightly prettified by removing any\n potential leading newlines.</p>\n",
       "group": "commit",
       "examples": {
         "cat-file.c": [
@@ -3469,7 +3744,7 @@
     },
     "git_commit_message_raw": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 117,
       "lineto": 117,
       "args": [
@@ -3491,7 +3766,7 @@
     },
     "git_commit_summary": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 128,
       "lineto": 128,
       "args": [
@@ -3508,12 +3783,12 @@
         "comment": " the summary of a commit or NULL on error"
       },
       "description": "<p>Get the short &quot;summary&quot; of the git commit message.</p>\n",
-      "comments": "<p>The returned message is the summary of the commit, comprising the first paragraph of the message with whitespace trimmed and squashed.</p>\n",
+      "comments": "<p>The returned message is the summary of the commit, comprising the\n first paragraph of the message with whitespace trimmed and squashed.</p>\n",
       "group": "commit"
     },
     "git_commit_body": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 141,
       "lineto": 141,
       "args": [
@@ -3530,12 +3805,12 @@
         "comment": " the body of a commit or NULL when no the message only\n   consists of a summary"
       },
       "description": "<p>Get the long &quot;body&quot; of the git commit message.</p>\n",
-      "comments": "<p>The returned message is the body of the commit, comprising everything but the first paragraph of the message. Leading and trailing whitespaces are trimmed.</p>\n",
+      "comments": "<p>The returned message is the body of the commit, comprising\n everything but the first paragraph of the message. Leading and\n trailing whitespaces are trimmed.</p>\n",
       "group": "commit"
     },
     "git_commit_time": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 149,
       "lineto": 149,
       "args": [
@@ -3563,7 +3838,7 @@
     },
     "git_commit_time_offset": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 157,
       "lineto": 157,
       "args": [
@@ -3585,7 +3860,7 @@
     },
     "git_commit_committer": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 165,
       "lineto": 165,
       "args": [
@@ -3618,7 +3893,7 @@
     },
     "git_commit_author": {
       "type": "function",
-      "file": "commit.h",
+      "file": "git2/commit.h",
       "line": 173,
       "lineto": 173,
       "args": [
@@ -3651,11 +3926,75 @@
         ]
       }
     },
+    "git_commit_committer_with_mailmap": {
+      "type": "function",
+      "file": "git2/commit.h",
+      "line": 186,
+      "lineto": 187,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_signature **",
+          "comment": "a pointer to store the resolved signature."
+        },
+        {
+          "name": "commit",
+          "type": "const git_commit *",
+          "comment": "a previously loaded commit."
+        },
+        {
+          "name": "mailmap",
+          "type": "const git_mailmap *",
+          "comment": "the mailmap to resolve with. (may be NULL)"
+        }
+      ],
+      "argline": "git_signature **out, const git_commit *commit, const git_mailmap *mailmap",
+      "sig": "git_signature **::const git_commit *::const git_mailmap *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Get the committer of a commit, using the mailmap to map names and email\n addresses to canonical real names and email addresses.</p>\n",
+      "comments": "<p>Call <code>git_signature_free</code> to free the signature.</p>\n",
+      "group": "commit"
+    },
+    "git_commit_author_with_mailmap": {
+      "type": "function",
+      "file": "git2/commit.h",
+      "line": 200,
+      "lineto": 201,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_signature **",
+          "comment": "a pointer to store the resolved signature."
+        },
+        {
+          "name": "commit",
+          "type": "const git_commit *",
+          "comment": "a previously loaded commit."
+        },
+        {
+          "name": "mailmap",
+          "type": "const git_mailmap *",
+          "comment": "the mailmap to resolve with. (may be NULL)"
+        }
+      ],
+      "argline": "git_signature **out, const git_commit *commit, const git_mailmap *mailmap",
+      "sig": "git_signature **::const git_commit *::const git_mailmap *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Get the author of a commit, using the mailmap to map names and email\n addresses to canonical real names and email addresses.</p>\n",
+      "comments": "<p>Call <code>git_signature_free</code> to free the signature.</p>\n",
+      "group": "commit"
+    },
     "git_commit_raw_header": {
       "type": "function",
-      "file": "commit.h",
-      "line": 181,
-      "lineto": 181,
+      "file": "git2/commit.h",
+      "line": 209,
+      "lineto": 209,
       "args": [
         {
           "name": "commit",
@@ -3675,9 +4014,9 @@
     },
     "git_commit_tree": {
       "type": "function",
-      "file": "commit.h",
-      "line": 190,
-      "lineto": 190,
+      "file": "git2/commit.h",
+      "line": 218,
+      "lineto": 218,
       "args": [
         {
           "name": "tree_out",
@@ -3711,9 +4050,9 @@
     },
     "git_commit_tree_id": {
       "type": "function",
-      "file": "commit.h",
-      "line": 200,
-      "lineto": 200,
+      "file": "git2/commit.h",
+      "line": 228,
+      "lineto": 228,
       "args": [
         {
           "name": "commit",
@@ -3738,9 +4077,9 @@
     },
     "git_commit_parentcount": {
       "type": "function",
-      "file": "commit.h",
-      "line": 208,
-      "lineto": 208,
+      "file": "git2/commit.h",
+      "line": 236,
+      "lineto": 236,
       "args": [
         {
           "name": "commit",
@@ -3772,9 +4111,9 @@
     },
     "git_commit_parent": {
       "type": "function",
-      "file": "commit.h",
-      "line": 218,
-      "lineto": 221,
+      "file": "git2/commit.h",
+      "line": 246,
+      "lineto": 249,
       "args": [
         {
           "name": "out",
@@ -3813,9 +4152,9 @@
     },
     "git_commit_parent_id": {
       "type": "function",
-      "file": "commit.h",
-      "line": 232,
-      "lineto": 234,
+      "file": "git2/commit.h",
+      "line": 260,
+      "lineto": 262,
       "args": [
         {
           "name": "commit",
@@ -3848,9 +4187,9 @@
     },
     "git_commit_nth_gen_ancestor": {
       "type": "function",
-      "file": "commit.h",
-      "line": 250,
-      "lineto": 253,
+      "file": "git2/commit.h",
+      "line": 278,
+      "lineto": 281,
       "args": [
         {
           "name": "ancestor",
@@ -3875,14 +4214,14 @@
         "comment": " 0 on success; GIT_ENOTFOUND if no matching ancestor exists\n or an error code"
       },
       "description": "<p>Get the commit object that is the \n&lt;n</p>\n\n<blockquote>\n<p>th generation ancestor\n of the named commit object, following only the first parents.\n The returned commit has to be freed by the caller.</p>\n</blockquote>\n",
-      "comments": "<p>Passing <code>0</code> as the generation number returns another instance of the base commit itself.</p>\n",
+      "comments": "<p>Passing <code>0</code> as the generation number returns another instance of the\n base commit itself.</p>\n",
       "group": "commit"
     },
     "git_commit_header_field": {
       "type": "function",
-      "file": "commit.h",
-      "line": 265,
-      "lineto": 265,
+      "file": "git2/commit.h",
+      "line": 293,
+      "lineto": 293,
       "args": [
         {
           "name": "out",
@@ -3912,9 +4251,9 @@
     },
     "git_commit_extract_signature": {
       "type": "function",
-      "file": "commit.h",
-      "line": 285,
-      "lineto": 285,
+      "file": "git2/commit.h",
+      "line": 313,
+      "lineto": 313,
       "args": [
         {
           "name": "signature",
@@ -3949,14 +4288,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the id is not for a commit\n or the commit does not have a signature."
       },
       "description": "<p>Extract the signature from a commit</p>\n",
-      "comments": "<p>If the id is not for a commit, the error class will be <code>GITERR_INVALID</code>. If the commit does not have a signature, the error class will be <code>GITERR_OBJECT</code>.</p>\n",
+      "comments": "<p>If the id is not for a commit, the error class will be\n <code>GITERR_INVALID</code>. If the commit does not have a signature, the\n error class will be <code>GITERR_OBJECT</code>.</p>\n",
       "group": "commit"
     },
     "git_commit_create": {
       "type": "function",
-      "file": "commit.h",
-      "line": 331,
-      "lineto": 341,
+      "file": "git2/commit.h",
+      "line": 359,
+      "lineto": 369,
       "args": [
         {
           "name": "id",
@@ -4016,19 +4355,19 @@
         "comment": " 0 or an error code\n\tThe created commit will be written to the Object Database and\n\tthe given reference will be updated to point to it"
       },
       "description": "<p>Create new commit in the repository from a list of <code>git_object</code> pointers</p>\n",
-      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that with the <code>git_message_prettify()</code> function.</p>\n",
+      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that\n with the <code>git_message_prettify()</code> function.</p>\n",
       "group": "commit",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_commit_create-9"
+          "ex/HEAD/merge.html#git_commit_create-7"
         ]
       }
     },
     "git_commit_create_v": {
       "type": "function",
-      "file": "commit.h",
-      "line": 357,
-      "lineto": 367,
+      "file": "git2/commit.h",
+      "line": 385,
+      "lineto": 395,
       "args": [
         {
           "name": "id",
@@ -4083,7 +4422,7 @@
         "comment": null
       },
       "description": "<p>Create new commit in the repository using a variable argument list.</p>\n",
-      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that with the <code>git_message_prettify()</code> function.</p>\n\n<p>The parents for the commit are specified as a variable list of pointers to <code>const git_commit *</code>. Note that this is a convenience method which may not be safe to export for certain languages or compilers</p>\n\n<p>All other parameters remain the same as <code>git_commit_create()</code>.</p>\n",
+      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that\n with the <code>git_message_prettify()</code> function.</p>\n\n<p>The parents for the commit are specified as a variable list of pointers\n to <code>const git_commit *</code>. Note that this is a convenience method which may\n not be safe to export for certain languages or compilers</p>\n\n<p>All other parameters remain the same as <code>git_commit_create()</code>.</p>\n",
       "group": "commit",
       "examples": {
         "general.c": [
@@ -4096,9 +4435,9 @@
     },
     "git_commit_amend": {
       "type": "function",
-      "file": "commit.h",
-      "line": 390,
-      "lineto": 398,
+      "file": "git2/commit.h",
+      "line": 418,
+      "lineto": 426,
       "args": [
         {
           "name": "id",
@@ -4148,14 +4487,14 @@
         "comment": null
       },
       "description": "<p>Amend an existing commit by replacing only non-NULL values.</p>\n",
-      "comments": "<p>This creates a new commit that is exactly the same as the old commit, except that any non-NULL values will be updated.  The new commit has the same parents as the old commit.</p>\n\n<p>The <code>update_ref</code> value works as in the regular <code>git_commit_create()</code>, updating the ref to point to the newly rewritten commit.  If you want to amend a commit that is not currently the tip of the branch and then rewrite the following commits to reach a ref, pass this as NULL and update the rest of the commit chain and ref separately.</p>\n\n<p>Unlike <code>git_commit_create()</code>, the <code>author</code>, <code>committer</code>, <code>message</code>, <code>message_encoding</code>, and <code>tree</code> parameters can be NULL in which case this will use the values from the original <code>commit_to_amend</code>.</p>\n\n<p>All parameters have the same meanings as in <code>git_commit_create()</code>.</p>\n",
+      "comments": "<p>This creates a new commit that is exactly the same as the old commit,\n except that any non-NULL values will be updated.  The new commit has\n the same parents as the old commit.</p>\n\n<p>The <code>update_ref</code> value works as in the regular <code>git_commit_create()</code>,\n updating the ref to point to the newly rewritten commit.  If you want\n to amend a commit that is not currently the tip of the branch and then\n rewrite the following commits to reach a ref, pass this as NULL and\n update the rest of the commit chain and ref separately.</p>\n\n<p>Unlike <code>git_commit_create()</code>, the <code>author</code>, <code>committer</code>, <code>message</code>,\n <code>message_encoding</code>, and <code>tree</code> parameters can be NULL in which case this\n will use the values from the original <code>commit_to_amend</code>.</p>\n\n<p>All parameters have the same meanings as in <code>git_commit_create()</code>.</p>\n",
       "group": "commit"
     },
     "git_commit_create_buffer": {
       "type": "function",
-      "file": "commit.h",
-      "line": 435,
-      "lineto": 444,
+      "file": "git2/commit.h",
+      "line": 463,
+      "lineto": 472,
       "args": [
         {
           "name": "out",
@@ -4210,14 +4549,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a commit and write it into a buffer</p>\n",
-      "comments": "<p>Create a commit as with <code>git_commit_create()</code> but instead of writing it to the objectdb, write the contents of the object into a buffer.</p>\n",
+      "comments": "<p>Create a commit as with <code>git_commit_create()</code> but instead of\n writing it to the objectdb, write the contents of the object into a\n buffer.</p>\n",
       "group": "commit"
     },
     "git_commit_create_with_signature": {
       "type": "function",
-      "file": "commit.h",
-      "line": 460,
-      "lineto": 465,
+      "file": "git2/commit.h",
+      "line": 488,
+      "lineto": 493,
       "args": [
         {
           "name": "out",
@@ -4252,14 +4591,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a commit object from the given buffer and signature</p>\n",
-      "comments": "<p>Given the unsigned commit object&#39;s contents, its signature and the header field in which to store the signature, attach the signature to the commit and write it into the given repository.</p>\n",
+      "comments": "<p>Given the unsigned commit object&#39;s contents, its signature and the\n header field in which to store the signature, attach the signature\n to the commit and write it into the given repository.</p>\n",
       "group": "commit"
     },
     "git_commit_dup": {
       "type": "function",
-      "file": "commit.h",
-      "line": 474,
-      "lineto": 474,
+      "file": "git2/commit.h",
+      "line": 502,
+      "lineto": 502,
       "args": [
         {
           "name": "out",
@@ -4284,9 +4623,9 @@
     },
     "git_libgit2_version": {
       "type": "function",
-      "file": "common.h",
-      "line": 105,
-      "lineto": 105,
+      "file": "git2/common.h",
+      "line": 116,
+      "lineto": 116,
       "args": [
         {
           "name": "major",
@@ -4316,9 +4655,9 @@
     },
     "git_libgit2_features": {
       "type": "function",
-      "file": "common.h",
-      "line": 154,
-      "lineto": 154,
+      "file": "git2/common.h",
+      "line": 165,
+      "lineto": 165,
       "args": [],
       "argline": "",
       "sig": "",
@@ -4327,14 +4666,14 @@
         "comment": " A combination of GIT_FEATURE_* values."
       },
       "description": "<p>Query compile time options for libgit2.</p>\n",
-      "comments": "<ul>\n<li><p>GIT_FEATURE_THREADS   Libgit2 was compiled with thread support. Note that thread support is   still to be seen as a &#39;work in progress&#39; - basic object lookups are   believed to be threadsafe, but other operations may not be.</p></li>\n<li><p>GIT_FEATURE_HTTPS   Libgit2 supports the https:// protocol. This requires the openssl   library to be found when compiling libgit2.</p></li>\n<li><p>GIT_FEATURE_SSH   Libgit2 supports the SSH protocol for network operations. This requires   the libssh2 library to be found when compiling libgit2</p></li>\n</ul>\n",
+      "comments": "<ul>\n<li><p>GIT_FEATURE_THREADS\nLibgit2 was compiled with thread support. Note that thread support is\nstill to be seen as a &#39;work in progress&#39; - basic object lookups are\nbelieved to be threadsafe, but other operations may not be.</p></li>\n<li><p>GIT_FEATURE_HTTPS\nLibgit2 supports the https:// protocol. This requires the openssl\nlibrary to be found when compiling libgit2.</p></li>\n<li><p>GIT_FEATURE_SSH\nLibgit2 supports the SSH protocol for network operations. This requires\nthe libssh2 library to be found when compiling libgit2</p></li>\n</ul>\n",
       "group": "libgit2"
     },
     "git_libgit2_opts": {
       "type": "function",
-      "file": "common.h",
-      "line": 352,
-      "lineto": 352,
+      "file": "git2/common.h",
+      "line": 393,
+      "lineto": 393,
       "args": [
         {
           "name": "option",
@@ -4349,14 +4688,14 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set or query a library global option</p>\n",
-      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time        by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must       &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,       &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.        &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path      &gt; applied to shared attributes and ignore files, too.       &gt;       &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.      &gt;   Pass NULL to reset to the default (generally based on environment       &gt;   variables).  Use magic path `$PATH` to include the old value        &gt;   of the path (if you want to prepend or append, for instance).       &gt;       &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,      &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or       &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be      &gt; considered eligible for caching in memory.  Setting to value to       &gt; zero means that that type of object will not be cached.       &gt; Defaults to 0 for GIT_OBJ_BLOB (i.e. won&#39;t cache blobs) and 4k        &gt; for GIT_OBJ_COMMIT, GIT_OBJ_TREE, and GIT_OBJ_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory     &gt; across all repositories before libgit2 starts evicting objects        &gt; from the cache.  This is a soft limit, in that the library might      &gt; briefly exceed it, but will start aggressively evicting objects       &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.     &gt;       &gt; Because caches are repository-specific, disabling the cache       &gt; cannot immediately clear all cached objects, but each cache will      &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be      &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.        &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.        &gt;       &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.      &gt;       &gt; - `file` is the location of a file containing several     &gt;   certificates concatenated together.     &gt; - `path` is the location of a directory holding several       &gt;   certificates, one per file.     &gt;       &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be       &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.      &gt;       &gt; - `user_agent` is the value that will be delivered as the     &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.        &gt; For more information, see the documentation for CreateFile.       &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is      &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects      &gt; to ensure that all inputs to the new objects are valid.  For      &gt; example, when this is enabled, the parent(s) and tree inputs      &gt; will be validated when creating a new commit.  This defaults      &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For      &gt; example, `foobar` is not a valid ref, therefore `foobar` is       &gt; not a valid target for a symbolic ref by default, whereas     &gt; `refs/heads/foobar` is.  Disabling this bypasses validation       &gt; so that an arbitrary strings such as `foobar` can be used     &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.        &gt;       &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,     &gt; and the negotiation of them when talking to a remote server.      &gt; Offset deltas store a delta base location as an offset into the       &gt; packfile from the current location, which provides a shorter encoding     &gt; and thus smaller resultant packfiles.     &gt; Packfiles containing offset deltas can still be read.     &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`       &gt; (or the platform equivalent) to ensure that new object data       &gt; is written to permanent storage, not simply cached.  This     &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading        &gt; objects from disk. This may impact performance due to an      &gt; additional checksum calculation on each object. This defaults     &gt; to enabled.\n</code></pre>\n",
+      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time\n    by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must\n    &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,\n    &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n    &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path\n    &gt; applied to shared attributes and ignore files, too.\n    &gt;\n    &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.\n    &gt;   Pass NULL to reset to the default (generally based on environment\n    &gt;   variables).  Use magic path `$PATH` to include the old value\n    &gt;   of the path (if you want to prepend or append, for instance).\n    &gt;\n    &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,\n    &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or\n    &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be\n    &gt; considered eligible for caching in memory.  Setting to value to\n    &gt; zero means that that type of object will not be cached.\n    &gt; Defaults to 0 for GIT_OBJ_BLOB (i.e. won&#39;t cache blobs) and 4k\n    &gt; for GIT_OBJ_COMMIT, GIT_OBJ_TREE, and GIT_OBJ_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory\n    &gt; across all repositories before libgit2 starts evicting objects\n    &gt; from the cache.  This is a soft limit, in that the library might\n    &gt; briefly exceed it, but will start aggressively evicting objects\n    &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.\n    &gt;\n    &gt; Because caches are repository-specific, disabling the cache\n    &gt; cannot immediately clear all cached objects, but each cache will\n    &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be\n    &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.\n    &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.\n    &gt;\n    &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.\n    &gt;\n    &gt; - `file` is the location of a file containing several\n    &gt;   certificates concatenated together.\n    &gt; - `path` is the location of a directory holding several\n    &gt;   certificates, one per file.\n    &gt;\n    &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be\n    &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.\n    &gt;\n    &gt; - `user_agent` is the value that will be delivered as the\n    &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.\n    &gt; For more information, see the documentation for CreateFile.\n    &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is\n    &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects\n    &gt; to ensure that all inputs to the new objects are valid.  For\n    &gt; example, when this is enabled, the parent(s) and tree inputs\n    &gt; will be validated when creating a new commit.  This defaults\n    &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For\n    &gt; example, `foobar` is not a valid ref, therefore `foobar` is\n    &gt; not a valid target for a symbolic ref by default, whereas\n    &gt; `refs/heads/foobar` is.  Disabling this bypasses validation\n    &gt; so that an arbitrary strings such as `foobar` can be used\n    &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.\n    &gt;\n    &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,\n    &gt; and the negotiation of them when talking to a remote server.\n    &gt; Offset deltas store a delta base location as an offset into the\n    &gt; packfile from the current location, which provides a shorter encoding\n    &gt; and thus smaller resultant packfiles.\n    &gt; Packfiles containing offset deltas can still be read.\n    &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`\n    &gt; (or the platform equivalent) to ensure that new object data\n    &gt; is written to permanent storage, not simply cached.  This\n    &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading\n    &gt; objects from disk. This may impact performance due to an\n    &gt; additional checksum calculation on each object. This defaults\n    &gt; to enabled.\n\n opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)\n\n    &gt; Set the memory allocator to a different memory allocator. This\n    &gt; allocator will then be used to make all memory allocations for\n    &gt; libgit2 operations.\n\n opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, int enabled)\n\n    &gt; Ensure that there are no unsaved changes in the index before\n    &gt; beginning any operation that reloads the index from disk (eg,\n    &gt; checkout).  If there are unsaved changes, the instruction will\n    &gt; fail.  (Using the FORCE flag to checkout will still overwrite\n    &gt; these changes.)\n\n opts(GIT_OPT_GET_PACK_MAX_OBJECTS, size_t *out)\n\n    &gt; Get the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote. This can be\n    &gt; used to limit maximum memory usage when fetching from an untrusted\n    &gt; remote.\n\n opts(GIT_OPT_SET_PACK_MAX_OBJECTS, size_t objects)\n\n    &gt; Set the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote.\n</code></pre>\n",
       "group": "libgit2"
     },
     "git_config_entry_free": {
       "type": "function",
-      "file": "config.h",
-      "line": 75,
-      "lineto": 75,
+      "file": "git2/config.h",
+      "line": 76,
+      "lineto": 76,
       "args": [
         {
           "name": "",
@@ -4376,9 +4715,9 @@
     },
     "git_config_find_global": {
       "type": "function",
-      "file": "config.h",
-      "line": 116,
-      "lineto": 116,
+      "file": "git2/config.h",
+      "line": 127,
+      "lineto": 127,
       "args": [
         {
           "name": "out",
@@ -4393,14 +4732,14 @@
         "comment": " 0 if a global configuration file has been found. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the global configuration file</p>\n",
-      "comments": "<p>The user or global configuration file is usually located in <code>$HOME/.gitconfig</code>.</p>\n\n<p>This method will try to guess the full path to that file, if the file exists. The returned path may be used on any <code>git_config</code> call to load the global configuration file.</p>\n\n<p>This method will not guess the path to the xdg compatible config file (.config/git/config).</p>\n",
+      "comments": "<p>The user or global configuration file is usually\n located in <code>$HOME/.gitconfig</code>.</p>\n\n<p>This method will try to guess the full path to that\n file, if the file exists. The returned path\n may be used on any <code>git_config</code> call to load the\n global configuration file.</p>\n\n<p>This method will not guess the path to the xdg compatible\n config file (.config/git/config).</p>\n",
       "group": "config"
     },
     "git_config_find_xdg": {
       "type": "function",
-      "file": "config.h",
-      "line": 133,
-      "lineto": 133,
+      "file": "git2/config.h",
+      "line": 144,
+      "lineto": 144,
       "args": [
         {
           "name": "out",
@@ -4415,14 +4754,14 @@
         "comment": " 0 if a xdg compatible configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the global xdg compatible configuration file</p>\n",
-      "comments": "<p>The xdg compatible configuration file is usually located in <code>$HOME/.config/git/config</code>.</p>\n\n<p>This method will try to guess the full path to that file, if the file exists. The returned path may be used on any <code>git_config</code> call to load the xdg compatible configuration file.</p>\n",
+      "comments": "<p>The xdg compatible configuration file is usually\n located in <code>$HOME/.config/git/config</code>.</p>\n\n<p>This method will try to guess the full path to that\n file, if the file exists. The returned path\n may be used on any <code>git_config</code> call to load the\n xdg compatible configuration file.</p>\n",
       "group": "config"
     },
     "git_config_find_system": {
       "type": "function",
-      "file": "config.h",
-      "line": 145,
-      "lineto": 145,
+      "file": "git2/config.h",
+      "line": 156,
+      "lineto": 156,
       "args": [
         {
           "name": "out",
@@ -4437,14 +4776,14 @@
         "comment": " 0 if a system configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the system configuration file</p>\n",
-      "comments": "<p>If /etc/gitconfig doesn&#39;t exist, it will look for %PROGRAMFILES%.</p>\n",
+      "comments": "<p>If /etc/gitconfig doesn&#39;t exist, it will look for\n %PROGRAMFILES%</p>\n\n<p>.</p>\n",
       "group": "config"
     },
     "git_config_find_programdata": {
       "type": "function",
-      "file": "config.h",
-      "line": 156,
-      "lineto": 156,
+      "file": "git2/config.h",
+      "line": 167,
+      "lineto": 167,
       "args": [
         {
           "name": "out",
@@ -4459,14 +4798,14 @@
         "comment": " 0 if a ProgramData configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the configuration file in ProgramData</p>\n",
-      "comments": "<p>Look for the file in %PROGRAMDATA% used by portable git.</p>\n",
+      "comments": "<p>Look for the file in %PROGRAMDATA%</p>\n\n<p>used by portable git.</p>\n",
       "group": "config"
     },
     "git_config_open_default": {
       "type": "function",
-      "file": "config.h",
-      "line": 168,
-      "lineto": 168,
+      "file": "git2/config.h",
+      "line": 179,
+      "lineto": 179,
       "args": [
         {
           "name": "out",
@@ -4481,14 +4820,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open the global, XDG and system configuration files</p>\n",
-      "comments": "<p>Utility wrapper that finds the global, XDG and system configuration files and opens them into a single prioritized config object that can be used when accessing default config data outside a repository.</p>\n",
+      "comments": "<p>Utility wrapper that finds the global, XDG and system configuration files\n and opens them into a single prioritized config object that can be\n used when accessing default config data outside a repository.</p>\n",
       "group": "config"
     },
     "git_config_new": {
       "type": "function",
-      "file": "config.h",
-      "line": 179,
-      "lineto": 179,
+      "file": "git2/config.h",
+      "line": 190,
+      "lineto": 190,
       "args": [
         {
           "name": "out",
@@ -4503,14 +4842,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Allocate a new configuration object</p>\n",
-      "comments": "<p>This object is empty, so you have to add a file to it before you can do anything with it.</p>\n",
+      "comments": "<p>This object is empty, so you have to add a file to it before you\n can do anything with it.</p>\n",
       "group": "config"
     },
     "git_config_add_file_ondisk": {
       "type": "function",
-      "file": "config.h",
-      "line": 208,
-      "lineto": 213,
+      "file": "git2/config.h",
+      "line": 219,
+      "lineto": 224,
       "args": [
         {
           "name": "cfg",
@@ -4545,14 +4884,14 @@
         "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0),\n  GIT_ENOTFOUND when the file doesn't exist or error code"
       },
       "description": "<p>Add an on-disk config file instance to an existing config</p>\n",
-      "comments": "<p>The on-disk file pointed at by <code>path</code> will be opened and parsed; it&#39;s expected to be a native Git config file following the default Git config syntax (see man git-config).</p>\n\n<p>If the file does not exist, the file will still be added and it will be created the first time we write to it.</p>\n\n<p>Note that the configuration object will free the file automatically.</p>\n\n<p>Further queries on this config object will access each of the config file instances in order (instances with a higher priority level will be accessed first).</p>\n",
+      "comments": "<p>The on-disk file pointed at by <code>path</code> will be opened and\n parsed; it&#39;s expected to be a native Git config file following\n the default Git config syntax (see man git-config).</p>\n\n<p>If the file does not exist, the file will still be added and it\n will be created the first time we write to it.</p>\n\n<p>Note that the configuration object will free the file\n automatically.</p>\n\n<p>Further queries on this config object will access each\n of the config file instances in order (instances with\n a higher priority level will be accessed first).</p>\n",
       "group": "config"
     },
     "git_config_open_ondisk": {
       "type": "function",
-      "file": "config.h",
-      "line": 227,
-      "lineto": 227,
+      "file": "git2/config.h",
+      "line": 238,
+      "lineto": 238,
       "args": [
         {
           "name": "out",
@@ -4572,7 +4911,7 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Create a new config instance containing a single on-disk file</p>\n",
-      "comments": "<p>This method is a simple utility wrapper for the following sequence of calls:   - git_config_new    - git_config_add_file_ondisk</p>\n",
+      "comments": "<p>This method is a simple utility wrapper for the following sequence\n of calls:\n    - git_config_new\n    - git_config_add_file_ondisk</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
@@ -4582,9 +4921,9 @@
     },
     "git_config_open_level": {
       "type": "function",
-      "file": "config.h",
-      "line": 245,
-      "lineto": 248,
+      "file": "git2/config.h",
+      "line": 256,
+      "lineto": 259,
       "args": [
         {
           "name": "out",
@@ -4609,14 +4948,14 @@
         "comment": " 0, GIT_ENOTFOUND if the passed level cannot be found in the\n multi-level parent config, or an error code"
       },
       "description": "<p>Build a single-level focused config object from a multi-level one.</p>\n",
-      "comments": "<p>The returned config object can be used to perform get/set/delete operations on a single specific level.</p>\n\n<p>Getting several times the same level from the same parent multi-level config will return different config instances, but containing the same config_file instance.</p>\n",
+      "comments": "<p>The returned config object can be used to perform get/set/delete operations\n on a single specific level.</p>\n\n<p>Getting several times the same level from the same parent multi-level config\n will return different config instances, but containing the same config_file\n instance.</p>\n",
       "group": "config"
     },
     "git_config_open_global": {
       "type": "function",
-      "file": "config.h",
-      "line": 262,
-      "lineto": 262,
+      "file": "git2/config.h",
+      "line": 273,
+      "lineto": 273,
       "args": [
         {
           "name": "out",
@@ -4636,14 +4975,14 @@
         "comment": null
       },
       "description": "<p>Open the global/XDG configuration file according to git&#39;s rules</p>\n",
-      "comments": "<p>Git allows you to store your global configuration at <code>$HOME/.config</code> or <code>$XDG_CONFIG_HOME/git/config</code>. For backwards compatability, the XDG file shouldn&#39;t be used unless the use has created it explicitly. With this function you&#39;ll open the correct one to write to.</p>\n",
+      "comments": "<p>Git allows you to store your global configuration at\n <code>$HOME/.gitconfig</code> or <code>$XDG_CONFIG_HOME/git/config</code>. For backwards\n compatability, the XDG file shouldn&#39;t be used unless the use has\n created it explicitly. With this function you&#39;ll open the correct\n one to write to.</p>\n",
       "group": "config"
     },
     "git_config_snapshot": {
       "type": "function",
-      "file": "config.h",
-      "line": 278,
-      "lineto": 278,
+      "file": "git2/config.h",
+      "line": 289,
+      "lineto": 289,
       "args": [
         {
           "name": "out",
@@ -4663,14 +5002,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a snapshot of the configuration</p>\n",
-      "comments": "<p>Create a snapshot of the current state of a configuration, which allows you to look into a consistent view of the configuration for looking up complex values (e.g. a remote, submodule).</p>\n\n<p>The string returned when querying such a config object is valid until it is freed.</p>\n",
+      "comments": "<p>Create a snapshot of the current state of a configuration, which\n allows you to look into a consistent view of the configuration for\n looking up complex values (e.g. a remote, submodule).</p>\n\n<p>The string returned when querying such a config object is valid\n until it is freed.</p>\n",
       "group": "config"
     },
     "git_config_free": {
       "type": "function",
-      "file": "config.h",
-      "line": 285,
-      "lineto": 285,
+      "file": "git2/config.h",
+      "line": 296,
+      "lineto": 296,
       "args": [
         {
           "name": "cfg",
@@ -4696,9 +5035,9 @@
     },
     "git_config_get_entry": {
       "type": "function",
-      "file": "config.h",
-      "line": 297,
-      "lineto": 300,
+      "file": "git2/config.h",
+      "line": 308,
+      "lineto": 311,
       "args": [
         {
           "name": "out",
@@ -4728,9 +5067,9 @@
     },
     "git_config_get_int32": {
       "type": "function",
-      "file": "config.h",
-      "line": 314,
-      "lineto": 314,
+      "file": "git2/config.h",
+      "line": 325,
+      "lineto": 325,
       "args": [
         {
           "name": "out",
@@ -4755,7 +5094,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of an integer config variable.</p>\n",
-      "comments": "<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
@@ -4766,9 +5105,9 @@
     },
     "git_config_get_int64": {
       "type": "function",
-      "file": "config.h",
-      "line": 328,
-      "lineto": 328,
+      "file": "git2/config.h",
+      "line": 339,
+      "lineto": 339,
       "args": [
         {
           "name": "out",
@@ -4793,14 +5132,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a long integer config variable.</p>\n",
-      "comments": "<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_bool": {
       "type": "function",
-      "file": "config.h",
-      "line": 345,
-      "lineto": 345,
+      "file": "git2/config.h",
+      "line": 356,
+      "lineto": 356,
       "args": [
         {
           "name": "out",
@@ -4825,14 +5164,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a boolean config variable.</p>\n",
-      "comments": "<p>This function uses the usual C convention of 0 being false and anything else true.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>This function uses the usual C convention of 0 being false and\n anything else true.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_path": {
       "type": "function",
-      "file": "config.h",
-      "line": 363,
-      "lineto": 363,
+      "file": "git2/config.h",
+      "line": 374,
+      "lineto": 374,
       "args": [
         {
           "name": "out",
@@ -4857,14 +5196,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a path config variable.</p>\n",
-      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which defaults to the user&#39;s home directory but can be overridden via <code>git_libgit2_opts()</code>.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which\n defaults to the user&#39;s home directory but can be overridden via\n <code>git_libgit2_opts()</code>.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_string": {
       "type": "function",
-      "file": "config.h",
-      "line": 381,
-      "lineto": 381,
+      "file": "git2/config.h",
+      "line": 392,
+      "lineto": 392,
       "args": [
         {
           "name": "out",
@@ -4889,7 +5228,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a string config variable.</p>\n",
-      "comments": "<p>This function can only be used on snapshot config objects. The string is owned by the config and should not be freed by the user. The pointer will be valid until the config is freed.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>This function can only be used on snapshot config objects. The\n string is owned by the config and should not be freed by the\n user. The pointer will be valid until the config is freed.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
@@ -4900,9 +5239,9 @@
     },
     "git_config_get_string_buf": {
       "type": "function",
-      "file": "config.h",
-      "line": 397,
-      "lineto": 397,
+      "file": "git2/config.h",
+      "line": 408,
+      "lineto": 408,
       "args": [
         {
           "name": "out",
@@ -4927,14 +5266,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a string config variable.</p>\n",
-      "comments": "<p>The value of the config will be copied into the buffer.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>The value of the config will be copied into the buffer.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_multivar_foreach": {
       "type": "function",
-      "file": "config.h",
-      "line": 415,
-      "lineto": 415,
+      "file": "git2/config.h",
+      "line": 426,
+      "lineto": 426,
       "args": [
         {
           "name": "cfg",
@@ -4969,14 +5308,14 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar in a foreach callback</p>\n",
-      "comments": "<p>The callback will be called on each variable found</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
+      "comments": "<p>The callback will be called on each variable found</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_multivar_iterator_new": {
       "type": "function",
-      "file": "config.h",
-      "line": 430,
-      "lineto": 430,
+      "file": "git2/config.h",
+      "line": 441,
+      "lineto": 441,
       "args": [
         {
           "name": "out",
@@ -5006,14 +5345,14 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar</p>\n",
-      "comments": "<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
+      "comments": "<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_next": {
       "type": "function",
-      "file": "config.h",
-      "line": 442,
-      "lineto": 442,
+      "file": "git2/config.h",
+      "line": 453,
+      "lineto": 453,
       "args": [
         {
           "name": "entry",
@@ -5033,14 +5372,14 @@
         "comment": " 0 or an error code. GIT_ITEROVER if the iteration has completed"
       },
       "description": "<p>Return the current entry and advance the iterator</p>\n",
-      "comments": "<p>The pointers returned by this function are valid until the iterator is freed.</p>\n",
+      "comments": "<p>The pointers returned by this function are valid until the iterator\n is freed.</p>\n",
       "group": "config"
     },
     "git_config_iterator_free": {
       "type": "function",
-      "file": "config.h",
-      "line": 449,
-      "lineto": 449,
+      "file": "git2/config.h",
+      "line": 460,
+      "lineto": 460,
       "args": [
         {
           "name": "iter",
@@ -5060,9 +5399,9 @@
     },
     "git_config_set_int32": {
       "type": "function",
-      "file": "config.h",
-      "line": 460,
-      "lineto": 460,
+      "file": "git2/config.h",
+      "line": 471,
+      "lineto": 471,
       "args": [
         {
           "name": "cfg",
@@ -5092,9 +5431,9 @@
     },
     "git_config_set_int64": {
       "type": "function",
-      "file": "config.h",
-      "line": 471,
-      "lineto": 471,
+      "file": "git2/config.h",
+      "line": 482,
+      "lineto": 482,
       "args": [
         {
           "name": "cfg",
@@ -5124,9 +5463,9 @@
     },
     "git_config_set_bool": {
       "type": "function",
-      "file": "config.h",
-      "line": 482,
-      "lineto": 482,
+      "file": "git2/config.h",
+      "line": 493,
+      "lineto": 493,
       "args": [
         {
           "name": "cfg",
@@ -5156,9 +5495,9 @@
     },
     "git_config_set_string": {
       "type": "function",
-      "file": "config.h",
-      "line": 496,
-      "lineto": 496,
+      "file": "git2/config.h",
+      "line": 507,
+      "lineto": 507,
       "args": [
         {
           "name": "cfg",
@@ -5183,14 +5522,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Set the value of a string config variable in the config file\n with the highest level (usually the local one).</p>\n",
-      "comments": "<p>A copy of the string is made and the user is free to use it afterwards.</p>\n",
+      "comments": "<p>A copy of the string is made and the user is free to use it\n afterwards.</p>\n",
       "group": "config"
     },
     "git_config_set_multivar": {
       "type": "function",
-      "file": "config.h",
-      "line": 508,
-      "lineto": 508,
+      "file": "git2/config.h",
+      "line": 519,
+      "lineto": 519,
       "args": [
         {
           "name": "cfg",
@@ -5225,9 +5564,9 @@
     },
     "git_config_delete_entry": {
       "type": "function",
-      "file": "config.h",
-      "line": 517,
-      "lineto": 517,
+      "file": "git2/config.h",
+      "line": 528,
+      "lineto": 528,
       "args": [
         {
           "name": "cfg",
@@ -5252,9 +5591,9 @@
     },
     "git_config_delete_multivar": {
       "type": "function",
-      "file": "config.h",
-      "line": 530,
-      "lineto": 530,
+      "file": "git2/config.h",
+      "line": 541,
+      "lineto": 541,
       "args": [
         {
           "name": "cfg",
@@ -5284,9 +5623,9 @@
     },
     "git_config_foreach": {
       "type": "function",
-      "file": "config.h",
-      "line": 548,
-      "lineto": 551,
+      "file": "git2/config.h",
+      "line": 559,
+      "lineto": 562,
       "args": [
         {
           "name": "cfg",
@@ -5311,14 +5650,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform an operation on each config variable.</p>\n",
-      "comments": "<p>The callback receives the normalized name and value of each variable in the config backend, and the data pointer passed to this function. If the callback returns a non-zero value, the function stops iterating and returns that value to the caller.</p>\n\n<p>The pointers passed to the callback are only valid as long as the iteration is ongoing.</p>\n",
+      "comments": "<p>The callback receives the normalized name and value of each variable\n in the config backend, and the data pointer passed to this function.\n If the callback returns a non-zero value, the function stops iterating\n and returns that value to the caller.</p>\n\n<p>The pointers passed to the callback are only valid as long as the\n iteration is ongoing.</p>\n",
       "group": "config"
     },
     "git_config_iterator_new": {
       "type": "function",
-      "file": "config.h",
-      "line": 562,
-      "lineto": 562,
+      "file": "git2/config.h",
+      "line": 573,
+      "lineto": 573,
       "args": [
         {
           "name": "out",
@@ -5338,14 +5677,14 @@
         "comment": null
       },
       "description": "<p>Iterate over all the config variables</p>\n",
-      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n",
+      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and\n <code>git_config_iterator_free</code> when done.</p>\n",
       "group": "config"
     },
     "git_config_iterator_glob_new": {
       "type": "function",
-      "file": "config.h",
-      "line": 578,
-      "lineto": 578,
+      "file": "git2/config.h",
+      "line": 589,
+      "lineto": 589,
       "args": [
         {
           "name": "out",
@@ -5370,14 +5709,14 @@
         "comment": null
       },
       "description": "<p>Iterate over all the config variables whose name matches a pattern</p>\n",
-      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
+      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and\n <code>git_config_iterator_free</code> when done.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_foreach_match": {
       "type": "function",
-      "file": "config.h",
-      "line": 600,
-      "lineto": 604,
+      "file": "git2/config.h",
+      "line": 611,
+      "lineto": 615,
       "args": [
         {
           "name": "cfg",
@@ -5407,14 +5746,14 @@
         "comment": " 0 or the return value of the callback which didn't return 0"
       },
       "description": "<p>Perform an operation on each config variable matching a regular expression.</p>\n",
-      "comments": "<p>This behaviors like <code>git_config_foreach</code> with an additional filter of a regular expression that filters which config keys are passed to the callback.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the case-insensitive parts are lower-case.</p>\n",
+      "comments": "<p>This behaves like <code>git_config_foreach</code> with an additional filter of a\n regular expression that filters which config keys are passed to the\n callback.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the case-insensitive parts are lower-case.</p>\n",
       "group": "config"
     },
     "git_config_get_mapped": {
       "type": "function",
-      "file": "config.h",
-      "line": 640,
-      "lineto": 645,
+      "file": "git2/config.h",
+      "line": 651,
+      "lineto": 656,
       "args": [
         {
           "name": "out",
@@ -5449,14 +5788,14 @@
         "comment": " 0 on success, error code otherwise"
       },
       "description": "<p>Query the value of a config variable and return it mapped to\n an integer constant.</p>\n",
-      "comments": "<p>This is a helper method to easily map different possible values to a variable to integer constants that easily identify them.</p>\n\n<p>A mapping array looks as follows:</p>\n\n<pre><code>git_cvar_map autocrlf_mapping[] = {     {GIT_CVAR_FALSE, NULL, GIT_AUTO_CRLF_FALSE},        {GIT_CVAR_TRUE, NULL, GIT_AUTO_CRLF_TRUE},      {GIT_CVAR_STRING, &quot;input&quot;, GIT_AUTO_CRLF_INPUT},        {GIT_CVAR_STRING, &quot;default&quot;, GIT_AUTO_CRLF_DEFAULT}};\n</code></pre>\n\n<p>On any &quot;false&quot; value for the variable (e.g. &quot;false&quot;, &quot;FALSE&quot;, &quot;no&quot;), the mapping will store <code>GIT_AUTO_CRLF_FALSE</code> in the <code>out</code> parameter.</p>\n\n<p>The same thing applies for any &quot;true&quot; value such as &quot;true&quot;, &quot;yes&quot; or &quot;1&quot;, storing the <code>GIT_AUTO_CRLF_TRUE</code> variable.</p>\n\n<p>Otherwise, if the value matches the string &quot;input&quot; (with case insensitive comparison), the given constant will be stored in <code>out</code>, and likewise for &quot;default&quot;.</p>\n\n<p>If not a single match can be made to store in <code>out</code>, an error code will be returned.</p>\n",
+      "comments": "<p>This is a helper method to easily map different possible values\n to a variable to integer constants that easily identify them.</p>\n\n<p>A mapping array looks as follows:</p>\n\n<pre><code>git_cvar_map autocrlf_mapping[] = {\n    {GIT_CVAR_FALSE, NULL, GIT_AUTO_CRLF_FALSE},\n    {GIT_CVAR_TRUE, NULL, GIT_AUTO_CRLF_TRUE},\n    {GIT_CVAR_STRING, &quot;input&quot;, GIT_AUTO_CRLF_INPUT},\n    {GIT_CVAR_STRING, &quot;default&quot;, GIT_AUTO_CRLF_DEFAULT}};\n</code></pre>\n\n<p>On any &quot;false&quot; value for the variable (e.g. &quot;false&quot;, &quot;FALSE&quot;, &quot;no&quot;), the\n mapping will store <code>GIT_AUTO_CRLF_FALSE</code> in the <code>out</code> parameter.</p>\n\n<p>The same thing applies for any &quot;true&quot; value such as &quot;true&quot;, &quot;yes&quot; or &quot;1&quot;, storing\n the <code>GIT_AUTO_CRLF_TRUE</code> variable.</p>\n\n<p>Otherwise, if the value matches the string &quot;input&quot; (with case insensitive comparison),\n the given constant will be stored in <code>out</code>, and likewise for &quot;default&quot;.</p>\n\n<p>If not a single match can be made to store in <code>out</code>, an error code will be\n returned.</p>\n",
       "group": "config"
     },
     "git_config_lookup_map_value": {
       "type": "function",
-      "file": "config.h",
-      "line": 655,
-      "lineto": 659,
+      "file": "git2/config.h",
+      "line": 666,
+      "lineto": 670,
       "args": [
         {
           "name": "out",
@@ -5491,9 +5830,9 @@
     },
     "git_config_parse_bool": {
       "type": "function",
-      "file": "config.h",
-      "line": 671,
-      "lineto": 671,
+      "file": "git2/config.h",
+      "line": 682,
+      "lineto": 682,
       "args": [
         {
           "name": "out",
@@ -5513,14 +5852,14 @@
         "comment": null
       },
       "description": "<p>Parse a string value as a bool.</p>\n",
-      "comments": "<p>Valid values for true are: &#39;true&#39;, &#39;yes&#39;, &#39;on&#39;, 1 or any  number different from 0 Valid values for false are: &#39;false&#39;, &#39;no&#39;, &#39;off&#39;, 0</p>\n",
+      "comments": "<p>Valid values for true are: &#39;true&#39;, &#39;yes&#39;, &#39;on&#39;, 1 or any\n  number different from 0\n Valid values for false are: &#39;false&#39;, &#39;no&#39;, &#39;off&#39;, 0</p>\n",
       "group": "config"
     },
     "git_config_parse_int32": {
       "type": "function",
-      "file": "config.h",
-      "line": 683,
-      "lineto": 683,
+      "file": "git2/config.h",
+      "line": 694,
+      "lineto": 694,
       "args": [
         {
           "name": "out",
@@ -5540,14 +5879,14 @@
         "comment": null
       },
       "description": "<p>Parse a string value as an int32.</p>\n",
-      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will cause the value to be multiplied by 1024, 1048576, or 1073741824 prior to output.</p>\n",
+      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will\n cause the value to be multiplied by 1024, 1048576,\n or 1073741824 prior to output.</p>\n",
       "group": "config"
     },
     "git_config_parse_int64": {
       "type": "function",
-      "file": "config.h",
-      "line": 695,
-      "lineto": 695,
+      "file": "git2/config.h",
+      "line": 706,
+      "lineto": 706,
       "args": [
         {
           "name": "out",
@@ -5567,14 +5906,14 @@
         "comment": null
       },
       "description": "<p>Parse a string value as an int64.</p>\n",
-      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will cause the value to be multiplied by 1024, 1048576, or 1073741824 prior to output.</p>\n",
+      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will\n cause the value to be multiplied by 1024, 1048576,\n or 1073741824 prior to output.</p>\n",
       "group": "config"
     },
     "git_config_parse_path": {
       "type": "function",
-      "file": "config.h",
-      "line": 710,
-      "lineto": 710,
+      "file": "git2/config.h",
+      "line": 721,
+      "lineto": 721,
       "args": [
         {
           "name": "out",
@@ -5594,14 +5933,14 @@
         "comment": null
       },
       "description": "<p>Parse a string value as a path.</p>\n",
-      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which defaults to the user&#39;s home directory but can be overridden via <code>git_libgit2_opts()</code>.</p>\n\n<p>If the value does not begin with a tilde, the input will be returned.</p>\n",
+      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which\n defaults to the user&#39;s home directory but can be overridden via\n <code>git_libgit2_opts()</code>.</p>\n\n<p>If the value does not begin with a tilde, the input will be\n returned.</p>\n",
       "group": "config"
     },
     "git_config_backend_foreach_match": {
       "type": "function",
-      "file": "config.h",
-      "line": 728,
-      "lineto": 732,
+      "file": "git2/config.h",
+      "line": 739,
+      "lineto": 743,
       "args": [
         {
           "name": "backend",
@@ -5630,15 +5969,15 @@
         "type": "int",
         "comment": null
       },
-      "description": "<p>Perform an operation on each config variable in given config backend\n matching a regular expression.</p>\n",
-      "comments": "<p>This behaviors like <code>git_config_foreach_match</code> except instead of all config entries it just enumerates through the given backend entry.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
+      "description": "<p>Perform an operation on each config variable in a given config backend,\n matching a regular expression.</p>\n",
+      "comments": "<p>This behaves like <code>git_config_foreach_match</code> except that only config\n entries from the given backend entry are enumerated.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_lock": {
       "type": "function",
-      "file": "config.h",
-      "line": 751,
-      "lineto": 751,
+      "file": "git2/config.h",
+      "line": 762,
+      "lineto": 762,
       "args": [
         {
           "name": "tx",
@@ -5658,12 +5997,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lock the backend with the highest priority</p>\n",
-      "comments": "<p>Locking disallows anybody else from writing to that backend. Any updates made after locking will not be visible to a reader until the file is unlocked.</p>\n\n<p>You can apply the changes by calling <code>git_transaction_commit()</code> before freeing the transaction. Either of these actions will unlock the config.</p>\n",
+      "comments": "<p>Locking disallows anybody else from writing to that backend. Any\n updates made after locking will not be visible to a reader until\n the file is unlocked.</p>\n\n<p>You can apply the changes by calling <code>git_transaction_commit()</code>\n before freeing the transaction. Either of these actions will unlock\n the config.</p>\n",
       "group": "config"
     },
     "git_cred_userpass": {
       "type": "function",
-      "file": "cred_helpers.h",
+      "file": "git2/cred_helpers.h",
       "line": 43,
       "lineto": 48,
       "args": [
@@ -5703,11 +6042,75 @@
       "comments": "",
       "group": "cred"
     },
+    "git_describe_init_options": {
+      "type": "function",
+      "file": "git2/describe.h",
+      "line": 82,
+      "lineto": 82,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_describe_options *",
+          "comment": "The `git_describe_options` struct to initialize."
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "The struct version; pass `GIT_DESCRIBE_OPTIONS_VERSION`."
+        }
+      ],
+      "argline": "git_describe_options *opts, unsigned int version",
+      "sig": "git_describe_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initialize git_describe_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_describe_options</code> with default values. Equivalent to creating\n an instance with GIT_DESCRIBE_OPTIONS_INIT.</p>\n",
+      "group": "describe",
+      "examples": {
+        "describe.c": [
+          "ex/HEAD/describe.html#git_describe_init_options-1"
+        ]
+      }
+    },
+    "git_describe_init_format_options": {
+      "type": "function",
+      "file": "git2/describe.h",
+      "line": 129,
+      "lineto": 129,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_describe_format_options *",
+          "comment": "The `git_describe_format_options` struct to initialize."
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "The struct version; pass `GIT_DESCRIBE_FORMAT_OPTIONS_VERSION`."
+        }
+      ],
+      "argline": "git_describe_format_options *opts, unsigned int version",
+      "sig": "git_describe_format_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initialize git_describe_format_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_describe_format_options</code> with default values. Equivalent to creating\n an instance with GIT_DESCRIBE_FORMAT_OPTIONS_INIT.</p>\n",
+      "group": "describe",
+      "examples": {
+        "describe.c": [
+          "ex/HEAD/describe.html#git_describe_init_format_options-2"
+        ]
+      }
+    },
     "git_describe_commit": {
       "type": "function",
-      "file": "describe.h",
-      "line": 123,
-      "lineto": 126,
+      "file": "git2/describe.h",
+      "line": 146,
+      "lineto": 149,
       "args": [
         {
           "name": "result",
@@ -5722,7 +6125,7 @@
         {
           "name": "opts",
           "type": "git_describe_options *",
-          "comment": "the lookup options"
+          "comment": "the lookup options (or NULL for defaults)"
         }
       ],
       "argline": "git_describe_result **result, git_object *committish, git_describe_options *opts",
@@ -5736,15 +6139,15 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_commit-1"
+          "ex/HEAD/describe.html#git_describe_commit-3"
         ]
       }
     },
     "git_describe_workdir": {
       "type": "function",
-      "file": "describe.h",
-      "line": 140,
-      "lineto": 143,
+      "file": "git2/describe.h",
+      "line": 163,
+      "lineto": 166,
       "args": [
         {
           "name": "out",
@@ -5759,7 +6162,7 @@
         {
           "name": "opts",
           "type": "git_describe_options *",
-          "comment": "the lookup options"
+          "comment": "the lookup options (or NULL for defaults)"
         }
       ],
       "argline": "git_describe_result **out, git_repository *repo, git_describe_options *opts",
@@ -5769,19 +6172,19 @@
         "comment": null
       },
       "description": "<p>Describe a commit</p>\n",
-      "comments": "<p>Perform the describe operation on the current commit and the worktree. After peforming describe on HEAD, a status is run and the description is considered to be dirty if there are.</p>\n",
+      "comments": "<p>Perform the describe operation on the current commit and the\n worktree. After peforming describe on HEAD, a status is run and the\n description is considered to be dirty if there are.</p>\n",
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_workdir-2"
+          "ex/HEAD/describe.html#git_describe_workdir-4"
         ]
       }
     },
     "git_describe_format": {
       "type": "function",
-      "file": "describe.h",
-      "line": 153,
-      "lineto": 156,
+      "file": "git2/describe.h",
+      "line": 176,
+      "lineto": 179,
       "args": [
         {
           "name": "out",
@@ -5796,7 +6199,7 @@
         {
           "name": "opts",
           "type": "const git_describe_format_options *",
-          "comment": "the formatting options"
+          "comment": "the formatting options (or NULL for defaults)"
         }
       ],
       "argline": "git_buf *out, const git_describe_result *result, const git_describe_format_options *opts",
@@ -5810,15 +6213,15 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_format-3"
+          "ex/HEAD/describe.html#git_describe_format-5"
         ]
       }
     },
     "git_describe_result_free": {
       "type": "function",
-      "file": "describe.h",
-      "line": 161,
-      "lineto": 161,
+      "file": "git2/describe.h",
+      "line": 184,
+      "lineto": 184,
       "args": [
         {
           "name": "result",
@@ -5838,19 +6241,19 @@
     },
     "git_diff_init_options": {
       "type": "function",
-      "file": "diff.h",
-      "line": 447,
-      "lineto": 449,
+      "file": "git2/diff.h",
+      "line": 454,
+      "lineto": 456,
       "args": [
         {
           "name": "opts",
           "type": "git_diff_options *",
-          "comment": "The `git_diff_options` struct to initialize"
+          "comment": "The `git_diff_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_DIFF_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_DIFF_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_diff_options *opts, unsigned int version",
@@ -5859,25 +6262,25 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_diff_options</code> with default values. Equivalent to\n creating an instance with GIT_DIFF_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_diff_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_options</code> with default values. Equivalent to creating\n an instance with GIT_DIFF_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
     "git_diff_find_init_options": {
       "type": "function",
-      "file": "diff.h",
-      "line": 742,
-      "lineto": 744,
+      "file": "git2/diff.h",
+      "line": 787,
+      "lineto": 789,
       "args": [
         {
           "name": "opts",
           "type": "git_diff_find_options *",
-          "comment": "The `git_diff_find_options` struct to initialize"
+          "comment": "The `git_diff_find_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_DIFF_FIND_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_DIFF_FIND_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_diff_find_options *opts, unsigned int version",
@@ -5886,15 +6289,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_diff_find_options</code> with default values. Equivalent to\n creating an instance with GIT_DIFF_FIND_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_diff_find_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_find_options</code> with default values. Equivalent to creating\n an instance with GIT_DIFF_FIND_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
     "git_diff_free": {
       "type": "function",
-      "file": "diff.h",
-      "line": 758,
-      "lineto": 758,
+      "file": "git2/diff.h",
+      "line": 803,
+      "lineto": 803,
       "args": [
         {
           "name": "diff",
@@ -5923,9 +6326,9 @@
     },
     "git_diff_tree_to_tree": {
       "type": "function",
-      "file": "diff.h",
-      "line": 776,
-      "lineto": 781,
+      "file": "git2/diff.h",
+      "line": 821,
+      "lineto": 826,
       "args": [
         {
           "name": "diff",
@@ -5960,7 +6363,7 @@
         "comment": null
       },
       "description": "<p>Create a diff with the difference between two tree objects.</p>\n",
-      "comments": "<p>This is equivalent to <code>git diff &lt;old-tree&gt; &lt;new-tree&gt;</code></p>\n\n<p>The first tree will be used for the &quot;old_file&quot; side of the delta and the second tree will be used for the &quot;new_file&quot; side of the delta.  You can pass NULL to indicate an empty tree, although it is an error to pass NULL for both the <code>old_tree</code> and <code>new_tree</code>.</p>\n",
+      "comments": "<p>This is equivalent to <code>git diff \n&lt;old\n-tree&gt; \n&lt;new\n-tree&gt;</code></p>\n\n<p>The first tree will be used for the &quot;old_file&quot; side of the delta and the\n second tree will be used for the &quot;new_file&quot; side of the delta.  You can\n pass NULL to indicate an empty tree, although it is an error to pass\n NULL for both the <code>old_tree</code> and <code>new_tree</code>.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -5974,9 +6377,9 @@
     },
     "git_diff_tree_to_index": {
       "type": "function",
-      "file": "diff.h",
-      "line": 802,
-      "lineto": 807,
+      "file": "git2/diff.h",
+      "line": 847,
+      "lineto": 852,
       "args": [
         {
           "name": "diff",
@@ -6011,7 +6414,7 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and repository index.</p>\n",
-      "comments": "<p>This is equivalent to <code>git diff --cached &lt;treeish&gt;</code> or if you pass the HEAD tree, then like <code>git diff --cached</code>.</p>\n\n<p>The tree you pass will be used for the &quot;old_file&quot; side of the delta, and the index will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code> will be used.  In this case, the index will be refreshed from disk (if it has changed) before the diff is generated.</p>\n",
+      "comments": "<p>This is equivalent to `git diff --cached \n&lt;treeish</p>\n\n<blockquote>\n<p><code>or if you pass\n the HEAD tree, then like</code>git diff --cached`.</p>\n</blockquote>\n\n<p>The tree you pass will be used for the &quot;old_file&quot; side of the delta, and\n the index will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code>\n will be used.  In this case, the index will be refreshed from disk\n (if it has changed) before the diff is generated.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6021,9 +6424,9 @@
     },
     "git_diff_index_to_workdir": {
       "type": "function",
-      "file": "diff.h",
-      "line": 829,
-      "lineto": 833,
+      "file": "git2/diff.h",
+      "line": 874,
+      "lineto": 878,
       "args": [
         {
           "name": "diff",
@@ -6053,7 +6456,7 @@
         "comment": null
       },
       "description": "<p>Create a diff between the repository index and the workdir directory.</p>\n",
-      "comments": "<p>This matches the <code>git diff</code> command.  See the note below on <code>git_diff_tree_to_workdir</code> for a discussion of the difference between <code>git diff</code> and <code>git diff HEAD</code> and how to emulate a <code>git diff &lt;treeish&gt;</code> using libgit2.</p>\n\n<p>The index will be used for the &quot;old_file&quot; side of the delta, and the working directory will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code> will be used.  In this case, the index will be refreshed from disk (if it has changed) before the diff is generated.</p>\n",
+      "comments": "<p>This matches the <code>git diff</code> command.  See the note below on\n <code>git_diff_tree_to_workdir</code> for a discussion of the difference between\n <code>git diff</code> and <code>git diff HEAD</code> and how to emulate a `git diff \n&lt;treeish</p>\n\n<blockquote>\n<p>`\n using libgit2.</p>\n</blockquote>\n\n<p>The index will be used for the &quot;old_file&quot; side of the delta, and the\n working directory will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code>\n will be used.  In this case, the index will be refreshed from disk\n (if it has changed) before the diff is generated.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6063,9 +6466,9 @@
     },
     "git_diff_tree_to_workdir": {
       "type": "function",
-      "file": "diff.h",
-      "line": 858,
-      "lineto": 862,
+      "file": "git2/diff.h",
+      "line": 903,
+      "lineto": 907,
       "args": [
         {
           "name": "diff",
@@ -6095,7 +6498,7 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and the working directory.</p>\n",
-      "comments": "<p>The tree you provide will be used for the &quot;old_file&quot; side of the delta, and the working directory will be used for the &quot;new_file&quot; side.</p>\n\n<p>This is not the same as <code>git diff &lt;treeish&gt;</code> or <code>git diff-index &lt;treeish&gt;</code>.  Those commands use information from the index, whereas this function strictly returns the differences between the tree and the files in the working directory, regardless of the state of the index.  Use <code>git_diff_tree_to_workdir_with_index</code> to emulate those commands.</p>\n\n<p>To see difference between this and <code>git_diff_tree_to_workdir_with_index</code>, consider the example of a staged file deletion where the file has then been put back into the working dir and further modified.  The tree-to-workdir diff for that file is &#39;modified&#39;, but <code>git diff</code> would show status &#39;deleted&#39; since there is a staged delete.</p>\n",
+      "comments": "<p>The tree you provide will be used for the &quot;old_file&quot; side of the delta,\n and the working directory will be used for the &quot;new_file&quot; side.</p>\n\n<p>This is not the same as `git diff \n&lt;treeish</p>\n\n<blockquote>\n<p><code>or</code>git diff-index</p>\n</blockquote>\n\n<p>&lt;treeish</p>\n\n<blockquote>\n<p><code>.  Those commands use information from the index, whereas this\n function strictly returns the differences between the tree and the files\n in the working directory, regardless of the state of the index.  Use\n</code>git_diff_tree_to_workdir_with_index` to emulate those commands.</p>\n</blockquote>\n\n<p>To see difference between this and <code>git_diff_tree_to_workdir_with_index</code>,\n consider the example of a staged file deletion where the file has then\n been put back into the working dir and further modified.  The\n tree-to-workdir diff for that file is &#39;modified&#39;, but <code>git diff</code> would\n show status &#39;deleted&#39; since there is a staged delete.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6105,9 +6508,9 @@
     },
     "git_diff_tree_to_workdir_with_index": {
       "type": "function",
-      "file": "diff.h",
-      "line": 877,
-      "lineto": 881,
+      "file": "git2/diff.h",
+      "line": 922,
+      "lineto": 926,
       "args": [
         {
           "name": "diff",
@@ -6137,7 +6540,7 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and the working directory using index data\n to account for staged deletes, tracked files, etc.</p>\n",
-      "comments": "<p>This emulates <code>git diff &lt;tree&gt;</code> by diffing the tree to the index and the index to the working directory and blending the results into a single diff that includes staged deleted, etc.</p>\n",
+      "comments": "<p>This emulates `git diff \n&lt;tree</p>\n\n<blockquote>\n<p>` by diffing the tree to the index and\n the index to the working directory and blending the results into a\n single diff that includes staged deleted, etc.</p>\n</blockquote>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6147,9 +6550,9 @@
     },
     "git_diff_index_to_index": {
       "type": "function",
-      "file": "diff.h",
-      "line": 895,
-      "lineto": 900,
+      "file": "git2/diff.h",
+      "line": 940,
+      "lineto": 945,
       "args": [
         {
           "name": "diff",
@@ -6184,14 +6587,14 @@
         "comment": null
       },
       "description": "<p>Create a diff with the difference between two index objects.</p>\n",
-      "comments": "<p>The first index will be used for the &quot;old_file&quot; side of the delta and the second index will be used for the &quot;new_file&quot; side of the delta.</p>\n",
+      "comments": "<p>The first index will be used for the &quot;old_file&quot; side of the delta and the\n second index will be used for the &quot;new_file&quot; side of the delta.</p>\n",
       "group": "diff"
     },
     "git_diff_merge": {
       "type": "function",
-      "file": "diff.h",
-      "line": 915,
-      "lineto": 917,
+      "file": "git2/diff.h",
+      "line": 960,
+      "lineto": 962,
       "args": [
         {
           "name": "onto",
@@ -6211,14 +6614,14 @@
         "comment": null
       },
       "description": "<p>Merge one diff into another.</p>\n",
-      "comments": "<p>This merges items from the &quot;from&quot; list into the &quot;onto&quot; list.  The resulting diff will have all items that appear in either list. If an item appears in both lists, then it will be &quot;merged&quot; to appear as if the old version was from the &quot;onto&quot; list and the new version is from the &quot;from&quot; list (with the exception that if the item has a pending DELETE in the middle, then it will show as deleted).</p>\n",
+      "comments": "<p>This merges items from the &quot;from&quot; list into the &quot;onto&quot; list.  The\n resulting diff will have all items that appear in either list.\n If an item appears in both lists, then it will be &quot;merged&quot; to appear\n as if the old version was from the &quot;onto&quot; list and the new version\n is from the &quot;from&quot; list (with the exception that if the item has a\n pending DELETE in the middle, then it will show as deleted).</p>\n",
       "group": "diff"
     },
     "git_diff_find_similar": {
       "type": "function",
-      "file": "diff.h",
-      "line": 931,
-      "lineto": 933,
+      "file": "git2/diff.h",
+      "line": 976,
+      "lineto": 978,
       "args": [
         {
           "name": "diff",
@@ -6238,7 +6641,7 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Transform a diff marking file renames, copies, etc.</p>\n",
-      "comments": "<p>This modifies a diff in place, replacing old entries that look like renames or copies with new entries reflecting those changes. This also will, if requested, break modified files into add/remove pairs if the amount of change is above a threshold.</p>\n",
+      "comments": "<p>This modifies a diff in place, replacing old entries that look\n like renames or copies with new entries reflecting those changes.\n This also will, if requested, break modified files into add/remove\n pairs if the amount of change is above a threshold.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6248,9 +6651,9 @@
     },
     "git_diff_num_deltas": {
       "type": "function",
-      "file": "diff.h",
-      "line": 951,
-      "lineto": 951,
+      "file": "git2/diff.h",
+      "line": 996,
+      "lineto": 996,
       "args": [
         {
           "name": "diff",
@@ -6275,9 +6678,9 @@
     },
     "git_diff_num_deltas_of_type": {
       "type": "function",
-      "file": "diff.h",
-      "line": 964,
-      "lineto": 965,
+      "file": "git2/diff.h",
+      "line": 1009,
+      "lineto": 1010,
       "args": [
         {
           "name": "diff",
@@ -6297,14 +6700,14 @@
         "comment": " Count of number of deltas matching delta_t type"
       },
       "description": "<p>Query how many diff deltas are there in a diff filtered by type.</p>\n",
-      "comments": "<p>This works just like <code>git_diff_entrycount()</code> with an extra parameter that is a <code>git_delta_t</code> and returns just the count of how many deltas match that particular type.</p>\n",
+      "comments": "<p>This works just like <code>git_diff_entrycount()</code> with an extra parameter\n that is a <code>git_delta_t</code> and returns just the count of how many deltas\n match that particular type.</p>\n",
       "group": "diff"
     },
     "git_diff_get_delta": {
       "type": "function",
-      "file": "diff.h",
-      "line": 984,
-      "lineto": 985,
+      "file": "git2/diff.h",
+      "line": 1029,
+      "lineto": 1030,
       "args": [
         {
           "name": "diff",
@@ -6324,14 +6727,14 @@
         "comment": " Pointer to git_diff_delta (or NULL if `idx` out of range)"
       },
       "description": "<p>Return the diff delta for an entry in the diff list.</p>\n",
-      "comments": "<p>The <code>git_diff_delta</code> pointer points to internal data and you do not have to release it when you are done with it.  It will go away when the * <code>git_diff</code> (or any associated <code>git_patch</code>) goes away.</p>\n\n<p>Note that the flags on the delta related to whether it has binary content or not may not be set if there are no attributes set for the file and there has been no reason to load the file data at this point. For now, if you need those flags to be up to date, your only option is to either use <code>git_diff_foreach</code> or create a <code>git_patch</code>.</p>\n",
+      "comments": "<p>The <code>git_diff_delta</code> pointer points to internal data and you do not\n have to release it when you are done with it.  It will go away when\n the * <code>git_diff</code> (or any associated <code>git_patch</code>) goes away.</p>\n\n<p>Note that the flags on the delta related to whether it has binary\n content or not may not be set if there are no attributes set for the\n file and there has been no reason to load the file data at this point.\n For now, if you need those flags to be up to date, your only option is\n to either use <code>git_diff_foreach</code> or create a <code>git_patch</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_is_sorted_icase": {
       "type": "function",
-      "file": "diff.h",
-      "line": 993,
-      "lineto": 993,
+      "file": "git2/diff.h",
+      "line": 1038,
+      "lineto": 1038,
       "args": [
         {
           "name": "diff",
@@ -6351,9 +6754,9 @@
     },
     "git_diff_foreach": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1021,
-      "lineto": 1027,
+      "file": "git2/diff.h",
+      "line": 1066,
+      "lineto": 1072,
       "args": [
         {
           "name": "diff",
@@ -6393,14 +6796,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Loop over all deltas in a diff issuing callbacks.</p>\n",
-      "comments": "<p>This will iterate through all of the files described in a diff.  You should provide a file callback to learn about each file.</p>\n\n<p>The &quot;hunk&quot; and &quot;line&quot; callbacks are optional, and the text diff of the files will only be calculated if they are not NULL.  Of course, these callbacks will not be invoked for binary files on the diff or for files whose only changed is a file mode change.</p>\n\n<p>Returning a non-zero value from any of the callbacks will terminate the iteration and return the value to the user.</p>\n",
+      "comments": "<p>This will iterate through all of the files described in a diff.  You\n should provide a file callback to learn about each file.</p>\n\n<p>The &quot;hunk&quot; and &quot;line&quot; callbacks are optional, and the text diff of the\n files will only be calculated if they are not NULL.  Of course, these\n callbacks will not be invoked for binary files on the diff or for\n files whose only changed is a file mode change.</p>\n\n<p>Returning a non-zero value from any of the callbacks will terminate\n the iteration and return the value to the user.</p>\n",
       "group": "diff"
     },
     "git_diff_status_char": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1040,
-      "lineto": 1040,
+      "file": "git2/diff.h",
+      "line": 1085,
+      "lineto": 1085,
       "args": [
         {
           "name": "status",
@@ -6415,14 +6818,14 @@
         "comment": " The single character label for that code"
       },
       "description": "<p>Look up the single character abbreviation for a delta status code.</p>\n",
-      "comments": "<p>When you run <code>git diff --name-status</code> it uses single letter codes in the output such as &#39;A&#39; for added, &#39;D&#39; for deleted, &#39;M&#39; for modified, etc.  This function converts a git_delta_t value into these letters for your own purposes.  GIT_DELTA_UNTRACKED will return a space (i.e. &#39; &#39;).</p>\n",
+      "comments": "<p>When you run <code>git diff --name-status</code> it uses single letter codes in\n the output such as &#39;A&#39; for added, &#39;D&#39; for deleted, &#39;M&#39; for modified,\n etc.  This function converts a git_delta_t value into these letters for\n your own purposes.  GIT_DELTA_UNTRACKED will return a space (i.e. &#39; &#39;).</p>\n",
       "group": "diff"
     },
     "git_diff_print": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1065,
-      "lineto": 1069,
+      "file": "git2/diff.h",
+      "line": 1110,
+      "lineto": 1114,
       "args": [
         {
           "name": "diff",
@@ -6452,7 +6855,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Iterate over a diff generating formatted text output.</p>\n",
-      "comments": "<p>Returning a non-zero value from the callbacks will terminate the iteration and return the non-zero value to the caller.</p>\n",
+      "comments": "<p>Returning a non-zero value from the callbacks will terminate the\n iteration and return the non-zero value to the caller.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
@@ -6465,9 +6868,9 @@
     },
     "git_diff_to_buf": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1081,
-      "lineto": 1084,
+      "file": "git2/diff.h",
+      "line": 1126,
+      "lineto": 1129,
       "args": [
         {
           "name": "out",
@@ -6497,9 +6900,9 @@
     },
     "git_diff_blobs": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1121,
-      "lineto": 1131,
+      "file": "git2/diff.h",
+      "line": 1166,
+      "lineto": 1176,
       "args": [
         {
           "name": "old_blob",
@@ -6559,14 +6962,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff on two blobs.</p>\n",
-      "comments": "<p>Compared to a file, a blob lacks some contextual information. As such, the <code>git_diff_file</code> given to the callback will have some fake data; i.e. <code>mode</code> will be 0 and <code>path</code> will be NULL.</p>\n\n<p>NULL is allowed for either <code>old_blob</code> or <code>new_blob</code> and will be treated as an empty blob, with the <code>oid</code> set to NULL in the <code>git_diff_file</code> data. Passing NULL for both blobs is a noop; no callbacks will be made at all.</p>\n\n<p>We do run a binary content check on the blob content and if either blob looks like binary data, the <code>git_diff_delta</code> binary attribute will be set to 1 and no call to the hunk_cb nor line_cb will be made (unless you pass <code>GIT_DIFF_FORCE_TEXT</code> of course).</p>\n",
+      "comments": "<p>Compared to a file, a blob lacks some contextual information. As such,\n the <code>git_diff_file</code> given to the callback will have some fake data; i.e.\n <code>mode</code> will be 0 and <code>path</code> will be NULL.</p>\n\n<p>NULL is allowed for either <code>old_blob</code> or <code>new_blob</code> and will be treated\n as an empty blob, with the <code>oid</code> set to NULL in the <code>git_diff_file</code> data.\n Passing NULL for both blobs is a noop; no callbacks will be made at all.</p>\n\n<p>We do run a binary content check on the blob content and if either blob\n looks like binary data, the <code>git_diff_delta</code> binary attribute will be set\n to 1 and no call to the hunk_cb nor line_cb will be made (unless you pass\n <code>GIT_DIFF_FORCE_TEXT</code> of course).</p>\n",
       "group": "diff"
     },
     "git_diff_blob_to_buffer": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1158,
-      "lineto": 1169,
+      "file": "git2/diff.h",
+      "line": 1203,
+      "lineto": 1214,
       "args": [
         {
           "name": "old_blob",
@@ -6631,14 +7034,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff between a blob and a buffer.</p>\n",
-      "comments": "<p>As with <code>git_diff_blobs</code>, comparing a blob and buffer lacks some context, so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the rules for <code>git_diff_blobs()</code>.</p>\n\n<p>Passing NULL for <code>old_blob</code> will be treated as an empty blob (i.e. the <code>file_cb</code> will be invoked with GIT_DELTA_ADDED and the diff will be the entire content of the buffer added).  Passing NULL to the buffer will do the reverse, with GIT_DELTA_REMOVED and blob content removed.</p>\n",
+      "comments": "<p>As with <code>git_diff_blobs</code>, comparing a blob and buffer lacks some context,\n so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the\n rules for <code>git_diff_blobs()</code>.</p>\n\n<p>Passing NULL for <code>old_blob</code> will be treated as an empty blob (i.e. the\n <code>file_cb</code> will be invoked with GIT_DELTA_ADDED and the diff will be the\n entire content of the buffer added).  Passing NULL to the buffer will do\n the reverse, with GIT_DELTA_REMOVED and blob content removed.</p>\n",
       "group": "diff"
     },
     "git_diff_buffers": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1192,
-      "lineto": 1204,
+      "file": "git2/diff.h",
+      "line": 1237,
+      "lineto": 1249,
       "args": [
         {
           "name": "old_buffer",
@@ -6708,14 +7111,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff between two buffers.</p>\n",
-      "comments": "<p>Even more than with <code>git_diff_blobs</code>, comparing two buffer lacks context, so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the rules for <code>git_diff_blobs()</code>.</p>\n",
+      "comments": "<p>Even more than with <code>git_diff_blobs</code>, comparing two buffer lacks\n context, so the <code>git_diff_file</code> parameters to the callbacks will be\n faked a la the rules for <code>git_diff_blobs()</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_from_buffer": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1225,
-      "lineto": 1228,
+      "file": "git2/diff.h",
+      "line": 1270,
+      "lineto": 1273,
       "args": [
         {
           "name": "out",
@@ -6740,14 +7143,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Read the contents of a git patch file into a <code>git_diff</code> object.</p>\n",
-      "comments": "<p>The diff object produced is similar to the one that would be produced if you actually produced it computationally by comparing two trees, however there may be subtle differences.  For example, a patch file likely contains abbreviated object IDs, so the object IDs in a <code>git_diff_delta</code> produced by this function will also be abbreviated.</p>\n\n<p>This function will only read patch files created by a git implementation, it will not read unified diffs produced by the <code>diff</code> program, nor any other types of patch files.</p>\n",
+      "comments": "<p>The diff object produced is similar to the one that would be\n produced if you actually produced it computationally by comparing\n two trees, however there may be subtle differences.  For example,\n a patch file likely contains abbreviated object IDs, so the\n object IDs in a <code>git_diff_delta</code> produced by this function will\n also be abbreviated.</p>\n\n<p>This function will only read patch files created by a git\n implementation, it will not read unified diffs produced by\n the <code>diff</code> program, nor any other types of patch files.</p>\n",
       "group": "diff"
     },
     "git_diff_get_stats": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1264,
-      "lineto": 1266,
+      "file": "git2/diff.h",
+      "line": 1309,
+      "lineto": 1311,
       "args": [
         {
           "name": "out",
@@ -6777,9 +7180,9 @@
     },
     "git_diff_stats_files_changed": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1274,
-      "lineto": 1275,
+      "file": "git2/diff.h",
+      "line": 1319,
+      "lineto": 1320,
       "args": [
         {
           "name": "stats",
@@ -6799,9 +7202,9 @@
     },
     "git_diff_stats_insertions": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1283,
-      "lineto": 1284,
+      "file": "git2/diff.h",
+      "line": 1328,
+      "lineto": 1329,
       "args": [
         {
           "name": "stats",
@@ -6821,9 +7224,9 @@
     },
     "git_diff_stats_deletions": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1292,
-      "lineto": 1293,
+      "file": "git2/diff.h",
+      "line": 1337,
+      "lineto": 1338,
       "args": [
         {
           "name": "stats",
@@ -6843,9 +7246,9 @@
     },
     "git_diff_stats_to_buf": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1304,
-      "lineto": 1308,
+      "file": "git2/diff.h",
+      "line": 1349,
+      "lineto": 1353,
       "args": [
         {
           "name": "out",
@@ -6885,9 +7288,9 @@
     },
     "git_diff_stats_free": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1316,
-      "lineto": 1316,
+      "file": "git2/diff.h",
+      "line": 1361,
+      "lineto": 1361,
       "args": [
         {
           "name": "stats",
@@ -6912,9 +7315,9 @@
     },
     "git_diff_format_email": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1368,
-      "lineto": 1371,
+      "file": "git2/diff.h",
+      "line": 1413,
+      "lineto": 1416,
       "args": [
         {
           "name": "out",
@@ -6944,9 +7347,9 @@
     },
     "git_diff_commit_as_email": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1387,
-      "lineto": 1394,
+      "file": "git2/diff.h",
+      "line": 1432,
+      "lineto": 1439,
       "args": [
         {
           "name": "out",
@@ -6996,19 +7399,19 @@
     },
     "git_diff_format_email_init_options": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1405,
-      "lineto": 1407,
+      "file": "git2/diff.h",
+      "line": 1451,
+      "lineto": 1453,
       "args": [
         {
           "name": "opts",
           "type": "git_diff_format_email_options *",
-          "comment": "The `git_diff_format_email_options` struct to initialize"
+          "comment": "The `git_blame_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_DIFF_FORMAT_EMAIL_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_DIFF_FORMAT_EMAIL_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_diff_format_email_options *opts, unsigned int version",
@@ -7017,47 +7420,47 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_diff_format_email_options</code> with default values.</p>\n",
-      "comments": "<p>Equivalent to creating an instance with GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT.</p>\n",
+      "description": "<p>Initialize git_diff_format_email_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_format_email_options</code> with default values. Equivalent\n to creating an instance with GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
     "git_diff_patchid_init_options": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1428,
-      "lineto": 1430,
+      "file": "git2/diff.h",
+      "line": 1479,
+      "lineto": 1481,
       "args": [
         {
           "name": "opts",
           "type": "git_diff_patchid_options *",
-          "comment": null
+          "comment": "The `git_diff_patchid_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": null
+          "comment": "The struct version; pass `GIT_DIFF_PATCHID_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_diff_patchid_options *opts, unsigned int version",
       "sig": "git_diff_patchid_options *::unsigned int",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initialize <code>git_diff_patchid_options</code> structure.</p>\n",
-      "comments": "<p>Initializes the structure with default values. Equivalent to creating an instance with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code>.</p>\n",
+      "description": "<p>Initialize git_diff_patchid_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_patchid_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_patchid": {
       "type": "function",
-      "file": "diff.h",
-      "line": 1452,
-      "lineto": 1452,
+      "file": "git2/diff.h",
+      "line": 1502,
+      "lineto": 1502,
       "args": [
         {
           "name": "out",
           "type": "git_oid *",
-          "comment": "Pointer where the calculated patch ID shoul be\n  stored"
+          "comment": "Pointer where the calculated patch ID should be stored"
         },
         {
           "name": "diff",
@@ -7077,14 +7480,14 @@
         "comment": " 0 on success, an error code otherwise."
       },
       "description": "<p>Calculate the patch ID for the given patch.</p>\n",
-      "comments": "<p>Calculate a stable patch ID for the given patch by summing the hash of the file diffs, ignoring whitespace and line numbers. This can be used to derive whether two diffs are the same with a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as defined in git-patch-id(1), and should in fact generate the same IDs as the upstream git project does.</p>\n",
+      "comments": "<p>Calculate a stable patch ID for the given patch by summing the\n hash of the file diffs, ignoring whitespace and line numbers.\n This can be used to derive whether two diffs are the same with\n a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as\n defined in git-patch-id(1), and should in fact generate the\n same IDs as the upstream git project does.</p>\n",
       "group": "diff"
     },
     "giterr_last": {
       "type": "function",
-      "file": "errors.h",
-      "line": 115,
-      "lineto": 115,
+      "file": "git2/errors.h",
+      "line": 122,
+      "lineto": 122,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7092,27 +7495,30 @@
         "type": "const git_error *",
         "comment": " A git_error object."
       },
-      "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread or NULL if no error has occurred.</p>\n",
-      "comments": "",
+      "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread.</p>\n",
+      "comments": "<p>The default behaviour of this function is to return NULL if no previous error has occurred.\n However, libgit2&#39;s error strings are not cleared aggressively, so a prior\n (unrelated) error may be returned. This can be avoided by only calling\n this function if the prior call to a libgit2 API returned an error.</p>\n",
       "group": "giterr",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#giterr_last-8",
+          "ex/HEAD/checkout.html#giterr_last-9",
+          "ex/HEAD/checkout.html#giterr_last-10",
+          "ex/HEAD/checkout.html#giterr_last-11"
+        ],
         "general.c": [
           "ex/HEAD/general.html#giterr_last-33"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#giterr_last-10",
-          "ex/HEAD/merge.html#giterr_last-11"
-        ],
-        "network/clone.c": [
-          "ex/HEAD/network/clone.html#giterr_last-2"
+          "ex/HEAD/merge.html#giterr_last-8",
+          "ex/HEAD/merge.html#giterr_last-9"
         ]
       }
     },
     "giterr_clear": {
       "type": "function",
-      "file": "errors.h",
-      "line": 120,
-      "lineto": 120,
+      "file": "git2/errors.h",
+      "line": 127,
+      "lineto": 127,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7126,9 +7532,9 @@
     },
     "giterr_set_str": {
       "type": "function",
-      "file": "errors.h",
-      "line": 138,
-      "lineto": 138,
+      "file": "git2/errors.h",
+      "line": 145,
+      "lineto": 145,
       "args": [
         {
           "name": "error_class",
@@ -7148,14 +7554,14 @@
         "comment": null
       },
       "description": "<p>Set the error message string for this thread.</p>\n",
-      "comments": "<p>This function is public so that custom ODB backends and the like can relay an error message through libgit2.  Most regular users of libgit2 will never need to call this function -- actually, calling it in most circumstances (for example, calling from within a callback function) will just end up having the value overwritten by libgit2 internals.</p>\n\n<p>This error message is stored in thread-local storage and only applies to the particular thread that this libgit2 call is made from.</p>\n",
+      "comments": "<p>This function is public so that custom ODB backends and the like can\n relay an error message through libgit2.  Most regular users of libgit2\n will never need to call this function -- actually, calling it in most\n circumstances (for example, calling from within a callback function)\n will just end up having the value overwritten by libgit2 internals.</p>\n\n<p>This error message is stored in thread-local storage and only applies\n to the particular thread that this libgit2 call is made from.</p>\n",
       "group": "giterr"
     },
     "giterr_set_oom": {
       "type": "function",
-      "file": "errors.h",
-      "line": 149,
-      "lineto": 149,
+      "file": "git2/errors.h",
+      "line": 156,
+      "lineto": 156,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7164,12 +7570,12 @@
         "comment": null
       },
       "description": "<p>Set the error message to a special value for memory allocation failure.</p>\n",
-      "comments": "<p>The normal <code>giterr_set_str()</code> function attempts to <code>strdup()</code> the string that is passed in.  This is not a good idea when the error in question is a memory allocation failure.  That circumstance has a special setter function that sets the error string to a known and statically allocated internal value.</p>\n",
+      "comments": "<p>The normal <code>giterr_set_str()</code> function attempts to <code>strdup()</code> the string\n that is passed in.  This is not a good idea when the error in question\n is a memory allocation failure.  That circumstance has a special setter\n function that sets the error string to a known and statically allocated\n internal value.</p>\n",
       "group": "giterr"
     },
     "git_filter_list_load": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 90,
       "lineto": 96,
       "args": [
@@ -7211,12 +7617,12 @@
         "comment": " 0 on success (which could still return NULL if no filters are\n         needed for the requested file), \n<\n0 on error"
       },
       "description": "<p>Load the filter list for a given path.</p>\n",
-      "comments": "<p>This will return 0 (success) but set the output git_filter_list to NULL if no filters are requested for the given file.</p>\n",
+      "comments": "<p>This will return 0 (success) but set the output git_filter_list to NULL\n if no filters are requested for the given file.</p>\n",
       "group": "filter"
     },
     "git_filter_list_contains": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 110,
       "lineto": 112,
       "args": [
@@ -7238,12 +7644,12 @@
         "comment": " 1 if the filter is in the list, 0 otherwise"
       },
       "description": "<p>Query the filter list to see if a given filter (by name) will run.\n The built-in filters &quot;crlf&quot; and &quot;ident&quot; can be queried, otherwise this\n is the name of the filter specified by the filter attribute.</p>\n",
-      "comments": "<p>This will return 0 if the given filter is not in the list, or 1 if the filter will be applied.</p>\n",
+      "comments": "<p>This will return 0 if the given filter is not in the list, or 1 if\n the filter will be applied.</p>\n",
       "group": "filter"
     },
     "git_filter_list_apply_to_data": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 134,
       "lineto": 137,
       "args": [
@@ -7270,12 +7676,12 @@
         "comment": " 0 on success, an error code otherwise"
       },
       "description": "<p>Apply filter list to a data buffer.</p>\n",
-      "comments": "<p>See <code>git2/buffer.h</code> for background on <code>git_buf</code> objects.</p>\n\n<p>If the <code>in</code> buffer holds data allocated by libgit2 (i.e. <code>in-&gt;asize</code> is not zero), then it will be overwritten when applying the filters.  If not, then it will be left untouched.</p>\n\n<p>If there are no filters to apply (or <code>filters</code> is NULL), then the <code>out</code> buffer will reference the <code>in</code> buffer data (with <code>asize</code> set to zero) instead of allocating data.  This keeps allocations to a minimum, but it means you have to be careful about freeing the <code>in</code> data since <code>out</code> may be pointing to it!</p>\n",
+      "comments": "<p>See <code>git2/buffer.h</code> for background on <code>git_buf</code> objects.</p>\n\n<p>If the <code>in</code> buffer holds data allocated by libgit2 (i.e. <code>in-&gt;asize</code> is\n not zero), then it will be overwritten when applying the filters.  If\n not, then it will be left untouched.</p>\n\n<p>If there are no filters to apply (or <code>filters</code> is NULL), then the <code>out</code>\n buffer will reference the <code>in</code> buffer data (with <code>asize</code> set to zero)\n instead of allocating data.  This keeps allocations to a minimum, but\n it means you have to be careful about freeing the <code>in</code> data since <code>out</code>\n may be pointing to it!</p>\n",
       "group": "filter"
     },
     "git_filter_list_apply_to_file": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 148,
       "lineto": 152,
       "args": [
@@ -7312,7 +7718,7 @@
     },
     "git_filter_list_apply_to_blob": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 161,
       "lineto": 164,
       "args": [
@@ -7344,7 +7750,7 @@
     },
     "git_filter_list_stream_data": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 173,
       "lineto": 176,
       "args": [
@@ -7376,7 +7782,7 @@
     },
     "git_filter_list_stream_file": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 187,
       "lineto": 191,
       "args": [
@@ -7413,7 +7819,7 @@
     },
     "git_filter_list_stream_blob": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 200,
       "lineto": 203,
       "args": [
@@ -7445,7 +7851,7 @@
     },
     "git_filter_list_free": {
       "type": "function",
-      "file": "filter.h",
+      "file": "git2/filter.h",
       "line": 210,
       "lineto": 210,
       "args": [
@@ -7467,7 +7873,7 @@
     },
     "git_libgit2_init": {
       "type": "function",
-      "file": "global.h",
+      "file": "git2/global.h",
       "line": 26,
       "lineto": 26,
       "args": [],
@@ -7478,7 +7884,7 @@
         "comment": " the number of initializations of the library, or an error code."
       },
       "description": "<p>Init the global state</p>\n",
-      "comments": "<p>This function must be called before any other libgit2 function in order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number of times the initialization has been called (including this one) that have not subsequently been shutdown.</p>\n",
+      "comments": "<p>This function must be called before any other libgit2 function in\n order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number\n of times the initialization has been called (including this one) that have\n not subsequently been shutdown.</p>\n",
       "group": "libgit2",
       "examples": {
         "blame.c": [
@@ -7487,8 +7893,11 @@
         "cat-file.c": [
           "ex/HEAD/cat-file.html#git_libgit2_init-10"
         ],
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_libgit2_init-12"
+        ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_libgit2_init-4"
+          "ex/HEAD/describe.html#git_libgit2_init-6"
         ],
         "diff.c": [
           "ex/HEAD/diff.html#git_libgit2_init-13"
@@ -7502,8 +7911,11 @@
         "log.c": [
           "ex/HEAD/log.html#git_libgit2_init-31"
         ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_libgit2_init-1"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_libgit2_init-12"
+          "ex/HEAD/merge.html#git_libgit2_init-10"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_libgit2_init-2"
@@ -7521,7 +7933,7 @@
     },
     "git_libgit2_shutdown": {
       "type": "function",
-      "file": "global.h",
+      "file": "git2/global.h",
       "line": 39,
       "lineto": 39,
       "args": [],
@@ -7532,7 +7944,7 @@
         "comment": " the number of remaining initializations of the library, or an\n error code."
       },
       "description": "<p>Shutdown the global state</p>\n",
-      "comments": "<p>Clean up the global state and threading context after calling it as many times as <code>git_libgit2_init()</code> was called - it will return the number of remainining initializations that have not been shutdown (after this one).</p>\n",
+      "comments": "<p>Clean up the global state and threading context after calling it as\n many times as <code>git_libgit2_init()</code> was called - it will return the\n number of remainining initializations that have not been shutdown\n (after this one).</p>\n",
       "group": "libgit2",
       "examples": {
         "blame.c": [
@@ -7541,8 +7953,11 @@
         "cat-file.c": [
           "ex/HEAD/cat-file.html#git_libgit2_shutdown-11"
         ],
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_libgit2_shutdown-13"
+        ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_libgit2_shutdown-5"
+          "ex/HEAD/describe.html#git_libgit2_shutdown-7"
         ],
         "diff.c": [
           "ex/HEAD/diff.html#git_libgit2_shutdown-14"
@@ -7553,8 +7968,11 @@
         "log.c": [
           "ex/HEAD/log.html#git_libgit2_shutdown-32"
         ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_libgit2_shutdown-2"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_libgit2_shutdown-13"
+          "ex/HEAD/merge.html#git_libgit2_shutdown-11"
         ],
         "remote.c": [
           "ex/HEAD/remote.html#git_libgit2_shutdown-3"
@@ -7572,7 +7990,7 @@
     },
     "git_graph_ahead_behind": {
       "type": "function",
-      "file": "graph.h",
+      "file": "git2/graph.h",
       "line": 37,
       "lineto": 37,
       "args": [
@@ -7609,12 +8027,12 @@
         "comment": null
       },
       "description": "<p>Count the number of unique commits between two commit objects</p>\n",
-      "comments": "<p>There is no need for branches containing the commits to have any upstream relationship, but it helps to think of one as a branch and the other as its upstream, the <code>ahead</code> and <code>behind</code> values will be what git would report for the branches.</p>\n",
+      "comments": "<p>There is no need for branches containing the commits to have any\n upstream relationship, but it helps to think of one as a branch and\n the other as its upstream, the <code>ahead</code> and <code>behind</code> values will be\n what git would report for the branches.</p>\n",
       "group": "graph"
     },
     "git_graph_descendant_of": {
       "type": "function",
-      "file": "graph.h",
+      "file": "git2/graph.h",
       "line": 51,
       "lineto": 54,
       "args": [
@@ -7641,12 +8059,12 @@
         "comment": " 1 if the given commit is a descendant of the potential ancestor,\n 0 if not, error code otherwise."
       },
       "description": "<p>Determine if a commit is the descendant of another commit.</p>\n",
-      "comments": "<p>Note that a commit is not considered a descendant of itself, in contrast to <code>git merge-base --is-ancestor</code>.</p>\n",
+      "comments": "<p>Note that a commit is not considered a descendant of itself, in contrast\n to <code>git merge-base --is-ancestor</code>.</p>\n",
       "group": "graph"
     },
     "git_ignore_add_rule": {
       "type": "function",
-      "file": "ignore.h",
+      "file": "git2/ignore.h",
       "line": 37,
       "lineto": 39,
       "args": [
@@ -7668,12 +8086,12 @@
         "comment": " 0 on success"
       },
       "description": "<p>Add ignore rules for a repository.</p>\n",
-      "comments": "<p>Excludesfile rules (i.e. .gitignore rules) are generally read from .gitignore files in the repository tree or from a shared system file only if a &quot;core.excludesfile&quot; config value is set.  The library also keeps a set of per-repository internal ignores that can be configured in-memory and will not persist.  This function allows you to add to that internal rules list.</p>\n\n<p>Example usage:</p>\n\n<pre><code> error = git_ignore_add_rule(myrepo, &quot;*.c/ with space&quot;);\n</code></pre>\n\n<p>This would add three rules to the ignores.</p>\n",
+      "comments": "<p>Excludesfile rules (i.e. .gitignore rules) are generally read from\n .gitignore files in the repository tree or from a shared system file\n only if a &quot;core.excludesfile&quot; config value is set.  The library also\n keeps a set of per-repository internal ignores that can be configured\n in-memory and will not persist.  This function allows you to add to\n that internal rules list.</p>\n\n<p>Example usage:</p>\n\n<pre><code> error = git_ignore_add_rule(myrepo, &quot;*.c\n</code></pre>\n\n<p>/</p>\n\n<p>with space</p>\n\n<p>&quot;);</p>\n\n<p>This would add three rules to the ignores.</p>\n",
       "group": "ignore"
     },
     "git_ignore_clear_internal_rules": {
       "type": "function",
-      "file": "ignore.h",
+      "file": "git2/ignore.h",
       "line": 52,
       "lineto": 53,
       "args": [
@@ -7690,12 +8108,12 @@
         "comment": " 0 on success"
       },
       "description": "<p>Clear ignore rules that were explicitly added.</p>\n",
-      "comments": "<p>Resets to the default internal ignore rules.  This will not turn off rules in .gitignore files that actually exist in the filesystem.</p>\n\n<p>The default internal ignores ignore &quot;.&quot;, &quot;..&quot; and &quot;.git&quot; entries.</p>\n",
+      "comments": "<p>Resets to the default internal ignore rules.  This will not turn off\n rules in .gitignore files that actually exist in the filesystem.</p>\n\n<p>The default internal ignores ignore &quot;.&quot;, &quot;..&quot; and &quot;.git&quot; entries.</p>\n",
       "group": "ignore"
     },
     "git_ignore_path_is_ignored": {
       "type": "function",
-      "file": "ignore.h",
+      "file": "git2/ignore.h",
       "line": 71,
       "lineto": 74,
       "args": [
@@ -7722,12 +8140,12 @@
         "comment": " 0 if ignore rules could be processed for the file (regardless\n         of whether it exists or not), or an error \n<\n 0 if they could not."
       },
       "description": "<p>Test if the ignore rules apply to a given path.</p>\n",
-      "comments": "<p>This function checks the ignore rules to see if they would apply to the given file.  This indicates if the file would be ignored regardless of whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git add .&quot; on the directory containing the file, would it be added or not?</p>\n",
+      "comments": "<p>This function checks the ignore rules to see if they would apply to the\n given file.  This indicates if the file would be ignored regardless of\n whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git check-ignore --no-index&quot;\n on the given file, would it be shown or not?</p>\n",
       "group": "ignore"
     },
     "git_index_open": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 203,
       "lineto": 203,
       "args": [
@@ -7749,12 +8167,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new bare Git index object as a memory representation\n of the Git index file in &#39;index_path&#39;, without a repository\n to back it.</p>\n",
-      "comments": "<p>Since there is no ODB or working directory behind this index, any Index methods which rely on these (e.g. index_add_bypath) will fail with the GIT_ERROR error code.</p>\n\n<p>If you need to access the index of an actual repository, use the <code>git_repository_index</code> wrapper.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>Since there is no ODB or working directory behind this index,\n any Index methods which rely on these (e.g. index_add_bypath)\n will fail with the GIT_ERROR error code.</p>\n\n<p>If you need to access the index of an actual repository,\n use the <code>git_repository_index</code> wrapper.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
       "group": "index"
     },
     "git_index_new": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 216,
       "lineto": 216,
       "args": [
@@ -7771,12 +8189,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create an in-memory index object.</p>\n",
-      "comments": "<p>This index object cannot be read/written to the filesystem, but may be used to perform in-memory index operations.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This index object cannot be read/written to the filesystem,\n but may be used to perform in-memory index operations.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
       "group": "index"
     },
     "git_index_free": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 223,
       "lineto": 223,
       "args": [
@@ -7801,12 +8219,15 @@
         ],
         "init.c": [
           "ex/HEAD/init.html#git_index_free-4"
+        ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_index_free-3"
         ]
       }
     },
     "git_index_owner": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 231,
       "lineto": 231,
       "args": [
@@ -7828,7 +8249,7 @@
     },
     "git_index_caps": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 239,
       "lineto": 239,
       "args": [
@@ -7850,7 +8271,7 @@
     },
     "git_index_set_caps": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 252,
       "lineto": 252,
       "args": [
@@ -7872,12 +8293,12 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Set index capabilities flags.</p>\n",
-      "comments": "<p>If you pass <code>GIT_INDEXCAP_FROM_OWNER</code> for the caps, then the capabilities will be read from the config of the owner object, looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
+      "comments": "<p>If you pass <code>GIT_INDEXCAP_FROM_OWNER</code> for the caps, then the\n capabilities will be read from the config of the owner object,\n looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
       "group": "index"
     },
     "git_index_version": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 264,
       "lineto": 264,
       "args": [
@@ -7894,12 +8315,12 @@
         "comment": " the index version"
       },
       "description": "<p>Get index on-disk version.</p>\n",
-      "comments": "<p>Valid return values are 2, 3, or 4.  If 3 is returned, an index with version 2 may be written instead, if the extension data in version 3 is not necessary.</p>\n",
+      "comments": "<p>Valid return values are 2, 3, or 4.  If 3 is returned, an index\n with version 2 may be written instead, if the extension data in\n version 3 is not necessary.</p>\n",
       "group": "index"
     },
     "git_index_set_version": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 277,
       "lineto": 277,
       "args": [
@@ -7921,12 +8342,12 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Set index on-disk version.</p>\n",
-      "comments": "<p>Valid values are 2, 3, or 4.  If 2 is given, git_index_write may write an index with version 3 instead, if necessary to accurately represent the index.</p>\n",
+      "comments": "<p>Valid values are 2, 3, or 4.  If 2 is given, git_index_write may\n write an index with version 3 instead, if necessary to accurately\n represent the index.</p>\n",
       "group": "index"
     },
     "git_index_read": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 296,
       "lineto": 296,
       "args": [
@@ -7948,12 +8369,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Update the contents of an existing index object in memory by reading\n from the hard disk.</p>\n",
-      "comments": "<p>If <code>force</code> is true, this performs a &quot;hard&quot; read that discards in-memory changes and always reloads the on-disk index data.  If there is no on-disk version, the index will be cleared.</p>\n\n<p>If <code>force</code> is false, this does a &quot;soft&quot; read that reloads the index data from disk only if it has changed since the last time it was loaded.  Purely in-memory index data will be untouched.  Be aware: if there are changes on disk, unwritten in-memory changes are discarded.</p>\n",
+      "comments": "<p>If <code>force</code> is true, this performs a &quot;hard&quot; read that discards in-memory\n changes and always reloads the on-disk index data.  If there is no\n on-disk version, the index will be cleared.</p>\n\n<p>If <code>force</code> is false, this does a &quot;soft&quot; read that reloads the index\n data from disk only if it has changed since the last time it was\n loaded.  Purely in-memory index data will be untouched.  Be aware: if\n there are changes on disk, unwritten in-memory changes are discarded.</p>\n",
       "group": "index"
     },
     "git_index_write": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 305,
       "lineto": 305,
       "args": [
@@ -7975,7 +8396,7 @@
     },
     "git_index_path": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 313,
       "lineto": 313,
       "args": [
@@ -7997,7 +8418,7 @@
     },
     "git_index_checksum": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 325,
       "lineto": 325,
       "args": [
@@ -8014,12 +8435,12 @@
         "comment": " a pointer to the checksum of the index"
       },
       "description": "<p>Get the checksum of the index</p>\n",
-      "comments": "<p>This checksum is the SHA-1 hash over the index file (except the last 20 bytes which are the checksum itself). In cases where the index does not exist on-disk, it will be zeroed out.</p>\n",
+      "comments": "<p>This checksum is the SHA-1 hash over the index file (except the\n last 20 bytes which are the checksum itself). In cases where the\n index does not exist on-disk, it will be zeroed out.</p>\n",
       "group": "index"
     },
     "git_index_read_tree": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 336,
       "lineto": 336,
       "args": [
@@ -8046,7 +8467,7 @@
     },
     "git_index_write_tree": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 357,
       "lineto": 357,
       "args": [
@@ -8068,20 +8489,20 @@
         "comment": " 0 on success, GIT_EUNMERGED when the index is not clean\n or an error code"
       },
       "description": "<p>Write the index as a tree</p>\n",
-      "comments": "<p>This method will scan the index and write a representation of its current state back to disk; it recursively creates tree objects for each of the subtrees stored in the index, but only returns the OID of the root tree. This is the OID that can be used e.g. to create a commit.</p>\n\n<p>The index instance cannot be bare, and needs to be associated to an existing repository.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
+      "comments": "<p>This method will scan the index and write a representation\n of its current state back to disk; it recursively creates\n tree objects for each of the subtrees stored in the index,\n but only returns the OID of the root tree. This is the OID\n that can be used e.g. to create a commit.</p>\n\n<p>The index instance cannot be bare, and needs to be associated\n to an existing repository.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
       "group": "index",
       "examples": {
         "init.c": [
           "ex/HEAD/init.html#git_index_write_tree-5"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_write_tree-14"
+          "ex/HEAD/merge.html#git_index_write_tree-12"
         ]
       }
     },
     "git_index_write_tree_to": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 374,
       "lineto": 374,
       "args": [
@@ -8108,12 +8529,12 @@
         "comment": " 0 on success, GIT_EUNMERGED when the index is not clean\n or an error code"
       },
       "description": "<p>Write the index as a tree to the given repository</p>\n",
-      "comments": "<p>This method will do the same as <code>git_index_write_tree</code>, but letting the user choose the repository where the tree will be written.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
+      "comments": "<p>This method will do the same as <code>git_index_write_tree</code>, but\n letting the user choose the repository where the tree will\n be written.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
       "group": "index"
     },
     "git_index_entrycount": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 393,
       "lineto": 393,
       "args": [
@@ -8135,12 +8556,15 @@
       "examples": {
         "general.c": [
           "ex/HEAD/general.html#git_index_entrycount-36"
+        ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_index_entrycount-4"
         ]
       }
     },
     "git_index_clear": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 404,
       "lineto": 404,
       "args": [
@@ -8157,12 +8581,12 @@
         "comment": " 0 on success, error code \n<\n 0 on failure"
       },
       "description": "<p>Clear the contents (all the entries) of an index object.</p>\n",
-      "comments": "<p>This clears the index object in memory; changes must be explicitly written to disk for them to take effect persistently.</p>\n",
+      "comments": "<p>This clears the index object in memory; changes must be explicitly\n written to disk for them to take effect persistently.</p>\n",
       "group": "index"
     },
     "git_index_get_byindex": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 417,
       "lineto": 418,
       "args": [
@@ -8184,17 +8608,20 @@
         "comment": " a pointer to the entry; NULL if out of bounds"
       },
       "description": "<p>Get a pointer to one of the entries in the index</p>\n",
-      "comments": "<p>The entry is not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
+      "comments": "<p>The entry is not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
       "group": "index",
       "examples": {
         "general.c": [
           "ex/HEAD/general.html#git_index_get_byindex-37"
+        ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_index_get_byindex-5"
         ]
       }
     },
     "git_index_get_bypath": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 432,
       "lineto": 433,
       "args": [
@@ -8221,12 +8648,17 @@
         "comment": " a pointer to the entry; NULL if it was not found"
       },
       "description": "<p>Get a pointer to one of the entries in the index</p>\n",
-      "comments": "<p>The entry is not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
-      "group": "index"
+      "comments": "<p>The entry is not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
+      "group": "index",
+      "examples": {
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_index_get_bypath-6"
+        ]
+      }
     },
     "git_index_remove": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 443,
       "lineto": 443,
       "args": [
@@ -8258,7 +8690,7 @@
     },
     "git_index_remove_directory": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 453,
       "lineto": 454,
       "args": [
@@ -8290,7 +8722,7 @@
     },
     "git_index_add": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 470,
       "lineto": 470,
       "args": [
@@ -8312,12 +8744,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from an in-memory struct</p>\n",
-      "comments": "<p>If a previous index entry exists that has the same path and stage as the given &#39;source_entry&#39;, it will be replaced.  Otherwise, the &#39;source_entry&#39; will be added.</p>\n\n<p>A full copy (including the &#39;path&#39; string) of the given &#39;source_entry&#39; will be inserted on the index.</p>\n",
+      "comments": "<p>If a previous index entry exists that has the same path and stage\n as the given &#39;source_entry&#39;, it will be replaced.  Otherwise, the\n &#39;source_entry&#39; will be added.</p>\n\n<p>A full copy (including the &#39;path&#39; string) of the given\n &#39;source_entry&#39; will be inserted on the index.</p>\n",
       "group": "index"
     },
     "git_index_entry_stage": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 482,
       "lineto": 482,
       "args": [
@@ -8334,12 +8766,12 @@
         "comment": " the stage number"
       },
       "description": "<p>Return the stage number from a git index entry</p>\n",
-      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags &amp; GIT_IDXENTRY_STAGEMASK) &gt;&gt; GIT_IDXENTRY_STAGESHIFT\n</code></pre>\n",
+      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags \n</code></pre>\n\n<p>&amp;\n GIT_IDXENTRY_STAGEMASK) &gt;&gt; GIT_IDXENTRY_STAGESHIFT</p>\n",
       "group": "index"
     },
     "git_index_entry_is_conflict": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 491,
       "lineto": 491,
       "args": [
@@ -8361,7 +8793,7 @@
     },
     "git_index_add_bypath": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 522,
       "lineto": 522,
       "args": [
@@ -8383,12 +8815,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from a file on disk</p>\n",
-      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s working folder and must be readable.</p>\n\n<p>This method will fail in bare index instances.</p>\n\n<p>This forces the file to be added to the index, not looking at gitignore rules.  Those rules can be evaluated through the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s\n working folder and must be readable.</p>\n\n<p>This method will fail in bare index instances.</p>\n\n<p>This forces the file to be added to the index, not looking\n at gitignore rules.  Those rules can be evaluated through\n the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
     "git_index_add_frombuffer": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 551,
       "lineto": 554,
       "args": [
@@ -8420,12 +8852,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from a buffer in memory</p>\n",
-      "comments": "<p>This method will create a blob in the repository that owns the index and then add the index entry to the index.  The <code>path</code> of the entry represents the position of the blob relative to the repository&#39;s root folder.</p>\n\n<p>If a previous index entry exists that has the same path as the given &#39;entry&#39;, it will be replaced.  Otherwise, the &#39;entry&#39; will be added. The <code>id</code> and the <code>file_size</code> of the &#39;entry&#39; are updated with the real value of the blob.</p>\n\n<p>This forces the file to be added to the index, not looking at gitignore rules.  Those rules can be evaluated through the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>This method will create a blob in the repository that owns the\n index and then add the index entry to the index.  The <code>path</code> of the\n entry represents the position of the blob relative to the\n repository&#39;s root folder.</p>\n\n<p>If a previous index entry exists that has the same path as the\n given &#39;entry&#39;, it will be replaced.  Otherwise, the &#39;entry&#39; will be\n added. The <code>id</code> and the <code>file_size</code> of the &#39;entry&#39; are updated with the\n real value of the blob.</p>\n\n<p>This forces the file to be added to the index, not looking\n at gitignore rules.  Those rules can be evaluated through\n the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
     "git_index_remove_bypath": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 570,
       "lineto": 570,
       "args": [
@@ -8447,12 +8879,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Remove an index entry corresponding to a file on disk</p>\n",
-      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s working folder.  It may exist.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s\n working folder.  It may exist.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
     "git_index_add_all": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 618,
       "lineto": 623,
       "args": [
@@ -8489,12 +8921,12 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Add or update index entries matching files in the working directory.</p>\n",
-      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will be matched against files in the repository&#39;s working directory.  Each file that matches will be added to the index (either updating an existing entry or adding a new entry).  You can disable glob expansion and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code> flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>). If a file is already tracked in the index, then it <em>will</em> be updated even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains the exact path of an ignored file (when not using FORCE), add the <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry in the <code>pathspec</code> that is an exact match to a filename on disk is either not ignored or already in the index.  If this check fails, the function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files will no longer be marked as conflicting.  The data about the conflicts will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the working directory immediately <em>before</em> it is added to / updated in the index.  Returning zero will add the item to the index, greater than zero will skip the item, and less than zero will abort the scan and return that value to the caller.</p>\n",
+      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will\n be matched against files in the repository&#39;s working directory.  Each\n file that matches will be added to the index (either updating an\n existing entry or adding a new entry).  You can disable glob expansion\n and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code>\n flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>).\n If a file is already tracked in the index, then it <em>will</em> be updated\n even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip\n the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains\n the exact path of an ignored file (when not using FORCE), add the\n <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry\n in the <code>pathspec</code> that is an exact match to a filename on disk is\n either not ignored or already in the index.  If this check fails, the\n function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback\n function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files\n will no longer be marked as conflicting.  The data about the conflicts\n will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching\n item in the working directory immediately <em>before</em> it is added to /\n updated in the index.  Returning zero will add the item to the index,\n greater than zero will skip the item, and less than zero will abort the\n scan and return that value to the caller.</p>\n",
       "group": "index"
     },
     "git_index_remove_all": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 640,
       "lineto": 644,
       "args": [
@@ -8526,12 +8958,12 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Remove all matching index entries.</p>\n",
-      "comments": "<p>If you provide a callback function, it will be invoked on each matching item in the index immediately <em>before</em> it is removed.  Return 0 to remove the item, &gt; 0 to skip the item, and &lt; 0 to abort the scan.</p>\n",
+      "comments": "<p>If you provide a callback function, it will be invoked on each matching\n item in the index immediately <em>before</em> it is removed.  Return 0 to\n remove the item, &gt; 0 to skip the item, and \n&lt;\n 0 to abort the scan.</p>\n",
       "group": "index"
     },
     "git_index_update_all": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 669,
       "lineto": 673,
       "args": [
@@ -8563,12 +8995,12 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Update all index entries to match the working directory</p>\n",
-      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>This scans the existing index entries and synchronizes them with the working directory, deleting them if the corresponding working directory file no longer exists otherwise updating the information (including adding the latest version of file to the ODB if needed).</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the index immediately <em>before</em> it is updated (either refreshed or removed depending on working directory state).  Return 0 to proceed with updating the item, &gt; 0 to skip the item, and &lt; 0 to abort the scan.</p>\n",
+      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>This scans the existing index entries and synchronizes them with the\n working directory, deleting them if the corresponding working directory\n file no longer exists otherwise updating the information (including\n adding the latest version of file to the ODB if needed).</p>\n\n<p>If you provide a callback function, it will be invoked on each matching\n item in the index immediately <em>before</em> it is updated (either refreshed\n or removed depending on working directory state).  Return 0 to proceed\n with updating the item, &gt; 0 to skip the item, and \n&lt;\n 0 to abort the scan.</p>\n",
       "group": "index"
     },
     "git_index_find": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 684,
       "lineto": 684,
       "args": [
@@ -8600,7 +9032,7 @@
     },
     "git_index_find_prefix": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 695,
       "lineto": 695,
       "args": [
@@ -8632,7 +9064,7 @@
     },
     "git_index_conflict_add": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 720,
       "lineto": 724,
       "args": [
@@ -8664,12 +9096,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update index entries to represent a conflict.  Any staged\n entries that exist at the given paths will be removed.</p>\n",
-      "comments": "<p>The entries are the entries from the tree included in the merge.  Any entry may be null to indicate that that file was not present in the trees during the merge.  For example, ancestor_entry may be NULL to indicate that a file was added in both branches and must be resolved.</p>\n",
+      "comments": "<p>The entries are the entries from the tree included in the merge.  Any\n entry may be null to indicate that that file was not present in the\n trees during the merge.  For example, ancestor_entry may be NULL to\n indicate that a file was added in both branches and must be resolved.</p>\n",
       "group": "index"
     },
     "git_index_conflict_get": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 740,
       "lineto": 745,
       "args": [
@@ -8706,12 +9138,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the index entries that represent a conflict of a single file.</p>\n",
-      "comments": "<p>The entries are not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
+      "comments": "<p>The entries are not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
       "group": "index"
     },
     "git_index_conflict_remove": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 754,
       "lineto": 754,
       "args": [
@@ -8738,7 +9170,7 @@
     },
     "git_index_conflict_cleanup": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 762,
       "lineto": 762,
       "args": [
@@ -8760,7 +9192,7 @@
     },
     "git_index_has_conflicts": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 769,
       "lineto": 769,
       "args": [
@@ -8781,13 +9213,13 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_has_conflicts-15"
+          "ex/HEAD/merge.html#git_index_has_conflicts-13"
         ]
       }
     },
     "git_index_conflict_iterator_new": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 780,
       "lineto": 782,
       "args": [
@@ -8813,13 +9245,13 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_iterator_new-16"
+          "ex/HEAD/merge.html#git_index_conflict_iterator_new-14"
         ]
       }
     },
     "git_index_conflict_next": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 794,
       "lineto": 798,
       "args": [
@@ -8855,13 +9287,13 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_next-17"
+          "ex/HEAD/merge.html#git_index_conflict_next-15"
         ]
       }
     },
     "git_index_conflict_iterator_free": {
       "type": "function",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 805,
       "lineto": 806,
       "args": [
@@ -8882,15 +9314,42 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_iterator_free-18"
+          "ex/HEAD/merge.html#git_index_conflict_iterator_free-16"
         ]
       }
     },
+    "git_indexer_init_options": {
+      "type": "function",
+      "file": "git2/indexer.h",
+      "line": 41,
+      "lineto": 43,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_indexer_options *",
+          "comment": "the `git_indexer_options` struct to initialize."
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "Version of struct; pass `GIT_INDEXER_OPTIONS_VERSION`"
+        }
+      ],
+      "argline": "git_indexer_options *opts, unsigned int version",
+      "sig": "git_indexer_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initializes a <code>git_indexer_options</code> with default values. Equivalent to\n creating an instance with GIT_INDEXER_OPTIONS_INIT.</p>\n",
+      "comments": "",
+      "group": "indexer"
+    },
     "git_indexer_new": {
       "type": "function",
-      "file": "indexer.h",
-      "line": 30,
-      "lineto": 36,
+      "file": "git2/indexer.h",
+      "line": 57,
+      "lineto": 62,
       "args": [
         {
           "name": "out",
@@ -8913,36 +9372,26 @@
           "comment": "object database from which to read base objects when\n fixing thin packs. Pass NULL if no thin pack is expected (an error\n will be returned if there are bases missing)"
         },
         {
-          "name": "progress_cb",
-          "type": "git_transfer_progress_cb",
-          "comment": "function to call with progress information"
-        },
-        {
-          "name": "progress_cb_payload",
-          "type": "void *",
-          "comment": "payload for the progress callback"
+          "name": "opts",
+          "type": "git_indexer_options *",
+          "comment": "Optional structure containing additional options. See\n `git_indexer_options` above."
         }
       ],
-      "argline": "git_indexer **out, const char *path, unsigned int mode, git_odb *odb, git_transfer_progress_cb progress_cb, void *progress_cb_payload",
-      "sig": "git_indexer **::const char *::unsigned int::git_odb *::git_transfer_progress_cb::void *",
+      "argline": "git_indexer **out, const char *path, unsigned int mode, git_odb *odb, git_indexer_options *opts",
+      "sig": "git_indexer **::const char *::unsigned int::git_odb *::git_indexer_options *",
       "return": {
         "type": "int",
         "comment": null
       },
       "description": "<p>Create a new indexer instance</p>\n",
       "comments": "",
-      "group": "indexer",
-      "examples": {
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_indexer_new-1"
-        ]
-      }
+      "group": "indexer"
     },
     "git_indexer_append": {
       "type": "function",
-      "file": "indexer.h",
-      "line": 46,
-      "lineto": 46,
+      "file": "git2/indexer.h",
+      "line": 72,
+      "lineto": 72,
       "args": [
         {
           "name": "idx",
@@ -8973,18 +9422,13 @@
       },
       "description": "<p>Add data to the indexer</p>\n",
       "comments": "",
-      "group": "indexer",
-      "examples": {
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_indexer_append-2"
-        ]
-      }
+      "group": "indexer"
     },
     "git_indexer_commit": {
       "type": "function",
-      "file": "indexer.h",
-      "line": 55,
-      "lineto": 55,
+      "file": "git2/indexer.h",
+      "line": 81,
+      "lineto": 81,
       "args": [
         {
           "name": "idx",
@@ -9005,18 +9449,13 @@
       },
       "description": "<p>Finalize the pack and index</p>\n",
       "comments": "<p>Resolve any pending deltas and write out the index file</p>\n",
-      "group": "indexer",
-      "examples": {
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_indexer_commit-3"
-        ]
-      }
+      "group": "indexer"
     },
     "git_indexer_hash": {
       "type": "function",
-      "file": "indexer.h",
-      "line": 65,
-      "lineto": 65,
+      "file": "git2/indexer.h",
+      "line": 91,
+      "lineto": 91,
       "args": [
         {
           "name": "idx",
@@ -9031,19 +9470,14 @@
         "comment": null
       },
       "description": "<p>Get the packfile&#39;s hash</p>\n",
-      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object names. This is only correct after the index has been finalized.</p>\n",
-      "group": "indexer",
-      "examples": {
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_indexer_hash-4"
-        ]
-      }
+      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object\n names. This is only correct after the index has been finalized.</p>\n",
+      "group": "indexer"
     },
     "git_indexer_free": {
       "type": "function",
-      "file": "indexer.h",
-      "line": 72,
-      "lineto": 72,
+      "file": "git2/indexer.h",
+      "line": 98,
+      "lineto": 98,
       "args": [
         {
           "name": "idx",
@@ -9059,16 +9493,257 @@
       },
       "description": "<p>Free the indexer and its resources</p>\n",
       "comments": "",
-      "group": "indexer",
-      "examples": {
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_indexer_free-5"
-        ]
-      }
+      "group": "indexer"
+    },
+    "imaxdiv": {
+      "type": "function",
+      "file": "git2/inttypes.h",
+      "line": 284,
+      "lineto": 298,
+      "args": [
+        {
+          "name": "numer",
+          "type": "intmax_t",
+          "comment": null
+        },
+        {
+          "name": "denom",
+          "type": "intmax_t",
+          "comment": null
+        }
+      ],
+      "argline": "intmax_t numer, intmax_t denom",
+      "sig": "intmax_t::intmax_t",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": "",
+      "group": "imaxdiv"
+    },
+    "git_mailmap_new": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 32,
+      "lineto": 32,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_mailmap **",
+          "comment": "pointer to store the new mailmap"
+        }
+      ],
+      "argline": "git_mailmap **out",
+      "sig": "git_mailmap **",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or an error code"
+      },
+      "description": "<p>Allocate a new mailmap object.</p>\n",
+      "comments": "<p>This object is empty, so you&#39;ll have to add a mailmap file before you can do\n anything with it. The mailmap must be freed with &#39;git_mailmap_free&#39;.</p>\n",
+      "group": "mailmap"
+    },
+    "git_mailmap_free": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 39,
+      "lineto": 39,
+      "args": [
+        {
+          "name": "mm",
+          "type": "git_mailmap *",
+          "comment": "the mailmap to free"
+        }
+      ],
+      "argline": "git_mailmap *mm",
+      "sig": "git_mailmap *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free the mailmap and its associated memory.</p>\n",
+      "comments": "",
+      "group": "mailmap"
+    },
+    "git_mailmap_add_entry": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 52,
+      "lineto": 54,
+      "args": [
+        {
+          "name": "mm",
+          "type": "git_mailmap *",
+          "comment": "mailmap to add the entry to"
+        },
+        {
+          "name": "real_name",
+          "type": "const char *",
+          "comment": "the real name to use, or NULL"
+        },
+        {
+          "name": "real_email",
+          "type": "const char *",
+          "comment": "the real email to use, or NULL"
+        },
+        {
+          "name": "replace_name",
+          "type": "const char *",
+          "comment": "the name to replace, or NULL"
+        },
+        {
+          "name": "replace_email",
+          "type": "const char *",
+          "comment": "the email to replace"
+        }
+      ],
+      "argline": "git_mailmap *mm, const char *real_name, const char *real_email, const char *replace_name, const char *replace_email",
+      "sig": "git_mailmap *::const char *::const char *::const char *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or an error code"
+      },
+      "description": "<p>Add a single entry to the given mailmap object. If the entry already exists,\n it will be replaced with the new entry.</p>\n",
+      "comments": "",
+      "group": "mailmap"
+    },
+    "git_mailmap_from_buffer": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 64,
+      "lineto": 65,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_mailmap **",
+          "comment": "pointer to store the new mailmap"
+        },
+        {
+          "name": "buf",
+          "type": "const char *",
+          "comment": "buffer to parse the mailmap from"
+        },
+        {
+          "name": "len",
+          "type": "size_t",
+          "comment": "the length of the input buffer"
+        }
+      ],
+      "argline": "git_mailmap **out, const char *buf, size_t len",
+      "sig": "git_mailmap **::const char *::size_t",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or an error code"
+      },
+      "description": "<p>Create a new mailmap instance containing a single mailmap file</p>\n",
+      "comments": "",
+      "group": "mailmap"
+    },
+    "git_mailmap_from_repository": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 81,
+      "lineto": 82,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_mailmap **",
+          "comment": "pointer to store the new mailmap"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "repository to load mailmap information from"
+        }
+      ],
+      "argline": "git_mailmap **out, git_repository *repo",
+      "sig": "git_mailmap **::git_repository *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or an error code"
+      },
+      "description": "<p>Create a new mailmap instance from a repository, loading mailmap files based\n on the repository&#39;s configuration.</p>\n",
+      "comments": "<p>Mailmaps are loaded in the following order:\n  1. &#39;.mailmap&#39; in the root of the repository&#39;s working directory, if present.\n  2. The blob object identified by the &#39;mailmap.blob&#39; config entry, if set.\n       [NOTE: &#39;mailmap.blob&#39; defaults to &#39;HEAD:.mailmap&#39; in bare repositories]\n  3. The path in the &#39;mailmap.file&#39; config entry, if set.</p>\n",
+      "group": "mailmap"
+    },
+    "git_mailmap_resolve": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 96,
+      "lineto": 98,
+      "args": [
+        {
+          "name": "real_name",
+          "type": "const char **",
+          "comment": "pointer to store the real name"
+        },
+        {
+          "name": "real_email",
+          "type": "const char **",
+          "comment": "pointer to store the real email"
+        },
+        {
+          "name": "mm",
+          "type": "const git_mailmap *",
+          "comment": "the mailmap to perform a lookup with (may be NULL)"
+        },
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "the name to look up"
+        },
+        {
+          "name": "email",
+          "type": "const char *",
+          "comment": "the email to look up"
+        }
+      ],
+      "argline": "const char **real_name, const char **real_email, const git_mailmap *mm, const char *name, const char *email",
+      "sig": "const char **::const char **::const git_mailmap *::const char *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, or an error code"
+      },
+      "description": "<p>Resolve a name and email to the corresponding real name and email.</p>\n",
+      "comments": "<p>The lifetime of the strings are tied to <code>mm</code>, <code>name</code>, and <code>email</code> parameters.</p>\n",
+      "group": "mailmap"
+    },
+    "git_mailmap_resolve_signature": {
+      "type": "function",
+      "file": "git2/mailmap.h",
+      "line": 110,
+      "lineto": 111,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_signature **",
+          "comment": "new signature"
+        },
+        {
+          "name": "mm",
+          "type": "const git_mailmap *",
+          "comment": "mailmap to resolve with"
+        },
+        {
+          "name": "sig",
+          "type": "const git_signature *",
+          "comment": "signature to resolve"
+        }
+      ],
+      "argline": "git_signature **out, const git_mailmap *mm, const git_signature *sig",
+      "sig": "git_signature **::const git_mailmap *::const git_signature *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Resolve a signature to use real names and emails with a mailmap.</p>\n",
+      "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n",
+      "group": "mailmap"
     },
     "git_merge_file_init_input": {
       "type": "function",
-      "file": "merge.h",
+      "file": "git2/merge.h",
       "line": 60,
       "lineto": 62,
       "args": [
@@ -9095,19 +9770,19 @@
     },
     "git_merge_file_init_options": {
       "type": "function",
-      "file": "merge.h",
-      "line": 214,
-      "lineto": 216,
+      "file": "git2/merge.h",
+      "line": 215,
+      "lineto": 217,
       "args": [
         {
           "name": "opts",
           "type": "git_merge_file_options *",
-          "comment": "the `git_merge_file_options` instance to initialize."
+          "comment": "The `git_merge_file_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_MERGE_FILE_OPTIONS_VERSION` here."
+          "comment": "The struct version; pass `GIT_MERGE_FILE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_merge_file_options *opts, unsigned int version",
@@ -9116,25 +9791,25 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_merge_file_options</code> with default values. Equivalent to\n creating an instance with GIT_MERGE_FILE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_merge_file_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_merge_file_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_MERGE_FILE_OPTIONS_INIT</code>.</p>\n",
       "group": "merge"
     },
     "git_merge_init_options": {
       "type": "function",
-      "file": "merge.h",
-      "line": 311,
-      "lineto": 313,
+      "file": "git2/merge.h",
+      "line": 313,
+      "lineto": 315,
       "args": [
         {
           "name": "opts",
           "type": "git_merge_options *",
-          "comment": "the `git_merge_options` instance to initialize."
+          "comment": "The `git_merge_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_MERGE_OPTIONS_VERSION` here."
+          "comment": "The struct version; pass `GIT_MERGE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_merge_options *opts, unsigned int version",
@@ -9143,15 +9818,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_merge_options</code> with default values. Equivalent to\n creating an instance with GIT_MERGE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_merge_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_merge_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_MERGE_OPTIONS_INIT</code>.</p>\n",
       "group": "merge"
     },
     "git_merge_analysis": {
       "type": "function",
-      "file": "merge.h",
-      "line": 382,
-      "lineto": 387,
+      "file": "git2/merge.h",
+      "line": 384,
+      "lineto": 389,
       "args": [
         {
           "name": "analysis_out",
@@ -9190,15 +9865,15 @@
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_merge_analysis-19"
+          "ex/HEAD/merge.html#git_merge_analysis-17"
         ]
       }
     },
     "git_merge_base": {
       "type": "function",
-      "file": "merge.h",
-      "line": 398,
-      "lineto": 402,
+      "file": "git2/merge.h",
+      "line": 400,
+      "lineto": 404,
       "args": [
         {
           "name": "out",
@@ -9241,9 +9916,9 @@
     },
     "git_merge_bases": {
       "type": "function",
-      "file": "merge.h",
-      "line": 413,
-      "lineto": 417,
+      "file": "git2/merge.h",
+      "line": 415,
+      "lineto": 419,
       "args": [
         {
           "name": "out",
@@ -9278,9 +9953,9 @@
     },
     "git_merge_base_many": {
       "type": "function",
-      "file": "merge.h",
-      "line": 428,
-      "lineto": 432,
+      "file": "git2/merge.h",
+      "line": 430,
+      "lineto": 434,
       "args": [
         {
           "name": "out",
@@ -9315,9 +9990,9 @@
     },
     "git_merge_bases_many": {
       "type": "function",
-      "file": "merge.h",
-      "line": 443,
-      "lineto": 447,
+      "file": "git2/merge.h",
+      "line": 445,
+      "lineto": 449,
       "args": [
         {
           "name": "out",
@@ -9352,9 +10027,9 @@
     },
     "git_merge_base_octopus": {
       "type": "function",
-      "file": "merge.h",
-      "line": 458,
-      "lineto": 462,
+      "file": "git2/merge.h",
+      "line": 460,
+      "lineto": 464,
       "args": [
         {
           "name": "out",
@@ -9389,9 +10064,9 @@
     },
     "git_merge_file": {
       "type": "function",
-      "file": "merge.h",
-      "line": 480,
-      "lineto": 485,
+      "file": "git2/merge.h",
+      "line": 482,
+      "lineto": 487,
       "args": [
         {
           "name": "out",
@@ -9426,14 +10101,14 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Merge two files as they exist in the in-memory data structures, using\n the given common ancestor as the baseline, producing a\n <code>git_merge_file_result</code> that reflects the merge result.  The\n <code>git_merge_file_result</code> must be freed with <code>git_merge_file_result_free</code>.</p>\n",
-      "comments": "<p>Note that this function does not reference a repository and any configuration must be passed as <code>git_merge_file_options</code>.</p>\n",
+      "comments": "<p>Note that this function does not reference a repository and any\n configuration must be passed as <code>git_merge_file_options</code>.</p>\n",
       "group": "merge"
     },
     "git_merge_file_from_index": {
       "type": "function",
-      "file": "merge.h",
-      "line": 501,
-      "lineto": 507,
+      "file": "git2/merge.h",
+      "line": 503,
+      "lineto": 509,
       "args": [
         {
           "name": "out",
@@ -9478,9 +10153,9 @@
     },
     "git_merge_file_result_free": {
       "type": "function",
-      "file": "merge.h",
-      "line": 514,
-      "lineto": 514,
+      "file": "git2/merge.h",
+      "line": 516,
+      "lineto": 516,
       "args": [
         {
           "name": "result",
@@ -9500,9 +10175,9 @@
     },
     "git_merge_trees": {
       "type": "function",
-      "file": "merge.h",
-      "line": 532,
-      "lineto": 538,
+      "file": "git2/merge.h",
+      "line": 534,
+      "lineto": 540,
       "args": [
         {
           "name": "out",
@@ -9547,9 +10222,9 @@
     },
     "git_merge_commits": {
       "type": "function",
-      "file": "merge.h",
-      "line": 555,
-      "lineto": 560,
+      "file": "git2/merge.h",
+      "line": 557,
+      "lineto": 562,
       "args": [
         {
           "name": "out",
@@ -9589,9 +10264,9 @@
     },
     "git_merge": {
       "type": "function",
-      "file": "merge.h",
-      "line": 580,
-      "lineto": 585,
+      "file": "git2/merge.h",
+      "line": 582,
+      "lineto": 587,
       "args": [
         {
           "name": "repo",
@@ -9626,17 +10301,17 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Merges the given commit(s) into HEAD, writing the results into the working\n directory.  Any changes are staged for commit and any conflicts are written\n to the index.  Callers should inspect the repository&#39;s index after this\n completes, resolve any conflicts and prepare a commit.</p>\n",
-      "comments": "<p>For compatibility with git, the repository is put into a merging state. Once the commit is done (or if the uses wishes to abort), you should clear this state by calling <code>git_repository_state_cleanup()</code>.</p>\n",
+      "comments": "<p>For compatibility with git, the repository is put into a merging\n state. Once the commit is done (or if the uses wishes to abort),\n you should clear this state by calling\n <code>git_repository_state_cleanup()</code>.</p>\n",
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_merge-20"
+          "ex/HEAD/merge.html#git_merge-18"
         ]
       }
     },
     "git_message_prettify": {
       "type": "function",
-      "file": "message.h",
+      "file": "git2/message.h",
       "line": 38,
       "lineto": 38,
       "args": [
@@ -9673,7 +10348,7 @@
     },
     "git_message_trailers": {
       "type": "function",
-      "file": "message.h",
+      "file": "git2/message.h",
       "line": 73,
       "lineto": 73,
       "args": [
@@ -9695,12 +10370,12 @@
         "comment": " 0 on success, or non-zero on error."
       },
       "description": "<p>Parse trailers out of a message, filling the array pointed to by +arr+.</p>\n",
-      "comments": "<p>Trailers are key/value pairs in the last paragraph of a message, not including any patches or conflicts that may be present.</p>\n",
+      "comments": "<p>Trailers are key/value pairs in the last paragraph of a message, not\n including any patches or conflicts that may be present.</p>\n",
       "group": "message"
     },
     "git_message_trailer_array_free": {
       "type": "function",
-      "file": "message.h",
+      "file": "git2/message.h",
       "line": 79,
       "lineto": 79,
       "args": [
@@ -9722,7 +10397,7 @@
     },
     "git_note_iterator_new": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 49,
       "lineto": 52,
       "args": [
@@ -9754,7 +10429,7 @@
     },
     "git_note_commit_iterator_new": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 64,
       "lineto": 66,
       "args": [
@@ -9781,7 +10456,7 @@
     },
     "git_note_iterator_free": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 73,
       "lineto": 73,
       "args": [
@@ -9803,7 +10478,7 @@
     },
     "git_note_next": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 86,
       "lineto": 89,
       "args": [
@@ -9835,7 +10510,7 @@
     },
     "git_note_read": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 105,
       "lineto": 109,
       "args": [
@@ -9872,7 +10547,7 @@
     },
     "git_note_commit_read": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 124,
       "lineto": 128,
       "args": [
@@ -9909,7 +10584,7 @@
     },
     "git_note_author": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 136,
       "lineto": 136,
       "args": [
@@ -9931,7 +10606,7 @@
     },
     "git_note_committer": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 144,
       "lineto": 144,
       "args": [
@@ -9953,7 +10628,7 @@
     },
     "git_note_message": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 153,
       "lineto": 153,
       "args": [
@@ -9975,7 +10650,7 @@
     },
     "git_note_id": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 162,
       "lineto": 162,
       "args": [
@@ -9997,7 +10672,7 @@
     },
     "git_note_create": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 179,
       "lineto": 187,
       "args": [
@@ -10054,7 +10729,7 @@
     },
     "git_note_commit_create": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 209,
       "lineto": 218,
       "args": [
@@ -10111,12 +10786,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a note for an object from a commit</p>\n",
-      "comments": "<p>This function will create a notes commit for a given object, the commit is a dangling commit, no reference is created.</p>\n",
+      "comments": "<p>This function will create a notes commit for a given object,\n the commit is a dangling commit, no reference is created.</p>\n",
       "group": "note"
     },
     "git_note_remove": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 232,
       "lineto": 237,
       "args": [
@@ -10158,7 +10833,7 @@
     },
     "git_note_commit_remove": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 257,
       "lineto": 263,
       "args": [
@@ -10205,7 +10880,7 @@
     },
     "git_note_free": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 270,
       "lineto": 270,
       "args": [
@@ -10225,9 +10900,36 @@
       "comments": "",
       "group": "note"
     },
+    "git_note_default_ref": {
+      "type": "function",
+      "file": "git2/notes.h",
+      "line": 280,
+      "lineto": 280,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_buf *",
+          "comment": "buffer in which to store the name of the default notes reference"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "The Git repository"
+        }
+      ],
+      "argline": "git_buf *out, git_repository *repo",
+      "sig": "git_buf *::git_repository *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Get the default notes reference for a repository</p>\n",
+      "comments": "",
+      "group": "note"
+    },
     "git_note_foreach": {
       "type": "function",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 298,
       "lineto": 302,
       "args": [
@@ -10264,7 +10966,7 @@
     },
     "git_object_lookup": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 42,
       "lineto": 46,
       "args": [
@@ -10296,20 +10998,20 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository.</p>\n",
-      "comments": "<p>The generated reference is owned by the repository and should be closed with the <code>git_object_free</code> method instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object in the odb; the method will fail otherwise. The special value &#39;GIT_OBJ_ANY&#39; may be passed to let the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJ_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
       "group": "object",
       "examples": {
         "log.c": [
           "ex/HEAD/log.html#git_object_lookup-34"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_object_lookup-21"
+          "ex/HEAD/merge.html#git_object_lookup-19"
         ]
       }
     },
     "git_object_lookup_prefix": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 75,
       "lineto": 80,
       "args": [
@@ -10346,12 +11048,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository,\n given a prefix of its identifier (short id).</p>\n",
-      "comments": "<p>The object obtained will be so that its identifier matches the first &#39;len&#39; hexadecimal characters (packets of 4 bits) of the given &#39;id&#39;. &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and long enough to identify a unique object matching the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and should be closed with the <code>git_object_free</code> method instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object in the odb; the method will fail otherwise. The special value &#39;GIT_OBJ_ANY&#39; may be passed to let the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The object obtained will be so that its identifier\n matches the first &#39;len&#39; hexadecimal characters\n (packets of 4 bits) of the given &#39;id&#39;.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and\n long enough to identify a unique object matching\n the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJ_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
       "group": "object"
     },
     "git_object_lookup_bypath": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 93,
       "lineto": 97,
       "args": [
@@ -10388,7 +11090,7 @@
     },
     "git_object_id": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 105,
       "lineto": 105,
       "args": [
@@ -10435,7 +11137,7 @@
     },
     "git_object_short_id": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 119,
       "lineto": 119,
       "args": [
@@ -10457,7 +11159,7 @@
         "comment": " 0 on success, \n<\n0 for error"
       },
       "description": "<p>Get a short abbreviated OID string for the object</p>\n",
-      "comments": "<p>This starts at the &quot;core.abbrev&quot; length (default 7 characters) and iteratively extends to a longer string if that length is ambiguous. The result will be unambiguous (at least until new objects are added to the repository).</p>\n",
+      "comments": "<p>This starts at the &quot;core.abbrev&quot; length (default 7 characters) and\n iteratively extends to a longer string if that length is ambiguous.\n The result will be unambiguous (at least until new objects are added to\n the repository).</p>\n",
       "group": "object",
       "examples": {
         "tag.c": [
@@ -10467,7 +11169,7 @@
     },
     "git_object_type": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 127,
       "lineto": 127,
       "args": [
@@ -10499,7 +11201,7 @@
     },
     "git_object_owner": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 141,
       "lineto": 141,
       "args": [
@@ -10516,12 +11218,12 @@
         "comment": " the repository who owns this object"
       },
       "description": "<p>Get the repository that owns this object</p>\n",
-      "comments": "<p>Freeing or calling <code>git_repository_close</code> on the returned pointer will invalidate the actual object.</p>\n\n<p>Any other operation may be run on the repository without affecting the object.</p>\n",
+      "comments": "<p>Freeing or calling <code>git_repository_close</code> on the\n returned pointer will invalidate the actual object.</p>\n\n<p>Any other operation may be run on the repository without\n affecting the object.</p>\n",
       "group": "object"
     },
     "git_object_free": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 158,
       "lineto": 158,
       "args": [
@@ -10538,7 +11240,7 @@
         "comment": null
       },
       "description": "<p>Close an open object</p>\n",
-      "comments": "<p>This method instructs the library to close an existing object; note that git_objects are owned and cached by the repository so the object may or may not be freed after this library call, depending on how aggressive is the caching mechanism used by the repository.</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using an object. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This method instructs the library to close an existing\n object; note that git_objects are owned and cached by the repository\n so the object may or may not be freed after this library call,\n depending on how aggressive is the caching mechanism used\n by the repository.</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop using\n an object. Failure to do so will cause a memory leak.</p>\n",
       "group": "object",
       "examples": {
         "blame.c": [
@@ -10557,7 +11259,7 @@
           "ex/HEAD/log.html#git_object_free-39"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_object_free-22"
+          "ex/HEAD/merge.html#git_object_free-20"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_object_free-9",
@@ -10574,7 +11276,7 @@
     },
     "git_object_type2string": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 169,
       "lineto": 169,
       "args": [
@@ -10591,7 +11293,7 @@
         "comment": " the corresponding string representation."
       },
       "description": "<p>Convert an object type to its string representation.</p>\n",
-      "comments": "<p>The result is a pointer to a string in static memory and should not be free()&#39;ed.</p>\n",
+      "comments": "<p>The result is a pointer to a string in static memory and\n should not be free()&#39;ed.</p>\n",
       "group": "object",
       "examples": {
         "cat-file.c": [
@@ -10608,7 +11310,7 @@
     },
     "git_object_string2type": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 177,
       "lineto": 177,
       "args": [
@@ -10630,7 +11332,7 @@
     },
     "git_object_typeisloose": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 186,
       "lineto": 186,
       "args": [
@@ -10652,7 +11354,7 @@
     },
     "git_object__size": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 200,
       "lineto": 200,
       "args": [
@@ -10669,12 +11371,12 @@
         "comment": " size in bytes of the object"
       },
       "description": "<p>Get the size in bytes for the structure which\n acts as an in-memory representation of any given\n object type.</p>\n",
-      "comments": "<p>For all the core types, this would the equivalent of calling <code>sizeof(git_commit)</code> if the core types were not opaque on the external API.</p>\n",
+      "comments": "<p>For all the core types, this would the equivalent\n of calling <code>sizeof(git_commit)</code> if the core types\n were not opaque on the external API.</p>\n",
       "group": "object"
     },
     "git_object_peel": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 225,
       "lineto": 228,
       "args": [
@@ -10701,12 +11403,12 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC, GIT_EPEEL, or an error code"
       },
       "description": "<p>Recursively peel an object until an object of the specified type is met.</p>\n",
-      "comments": "<p>If the query cannot be satisfied due to the object model, GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a tree).</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object will be peeled until the type changes. A tag will be peeled until the referenced object is no longer a tag, and a commit will be peeled to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to the target type due to the object model, GIT_EPEEL will be returned.</p>\n\n<p>You must free the returned object.</p>\n",
+      "comments": "<p>If the query cannot be satisfied due to the object model,\n GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a\n tree).</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object will\n be peeled until the type changes. A tag will be peeled until the\n referenced object is no longer a tag, and a commit will be peeled\n to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to\n the target type due to the object model, GIT_EPEEL will be\n returned.</p>\n\n<p>You must free the returned object.</p>\n",
       "group": "object"
     },
     "git_object_dup": {
       "type": "function",
-      "file": "object.h",
+      "file": "git2/object.h",
       "line": 237,
       "lineto": 237,
       "args": [
@@ -10733,7 +11435,7 @@
     },
     "git_odb_new": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 39,
       "lineto": 39,
       "args": [
@@ -10750,12 +11452,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new object database with no backends.</p>\n",
-      "comments": "<p>Before the ODB can be used for read/writing, a custom database backend must be manually added using <code>git_odb_add_backend()</code></p>\n",
+      "comments": "<p>Before the ODB can be used for read/writing, a custom database\n backend must be manually added using <code>git_odb_add_backend()</code></p>\n",
       "group": "odb"
     },
     "git_odb_open": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 57,
       "lineto": 57,
       "args": [
@@ -10777,12 +11479,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new object database and automatically add\n the two default backends:</p>\n",
-      "comments": "<pre><code>- git_odb_backend_loose: read and write loose object files      from disk, assuming `objects_dir` as the Objects folder\n\n- git_odb_backend_pack: read objects from packfiles,        assuming `objects_dir` as the Objects folder which      contains a &#39;pack/&#39; folder with the corresponding data\n</code></pre>\n",
+      "comments": "<pre><code>- git_odb_backend_loose: read and write loose object files\n    from disk, assuming `objects_dir` as the Objects folder\n\n- git_odb_backend_pack: read objects from packfiles,\n    assuming `objects_dir` as the Objects folder which\n    contains a &#39;pack/&#39; folder with the corresponding data\n</code></pre>\n",
       "group": "odb"
     },
     "git_odb_add_disk_alternate": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 74,
       "lineto": 74,
       "args": [
@@ -10804,12 +11506,12 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add an on-disk alternate to an existing Object DB.</p>\n",
-      "comments": "<p>Note that the added path must point to an <code>objects</code>, not to a full repository, to use it as an alternate store.</p>\n\n<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n",
+      "comments": "<p>Note that the added path must point to an <code>objects</code>, not\n to a full repository, to use it as an alternate store.</p>\n\n<p>Alternate backends are always checked for objects <em>after</em>\n all the main backends have been exhausted.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n",
       "group": "odb"
     },
     "git_odb_free": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 81,
       "lineto": 81,
       "args": [
@@ -10839,7 +11541,7 @@
     },
     "git_odb_read": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 100,
       "lineto": 100,
       "args": [
@@ -10866,7 +11568,7 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database."
       },
       "description": "<p>Read an object from the database.</p>\n",
-      "comments": "<p>This method queries all available ODB backends trying to read the given OID.</p>\n\n<p>The returned object is reference counted and internally cached, so it should be closed by the user once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This method queries all available ODB backends\n trying to read the given OID.</p>\n\n<p>The returned object is reference counted and\n internally cached, so it should be closed\n by the user once it&#39;s no longer in use.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
@@ -10879,7 +11581,7 @@
     },
     "git_odb_read_prefix": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 129,
       "lineto": 129,
       "args": [
@@ -10911,12 +11613,12 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database.\n - GIT_EAMBIGUOUS if the prefix is ambiguous (several objects match the prefix)"
       },
       "description": "<p>Read an object from the database, given a prefix\n of its identifier.</p>\n",
-      "comments": "<p>This method queries all available ODB backends trying to match the &#39;len&#39; first hexadecimal characters of the &#39;short_id&#39;. The remaining (GIT_OID_HEXSZ-len)*4 bits of &#39;short_id&#39; must be 0s. &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and the prefix must be long enough to identify a unique object in all the backends; the method will fail otherwise.</p>\n\n<p>The returned object is reference counted and internally cached, so it should be closed by the user once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This method queries all available ODB backends\n trying to match the &#39;len&#39; first hexadecimal\n characters of the &#39;short_id&#39;.\n The remaining (GIT_OID_HEXSZ-len)*4 bits of\n &#39;short_id&#39; must be 0s.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN,\n and the prefix must be long enough to identify\n a unique object in all the backends; the\n method will fail otherwise.</p>\n\n<p>The returned object is reference counted and\n internally cached, so it should be closed\n by the user once it&#39;s no longer in use.</p>\n",
       "group": "odb"
     },
     "git_odb_read_header": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 149,
       "lineto": 149,
       "args": [
@@ -10948,12 +11650,12 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database."
       },
       "description": "<p>Read the header of an object from the database, without\n reading its full contents.</p>\n",
-      "comments": "<p>The header includes the length and the type of an object.</p>\n\n<p>Note that most backends do not support reading only the header of an object, so the whole object will be read and then the header will be returned.</p>\n",
+      "comments": "<p>The header includes the length and the type of an object.</p>\n\n<p>Note that most backends do not support reading only the header\n of an object, so the whole object will be read and then the\n header will be returned.</p>\n",
       "group": "odb"
     },
     "git_odb_exists": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 160,
       "lineto": 160,
       "args": [
@@ -10980,7 +11682,7 @@
     },
     "git_odb_exists_prefix": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 173,
       "lineto": 174,
       "args": [
@@ -11017,7 +11719,7 @@
     },
     "git_odb_expand_ids": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 215,
       "lineto": 218,
       "args": [
@@ -11044,12 +11746,12 @@
         "comment": " 0 on success or an error code on failure"
       },
       "description": "<p>Determine if one or more objects can be found in the object database\n by their abbreviated object ID and type.  The given array will be\n updated in place:  for each abbreviated ID that is unique in the\n database, and of the given type (if specified), the full object ID,\n object ID length (<code>GIT_OID_HEXSZ</code>) and type will be written back to\n the array.  For IDs that are not found (or are ambiguous), the\n array entry will be zeroed.</p>\n",
-      "comments": "<p>Note that since this function operates on multiple objects, the underlying database will not be asked to be reloaded if an object is not found (which is unlike other object database operations.)</p>\n",
+      "comments": "<p>Note that since this function operates on multiple objects, the\n underlying database will not be asked to be reloaded if an object is\n not found (which is unlike other object database operations.)</p>\n",
       "group": "odb"
     },
     "git_odb_refresh": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 238,
       "lineto": 238,
       "args": [
@@ -11066,12 +11768,12 @@
         "comment": " 0 on success, error code otherwise"
       },
       "description": "<p>Refresh the object database to load newly added files.</p>\n",
-      "comments": "<p>If the object databases have changed on disk while the library is running, this function will force a reload of the underlying indexes.</p>\n\n<p>Use this function when you&#39;re confident that an external application has tampered with the ODB.</p>\n\n<p>NOTE that it is not necessary to call this function at all. The library will automatically attempt to refresh the ODB when a lookup fails, to see if the looked up object exists on disk but hasn&#39;t been loaded yet.</p>\n",
+      "comments": "<p>If the object databases have changed on disk while the library\n is running, this function will force a reload of the underlying\n indexes.</p>\n\n<p>Use this function when you&#39;re confident that an external\n application has tampered with the ODB.</p>\n\n<p>NOTE that it is not necessary to call this function at all. The\n library will automatically attempt to refresh the ODB\n when a lookup fails, to see if the looked up object exists\n on disk but hasn&#39;t been loaded yet.</p>\n",
       "group": "odb"
     },
     "git_odb_foreach": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 253,
       "lineto": 253,
       "args": [
@@ -11098,12 +11800,12 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>List all objects available in the database</p>\n",
-      "comments": "<p>The callback will be called for each object available in the database. Note that the objects are likely to be returned in the index order, which would make accessing the objects in that order inefficient. Return a non-zero value from the callback to stop looping.</p>\n",
+      "comments": "<p>The callback will be called for each object available in the\n database. Note that the objects are likely to be returned in the index\n order, which would make accessing the objects in that order inefficient.\n Return a non-zero value from the callback to stop looping.</p>\n",
       "group": "odb"
     },
     "git_odb_write": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 273,
       "lineto": 273,
       "args": [
@@ -11140,7 +11842,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Write an object directly into the ODB</p>\n",
-      "comments": "<p>This method writes a full object straight into the ODB. For most cases, it is preferred to write objects through a write stream, which is both faster and less memory intensive, specially for big objects.</p>\n\n<p>This method is provided for compatibility with custom backends which are not able to support streaming writes</p>\n",
+      "comments": "<p>This method writes a full object straight into the ODB.\n For most cases, it is preferred to write objects through a write\n stream, which is both faster and less memory intensive, specially\n for big objects.</p>\n\n<p>This method is provided for compatibility with custom backends\n which are not able to support streaming writes</p>\n",
       "group": "odb",
       "examples": {
         "general.c": [
@@ -11150,7 +11852,7 @@
     },
     "git_odb_open_wstream": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 296,
       "lineto": 296,
       "args": [
@@ -11182,12 +11884,12 @@
         "comment": " 0 if the stream was created; error code otherwise"
       },
       "description": "<p>Open a stream to write an object into the ODB</p>\n",
-      "comments": "<p>The type and final length of the object must be specified when opening the stream.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_WRONLY</code>, and it won&#39;t be effective until <code>git_odb_stream_finalize_write</code> is called and returns without an error</p>\n\n<p>The stream must always be freed when done with <code>git_odb_stream_free</code> or will leak memory.</p>\n",
+      "comments": "<p>The type and final length of the object must be specified\n when opening the stream.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_WRONLY</code>, and it\n won&#39;t be effective until <code>git_odb_stream_finalize_write</code> is called\n and returns without an error</p>\n\n<p>The stream must always be freed when done with <code>git_odb_stream_free</code> or\n will leak memory.</p>\n",
       "group": "odb"
     },
     "git_odb_stream_write": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 309,
       "lineto": 309,
       "args": [
@@ -11214,12 +11916,12 @@
         "comment": " 0 if the write succeeded; error code otherwise"
       },
       "description": "<p>Write to an odb stream</p>\n",
-      "comments": "<p>This method will fail if the total number of received bytes exceeds the size declared with <code>git_odb_open_wstream()</code></p>\n",
+      "comments": "<p>This method will fail if the total number of received bytes exceeds the\n size declared with <code>git_odb_open_wstream()</code></p>\n",
       "group": "odb"
     },
     "git_odb_stream_finalize_write": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 324,
       "lineto": 324,
       "args": [
@@ -11241,12 +11943,12 @@
         "comment": " 0 on success; an error code otherwise"
       },
       "description": "<p>Finish writing to an odb stream</p>\n",
-      "comments": "<p>The object will take its final name and will be available to the odb.</p>\n\n<p>This method will fail if the total number of received bytes differs from the size declared with <code>git_odb_open_wstream()</code></p>\n",
+      "comments": "<p>The object will take its final name and will be available to the\n odb.</p>\n\n<p>This method will fail if the total number of received bytes\n differs from the size declared with <code>git_odb_open_wstream()</code></p>\n",
       "group": "odb"
     },
     "git_odb_stream_read": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 331,
       "lineto": 331,
       "args": [
@@ -11278,7 +11980,7 @@
     },
     "git_odb_stream_free": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 338,
       "lineto": 338,
       "args": [
@@ -11300,7 +12002,7 @@
     },
     "git_odb_open_rstream": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 366,
       "lineto": 371,
       "args": [
@@ -11337,12 +12039,12 @@
         "comment": " 0 if the stream was created; error code otherwise"
       },
       "description": "<p>Open a stream to read an object from the ODB</p>\n",
-      "comments": "<p>Note that most backends do <em>not</em> support streaming reads because they store their objects as compressed/delta&#39;ed blobs.</p>\n\n<p>It&#39;s recommended to use <code>git_odb_read</code> instead, which is assured to work on all backends.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_RDONLY</code> and will have the following methods:</p>\n\n<pre><code>    - stream-&gt;read: read `n` bytes from the stream      - stream-&gt;free: free the stream\n</code></pre>\n\n<p>The stream must always be free&#39;d or will leak memory.</p>\n",
+      "comments": "<p>Note that most backends do <em>not</em> support streaming reads\n because they store their objects as compressed/delta&#39;ed blobs.</p>\n\n<p>It&#39;s recommended to use <code>git_odb_read</code> instead, which is\n assured to work on all backends.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_RDONLY</code> and\n will have the following methods:</p>\n\n<pre><code>    - stream-&gt;read: read `n` bytes from the stream\n    - stream-&gt;free: free the stream\n</code></pre>\n\n<p>The stream must always be free&#39;d or will leak memory.</p>\n",
       "group": "odb"
     },
     "git_odb_write_pack": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 391,
       "lineto": 395,
       "args": [
@@ -11374,12 +12076,12 @@
         "comment": null
       },
       "description": "<p>Open a stream for writing a pack file to the ODB.</p>\n",
-      "comments": "<p>If the ODB layer understands pack files, then the given packfile will likely be streamed directly to disk (and a corresponding index created).  If the ODB layer does not understand pack files, the objects will be stored in whatever format the ODB layer uses.</p>\n",
+      "comments": "<p>If the ODB layer understands pack files, then the given\n packfile will likely be streamed directly to disk (and a\n corresponding index created).  If the ODB layer does not\n understand pack files, the objects will be stored in whatever\n format the ODB layer uses.</p>\n",
       "group": "odb"
     },
     "git_odb_hash": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 409,
       "lineto": 409,
       "args": [
@@ -11411,12 +12113,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Determine the object-ID (sha1 hash) of a data buffer</p>\n",
-      "comments": "<p>The resulting SHA-1 OID will be the identifier for the data buffer as if the data buffer it were to written to the ODB.</p>\n",
+      "comments": "<p>The resulting SHA-1 OID will be the identifier for the data\n buffer as if the data buffer it were to written to the ODB.</p>\n",
       "group": "odb"
     },
     "git_odb_hashfile": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 424,
       "lineto": 424,
       "args": [
@@ -11448,7 +12150,7 @@
     },
     "git_odb_object_dup": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 438,
       "lineto": 438,
       "args": [
@@ -11470,12 +12172,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a copy of an odb_object</p>\n",
-      "comments": "<p>The returned copy must be manually freed with <code>git_odb_object_free</code>. Note that because of an implementation detail, the returned copy will be the same pointer as <code>source</code>: the object is internally refcounted, so the copy still needs to be freed twice.</p>\n",
+      "comments": "<p>The returned copy must be manually freed with <code>git_odb_object_free</code>.\n Note that because of an implementation detail, the returned copy will be\n the same pointer as <code>source</code>: the object is internally refcounted, so the\n copy still needs to be freed twice.</p>\n",
       "group": "odb"
     },
     "git_odb_object_free": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 448,
       "lineto": 448,
       "args": [
@@ -11492,7 +12194,7 @@
         "comment": null
       },
       "description": "<p>Close an ODB object</p>\n",
-      "comments": "<p>This method must always be called once a <code>git_odb_object</code> is no longer needed, otherwise memory will leak.</p>\n",
+      "comments": "<p>This method must always be called once a <code>git_odb_object</code> is no\n longer needed, otherwise memory will leak.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
@@ -11505,7 +12207,7 @@
     },
     "git_odb_object_id": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 458,
       "lineto": 458,
       "args": [
@@ -11527,7 +12229,7 @@
     },
     "git_odb_object_data": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 471,
       "lineto": 471,
       "args": [
@@ -11544,7 +12246,7 @@
         "comment": " a pointer to the data"
       },
       "description": "<p>Return the data of an ODB object</p>\n",
-      "comments": "<p>This is the uncompressed, raw data as read from the ODB, without the leading header.</p>\n\n<p>This pointer is owned by the object and shall not be free&#39;d.</p>\n",
+      "comments": "<p>This is the uncompressed, raw data as read from the ODB,\n without the leading header.</p>\n\n<p>This pointer is owned by the object and shall not be free&#39;d.</p>\n",
       "group": "odb",
       "examples": {
         "general.c": [
@@ -11554,7 +12256,7 @@
     },
     "git_odb_object_size": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 482,
       "lineto": 482,
       "args": [
@@ -11571,7 +12273,7 @@
         "comment": " the size"
       },
       "description": "<p>Return the size of an ODB object</p>\n",
-      "comments": "<p>This is the real size of the <code>data</code> buffer, not the actual size of the object.</p>\n",
+      "comments": "<p>This is the real size of the <code>data</code> buffer, not the\n actual size of the object.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
@@ -11584,7 +12286,7 @@
     },
     "git_odb_object_type": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 490,
       "lineto": 490,
       "args": [
@@ -11611,7 +12313,7 @@
     },
     "git_odb_add_backend": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 505,
       "lineto": 505,
       "args": [
@@ -11638,12 +12340,12 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB</p>\n",
-      "comments": "<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
+      "comments": "<p>The backends are checked in relative ordering, based on the\n value of the <code>priority</code> parameter.</p>\n\n<p>Read \n<sys\n/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_add_alternate": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 526,
       "lineto": 526,
       "args": [
@@ -11670,12 +12372,12 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB; this\n backend will work as an alternate.</p>\n",
-      "comments": "<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
+      "comments": "<p>Alternate backends are always checked for objects <em>after</em>\n all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the\n value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read \n<sys\n/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_num_backends": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 534,
       "lineto": 534,
       "args": [
@@ -11697,7 +12399,7 @@
     },
     "git_odb_get_backend": {
       "type": "function",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 544,
       "lineto": 544,
       "args": [
@@ -11729,7 +12431,7 @@
     },
     "git_odb_backend_pack": {
       "type": "function",
-      "file": "odb_backend.h",
+      "file": "git2/odb_backend.h",
       "line": 34,
       "lineto": 34,
       "args": [
@@ -11756,7 +12458,7 @@
     },
     "git_odb_backend_loose": {
       "type": "function",
-      "file": "odb_backend.h",
+      "file": "git2/odb_backend.h",
       "line": 48,
       "lineto": 54,
       "args": [
@@ -11803,7 +12505,7 @@
     },
     "git_odb_backend_one_pack": {
       "type": "function",
-      "file": "odb_backend.h",
+      "file": "git2/odb_backend.h",
       "line": 67,
       "lineto": 67,
       "args": [
@@ -11825,12 +12527,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a backend out of a single packfile</p>\n",
-      "comments": "<p>This can be useful for inspecting the contents of a single packfile.</p>\n",
+      "comments": "<p>This can be useful for inspecting the contents of a single\n packfile.</p>\n",
       "group": "odb"
     },
     "git_oid_fromstr": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 47,
       "lineto": 47,
       "args": [
@@ -11864,15 +12566,12 @@
           "ex/HEAD/general.html#git_oid_fromstr-53",
           "ex/HEAD/general.html#git_oid_fromstr-54",
           "ex/HEAD/general.html#git_oid_fromstr-55"
-        ],
-        "merge.c": [
-          "ex/HEAD/merge.html#git_oid_fromstr-23"
         ]
       }
     },
     "git_oid_fromstrp": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 56,
       "lineto": 56,
       "args": [
@@ -11899,7 +12598,7 @@
     },
     "git_oid_fromstrn": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 69,
       "lineto": 69,
       "args": [
@@ -11926,12 +12625,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Parse N characters of a hex formatted object id into a git_oid.</p>\n",
-      "comments": "<p>If N is odd, the last byte&#39;s high nibble will be read in and the low nibble set to zero.</p>\n",
+      "comments": "<p>If N is odd, the last byte&#39;s high nibble will be read in and the\n low nibble set to zero.</p>\n",
       "group": "oid"
     },
     "git_oid_fromraw": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 77,
       "lineto": 77,
       "args": [
@@ -11958,7 +12657,7 @@
     },
     "git_oid_fmt": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 89,
       "lineto": 89,
       "args": [
@@ -11995,9 +12694,6 @@
           "ex/HEAD/network/fetch.html#git_oid_fmt-1",
           "ex/HEAD/network/fetch.html#git_oid_fmt-2"
         ],
-        "network/index-pack.c": [
-          "ex/HEAD/network/index-pack.html#git_oid_fmt-6"
-        ],
         "network/ls-remote.c": [
           "ex/HEAD/network/ls-remote.html#git_oid_fmt-1"
         ]
@@ -12005,7 +12701,7 @@
     },
     "git_oid_nfmt": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 100,
       "lineto": 100,
       "args": [
@@ -12037,7 +12733,7 @@
     },
     "git_oid_pathfmt": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 115,
       "lineto": 115,
       "args": [
@@ -12059,12 +12755,12 @@
         "comment": null
       },
       "description": "<p>Format a git_oid into a loose-object path string.</p>\n",
-      "comments": "<p>The resulting string is &quot;aa/...&quot;, where &quot;aa&quot; is the first two hex digits of the oid and &quot;...&quot; is the remaining 38 digits.</p>\n",
+      "comments": "<p>The resulting string is &quot;aa/...&quot;, where &quot;aa&quot; is the first two\n hex digits of the oid and &quot;...&quot; is the remaining 38 digits.</p>\n",
       "group": "oid"
     },
     "git_oid_tostr_s": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 128,
       "lineto": 128,
       "args": [
@@ -12081,18 +12777,18 @@
         "comment": " the c-string"
       },
       "description": "<p>Format a git_oid into a statically allocated c-string.</p>\n",
-      "comments": "<p>The c-string is owned by the library and should not be freed by the user. If libgit2 is built with thread support, the string will be stored in TLS (i.e. one buffer per thread) to allow for concurrent calls of the function.</p>\n",
+      "comments": "<p>The c-string is owned by the library and should not be freed\n by the user. If libgit2 is built with thread support, the string\n will be stored in TLS (i.e. one buffer per thread) to allow for\n concurrent calls of the function.</p>\n",
       "group": "oid",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_oid_tostr_s-24",
-          "ex/HEAD/merge.html#git_oid_tostr_s-25"
+          "ex/HEAD/merge.html#git_oid_tostr_s-21",
+          "ex/HEAD/merge.html#git_oid_tostr_s-22"
         ]
       }
     },
     "git_oid_tostr": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 147,
       "lineto": 147,
       "args": [
@@ -12119,7 +12815,7 @@
         "comment": " the out buffer pointer, assuming no input parameter\n\t\t\terrors, otherwise a pointer to an empty string."
       },
       "description": "<p>Format a git_oid into a buffer as a hex format c-string.</p>\n",
-      "comments": "<p>If the buffer is smaller than GIT_OID_HEXSZ+1, then the resulting oid c-string will be truncated to n-1 characters (but will still be NUL-byte terminated).</p>\n\n<p>If there are any input parameter errors (out == NULL, n == 0, oid == NULL), then a pointer to an empty string is returned, so that the return value can always be printed.</p>\n",
+      "comments": "<p>If the buffer is smaller than GIT_OID_HEXSZ+1, then the resulting\n oid c-string will be truncated to n-1 characters (but will still be\n NUL-byte terminated).</p>\n\n<p>If there are any input parameter errors (out == NULL, n == 0, oid ==\n NULL), then a pointer to an empty string is returned, so that the\n return value can always be printed.</p>\n",
       "group": "oid",
       "examples": {
         "blame.c": [
@@ -12147,7 +12843,7 @@
     },
     "git_oid_cpy": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 155,
       "lineto": 155,
       "args": [
@@ -12181,7 +12877,7 @@
     },
     "git_oid_cmp": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 164,
       "lineto": 164,
       "args": [
@@ -12208,7 +12904,7 @@
     },
     "git_oid_equal": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 173,
       "lineto": 173,
       "args": [
@@ -12235,7 +12931,7 @@
     },
     "git_oid_ncmp": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 184,
       "lineto": 184,
       "args": [
@@ -12267,7 +12963,7 @@
     },
     "git_oid_streq": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 193,
       "lineto": 193,
       "args": [
@@ -12294,7 +12990,7 @@
     },
     "git_oid_strcmp": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 203,
       "lineto": 203,
       "args": [
@@ -12321,7 +13017,7 @@
     },
     "git_oid_iszero": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 210,
       "lineto": 210,
       "args": [
@@ -12351,7 +13047,7 @@
     },
     "git_oid_shorten_new": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 231,
       "lineto": 231,
       "args": [
@@ -12368,12 +13064,12 @@
         "comment": " a `git_oid_shorten` instance, NULL if OOM"
       },
       "description": "<p>Create a new OID shortener.</p>\n",
-      "comments": "<p>The OID shortener is used to process a list of OIDs in text form and return the shortest length that would uniquely identify all of them.</p>\n\n<p>E.g. look at the result of <code>git log --abbrev</code>.</p>\n",
+      "comments": "<p>The OID shortener is used to process a list of OIDs\n in text form and return the shortest length that would\n uniquely identify all of them.</p>\n\n<p>E.g. look at the result of <code>git log --abbrev</code>.</p>\n",
       "group": "oid"
     },
     "git_oid_shorten_add": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 257,
       "lineto": 257,
       "args": [
@@ -12395,12 +13091,12 @@
         "comment": " the minimal length to uniquely identify all OIDs\n\t\tadded so far to the set; or an error code (\n<\n0) if an\n\t\terror occurs."
       },
       "description": "<p>Add a new OID to set of shortened OIDs and calculate\n the minimal length to uniquely identify all the OIDs in\n the set.</p>\n",
-      "comments": "<p>The OID is expected to be a 40-char hexadecimal string. The OID is owned by the user and will not be modified or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many OIDs can be added to a single set (around ~32000, assuming a mostly randomized distribution), which should be enough for any kind of program, and keeps the algorithm fast and memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a GITERR_INVALID error</p>\n",
+      "comments": "<p>The OID is expected to be a 40-char hexadecimal string.\n The OID is owned by the user and will not be modified\n or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many\n OIDs can be added to a single set (around ~32000, assuming\n a mostly randomized distribution), which should be enough\n for any kind of program, and keeps the algorithm fast and\n memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a\n GITERR_INVALID error</p>\n",
       "group": "oid"
     },
     "git_oid_shorten_free": {
       "type": "function",
-      "file": "oid.h",
+      "file": "git2/oid.h",
       "line": 264,
       "lineto": 264,
       "args": [
@@ -12422,7 +13118,7 @@
     },
     "git_oidarray_free": {
       "type": "function",
-      "file": "oidarray.h",
+      "file": "git2/oidarray.h",
       "line": 34,
       "lineto": 34,
       "args": [
@@ -12439,12 +13135,12 @@
         "comment": null
       },
       "description": "<p>Free the OID array</p>\n",
-      "comments": "<p>This method must (and must only) be called on <code>git_oidarray</code> objects where the array is allocated by the library. Not doing so, will result in a memory leak.</p>\n\n<p>This does not free the <code>git_oidarray</code> itself, since the library will never allocate that object directly itself (it is more commonly embedded inside another struct or created on the stack).</p>\n",
+      "comments": "<p>This method must (and must only) be called on <code>git_oidarray</code>\n objects where the array is allocated by the library. Not doing so,\n will result in a memory leak.</p>\n\n<p>This does not free the <code>git_oidarray</code> itself, since the library will\n never allocate that object directly itself (it is more commonly embedded\n inside another struct or created on the stack).</p>\n",
       "group": "oidarray"
     },
     "git_packbuilder_new": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 64,
       "lineto": 64,
       "args": [
@@ -12471,7 +13167,7 @@
     },
     "git_packbuilder_set_threads": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 77,
       "lineto": 77,
       "args": [
@@ -12493,12 +13189,12 @@
         "comment": " number of actual threads to be used"
       },
       "description": "<p>Set number of threads to spawn</p>\n",
-      "comments": "<p>By default, libgit2 won&#39;t spawn any threads at all; when set to 0, libgit2 will autodetect the number of CPUs.</p>\n",
+      "comments": "<p>By default, libgit2 won&#39;t spawn any threads at all;\n when set to 0, libgit2 will autodetect the number of\n CPUs.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 91,
       "lineto": 91,
       "args": [
@@ -12525,12 +13221,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Insert a single object</p>\n",
-      "comments": "<p>For an optimal pack it&#39;s mandatory to insert objects in recency order, commits followed by trees and blobs.</p>\n",
+      "comments": "<p>For an optimal pack it&#39;s mandatory to insert objects in recency order,\n commits followed by trees and blobs.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert_tree": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 103,
       "lineto": 103,
       "args": [
@@ -12557,7 +13253,7 @@
     },
     "git_packbuilder_insert_commit": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 115,
       "lineto": 115,
       "args": [
@@ -12584,7 +13280,7 @@
     },
     "git_packbuilder_insert_walk": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 128,
       "lineto": 128,
       "args": [
@@ -12606,12 +13302,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Insert objects as given by the walk</p>\n",
-      "comments": "<p>Those commits and all objects they reference will be inserted into the packbuilder.</p>\n",
+      "comments": "<p>Those commits and all objects they reference will be inserted into\n the packbuilder.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert_recur": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 140,
       "lineto": 140,
       "args": [
@@ -12641,9 +13337,36 @@
       "comments": "<p>Insert the object as well as any object it references.</p>\n",
       "group": "packbuilder"
     },
+    "git_packbuilder_write_buf": {
+      "type": "function",
+      "file": "git2/pack.h",
+      "line": 151,
+      "lineto": 151,
+      "args": [
+        {
+          "name": "buf",
+          "type": "git_buf *",
+          "comment": "Buffer where to write the packfile"
+        },
+        {
+          "name": "pb",
+          "type": "git_packbuilder *",
+          "comment": "The packbuilder"
+        }
+      ],
+      "argline": "git_buf *buf, git_packbuilder *pb",
+      "sig": "git_buf *::git_packbuilder *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Write the contents of the packfile to an in-memory buffer</p>\n",
+      "comments": "<p>The contents of the buffer will become a valid packfile, even though there\n will be no attached index</p>\n",
+      "group": "packbuilder"
+    },
     "git_packbuilder_write": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 164,
       "lineto": 169,
       "args": [
@@ -12685,7 +13408,7 @@
     },
     "git_packbuilder_hash": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 179,
       "lineto": 179,
       "args": [
@@ -12702,12 +13425,12 @@
         "comment": null
       },
       "description": "<p>Get the packfile&#39;s hash</p>\n",
-      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object names. This is only correct after the packfile has been written.</p>\n",
+      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object\n names. This is only correct after the packfile has been written.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_foreach": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 191,
       "lineto": 191,
       "args": [
@@ -12739,7 +13462,7 @@
     },
     "git_packbuilder_object_count": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 199,
       "lineto": 199,
       "args": [
@@ -12761,7 +13484,7 @@
     },
     "git_packbuilder_written": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 207,
       "lineto": 207,
       "args": [
@@ -12783,7 +13506,7 @@
     },
     "git_packbuilder_set_callbacks": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 226,
       "lineto": 229,
       "args": [
@@ -12815,7 +13538,7 @@
     },
     "git_packbuilder_free": {
       "type": "function",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 236,
       "lineto": 236,
       "args": [
@@ -12837,7 +13560,7 @@
     },
     "git_patch_from_diff": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 51,
       "lineto": 52,
       "args": [
@@ -12864,12 +13587,12 @@
         "comment": " 0 on success, other value \n<\n 0 on error"
       },
       "description": "<p>Return a patch for an entry in the diff list.</p>\n",
-      "comments": "<p>The <code>git_patch</code> is a newly created object contains the text diffs for the delta.  You have to call <code>git_patch_free()</code> when you are done with it.  You can use the patch object to loop over all the hunks and lines in the diff of the one delta.</p>\n\n<p>For an unchanged file or a binary file, no <code>git_patch</code> will be created, the output will be set to NULL, and the <code>binary</code> flag will be set true in the <code>git_diff_delta</code> structure.</p>\n\n<p>It is okay to pass NULL for either of the output parameters; if you pass NULL for the <code>git_patch</code>, then the text diff will not be calculated.</p>\n",
+      "comments": "<p>The <code>git_patch</code> is a newly created object contains the text diffs\n for the delta.  You have to call <code>git_patch_free()</code> when you are\n done with it.  You can use the patch object to loop over all the hunks\n and lines in the diff of the one delta.</p>\n\n<p>For an unchanged file or a binary file, no <code>git_patch</code> will be\n created, the output will be set to NULL, and the <code>binary</code> flag will be\n set true in the <code>git_diff_delta</code> structure.</p>\n\n<p>It is okay to pass NULL for either of the output parameters; if you pass\n NULL for the <code>git_patch</code>, then the text diff will not be calculated.</p>\n",
       "group": "patch"
     },
     "git_patch_from_blobs": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 70,
       "lineto": 76,
       "args": [
@@ -12911,12 +13634,12 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between two blobs.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_blobs()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_blobs()</code> except it generates a patch object\n for the difference instead of directly making callbacks.  You can use the\n standard <code>git_patch</code> accessor functions to read the patch data, and\n you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_from_blob_and_buffer": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 95,
       "lineto": 102,
       "args": [
@@ -12963,12 +13686,12 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between a blob and a buffer.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_blob_to_buffer()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_blob_to_buffer()</code> except it generates a patch\n object for the difference instead of directly making callbacks.  You can\n use the standard <code>git_patch</code> accessor functions to read the patch\n data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_from_buffers": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 122,
       "lineto": 130,
       "args": [
@@ -13020,12 +13743,12 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between two buffers.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_buffers()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_buffers()</code> except it generates a patch\n object for the difference instead of directly making callbacks.  You can\n use the standard <code>git_patch</code> accessor functions to read the patch\n data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_free": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 135,
       "lineto": 135,
       "args": [
@@ -13047,7 +13770,7 @@
     },
     "git_patch_get_delta": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 141,
       "lineto": 141,
       "args": [
@@ -13069,7 +13792,7 @@
     },
     "git_patch_num_hunks": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 146,
       "lineto": 146,
       "args": [
@@ -13091,7 +13814,7 @@
     },
     "git_patch_line_stats": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 164,
       "lineto": 168,
       "args": [
@@ -13123,12 +13846,12 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get line counts of each type in a patch.</p>\n",
-      "comments": "<p>This helps imitate a diff --numstat type of output.  For that purpose, you only need the <code>total_additions</code> and <code>total_deletions</code> values, but we include the <code>total_context</code> line count in case you want the total number of lines of diff output that will be generated.</p>\n\n<p>All outputs are optional. Pass NULL if you don&#39;t need a particular count.</p>\n",
+      "comments": "<p>This helps imitate a diff --numstat type of output.  For that purpose,\n you only need the <code>total_additions</code> and <code>total_deletions</code> values, but we\n include the <code>total_context</code> line count in case you want the total number\n of lines of diff output that will be generated.</p>\n\n<p>All outputs are optional. Pass NULL if you don&#39;t need a particular count.</p>\n",
       "group": "patch"
     },
     "git_patch_get_hunk": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 183,
       "lineto": 187,
       "args": [
@@ -13160,12 +13883,12 @@
         "comment": " 0 on success, GIT_ENOTFOUND if hunk_idx out of range, \n<\n0 on error"
       },
       "description": "<p>Get the information about a hunk in a patch</p>\n",
-      "comments": "<p>Given a patch and a hunk index into the patch, this returns detailed information about that hunk.  Any of the output pointers can be passed as NULL if you don&#39;t care about that particular piece of information.</p>\n",
+      "comments": "<p>Given a patch and a hunk index into the patch, this returns detailed\n information about that hunk.  Any of the output pointers can be passed\n as NULL if you don&#39;t care about that particular piece of information.</p>\n",
       "group": "patch"
     },
     "git_patch_num_lines_in_hunk": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 196,
       "lineto": 198,
       "args": [
@@ -13192,7 +13915,7 @@
     },
     "git_patch_get_line_in_hunk": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 214,
       "lineto": 218,
       "args": [
@@ -13224,12 +13947,12 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Get data about a line in a hunk of a patch.</p>\n",
-      "comments": "<p>Given a patch, a hunk index, and a line index in the hunk, this will return a lot of details about that line.  If you pass a hunk index larger than the number of hunks or a line index larger than the number of lines in the hunk, this will return -1.</p>\n",
+      "comments": "<p>Given a patch, a hunk index, and a line index in the hunk, this\n will return a lot of details about that line.  If you pass a hunk\n index larger than the number of hunks or a line index larger than\n the number of lines in the hunk, this will return -1.</p>\n",
       "group": "patch"
     },
     "git_patch_size": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 236,
       "lineto": 240,
       "args": [
@@ -13261,12 +13984,12 @@
         "comment": " The number of bytes of data"
       },
       "description": "<p>Look up size of patch diff data in bytes</p>\n",
-      "comments": "<p>This returns the raw size of the patch data.  This only includes the actual data from the lines of the diff, not the file or hunk headers.</p>\n\n<p>If you pass <code>include_context</code> as true (non-zero), this will be the size of all of the diff output; if you pass it as false (zero), this will only include the actual changed lines (as if <code>context_lines</code> was 0).</p>\n",
+      "comments": "<p>This returns the raw size of the patch data.  This only includes the\n actual data from the lines of the diff, not the file or hunk headers.</p>\n\n<p>If you pass <code>include_context</code> as true (non-zero), this will be the size\n of all of the diff output; if you pass it as false (zero), this will\n only include the actual changed lines (as if <code>context_lines</code> was 0).</p>\n",
       "group": "patch"
     },
     "git_patch_print": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 254,
       "lineto": 257,
       "args": [
@@ -13293,12 +14016,12 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Serialize the patch to text via callback.</p>\n",
-      "comments": "<p>Returning a non-zero value from the callback will terminate the iteration and return that value to the caller.</p>\n",
+      "comments": "<p>Returning a non-zero value from the callback will terminate the iteration\n and return that value to the caller.</p>\n",
       "group": "patch"
     },
     "git_patch_to_buf": {
       "type": "function",
-      "file": "patch.h",
+      "file": "git2/patch.h",
       "line": 266,
       "lineto": 268,
       "args": [
@@ -13325,7 +14048,7 @@
     },
     "git_pathspec_new": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 82,
       "lineto": 83,
       "args": [
@@ -13357,7 +14080,7 @@
     },
     "git_pathspec_free": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 90,
       "lineto": 90,
       "args": [
@@ -13384,7 +14107,7 @@
     },
     "git_pathspec_matches_path": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 105,
       "lineto": 106,
       "args": [
@@ -13411,12 +14134,12 @@
         "comment": " 1 is path matches spec, 0 if it does not"
       },
       "description": "<p>Try to match a path against a pathspec</p>\n",
-      "comments": "<p>Unlike most of the other pathspec matching functions, this will not fall back on the native case-sensitivity for your platform.  You must explicitly pass flags to control case sensitivity or else this will fall back on being case sensitive.</p>\n",
+      "comments": "<p>Unlike most of the other pathspec matching functions, this will not\n fall back on the native case-sensitivity for your platform.  You must\n explicitly pass flags to control case sensitivity or else this will\n fall back on being case sensitive.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_workdir": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 130,
       "lineto": 134,
       "args": [
@@ -13448,12 +14171,12 @@
         "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag was given"
       },
       "description": "<p>Match a pathspec against the working directory of a repository.</p>\n",
-      "comments": "<p>This matches the pathspec against the current files in the working directory of the repository.  It is an error to invoke this on a bare repo.  This handles git ignores (i.e. ignored files will not be considered to match the <code>pathspec</code> unless the file is tracked in the index).</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "comments": "<p>This matches the pathspec against the current files in the working\n directory of the repository.  It is an error to invoke this on a bare\n repo.  This handles git ignores (i.e. ignored files will not be\n considered to match the <code>pathspec</code> unless the file is tracked in the\n index).</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_index": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 159,
       "lineto": 163,
       "args": [
@@ -13485,12 +14208,12 @@
         "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
       "description": "<p>Match a pathspec against entries in an index.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the repository index.</p>\n\n<p>NOTE: At the moment, the case sensitivity of this match is controlled by the current case-sensitivity of the index object itself and the USE_CASE and IGNORE_CASE flags will have no effect.  This behavior will be corrected in a future release.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the repository index.</p>\n\n<p>NOTE: At the moment, the case sensitivity of this match is controlled\n by the current case-sensitivity of the index object itself and the\n USE_CASE and IGNORE_CASE flags will have no effect.  This behavior will\n be corrected in a future release.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_tree": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 183,
       "lineto": 187,
       "args": [
@@ -13522,7 +14245,7 @@
         "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
       "description": "<p>Match a pathspec against files in a tree.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the given tree.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the given tree.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec",
       "examples": {
         "log.c": [
@@ -13532,7 +14255,7 @@
     },
     "git_pathspec_match_diff": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 207,
       "lineto": 211,
       "args": [
@@ -13564,12 +14287,12 @@
         "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
       "description": "<p>Match a pathspec against files in a diff list.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the given diff list.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the given diff list.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_free": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 218,
       "lineto": 218,
       "args": [
@@ -13591,7 +14314,7 @@
     },
     "git_pathspec_match_list_entrycount": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 226,
       "lineto": 227,
       "args": [
@@ -13613,7 +14336,7 @@
     },
     "git_pathspec_match_list_entry": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 239,
       "lineto": 240,
       "args": [
@@ -13635,12 +14358,12 @@
         "comment": " The filename of the match"
       },
       "description": "<p>Get a matching filename by position.</p>\n",
-      "comments": "<p>This routine cannot be used if the match list was generated by <code>git_pathspec_match_diff</code>.  If so, it will always return NULL.</p>\n",
+      "comments": "<p>This routine cannot be used if the match list was generated by\n <code>git_pathspec_match_diff</code>.  If so, it will always return NULL.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_diff_entry": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 252,
       "lineto": 253,
       "args": [
@@ -13662,12 +14385,12 @@
         "comment": " The filename of the match"
       },
       "description": "<p>Get a matching diff delta by position.</p>\n",
-      "comments": "<p>This routine can only be used if the match list was generated by <code>git_pathspec_match_diff</code>.  Otherwise it will always return NULL.</p>\n",
+      "comments": "<p>This routine can only be used if the match list was generated by\n <code>git_pathspec_match_diff</code>.  Otherwise it will always return NULL.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_failed_entrycount": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 264,
       "lineto": 265,
       "args": [
@@ -13684,12 +14407,12 @@
         "comment": " Number of items in original pathspec that had no matches"
       },
       "description": "<p>Get the number of pathspec items that did not match.</p>\n",
-      "comments": "<p>This will be zero unless you passed GIT_PATHSPEC_FIND_FAILURES when generating the git_pathspec_match_list.</p>\n",
+      "comments": "<p>This will be zero unless you passed GIT_PATHSPEC_FIND_FAILURES when\n generating the git_pathspec_match_list.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_failed_entry": {
       "type": "function",
-      "file": "pathspec.h",
+      "file": "git2/pathspec.h",
       "line": 276,
       "lineto": 277,
       "args": [
@@ -13716,46 +14439,46 @@
     },
     "git_proxy_init_options": {
       "type": "function",
-      "file": "proxy.h",
-      "line": 88,
-      "lineto": 88,
+      "file": "git2/proxy.h",
+      "line": 92,
+      "lineto": 92,
       "args": [
         {
           "name": "opts",
           "type": "git_proxy_options *",
-          "comment": "the options struct to initialize"
+          "comment": "The `git_proxy_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct, use `GIT_PROXY_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_PROXY_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_proxy_options *opts, unsigned int version",
       "sig": "git_proxy_options *::unsigned int",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initialize a proxy options structure</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_proxy_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_proxy_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_PROXY_OPTIONS_INIT</code>.</p>\n",
       "group": "proxy"
     },
     "git_rebase_init_options": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 156,
-      "lineto": 158,
+      "file": "git2/rebase.h",
+      "line": 159,
+      "lineto": 161,
       "args": [
         {
           "name": "opts",
           "type": "git_rebase_options *",
-          "comment": "the `git_rebase_options` instance to initialize."
+          "comment": "The `git_rebase_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_REBASE_OPTIONS_VERSION` here."
+          "comment": "The struct version; pass `GIT_REBASE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_rebase_options *opts, unsigned int version",
@@ -13764,15 +14487,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_rebase_options</code> with default values. Equivalent to\n creating an instance with GIT_REBASE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_rebase_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_rebase_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REBASE_OPTIONS_INIT</code>.</p>\n",
       "group": "rebase"
     },
     "git_rebase_init": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 177,
-      "lineto": 183,
+      "file": "git2/rebase.h",
+      "line": 180,
+      "lineto": 186,
       "args": [
         {
           "name": "out",
@@ -13817,9 +14540,9 @@
     },
     "git_rebase_open": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 194,
-      "lineto": 197,
+      "file": "git2/rebase.h",
+      "line": 197,
+      "lineto": 200,
       "args": [
         {
           "name": "out",
@@ -13849,9 +14572,9 @@
     },
     "git_rebase_operation_entrycount": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 205,
-      "lineto": 205,
+      "file": "git2/rebase.h",
+      "line": 208,
+      "lineto": 208,
       "args": [
         {
           "name": "rebase",
@@ -13871,9 +14594,9 @@
     },
     "git_rebase_operation_current": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 216,
-      "lineto": 216,
+      "file": "git2/rebase.h",
+      "line": 219,
+      "lineto": 219,
       "args": [
         {
           "name": "rebase",
@@ -13893,9 +14616,9 @@
     },
     "git_rebase_operation_byindex": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 225,
-      "lineto": 227,
+      "file": "git2/rebase.h",
+      "line": 228,
+      "lineto": 230,
       "args": [
         {
           "name": "rebase",
@@ -13920,9 +14643,9 @@
     },
     "git_rebase_next": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 240,
-      "lineto": 242,
+      "file": "git2/rebase.h",
+      "line": 243,
+      "lineto": 245,
       "args": [
         {
           "name": "operation",
@@ -13947,9 +14670,9 @@
     },
     "git_rebase_inmemory_index": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 255,
-      "lineto": 257,
+      "file": "git2/rebase.h",
+      "line": 258,
+      "lineto": 260,
       "args": [
         {
           "name": "index",
@@ -13969,14 +14692,14 @@
         "comment": null
       },
       "description": "<p>Gets the index produced by the last operation, which is the result\n of <code>git_rebase_next</code> and which will be committed by the next\n invocation of <code>git_rebase_commit</code>.  This is useful for resolving\n conflicts in an in-memory rebase before committing them.  You must\n call <code>git_index_free</code> when you are finished with this.</p>\n",
-      "comments": "<p>This is only applicable for in-memory rebases; for rebases within a working directory, the changes were applied to the repository&#39;s index.</p>\n",
+      "comments": "<p>This is only applicable for in-memory rebases; for rebases within\n a working directory, the changes were applied to the repository&#39;s\n index.</p>\n",
       "group": "rebase"
     },
     "git_rebase_commit": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 281,
-      "lineto": 287,
+      "file": "git2/rebase.h",
+      "line": 284,
+      "lineto": 290,
       "args": [
         {
           "name": "id",
@@ -14021,9 +14744,9 @@
     },
     "git_rebase_abort": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 297,
-      "lineto": 297,
+      "file": "git2/rebase.h",
+      "line": 300,
+      "lineto": 300,
       "args": [
         {
           "name": "rebase",
@@ -14043,9 +14766,9 @@
     },
     "git_rebase_finish": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 307,
-      "lineto": 309,
+      "file": "git2/rebase.h",
+      "line": 310,
+      "lineto": 312,
       "args": [
         {
           "name": "rebase",
@@ -14070,9 +14793,9 @@
     },
     "git_rebase_free": {
       "type": "function",
-      "file": "rebase.h",
-      "line": 316,
-      "lineto": 316,
+      "file": "git2/rebase.h",
+      "line": 319,
+      "lineto": 319,
       "args": [
         {
           "name": "rebase",
@@ -14092,7 +14815,7 @@
     },
     "git_refdb_new": {
       "type": "function",
-      "file": "refdb.h",
+      "file": "git2/refdb.h",
       "line": 35,
       "lineto": 35,
       "args": [
@@ -14114,12 +14837,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new reference database with no backends.</p>\n",
-      "comments": "<p>Before the Ref DB can be used for read/writing, a custom database backend must be manually set using <code>git_refdb_set_backend()</code></p>\n",
+      "comments": "<p>Before the Ref DB can be used for read/writing, a custom database\n backend must be manually set using <code>git_refdb_set_backend()</code></p>\n",
       "group": "refdb"
     },
     "git_refdb_open": {
       "type": "function",
-      "file": "refdb.h",
+      "file": "git2/refdb.h",
       "line": 49,
       "lineto": 49,
       "args": [
@@ -14141,12 +14864,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new reference database and automatically add\n the default backends:</p>\n",
-      "comments": "<ul>\n<li>git_refdb_dir: read and write loose and packed refs      from disk, assuming the repository dir as the folder</li>\n</ul>\n",
+      "comments": "<ul>\n<li>git_refdb_dir: read and write loose and packed refs\n  from disk, assuming the repository dir as the folder</li>\n</ul>\n",
       "group": "refdb"
     },
     "git_refdb_compress": {
       "type": "function",
-      "file": "refdb.h",
+      "file": "git2/refdb.h",
       "line": 56,
       "lineto": 56,
       "args": [
@@ -14168,7 +14891,7 @@
     },
     "git_refdb_free": {
       "type": "function",
-      "file": "refdb.h",
+      "file": "git2/refdb.h",
       "line": 63,
       "lineto": 63,
       "args": [
@@ -14190,7 +14913,7 @@
     },
     "git_reflog_read": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 38,
       "lineto": 38,
       "args": [
@@ -14217,12 +14940,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Read the reflog for the given reference</p>\n",
-      "comments": "<p>If there is no reflog file for the given reference yet, an empty reflog object will be returned.</p>\n\n<p>The reflog must be freed manually by using git_reflog_free().</p>\n",
+      "comments": "<p>If there is no reflog file for the given\n reference yet, an empty reflog object will\n be returned.</p>\n\n<p>The reflog must be freed manually by using\n git_reflog_free().</p>\n",
       "group": "reflog"
     },
     "git_reflog_write": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 47,
       "lineto": 47,
       "args": [
@@ -14244,7 +14967,7 @@
     },
     "git_reflog_append": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 60,
       "lineto": 60,
       "args": [
@@ -14281,7 +15004,7 @@
     },
     "git_reflog_rename": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 75,
       "lineto": 75,
       "args": [
@@ -14308,12 +15031,12 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Rename a reflog</p>\n",
-      "comments": "<p>The reflog to be renamed is expected to already exist</p>\n\n<p>The new name will be checked for validity. See <code>git_reference_create_symbolic()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The reflog to be renamed is expected to already exist</p>\n\n<p>The new name will be checked for validity.\n See <code>git_reference_create_symbolic()</code> for rules about valid names.</p>\n",
       "group": "reflog"
     },
     "git_reflog_delete": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 84,
       "lineto": 84,
       "args": [
@@ -14340,7 +15063,7 @@
     },
     "git_reflog_entrycount": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 92,
       "lineto": 92,
       "args": [
@@ -14362,7 +15085,7 @@
     },
     "git_reflog_entry_byindex": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 105,
       "lineto": 105,
       "args": [
@@ -14384,12 +15107,12 @@
         "comment": " the entry; NULL if not found"
       },
       "description": "<p>Lookup an entry by its index</p>\n",
-      "comments": "<p>Requesting the reflog entry with an index of 0 (zero) will return the most recently created entry.</p>\n",
+      "comments": "<p>Requesting the reflog entry with an index of 0 (zero) will\n return the most recently created entry.</p>\n",
       "group": "reflog"
     },
     "git_reflog_drop": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 124,
       "lineto": 127,
       "args": [
@@ -14416,12 +15139,12 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the entry doesn't exist\n or an error code."
       },
       "description": "<p>Remove an entry from the reflog by its index</p>\n",
-      "comments": "<p>To ensure there&#39;s no gap in the log history, set <code>rewrite_previous_entry</code> param value to 1. When deleting entry <code>n</code>, member old_oid of entry <code>n-1</code> (if any) will be updated with the value of member new_oid of entry <code>n+1</code>.</p>\n",
+      "comments": "<p>To ensure there&#39;s no gap in the log history, set <code>rewrite_previous_entry</code>\n param value to 1. When deleting entry <code>n</code>, member old_oid of entry <code>n-1</code>\n (if any) will be updated with the value of member new_oid of entry <code>n+1</code>.</p>\n",
       "group": "reflog"
     },
     "git_reflog_entry_id_old": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 135,
       "lineto": 135,
       "args": [
@@ -14443,7 +15166,7 @@
     },
     "git_reflog_entry_id_new": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 143,
       "lineto": 143,
       "args": [
@@ -14465,7 +15188,7 @@
     },
     "git_reflog_entry_committer": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 151,
       "lineto": 151,
       "args": [
@@ -14487,7 +15210,7 @@
     },
     "git_reflog_entry_message": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 159,
       "lineto": 159,
       "args": [
@@ -14509,7 +15232,7 @@
     },
     "git_reflog_free": {
       "type": "function",
-      "file": "reflog.h",
+      "file": "git2/reflog.h",
       "line": 166,
       "lineto": 166,
       "args": [
@@ -14531,7 +15254,7 @@
     },
     "git_reference_lookup": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 37,
       "lineto": 37,
       "args": [
@@ -14558,20 +15281,20 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Lookup a reference by name in a repository.</p>\n",
-      "comments": "<p>The returned reference must be freed by the user.</p>\n\n<p>The name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The returned reference must be freed by the user.</p>\n\n<p>The name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
           "ex/HEAD/general.html#git_reference_lookup-62"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_lookup-26"
+          "ex/HEAD/merge.html#git_reference_lookup-23"
         ]
       }
     },
     "git_reference_name_to_id": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 54,
       "lineto": 55,
       "args": [
@@ -14598,12 +15321,12 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Lookup a reference by name and resolve immediately to OID.</p>\n",
-      "comments": "<p>This function provides a quick way to resolve a reference name straight through to the object id that it refers to.  This avoids having to allocate or free any <code>git_reference</code> objects for simple situations.</p>\n\n<p>The name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>This function provides a quick way to resolve a reference name straight\n through to the object id that it refers to.  This avoids having to\n allocate or free any <code>git_reference</code> objects for simple situations.</p>\n\n<p>The name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference"
     },
     "git_reference_dwim": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 68,
       "lineto": 68,
       "args": [
@@ -14630,18 +15353,17 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference by DWIMing its short name</p>\n",
-      "comments": "<p>Apply the git precendence rules to the given shorthand to determine which reference the user is referring to.</p>\n",
+      "comments": "<p>Apply the git precendence rules to the given shorthand to determine\n which reference the user is referring to.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_dwim-27",
-          "ex/HEAD/merge.html#git_reference_dwim-28"
+          "ex/HEAD/merge.html#git_reference_dwim-24"
         ]
       }
     },
     "git_reference_symbolic_create_matching": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 109,
       "lineto": 109,
       "args": [
@@ -14688,12 +15410,12 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC, GIT_EMODIFIED or an error code"
       },
       "description": "<p>Conditionally create a new symbolic reference.</p>\n",
-      "comments": "<p>A symbolic reference is a reference name that refers to another reference name.  If the other name moves, the symbolic name will move, too.  As a simple example, the &quot;HEAD&quot; reference might refer to &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time of updating does not match the one passed through <code>current_value</code> (i.e. if the ref has changed since the user read it).</p>\n",
+      "comments": "<p>A symbolic reference is a reference name that refers to another\n reference name.  If the other name moves, the symbolic name will move,\n too.  As a simple example, the &quot;HEAD&quot; reference might refer to\n &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time\n of updating does not match the one passed through <code>current_value</code>\n (i.e. if the ref has changed since the user read it).</p>\n",
       "group": "reference"
     },
     "git_reference_symbolic_create": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 145,
       "lineto": 145,
       "args": [
@@ -14735,12 +15457,12 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new symbolic reference.</p>\n",
-      "comments": "<p>A symbolic reference is a reference name that refers to another reference name.  If the other name moves, the symbolic name will move, too.  As a simple example, the &quot;HEAD&quot; reference might refer to &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and it does not have a reflog.</p>\n",
+      "comments": "<p>A symbolic reference is a reference name that refers to another\n reference name.  If the other name moves, the symbolic name will move,\n too.  As a simple example, the &quot;HEAD&quot; reference might refer to\n &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and it does not have a reflog.</p>\n",
       "group": "reference"
     },
     "git_reference_create": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 182,
       "lineto": 182,
       "args": [
@@ -14782,17 +15504,17 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new direct reference.</p>\n",
-      "comments": "<p>A direct reference (also called an object id reference) refers directly to a specific object id (a.k.a. OID or SHA) in the repository.  The id permanently refers to the object (although the reference itself can be moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot; refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n",
+      "comments": "<p>A direct reference (also called an object id reference) refers directly\n to a specific object id (a.k.a. OID or SHA) in the repository.  The id\n permanently refers to the object (although the reference itself can be\n moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot;\n refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_create-29"
+          "ex/HEAD/merge.html#git_reference_create-25"
         ]
       }
     },
     "git_reference_create_matching": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 225,
       "lineto": 225,
       "args": [
@@ -14839,12 +15561,12 @@
         "comment": " 0 on success, GIT_EMODIFIED if the value of the reference\n has changed, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Conditionally create new direct reference</p>\n",
-      "comments": "<p>A direct reference (also called an object id reference) refers directly to a specific object id (a.k.a. OID or SHA) in the repository.  The id permanently refers to the object (although the reference itself can be moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot; refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time of updating does not match the one passed through <code>current_id</code> (i.e. if the ref has changed since the user read it).</p>\n",
+      "comments": "<p>A direct reference (also called an object id reference) refers directly\n to a specific object id (a.k.a. OID or SHA) in the repository.  The id\n permanently refers to the object (although the reference itself can be\n moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot;\n refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time\n of updating does not match the one passed through <code>current_id</code>\n (i.e. if the ref has changed since the user read it).</p>\n",
       "group": "reference"
     },
     "git_reference_target": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 240,
       "lineto": 240,
       "args": [
@@ -14861,7 +15583,7 @@
         "comment": " a pointer to the oid if available, NULL otherwise"
       },
       "description": "<p>Get the OID pointed to by a direct reference.</p>\n",
-      "comments": "<p>Only available if the reference is direct (i.e. an object id reference, not a symbolic one).</p>\n\n<p>To find the OID of a symbolic ref, call <code>git_reference_resolve()</code> and then this function (or maybe use <code>git_reference_name_to_id()</code> to directly resolve a reference name all the way through to an OID).</p>\n",
+      "comments": "<p>Only available if the reference is direct (i.e. an object id reference,\n not a symbolic one).</p>\n\n<p>To find the OID of a symbolic ref, call <code>git_reference_resolve()</code> and\n then this function (or maybe use <code>git_reference_name_to_id()</code> to\n directly resolve a reference name all the way through to an OID).</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
@@ -14871,7 +15593,7 @@
     },
     "git_reference_target_peel": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 251,
       "lineto": 251,
       "args": [
@@ -14888,12 +15610,12 @@
         "comment": " a pointer to the oid if available, NULL otherwise"
       },
       "description": "<p>Return the peeled OID target of this reference.</p>\n",
-      "comments": "<p>This peeled OID only applies to direct references that point to a hard Tag object: it is the result of peeling such Tag.</p>\n",
+      "comments": "<p>This peeled OID only applies to direct references that point to\n a hard Tag object: it is the result of peeling such Tag.</p>\n",
       "group": "reference"
     },
     "git_reference_symbolic_target": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 261,
       "lineto": 261,
       "args": [
@@ -14917,13 +15639,13 @@
           "ex/HEAD/general.html#git_reference_symbolic_target-64"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_symbolic_target-30"
+          "ex/HEAD/merge.html#git_reference_symbolic_target-26"
         ]
       }
     },
     "git_reference_type": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 271,
       "lineto": 271,
       "args": [
@@ -14950,7 +15672,7 @@
     },
     "git_reference_name": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 281,
       "lineto": 281,
       "args": [
@@ -14971,13 +15693,13 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_name-31"
+          "ex/HEAD/merge.html#git_reference_name-27"
         ]
       }
     },
     "git_reference_resolve": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 299,
       "lineto": 299,
       "args": [
@@ -14999,12 +15721,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Resolve a symbolic reference to a direct reference.</p>\n",
-      "comments": "<p>This method iteratively peels a symbolic reference until it resolves to a direct reference to an OID.</p>\n\n<p>The peeled reference is returned in the <code>resolved_ref</code> argument, and must be freed manually once it&#39;s no longer needed.</p>\n\n<p>If a direct reference is passed as an argument, a copy of that reference is returned. This copy must be manually freed too.</p>\n",
+      "comments": "<p>This method iteratively peels a symbolic reference until it resolves to\n a direct reference to an OID.</p>\n\n<p>The peeled reference is returned in the <code>resolved_ref</code> argument, and\n must be freed manually once it&#39;s no longer needed.</p>\n\n<p>If a direct reference is passed as an argument, a copy of that\n reference is returned. This copy must be manually freed too.</p>\n",
       "group": "reference"
     },
     "git_reference_owner": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 307,
       "lineto": 307,
       "args": [
@@ -15026,7 +15748,7 @@
     },
     "git_reference_symbolic_set_target": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 329,
       "lineto": 333,
       "args": [
@@ -15058,12 +15780,12 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new reference with the same name as the given reference but a\n different symbolic target. The reference must be a symbolic reference,\n otherwise this will fail.</p>\n",
-      "comments": "<p>The new reference will be written to disk, overwriting the given reference.</p>\n\n<p>The target name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n",
+      "comments": "<p>The new reference will be written to disk, overwriting the given reference.</p>\n\n<p>The target name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n",
       "group": "reference"
     },
     "git_reference_set_target": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 349,
       "lineto": 353,
       "args": [
@@ -15099,13 +15821,13 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_set_target-32"
+          "ex/HEAD/merge.html#git_reference_set_target-28"
         ]
       }
     },
     "git_reference_rename": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 378,
       "lineto": 383,
       "args": [
@@ -15142,12 +15864,12 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>Rename an existing reference.</p>\n",
-      "comments": "<p>This method works for both direct and symbolic references.</p>\n\n<p>The new name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>If the <code>force</code> flag is not enabled, and there&#39;s already a reference with the given name, the renaming will fail.</p>\n\n<p>IMPORTANT: The user needs to write a proper reflog entry if the reflog is enabled for the repository. We only rename the reflog if it exists.</p>\n",
+      "comments": "<p>This method works for both direct and symbolic references.</p>\n\n<p>The new name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>If the <code>force</code> flag is not enabled, and there&#39;s already\n a reference with the given name, the renaming will fail.</p>\n\n<p>IMPORTANT:\n The user needs to write a proper reflog entry if the\n reflog is enabled for the repository. We only rename\n the reflog if it exists.</p>\n",
       "group": "reference"
     },
     "git_reference_delete": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 398,
       "lineto": 398,
       "args": [
@@ -15164,12 +15886,12 @@
         "comment": " 0, GIT_EMODIFIED or an error code"
       },
       "description": "<p>Delete an existing reference.</p>\n",
-      "comments": "<p>This method works for both direct and symbolic references.  The reference will be immediately removed on disk but the memory will not be freed. Callers must call <code>git_reference_free</code>.</p>\n\n<p>This function will return an error if the reference has changed from the time it was looked up.</p>\n",
+      "comments": "<p>This method works for both direct and symbolic references.  The reference\n will be immediately removed on disk but the memory will not be freed.\n Callers must call <code>git_reference_free</code>.</p>\n\n<p>This function will return an error if the reference has changed\n from the time it was looked up.</p>\n",
       "group": "reference"
     },
     "git_reference_remove": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 409,
       "lineto": 409,
       "args": [
@@ -15191,12 +15913,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Delete an existing reference by name</p>\n",
-      "comments": "<p>This method removes the named reference from the repository without looking at its old value.</p>\n",
+      "comments": "<p>This method removes the named reference from the repository without\n looking at its old value.</p>\n",
       "group": "reference"
     },
     "git_reference_list": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 423,
       "lineto": 423,
       "args": [
@@ -15218,7 +15940,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the references that can be found in a repository.</p>\n",
-      "comments": "<p>The string array will be filled with the names of all references; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free()</code>.</p>\n",
+      "comments": "<p>The string array will be filled with the names of all references; these\n values are owned by the user and should be free&#39;d manually when no\n longer needed, using <code>git_strarray_free()</code>.</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
@@ -15228,7 +15950,7 @@
     },
     "git_reference_foreach": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 444,
       "lineto": 447,
       "args": [
@@ -15255,12 +15977,12 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform a callback on each reference in the repository.</p>\n",
-      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the reference object and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n\n<p>Note that the callback function is responsible to call <code>git_reference_free</code> on each reference passed to it.</p>\n",
+      "comments": "<p>The <code>callback</code> function will be called for each reference in the\n repository, receiving the reference object and the <code>payload</code> value\n passed to this method.  Returning a non-zero value from the callback\n will terminate the iteration.</p>\n\n<p>Note that the callback function is responsible to call <code>git_reference_free</code>\n on each reference passed to it.</p>\n",
       "group": "reference"
     },
     "git_reference_foreach_name": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 462,
       "lineto": 465,
       "args": [
@@ -15287,12 +16009,12 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform a callback on the fully-qualified name of each reference.</p>\n",
-      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the name of the reference and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n",
+      "comments": "<p>The <code>callback</code> function will be called for each reference in the\n repository, receiving the name of the reference and the <code>payload</code> value\n passed to this method.  Returning a non-zero value from the callback\n will terminate the iteration.</p>\n",
       "group": "reference"
     },
     "git_reference_dup": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 476,
       "lineto": 476,
       "args": [
@@ -15319,7 +16041,7 @@
     },
     "git_reference_free": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 483,
       "lineto": 483,
       "args": [
@@ -15343,10 +16065,9 @@
           "ex/HEAD/general.html#git_reference_free-67"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_free-33",
-          "ex/HEAD/merge.html#git_reference_free-34",
-          "ex/HEAD/merge.html#git_reference_free-35",
-          "ex/HEAD/merge.html#git_reference_free-36"
+          "ex/HEAD/merge.html#git_reference_free-29",
+          "ex/HEAD/merge.html#git_reference_free-30",
+          "ex/HEAD/merge.html#git_reference_free-31"
         ],
         "status.c": [
           "ex/HEAD/status.html#git_reference_free-3"
@@ -15355,7 +16076,7 @@
     },
     "git_reference_cmp": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 492,
       "lineto": 494,
       "args": [
@@ -15382,7 +16103,7 @@
     },
     "git_reference_iterator_new": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 503,
       "lineto": 505,
       "args": [
@@ -15409,7 +16130,7 @@
     },
     "git_reference_iterator_glob_new": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 516,
       "lineto": 519,
       "args": [
@@ -15441,7 +16162,7 @@
     },
     "git_reference_next": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 528,
       "lineto": 528,
       "args": [
@@ -15468,7 +16189,7 @@
     },
     "git_reference_next_name": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 541,
       "lineto": 541,
       "args": [
@@ -15490,12 +16211,12 @@
         "comment": " 0, GIT_ITEROVER if there are no more; or an error code"
       },
       "description": "<p>Get the next reference&#39;s name</p>\n",
-      "comments": "<p>This function is provided for convenience in case only the names are interesting as it avoids the allocation of the <code>git_reference</code> object which <code>git_reference_next()</code> needs.</p>\n",
+      "comments": "<p>This function is provided for convenience in case only the names\n are interesting as it avoids the allocation of the <code>git_reference</code>\n object which <code>git_reference_next()</code> needs.</p>\n",
       "group": "reference"
     },
     "git_reference_iterator_free": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 548,
       "lineto": 548,
       "args": [
@@ -15517,7 +16238,7 @@
     },
     "git_reference_foreach_glob": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 568,
       "lineto": 572,
       "args": [
@@ -15549,12 +16270,12 @@
         "comment": " 0 on success, GIT_EUSER on non-zero callback, or error code"
       },
       "description": "<p>Perform a callback on each reference in the repository whose name\n matches the given pattern.</p>\n",
-      "comments": "<p>This function acts like <code>git_reference_foreach()</code> with an additional pattern match being applied to the reference name before issuing the callback function.  See that function for more information.</p>\n\n<p>The pattern is matched using fnmatch or &quot;glob&quot; style where a &#39;*&#39; matches any sequence of letters, a &#39;?&#39; matches any letter, and square brackets can be used to define character ranges (such as &quot;[0-9]&quot; for digits).</p>\n",
+      "comments": "<p>This function acts like <code>git_reference_foreach()</code> with an additional\n pattern match being applied to the reference name before issuing the\n callback function.  See that function for more information.</p>\n\n<p>The pattern is matched using fnmatch or &quot;glob&quot; style where a &#39;*&#39; matches\n any sequence of letters, a &#39;?&#39; matches any letter, and square brackets\n can be used to define character ranges (such as &quot;[0-9]&quot; for digits).</p>\n",
       "group": "reference"
     },
     "git_reference_has_log": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 582,
       "lineto": 582,
       "args": [
@@ -15581,7 +16302,7 @@
     },
     "git_reference_ensure_log": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 594,
       "lineto": 594,
       "args": [
@@ -15603,12 +16324,12 @@
         "comment": " 0 or an error code."
       },
       "description": "<p>Ensure there is a reflog for a particular reference.</p>\n",
-      "comments": "<p>Make sure that successive updates to the reference will append to its log.</p>\n",
+      "comments": "<p>Make sure that successive updates to the reference will append to\n its log.</p>\n",
       "group": "reference"
     },
     "git_reference_is_branch": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 604,
       "lineto": 604,
       "args": [
@@ -15630,7 +16351,7 @@
     },
     "git_reference_is_remote": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 614,
       "lineto": 614,
       "args": [
@@ -15652,7 +16373,7 @@
     },
     "git_reference_is_tag": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 624,
       "lineto": 624,
       "args": [
@@ -15674,7 +16395,7 @@
     },
     "git_reference_is_note": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 634,
       "lineto": 634,
       "args": [
@@ -15696,7 +16417,7 @@
     },
     "git_reference_normalize_name": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 690,
       "lineto": 694,
       "args": [
@@ -15728,12 +16449,12 @@
         "comment": " 0 on success, GIT_EBUFS if buffer is too small, GIT_EINVALIDSPEC\n or an error code."
       },
       "description": "<p>Normalize reference name and check validity.</p>\n",
-      "comments": "<p>This will normalize the reference name by removing any leading slash &#39;/&#39; characters and collapsing runs of adjacent slashes between name components into a single slash.</p>\n\n<p>Once normalized, if the reference name is valid, it will be returned in the user allocated buffer.</p>\n\n<p>See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>This will normalize the reference name by removing any leading slash\n &#39;/&#39; characters and collapsing runs of adjacent slashes between name\n components into a single slash.</p>\n\n<p>Once normalized, if the reference name is valid, it will be returned in\n the user allocated buffer.</p>\n\n<p>See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference"
     },
     "git_reference_peel": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 711,
       "lineto": 714,
       "args": [
@@ -15760,17 +16481,17 @@
         "comment": " 0 on success, GIT_EAMBIGUOUS, GIT_ENOTFOUND or an error code"
       },
       "description": "<p>Recursively peel reference until object of the specified type is found.</p>\n",
-      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object will be peeled until a non-tag object is met.</p>\n",
+      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object\n will be peeled until a non-tag object is met.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_peel-37"
+          "ex/HEAD/merge.html#git_reference_peel-32"
         ]
       }
     },
     "git_reference_is_valid_name": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 730,
       "lineto": 730,
       "args": [
@@ -15787,12 +16508,12 @@
         "comment": " 1 if the reference name is acceptable; 0 if it isn't"
       },
       "description": "<p>Ensure the reference name is well-formed.</p>\n",
-      "comments": "<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n",
+      "comments": "<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n",
       "group": "reference"
     },
     "git_reference_shorthand": {
       "type": "function",
-      "file": "refs.h",
+      "file": "git2/refs.h",
       "line": 744,
       "lineto": 744,
       "args": [
@@ -15809,7 +16530,7 @@
         "comment": " the human-readable version of the name"
       },
       "description": "<p>Get the reference&#39;s short name</p>\n",
-      "comments": "<p>This will transform the reference name into a name &quot;human-readable&quot; version. If no shortname is appropriate, it will return the full name.</p>\n\n<p>The memory is owned by the reference and must not be freed.</p>\n",
+      "comments": "<p>This will transform the reference name into a name &quot;human-readable&quot;\n version. If no shortname is appropriate, it will return the full\n name.</p>\n\n<p>The memory is owned by the reference and must not be freed.</p>\n",
       "group": "reference",
       "examples": {
         "status.c": [
@@ -15817,11 +16538,65 @@
         ]
       }
     },
+    "git_refspec_parse": {
+      "type": "function",
+      "file": "git2/refspec.h",
+      "line": 32,
+      "lineto": 32,
+      "args": [
+        {
+          "name": "refspec",
+          "type": "git_refspec **",
+          "comment": "a pointer to hold the refspec handle"
+        },
+        {
+          "name": "input",
+          "type": "const char *",
+          "comment": "the refspec string"
+        },
+        {
+          "name": "is_fetch",
+          "type": "int",
+          "comment": "is this a refspec for a fetch"
+        }
+      ],
+      "argline": "git_refspec **refspec, const char *input, int is_fetch",
+      "sig": "git_refspec **::const char *::int",
+      "return": {
+        "type": "int",
+        "comment": " 0 if the refspec string could be parsed, -1 otherwise"
+      },
+      "description": "<p>Parse a given refspec string</p>\n",
+      "comments": "",
+      "group": "refspec"
+    },
+    "git_refspec_free": {
+      "type": "function",
+      "file": "git2/refspec.h",
+      "line": 39,
+      "lineto": 39,
+      "args": [
+        {
+          "name": "refspec",
+          "type": "git_refspec *",
+          "comment": "the refspec object"
+        }
+      ],
+      "argline": "git_refspec *refspec",
+      "sig": "git_refspec *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free a refspec object which has been created by git_refspec_parse</p>\n",
+      "comments": "",
+      "group": "refspec"
+    },
     "git_refspec_src": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 30,
-      "lineto": 30,
+      "file": "git2/refspec.h",
+      "line": 47,
+      "lineto": 47,
       "args": [
         {
           "name": "refspec",
@@ -15841,9 +16616,9 @@
     },
     "git_refspec_dst": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 38,
-      "lineto": 38,
+      "file": "git2/refspec.h",
+      "line": 55,
+      "lineto": 55,
       "args": [
         {
           "name": "refspec",
@@ -15863,9 +16638,9 @@
     },
     "git_refspec_string": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 46,
-      "lineto": 46,
+      "file": "git2/refspec.h",
+      "line": 63,
+      "lineto": 63,
       "args": [
         {
           "name": "refspec",
@@ -15885,9 +16660,9 @@
     },
     "git_refspec_force": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 54,
-      "lineto": 54,
+      "file": "git2/refspec.h",
+      "line": 71,
+      "lineto": 71,
       "args": [
         {
           "name": "refspec",
@@ -15907,9 +16682,9 @@
     },
     "git_refspec_direction": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 62,
-      "lineto": 62,
+      "file": "git2/refspec.h",
+      "line": 79,
+      "lineto": 79,
       "args": [
         {
           "name": "spec",
@@ -15929,9 +16704,9 @@
     },
     "git_refspec_src_matches": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 71,
-      "lineto": 71,
+      "file": "git2/refspec.h",
+      "line": 88,
+      "lineto": 88,
       "args": [
         {
           "name": "refspec",
@@ -15956,9 +16731,9 @@
     },
     "git_refspec_dst_matches": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 80,
-      "lineto": 80,
+      "file": "git2/refspec.h",
+      "line": 97,
+      "lineto": 97,
       "args": [
         {
           "name": "refspec",
@@ -15983,9 +16758,9 @@
     },
     "git_refspec_transform": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 90,
-      "lineto": 90,
+      "file": "git2/refspec.h",
+      "line": 107,
+      "lineto": 107,
       "args": [
         {
           "name": "out",
@@ -16015,9 +16790,9 @@
     },
     "git_refspec_rtransform": {
       "type": "function",
-      "file": "refspec.h",
-      "line": 100,
-      "lineto": 100,
+      "file": "git2/refspec.h",
+      "line": 117,
+      "lineto": 117,
       "args": [
         {
           "name": "out",
@@ -16047,7 +16822,7 @@
     },
     "git_remote_create": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 38,
       "lineto": 42,
       "args": [
@@ -16089,7 +16864,7 @@
     },
     "git_remote_create_with_fetchspec": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 55,
       "lineto": 60,
       "args": [
@@ -16131,7 +16906,7 @@
     },
     "git_remote_create_anonymous": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 73,
       "lineto": 76,
       "args": [
@@ -16158,7 +16933,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create an anonymous remote</p>\n",
-      "comments": "<p>Create a remote with the given url in-memory. You can use this when you have a URL instead of a remote&#39;s name.</p>\n",
+      "comments": "<p>Create a remote with the given url in-memory. You can use this when\n you have a URL instead of a remote&#39;s name.</p>\n",
       "group": "remote",
       "examples": {
         "network/fetch.c": [
@@ -16171,7 +16946,7 @@
     },
     "git_remote_create_detached": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 92,
       "lineto": 94,
       "args": [
@@ -16193,12 +16968,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a remote without a connected local repo</p>\n",
-      "comments": "<p>Create a remote with the given url in-memory. You can use this when you have a URL instead of a remote&#39;s name.</p>\n\n<p>Contrasted with git_remote_create_anonymous, a detached remote will not consider any repo configuration values (such as insteadof url substitutions).</p>\n",
+      "comments": "<p>Create a remote with the given url in-memory. You can use this when\n you have a URL instead of a remote&#39;s name.</p>\n\n<p>Contrasted with git_remote_create_anonymous, a detached remote\n will not consider any repo configuration values (such as insteadof url\n substitutions).</p>\n",
       "group": "remote"
     },
     "git_remote_lookup": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 107,
       "lineto": 107,
       "args": [
@@ -16225,7 +17000,7 @@
         "comment": " 0, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Get the information for a particular remote</p>\n",
-      "comments": "<p>The name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "remote",
       "examples": {
         "network/fetch.c": [
@@ -16241,7 +17016,7 @@
     },
     "git_remote_dup": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 119,
       "lineto": 119,
       "args": [
@@ -16268,7 +17043,7 @@
     },
     "git_remote_owner": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 127,
       "lineto": 127,
       "args": [
@@ -16290,7 +17065,7 @@
     },
     "git_remote_name": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 135,
       "lineto": 135,
       "args": [
@@ -16312,7 +17087,7 @@
     },
     "git_remote_url": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 146,
       "lineto": 146,
       "args": [
@@ -16329,7 +17104,7 @@
         "comment": " a pointer to the url"
       },
       "description": "<p>Get the remote&#39;s url</p>\n",
-      "comments": "<p>If url.*.insteadOf has been configured for this URL, it will return the modified URL.</p>\n",
+      "comments": "<p>If url.*.insteadOf has been configured for this URL, it will\n return the modified URL.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -16339,7 +17114,7 @@
     },
     "git_remote_pushurl": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 157,
       "lineto": 157,
       "args": [
@@ -16356,7 +17131,7 @@
         "comment": " a pointer to the url or NULL if no special url for pushing is set"
       },
       "description": "<p>Get the remote&#39;s url for pushing</p>\n",
-      "comments": "<p>If url.*.pushInsteadOf has been configured for this URL, it will return the modified URL.</p>\n",
+      "comments": "<p>If url.*.pushInsteadOf has been configured for this URL, it\n will return the modified URL.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -16366,7 +17141,7 @@
     },
     "git_remote_set_url": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 170,
       "lineto": 170,
       "args": [
@@ -16393,7 +17168,7 @@
         "comment": " 0 or an error value"
       },
       "description": "<p>Set the remote&#39;s url in the configuration</p>\n",
-      "comments": "<p>Remote objects already in memory will not be affected. This assumes the common case of a single-url remote and will otherwise return an error.</p>\n",
+      "comments": "<p>Remote objects already in memory will not be affected. This assumes\n the common case of a single-url remote and will otherwise return an error.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -16403,7 +17178,7 @@
     },
     "git_remote_set_pushurl": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 183,
       "lineto": 183,
       "args": [
@@ -16430,7 +17205,7 @@
         "comment": null
       },
       "description": "<p>Set the remote&#39;s url for pushing in the configuration.</p>\n",
-      "comments": "<p>Remote objects already in memory will not be affected. This assumes the common case of a single-url remote and will otherwise return an error.</p>\n",
+      "comments": "<p>Remote objects already in memory will not be affected. This assumes\n the common case of a single-url remote and will otherwise return an error.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -16440,7 +17215,7 @@
     },
     "git_remote_add_fetch": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 196,
       "lineto": 196,
       "args": [
@@ -16467,12 +17242,12 @@
         "comment": " 0, GIT_EINVALIDSPEC if refspec is invalid or an error value"
       },
       "description": "<p>Add a fetch refspec to the remote&#39;s configuration</p>\n",
-      "comments": "<p>Add the given refspec to the fetch list in the configuration. No loaded remote instances will be affected.</p>\n",
+      "comments": "<p>Add the given refspec to the fetch list in the configuration. No\n loaded remote instances will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_get_fetch_refspecs": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 207,
       "lineto": 207,
       "args": [
@@ -16494,12 +17269,12 @@
         "comment": null
       },
       "description": "<p>Get the remote&#39;s list of fetch refspecs</p>\n",
-      "comments": "<p>The memory is owned by the user and should be freed with <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The memory is owned by the user and should be freed with\n <code>git_strarray_free</code>.</p>\n",
       "group": "remote"
     },
     "git_remote_add_push": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 220,
       "lineto": 220,
       "args": [
@@ -16526,12 +17301,12 @@
         "comment": " 0, GIT_EINVALIDSPEC if refspec is invalid or an error value"
       },
       "description": "<p>Add a push refspec to the remote&#39;s configuration</p>\n",
-      "comments": "<p>Add the given refspec to the push list in the configuration. No loaded remote instances will be affected.</p>\n",
+      "comments": "<p>Add the given refspec to the push list in the configuration. No\n loaded remote instances will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_get_push_refspecs": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 231,
       "lineto": 231,
       "args": [
@@ -16553,12 +17328,12 @@
         "comment": null
       },
       "description": "<p>Get the remote&#39;s list of push refspecs</p>\n",
-      "comments": "<p>The memory is owned by the user and should be freed with <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The memory is owned by the user and should be freed with\n <code>git_strarray_free</code>.</p>\n",
       "group": "remote"
     },
     "git_remote_refspec_count": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 239,
       "lineto": 239,
       "args": [
@@ -16580,7 +17355,7 @@
     },
     "git_remote_get_refspec": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 248,
       "lineto": 248,
       "args": [
@@ -16607,7 +17382,7 @@
     },
     "git_remote_connect": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 265,
       "lineto": 265,
       "args": [
@@ -16644,7 +17419,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open a connection to a remote</p>\n",
-      "comments": "<p>The transport is selected based on the URL. The direction argument is due to a limitation of the git protocol (over TCP or SSH) which starts up a specific binary which can only do the one or the other.</p>\n",
+      "comments": "<p>The transport is selected based on the URL. The direction argument\n is due to a limitation of the git protocol (over TCP or SSH) which\n starts up a specific binary which can only do the one or the other.</p>\n",
       "group": "remote",
       "examples": {
         "network/ls-remote.c": [
@@ -16654,7 +17429,7 @@
     },
     "git_remote_ls": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 287,
       "lineto": 287,
       "args": [
@@ -16681,7 +17456,7 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Get the remote repository&#39;s reference advertisement list</p>\n",
-      "comments": "<p>Get the list of references with which the server responds to a new connection.</p>\n\n<p>The remote (or more exactly its transport) must have connected to the remote repository. This list is available as soon as the connection to the remote is initiated and it remains available after disconnecting.</p>\n\n<p>The memory belongs to the remote. The pointer will be valid as long as a new connection is not initiated, but it is recommended that you make a copy in order to make use of the data.</p>\n",
+      "comments": "<p>Get the list of references with which the server responds to a new\n connection.</p>\n\n<p>The remote (or more exactly its transport) must have connected to\n the remote repository. This list is available as soon as the\n connection to the remote is initiated and it remains available\n after disconnecting.</p>\n\n<p>The memory belongs to the remote. The pointer will be valid as long\n as a new connection is not initiated, but it is recommended that\n you make a copy in order to make use of the data.</p>\n",
       "group": "remote",
       "examples": {
         "network/ls-remote.c": [
@@ -16691,7 +17466,7 @@
     },
     "git_remote_connected": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 298,
       "lineto": 298,
       "args": [
@@ -16708,12 +17483,12 @@
         "comment": " 1 if it's connected, 0 otherwise."
       },
       "description": "<p>Check whether the remote is connected</p>\n",
-      "comments": "<p>Check whether the remote&#39;s underlying transport is connected to the remote host.</p>\n",
+      "comments": "<p>Check whether the remote&#39;s underlying transport is connected to the\n remote host.</p>\n",
       "group": "remote"
     },
     "git_remote_stop": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 308,
       "lineto": 308,
       "args": [
@@ -16730,12 +17505,12 @@
         "comment": null
       },
       "description": "<p>Cancel the operation</p>\n",
-      "comments": "<p>At certain points in its operation, the network code checks whether the operation has been cancelled and if so stops the operation.</p>\n",
+      "comments": "<p>At certain points in its operation, the network code checks whether\n the operation has been cancelled and if so stops the operation.</p>\n",
       "group": "remote"
     },
     "git_remote_disconnect": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 317,
       "lineto": 317,
       "args": [
@@ -16757,7 +17532,7 @@
     },
     "git_remote_free": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 327,
       "lineto": 327,
       "args": [
@@ -16774,7 +17549,7 @@
         "comment": null
       },
       "description": "<p>Free the memory associated with a remote</p>\n",
-      "comments": "<p>This also disconnects from the remote, if the connection has not been closed yet (using git_remote_disconnect).</p>\n",
+      "comments": "<p>This also disconnects from the remote, if the connection\n has not been closed yet (using git_remote_disconnect).</p>\n",
       "group": "remote",
       "examples": {
         "network/fetch.c": [
@@ -16791,7 +17566,7 @@
     },
     "git_remote_list": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 338,
       "lineto": 338,
       "args": [
@@ -16823,7 +17598,7 @@
     },
     "git_remote_init_callbacks": {
       "type": "function",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 503,
       "lineto": 505,
       "args": [
@@ -16850,19 +17625,19 @@
     },
     "git_fetch_init_options": {
       "type": "function",
-      "file": "remote.h",
-      "line": 607,
-      "lineto": 609,
+      "file": "git2/remote.h",
+      "line": 608,
+      "lineto": 610,
       "args": [
         {
           "name": "opts",
           "type": "git_fetch_options *",
-          "comment": "the `git_fetch_options` instance to initialize."
+          "comment": "The `git_fetch_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_FETCH_OPTIONS_VERSION` here."
+          "comment": "The struct version; pass `GIT_FETCH_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_fetch_options *opts, unsigned int version",
@@ -16871,25 +17646,25 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_fetch_options</code> with default values. Equivalent to\n creating an instance with GIT_FETCH_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_fetch_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_fetch_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_FETCH_OPTIONS_INIT</code>.</p>\n",
       "group": "fetch"
     },
     "git_push_init_options": {
       "type": "function",
-      "file": "remote.h",
-      "line": 656,
-      "lineto": 658,
+      "file": "git2/remote.h",
+      "line": 658,
+      "lineto": 660,
       "args": [
         {
           "name": "opts",
           "type": "git_push_options *",
-          "comment": "the `git_push_options` instance to initialize."
+          "comment": "The `git_push_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_PUSH_OPTIONS_VERSION` here."
+          "comment": "The struct version; pass `GIT_PUSH_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_push_options *opts, unsigned int version",
@@ -16898,15 +17673,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_push_options</code> with default values. Equivalent to\n creating an instance with GIT_PUSH_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_push_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_push_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_PUSH_OPTIONS_INIT</code>.</p>\n",
       "group": "push"
     },
     "git_remote_download": {
       "type": "function",
-      "file": "remote.h",
-      "line": 676,
-      "lineto": 676,
+      "file": "git2/remote.h",
+      "line": 678,
+      "lineto": 678,
       "args": [
         {
           "name": "remote",
@@ -16931,14 +17706,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Download and index the packfile</p>\n",
-      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with the remote git which objects are missing, download and index the packfile.</p>\n\n<p>The .idx file will be created and both it and the packfile with be renamed to their final name.</p>\n",
+      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with\n the remote git which objects are missing, download and index the\n packfile.</p>\n\n<p>The .idx file will be created and both it and the packfile with be\n renamed to their final name.</p>\n",
       "group": "remote"
     },
     "git_remote_upload": {
       "type": "function",
-      "file": "remote.h",
-      "line": 690,
-      "lineto": 690,
+      "file": "git2/remote.h",
+      "line": 692,
+      "lineto": 692,
       "args": [
         {
           "name": "remote",
@@ -16963,14 +17738,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a packfile and send it to the server</p>\n",
-      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with the remote git which objects are missing, create a packfile with the missing objects and send it.</p>\n",
+      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with\n the remote git which objects are missing, create a packfile with the missing objects and send it.</p>\n",
       "group": "remote"
     },
     "git_remote_update_tips": {
       "type": "function",
-      "file": "remote.h",
-      "line": 706,
-      "lineto": 711,
+      "file": "git2/remote.h",
+      "line": 708,
+      "lineto": 713,
       "args": [
         {
           "name": "remote",
@@ -17010,9 +17785,9 @@
     },
     "git_remote_fetch": {
       "type": "function",
-      "file": "remote.h",
-      "line": 727,
-      "lineto": 731,
+      "file": "git2/remote.h",
+      "line": 729,
+      "lineto": 733,
       "args": [
         {
           "name": "remote",
@@ -17042,7 +17817,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Download new data and update tips</p>\n",
-      "comments": "<p>Convenience function to connect to a remote, download the data, disconnect and update the remote-tracking branches.</p>\n",
+      "comments": "<p>Convenience function to connect to a remote, download the data,\n disconnect and update the remote-tracking branches.</p>\n",
       "group": "remote",
       "examples": {
         "network/fetch.c": [
@@ -17052,9 +17827,9 @@
     },
     "git_remote_prune": {
       "type": "function",
-      "file": "remote.h",
-      "line": 740,
-      "lineto": 740,
+      "file": "git2/remote.h",
+      "line": 742,
+      "lineto": 742,
       "args": [
         {
           "name": "remote",
@@ -17079,9 +17854,9 @@
     },
     "git_remote_push": {
       "type": "function",
-      "file": "remote.h",
-      "line": 752,
-      "lineto": 754,
+      "file": "git2/remote.h",
+      "line": 754,
+      "lineto": 756,
       "args": [
         {
           "name": "remote",
@@ -17111,9 +17886,9 @@
     },
     "git_remote_stats": {
       "type": "function",
-      "file": "remote.h",
-      "line": 759,
-      "lineto": 759,
+      "file": "git2/remote.h",
+      "line": 761,
+      "lineto": 761,
       "args": [
         {
           "name": "remote",
@@ -17138,9 +17913,9 @@
     },
     "git_remote_autotag": {
       "type": "function",
-      "file": "remote.h",
-      "line": 767,
-      "lineto": 767,
+      "file": "git2/remote.h",
+      "line": 769,
+      "lineto": 769,
       "args": [
         {
           "name": "remote",
@@ -17160,9 +17935,9 @@
     },
     "git_remote_set_autotag": {
       "type": "function",
-      "file": "remote.h",
-      "line": 779,
-      "lineto": 779,
+      "file": "git2/remote.h",
+      "line": 781,
+      "lineto": 781,
       "args": [
         {
           "name": "repo",
@@ -17187,14 +17962,14 @@
         "comment": null
       },
       "description": "<p>Set the remote&#39;s tag following setting.</p>\n",
-      "comments": "<p>The change will be made in the configuration. No loaded remotes will be affected.</p>\n",
+      "comments": "<p>The change will be made in the configuration. No loaded remotes\n will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_prune_refs": {
       "type": "function",
-      "file": "remote.h",
-      "line": 786,
-      "lineto": 786,
+      "file": "git2/remote.h",
+      "line": 788,
+      "lineto": 788,
       "args": [
         {
           "name": "remote",
@@ -17214,9 +17989,9 @@
     },
     "git_remote_rename": {
       "type": "function",
-      "file": "remote.h",
-      "line": 808,
-      "lineto": 812,
+      "file": "git2/remote.h",
+      "line": 810,
+      "lineto": 814,
       "args": [
         {
           "name": "problems",
@@ -17246,7 +18021,7 @@
         "comment": " 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>Give the remote a new name</p>\n",
-      "comments": "<p>All remote-tracking branches and configuration settings for the remote are updated.</p>\n\n<p>The new name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n\n<p>No loaded instances of a the remote with the old name will change their name or their list of refspecs.</p>\n",
+      "comments": "<p>All remote-tracking branches and configuration settings\n for the remote are updated.</p>\n\n<p>The new name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n\n<p>No loaded instances of a the remote with the old name will change\n their name or their list of refspecs.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -17256,9 +18031,9 @@
     },
     "git_remote_is_valid_name": {
       "type": "function",
-      "file": "remote.h",
-      "line": 820,
-      "lineto": 820,
+      "file": "git2/remote.h",
+      "line": 822,
+      "lineto": 822,
       "args": [
         {
           "name": "remote_name",
@@ -17278,9 +18053,9 @@
     },
     "git_remote_delete": {
       "type": "function",
-      "file": "remote.h",
-      "line": 832,
-      "lineto": 832,
+      "file": "git2/remote.h",
+      "line": 834,
+      "lineto": 834,
       "args": [
         {
           "name": "repo",
@@ -17300,7 +18075,7 @@
         "comment": " 0 on success, or an error code."
       },
       "description": "<p>Delete an existing persisted remote.</p>\n",
-      "comments": "<p>All remote-tracking branches and configuration settings for the remote will be removed.</p>\n",
+      "comments": "<p>All remote-tracking branches and configuration settings\n for the remote will be removed.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
@@ -17310,9 +18085,9 @@
     },
     "git_remote_default_branch": {
       "type": "function",
-      "file": "remote.h",
-      "line": 850,
-      "lineto": 850,
+      "file": "git2/remote.h",
+      "line": 852,
+      "lineto": 852,
       "args": [
         {
           "name": "out",
@@ -17332,12 +18107,12 @@
         "comment": " 0, GIT_ENOTFOUND if the remote does not have any references\n or none of them point to HEAD's commit, or an error message."
       },
       "description": "<p>Retrieve the name of the remote&#39;s default branch</p>\n",
-      "comments": "<p>The default branch of a repository is the branch which HEAD points to. If the remote does not support reporting this information directly, it performs the guess as git does; that is, if there are multiple branches which point to the same commit, the first one is chosen. If the master branch is a candidate, it wins.</p>\n\n<p>This function must only be called after connecting.</p>\n",
+      "comments": "<p>The default branch of a repository is the branch which HEAD points\n to. If the remote does not support reporting this information\n directly, it performs the guess as git does; that is, if there are\n multiple branches which point to the same commit, the first one is\n chosen. If the master branch is a candidate, it wins.</p>\n\n<p>This function must only be called after connecting.</p>\n",
       "group": "remote"
     },
     "git_repository_open": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 37,
       "lineto": 37,
       "args": [
@@ -17359,7 +18134,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open a git repository.</p>\n",
-      "comments": "<p>The &#39;path&#39; argument must point to either a git repository folder, or an existing work dir.</p>\n\n<p>The method will automatically detect if &#39;path&#39; is a normal or bare repository or fail is &#39;path&#39; is neither.</p>\n",
+      "comments": "<p>The &#39;path&#39; argument must point to either a git repository\n folder, or an existing work dir.</p>\n\n<p>The method will automatically detect if &#39;path&#39; is a normal\n or bare repository or fail is &#39;path&#39; is neither.</p>\n",
       "group": "repository",
       "examples": {
         "general.c": [
@@ -17372,7 +18147,7 @@
     },
     "git_repository_open_from_worktree": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 48,
       "lineto": 48,
       "args": [
@@ -17394,12 +18169,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open working tree as a repository</p>\n",
-      "comments": "<p>Open the working directory of the working tree as a normal repository that can then be worked on.</p>\n",
+      "comments": "<p>Open the working directory of the working tree as a normal\n repository that can then be worked on.</p>\n",
       "group": "repository"
     },
     "git_repository_wrap_odb": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 61,
       "lineto": 61,
       "args": [
@@ -17421,12 +18196,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a &quot;fake&quot; repository to wrap an object database</p>\n",
-      "comments": "<p>Create a repository object to wrap an object database to be used with the API when all you have is an object database. This doesn&#39;t have any paths associated with it, so use with care.</p>\n",
+      "comments": "<p>Create a repository object to wrap an object database to be used\n with the API when all you have is an object database. This doesn&#39;t\n have any paths associated with it, so use with care.</p>\n",
       "group": "repository"
     },
     "git_repository_discover": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 89,
       "lineto": 93,
       "args": [
@@ -17458,7 +18233,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Look for a git repository and copy its path in the given buffer.\n The lookup start from base_path and walk across parent directories\n if nothing has been found. The lookup ends when the first repository\n is found, or when reaching a directory referenced in ceiling_dirs\n or when the filesystem changes (in case across_fs is true).</p>\n",
-      "comments": "<p>The method will automatically detect if the repository is bare (if there is a repository).</p>\n",
+      "comments": "<p>The method will automatically detect if the repository is bare\n (if there is a repository).</p>\n",
       "group": "repository",
       "examples": {
         "remote.c": [
@@ -17468,7 +18243,7 @@
     },
     "git_repository_open_ext": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 152,
       "lineto": 156,
       "args": [
@@ -17509,8 +18284,11 @@
         "cat-file.c": [
           "ex/HEAD/cat-file.html#git_repository_open_ext-31"
         ],
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_repository_open_ext-14"
+        ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_repository_open_ext-6"
+          "ex/HEAD/describe.html#git_repository_open_ext-8"
         ],
         "diff.c": [
           "ex/HEAD/diff.html#git_repository_open_ext-15"
@@ -17519,8 +18297,11 @@
           "ex/HEAD/log.html#git_repository_open_ext-45",
           "ex/HEAD/log.html#git_repository_open_ext-46"
         ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_repository_open_ext-7"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_open_ext-38"
+          "ex/HEAD/merge.html#git_repository_open_ext-33"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_repository_open_ext-16"
@@ -17535,7 +18316,7 @@
     },
     "git_repository_open_bare": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 169,
       "lineto": 169,
       "args": [
@@ -17557,12 +18338,12 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Open a bare repository on the serverside.</p>\n",
-      "comments": "<p>This is a fast open for bare repositories that will come in handy if you&#39;re e.g. hosting git repositories and need to access them efficiently</p>\n",
+      "comments": "<p>This is a fast open for bare repositories that will come in handy\n if you&#39;re e.g. hosting git repositories and need to access them\n efficiently</p>\n",
       "group": "repository"
     },
     "git_repository_free": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 182,
       "lineto": 182,
       "args": [
@@ -17579,7 +18360,7 @@
         "comment": null
       },
       "description": "<p>Free a previously allocated repository</p>\n",
-      "comments": "<p>Note that after a repository is free&#39;d, all the objects it has spawned will still exist until they are manually closed by the user with <code>git_object_free</code>, but accessing any of the attributes of an object without a backing repository will result in undefined behavior</p>\n",
+      "comments": "<p>Note that after a repository is free&#39;d, all the objects it has spawned\n will still exist until they are manually closed by the user\n with <code>git_object_free</code>, but accessing any of the attributes of\n an object without a backing repository will result in undefined\n behavior</p>\n",
       "group": "repository",
       "examples": {
         "blame.c": [
@@ -17588,8 +18369,11 @@
         "cat-file.c": [
           "ex/HEAD/cat-file.html#git_repository_free-32"
         ],
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_repository_free-15"
+        ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_repository_free-7"
+          "ex/HEAD/describe.html#git_repository_free-9"
         ],
         "diff.c": [
           "ex/HEAD/diff.html#git_repository_free-16"
@@ -17603,11 +18387,11 @@
         "log.c": [
           "ex/HEAD/log.html#git_repository_free-47"
         ],
-        "merge.c": [
-          "ex/HEAD/merge.html#git_repository_free-39"
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_repository_free-8"
         ],
-        "network/clone.c": [
-          "ex/HEAD/network/clone.html#git_repository_free-3"
+        "merge.c": [
+          "ex/HEAD/merge.html#git_repository_free-34"
         ],
         "rev-parse.c": [
           "ex/HEAD/rev-parse.html#git_repository_free-17"
@@ -17622,7 +18406,7 @@
     },
     "git_repository_init": {
       "type": "function",
-      "file": "repository.h",
+      "file": "git2/repository.h",
       "line": 199,
       "lineto": 202,
       "args": [
@@ -17649,7 +18433,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Creates a new Git repository in the given folder.</p>\n",
-      "comments": "<p>TODO:  - Reinit the repository</p>\n",
+      "comments": "<p>TODO:\n    - Reinit the repository</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
@@ -17659,19 +18443,19 @@
     },
     "git_repository_init_init_options": {
       "type": "function",
-      "file": "repository.h",
-      "line": 311,
-      "lineto": 313,
+      "file": "git2/repository.h",
+      "line": 313,
+      "lineto": 315,
       "args": [
         {
           "name": "opts",
           "type": "git_repository_init_options *",
-          "comment": "the `git_repository_init_options` struct to initialize"
+          "comment": "The `git_repository_init_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_REPOSITORY_INIT_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_REPOSITORY_INIT_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_repository_init_options *opts, unsigned int version",
@@ -17680,15 +18464,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_repository_init_options</code> with default values. Equivalent\n to creating an instance with GIT_REPOSITORY_INIT_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_repository_init_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_repository_init_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REPOSITORY_INIT_OPTIONS_INIT</code>.</p>\n",
       "group": "repository"
     },
     "git_repository_init_ext": {
       "type": "function",
-      "file": "repository.h",
-      "line": 328,
-      "lineto": 331,
+      "file": "git2/repository.h",
+      "line": 330,
+      "lineto": 333,
       "args": [
         {
           "name": "out",
@@ -17713,7 +18497,7 @@
         "comment": " 0 or an error code on failure."
       },
       "description": "<p>Create a new Git repository in the given folder with extended controls.</p>\n",
-      "comments": "<p>This will initialize a new git repository (creating the repo_path if requested by flags) and working directory as needed.  It will auto-detect the case sensitivity of the file system and if the file system supports file mode bits correctly.</p>\n",
+      "comments": "<p>This will initialize a new git repository (creating the repo_path\n if requested by flags) and working directory as needed.  It will\n auto-detect the case sensitivity of the file system and if the\n file system supports file mode bits correctly.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
@@ -17723,9 +18507,9 @@
     },
     "git_repository_head": {
       "type": "function",
-      "file": "repository.h",
-      "line": 346,
-      "lineto": 346,
+      "file": "git2/repository.h",
+      "line": 348,
+      "lineto": 348,
       "args": [
         {
           "name": "out",
@@ -17745,12 +18529,12 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing\n branch, GIT_ENOTFOUND when HEAD is missing; an error code otherwise"
       },
       "description": "<p>Retrieve and resolve the reference pointed at by HEAD.</p>\n",
-      "comments": "<p>The returned <code>git_reference</code> will be owned by caller and <code>git_reference_free()</code> must be called when done with it to release the allocated memory and prevent a leak.</p>\n",
+      "comments": "<p>The returned <code>git_reference</code> will be owned by caller and\n <code>git_reference_free()</code> must be called when done with it to release the\n allocated memory and prevent a leak.</p>\n",
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_head-40",
-          "ex/HEAD/merge.html#git_repository_head-41"
+          "ex/HEAD/merge.html#git_repository_head-35",
+          "ex/HEAD/merge.html#git_repository_head-36"
         ],
         "status.c": [
           "ex/HEAD/status.html#git_repository_head-7"
@@ -17759,9 +18543,9 @@
     },
     "git_repository_head_for_worktree": {
       "type": "function",
-      "file": "repository.h",
-      "line": 356,
-      "lineto": 357,
+      "file": "git2/repository.h",
+      "line": 358,
+      "lineto": 359,
       "args": [
         {
           "name": "out",
@@ -17791,9 +18575,9 @@
     },
     "git_repository_head_detached": {
       "type": "function",
-      "file": "repository.h",
-      "line": 369,
-      "lineto": 369,
+      "file": "git2/repository.h",
+      "line": 371,
+      "lineto": 371,
       "args": [
         {
           "name": "repo",
@@ -17808,14 +18592,41 @@
         "comment": " 1 if HEAD is detached, 0 if it's not; error code if there\n was an error."
       },
       "description": "<p>Check if a repository&#39;s HEAD is detached</p>\n",
-      "comments": "<p>A repository&#39;s HEAD is detached when it points directly to a commit instead of a branch.</p>\n",
+      "comments": "<p>A repository&#39;s HEAD is detached when it points directly to a commit\n instead of a branch.</p>\n",
+      "group": "repository"
+    },
+    "git_repository_head_detached_for_worktree": {
+      "type": "function",
+      "file": "git2/repository.h",
+      "line": 384,
+      "lineto": 385,
+      "args": [
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "a repository object"
+        },
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "name of the worktree to retrieve HEAD for"
+        }
+      ],
+      "argline": "git_repository *repo, const char *name",
+      "sig": "git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 1 if HEAD is detached, 0 if its not; error code if\n  there was an error"
+      },
+      "description": "<p>Check if a worktree&#39;s HEAD is detached</p>\n",
+      "comments": "<p>A worktree&#39;s HEAD is detached when it points directly to a\n commit instead of a branch.</p>\n",
       "group": "repository"
     },
     "git_repository_head_unborn": {
       "type": "function",
-      "file": "repository.h",
-      "line": 395,
-      "lineto": 395,
+      "file": "git2/repository.h",
+      "line": 397,
+      "lineto": 397,
       "args": [
         {
           "name": "repo",
@@ -17830,14 +18641,14 @@
         "comment": " 1 if the current branch is unborn, 0 if it's not; error\n code if there was an error"
       },
       "description": "<p>Check if the current branch is unborn</p>\n",
-      "comments": "<p>An unborn branch is one named from HEAD but which doesn&#39;t exist in the refs namespace, because it doesn&#39;t have any commit to point to.</p>\n",
+      "comments": "<p>An unborn branch is one named from HEAD but which doesn&#39;t exist in\n the refs namespace, because it doesn&#39;t have any commit to point to.</p>\n",
       "group": "repository"
     },
     "git_repository_is_empty": {
       "type": "function",
-      "file": "repository.h",
-      "line": 407,
-      "lineto": 407,
+      "file": "git2/repository.h",
+      "line": 409,
+      "lineto": 409,
       "args": [
         {
           "name": "repo",
@@ -17852,14 +18663,14 @@
         "comment": " 1 if the repository is empty, 0 if it isn't, error code\n if the repository is corrupted"
       },
       "description": "<p>Check if a repository is empty</p>\n",
-      "comments": "<p>An empty repository has just been initialized and contains no references apart from HEAD, which must be pointing to the unborn master branch.</p>\n",
+      "comments": "<p>An empty repository has just been initialized and contains no references\n apart from HEAD, which must be pointing to the unborn master branch.</p>\n",
       "group": "repository"
     },
     "git_repository_item_path": {
       "type": "function",
-      "file": "repository.h",
-      "line": 443,
-      "lineto": 443,
+      "file": "git2/repository.h",
+      "line": 445,
+      "lineto": 445,
       "args": [
         {
           "name": "out",
@@ -17884,14 +18695,14 @@
         "comment": " 0, GIT_ENOTFOUND if the path cannot exist or an error code"
       },
       "description": "<p>Get the location of a specific repository file or directory</p>\n",
-      "comments": "<p>This function will retrieve the path of a specific repository item. It will thereby honor things like the repository&#39;s common directory, gitdir, etc. In case a file path cannot exist for a given item (e.g. the working directory of a bare repository), GIT_ENOTFOUND is returned.</p>\n",
+      "comments": "<p>This function will retrieve the path of a specific repository\n item. It will thereby honor things like the repository&#39;s\n common directory, gitdir, etc. In case a file path cannot\n exist for a given item (e.g. the working directory of a bare\n repository), GIT_ENOTFOUND is returned.</p>\n",
       "group": "repository"
     },
     "git_repository_path": {
       "type": "function",
-      "file": "repository.h",
-      "line": 454,
-      "lineto": 454,
+      "file": "git2/repository.h",
+      "line": 456,
+      "lineto": 456,
       "args": [
         {
           "name": "repo",
@@ -17906,7 +18717,7 @@
         "comment": " the path to the repository"
       },
       "description": "<p>Get the path of this repository</p>\n",
-      "comments": "<p>This is the path of the <code>.git</code> folder for normal repositories, or of the repository itself for bare repositories.</p>\n",
+      "comments": "<p>This is the path of the <code>.git</code> folder for normal repositories,\n or of the repository itself for bare repositories.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
@@ -17919,9 +18730,9 @@
     },
     "git_repository_workdir": {
       "type": "function",
-      "file": "repository.h",
-      "line": 465,
-      "lineto": 465,
+      "file": "git2/repository.h",
+      "line": 467,
+      "lineto": 467,
       "args": [
         {
           "name": "repo",
@@ -17936,7 +18747,7 @@
         "comment": " the path to the working dir, if it exists"
       },
       "description": "<p>Get the path of the working directory for this repository</p>\n",
-      "comments": "<p>If the repository is bare, this function will always return NULL.</p>\n",
+      "comments": "<p>If the repository is bare, this function will always return\n NULL.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
@@ -17946,9 +18757,9 @@
     },
     "git_repository_commondir": {
       "type": "function",
-      "file": "repository.h",
-      "line": 476,
-      "lineto": 476,
+      "file": "git2/repository.h",
+      "line": 478,
+      "lineto": 478,
       "args": [
         {
           "name": "repo",
@@ -17963,14 +18774,14 @@
         "comment": " the path to the common dir"
       },
       "description": "<p>Get the path of the shared common directory for this repository</p>\n",
-      "comments": "<p>If the repository is bare is not a worktree, the git directory path is returned.</p>\n",
+      "comments": "<p>If the repository is bare is not a worktree, the git directory\n path is returned.</p>\n",
       "group": "repository"
     },
     "git_repository_set_workdir": {
       "type": "function",
-      "file": "repository.h",
-      "line": 495,
-      "lineto": 496,
+      "file": "git2/repository.h",
+      "line": 497,
+      "lineto": 498,
       "args": [
         {
           "name": "repo",
@@ -17995,14 +18806,14 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Set the path to the working directory for this repository</p>\n",
-      "comments": "<p>The working directory doesn&#39;t need to be the same one that contains the <code>.git</code> folder for this repository.</p>\n\n<p>If this repository is bare, setting its working directory will turn it into a normal repository, capable of performing all the common workdir operations (checkout, status, index manipulation, etc).</p>\n",
+      "comments": "<p>The working directory doesn&#39;t need to be the same one\n that contains the <code>.git</code> folder for this repository.</p>\n\n<p>If this repository is bare, setting its working directory\n will turn it into a normal repository, capable of performing\n all the common workdir operations (checkout, status, index\n manipulation, etc).</p>\n",
       "group": "repository"
     },
     "git_repository_is_bare": {
       "type": "function",
-      "file": "repository.h",
-      "line": 504,
-      "lineto": 504,
+      "file": "git2/repository.h",
+      "line": 506,
+      "lineto": 506,
       "args": [
         {
           "name": "repo",
@@ -18027,9 +18838,9 @@
     },
     "git_repository_is_worktree": {
       "type": "function",
-      "file": "repository.h",
-      "line": 512,
-      "lineto": 512,
+      "file": "git2/repository.h",
+      "line": 514,
+      "lineto": 514,
       "args": [
         {
           "name": "repo",
@@ -18049,9 +18860,9 @@
     },
     "git_repository_config": {
       "type": "function",
-      "file": "repository.h",
-      "line": 528,
-      "lineto": 528,
+      "file": "git2/repository.h",
+      "line": 530,
+      "lineto": 530,
       "args": [
         {
           "name": "out",
@@ -18071,14 +18882,14 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the configuration file for this repository.</p>\n",
-      "comments": "<p>If a configuration file has not been set, the default config set for the repository will be returned, including global and system configurations (if they are available).</p>\n\n<p>The configuration file must be freed once it&#39;s no longer being used by the user.</p>\n",
+      "comments": "<p>If a configuration file has not been set, the default\n config set for the repository will be returned, including\n global and system configurations (if they are available).</p>\n\n<p>The configuration file must be freed once it&#39;s no longer\n being used by the user.</p>\n",
       "group": "repository"
     },
     "git_repository_config_snapshot": {
       "type": "function",
-      "file": "repository.h",
-      "line": 544,
-      "lineto": 544,
+      "file": "git2/repository.h",
+      "line": 546,
+      "lineto": 546,
       "args": [
         {
           "name": "out",
@@ -18098,7 +18909,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get a snapshot of the repository&#39;s configuration</p>\n",
-      "comments": "<p>Convenience function to take a snapshot from the repository&#39;s configuration.  The contents of this snapshot will not change, even if the underlying config files are modified.</p>\n\n<p>The configuration file must be freed once it&#39;s no longer being used by the user.</p>\n",
+      "comments": "<p>Convenience function to take a snapshot from the repository&#39;s\n configuration.  The contents of this snapshot will not change,\n even if the underlying config files are modified.</p>\n\n<p>The configuration file must be freed once it&#39;s no longer\n being used by the user.</p>\n",
       "group": "repository",
       "examples": {
         "general.c": [
@@ -18109,9 +18920,9 @@
     },
     "git_repository_odb": {
       "type": "function",
-      "file": "repository.h",
-      "line": 560,
-      "lineto": 560,
+      "file": "git2/repository.h",
+      "line": 562,
+      "lineto": 562,
       "args": [
         {
           "name": "out",
@@ -18131,7 +18942,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Object Database for this repository.</p>\n",
-      "comments": "<p>If a custom ODB has not been set, the default database for the repository will be returned (the one located in <code>.git/objects</code>).</p>\n\n<p>The ODB must be freed once it&#39;s no longer being used by the user.</p>\n",
+      "comments": "<p>If a custom ODB has not been set, the default\n database for the repository will be returned (the one\n located in <code>.git/objects</code>).</p>\n\n<p>The ODB must be freed once it&#39;s no longer being used by\n the user.</p>\n",
       "group": "repository",
       "examples": {
         "cat-file.c": [
@@ -18144,9 +18955,9 @@
     },
     "git_repository_refdb": {
       "type": "function",
-      "file": "repository.h",
-      "line": 576,
-      "lineto": 576,
+      "file": "git2/repository.h",
+      "line": 578,
+      "lineto": 578,
       "args": [
         {
           "name": "out",
@@ -18166,14 +18977,14 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Reference Database Backend for this repository.</p>\n",
-      "comments": "<p>If a custom refsdb has not been set, the default database for the repository will be returned (the one that manipulates loose and packed references in the <code>.git</code> directory).</p>\n\n<p>The refdb must be freed once it&#39;s no longer being used by the user.</p>\n",
+      "comments": "<p>If a custom refsdb has not been set, the default database for\n the repository will be returned (the one that manipulates loose\n and packed references in the <code>.git</code> directory).</p>\n\n<p>The refdb must be freed once it&#39;s no longer being used by\n the user.</p>\n",
       "group": "repository"
     },
     "git_repository_index": {
       "type": "function",
-      "file": "repository.h",
-      "line": 592,
-      "lineto": 592,
+      "file": "git2/repository.h",
+      "line": 594,
+      "lineto": 594,
       "args": [
         {
           "name": "out",
@@ -18193,7 +19004,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Index file for this repository.</p>\n",
-      "comments": "<p>If a custom index has not been set, the default index for the repository will be returned (the one located in <code>.git/index</code>).</p>\n\n<p>The index must be freed once it&#39;s no longer being used by the user.</p>\n",
+      "comments": "<p>If a custom index has not been set, the default\n index for the repository will be returned (the one\n located in <code>.git/index</code>).</p>\n\n<p>The index must be freed once it&#39;s no longer being used by\n the user.</p>\n",
       "group": "repository",
       "examples": {
         "general.c": [
@@ -18202,16 +19013,19 @@
         "init.c": [
           "ex/HEAD/init.html#git_repository_index-11"
         ],
+        "ls-files.c": [
+          "ex/HEAD/ls-files.html#git_repository_index-9"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_index-42"
+          "ex/HEAD/merge.html#git_repository_index-37"
         ]
       }
     },
     "git_repository_message": {
       "type": "function",
-      "file": "repository.h",
-      "line": 610,
-      "lineto": 610,
+      "file": "git2/repository.h",
+      "line": 612,
+      "lineto": 612,
       "args": [
         {
           "name": "out",
@@ -18231,14 +19045,14 @@
         "comment": " 0, GIT_ENOTFOUND if no message exists or an error code"
       },
       "description": "<p>Retrieve git&#39;s prepared message</p>\n",
-      "comments": "<p>Operations such as git revert/cherry-pick/merge with the -n option stop just short of creating a commit with the changes and save their prepared message in .git/MERGE_MSG so the next git-commit execution can present it to the user for them to amend if they wish.</p>\n\n<p>Use this function to get the contents of this file. Don&#39;t forget to remove the file after you create the commit.</p>\n",
+      "comments": "<p>Operations such as git revert/cherry-pick/merge with the -n option\n stop just short of creating a commit with the changes and save\n their prepared message in .git/MERGE_MSG so the next git-commit\n execution can present it to the user for them to amend if they\n wish.</p>\n\n<p>Use this function to get the contents of this file. Don&#39;t forget to\n remove the file after you create the commit.</p>\n",
       "group": "repository"
     },
     "git_repository_message_remove": {
       "type": "function",
-      "file": "repository.h",
-      "line": 617,
-      "lineto": 617,
+      "file": "git2/repository.h",
+      "line": 619,
+      "lineto": 619,
       "args": [
         {
           "name": "repo",
@@ -18258,9 +19072,9 @@
     },
     "git_repository_state_cleanup": {
       "type": "function",
-      "file": "repository.h",
-      "line": 626,
-      "lineto": 626,
+      "file": "git2/repository.h",
+      "line": 628,
+      "lineto": 628,
       "args": [
         {
           "name": "repo",
@@ -18279,15 +19093,15 @@
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_state_cleanup-43"
+          "ex/HEAD/merge.html#git_repository_state_cleanup-38"
         ]
       }
     },
     "git_repository_fetchhead_foreach": {
       "type": "function",
-      "file": "repository.h",
-      "line": 645,
-      "lineto": 648,
+      "file": "git2/repository.h",
+      "line": 647,
+      "lineto": 650,
       "args": [
         {
           "name": "repo",
@@ -18317,9 +19131,9 @@
     },
     "git_repository_mergehead_foreach": {
       "type": "function",
-      "file": "repository.h",
-      "line": 665,
-      "lineto": 668,
+      "file": "git2/repository.h",
+      "line": 667,
+      "lineto": 670,
       "args": [
         {
           "name": "repo",
@@ -18349,9 +19163,9 @@
     },
     "git_repository_hashfile": {
       "type": "function",
-      "file": "repository.h",
-      "line": 693,
-      "lineto": 698,
+      "file": "git2/repository.h",
+      "line": 695,
+      "lineto": 700,
       "args": [
         {
           "name": "out",
@@ -18386,14 +19200,14 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Calculate hash of file using repository filtering rules.</p>\n",
-      "comments": "<p>If you simply want to calculate the hash of a file on disk with no filters, you can just use the <code>git_odb_hashfile()</code> API.  However, if you want to hash a file in the repository and you want to apply filtering rules (e.g. crlf filters) before generating the SHA, then use this function.</p>\n\n<p>Note: if the repository has <code>core.safecrlf</code> set to fail and the filtering triggers that failure, then this function will return an error and not calculate the hash of the file.</p>\n",
+      "comments": "<p>If you simply want to calculate the hash of a file on disk with no filters,\n you can just use the <code>git_odb_hashfile()</code> API.  However, if you want to\n hash a file in the repository and you want to apply filtering rules (e.g.\n crlf filters) before generating the SHA, then use this function.</p>\n\n<p>Note: if the repository has <code>core.safecrlf</code> set to fail and the\n filtering triggers that failure, then this function will return an\n error and not calculate the hash of the file.</p>\n",
       "group": "repository"
     },
     "git_repository_set_head": {
       "type": "function",
-      "file": "repository.h",
-      "line": 718,
-      "lineto": 720,
+      "file": "git2/repository.h",
+      "line": 720,
+      "lineto": 722,
       "args": [
         {
           "name": "repo",
@@ -18413,14 +19227,19 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Make the repository HEAD point to the specified reference.</p>\n",
-      "comments": "<p>If the provided reference points to a Tree or a Blob, the HEAD is unaltered and -1 is returned.</p>\n\n<p>If the provided reference points to a branch, the HEAD will point to that branch, staying attached, or become attached if it isn&#39;t yet. If the branch doesn&#39;t exist yet, no error will be return. The HEAD will then be attached to an unborn branch.</p>\n\n<p>Otherwise, the HEAD will be detached and will directly point to the Commit.</p>\n",
-      "group": "repository"
+      "comments": "<p>If the provided reference points to a Tree or a Blob, the HEAD is\n unaltered and -1 is returned.</p>\n\n<p>If the provided reference points to a branch, the HEAD will point\n to that branch, staying attached, or become attached if it isn&#39;t yet.\n If the branch doesn&#39;t exist yet, no error will be return. The HEAD\n will then be attached to an unborn branch.</p>\n\n<p>Otherwise, the HEAD will be detached and will directly point to\n the Commit.</p>\n",
+      "group": "repository",
+      "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_repository_set_head-16"
+        ]
+      }
     },
     "git_repository_set_head_detached": {
       "type": "function",
-      "file": "repository.h",
-      "line": 738,
-      "lineto": 740,
+      "file": "git2/repository.h",
+      "line": 740,
+      "lineto": 742,
       "args": [
         {
           "name": "repo",
@@ -18440,14 +19259,14 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Make the repository HEAD directly point to the Commit.</p>\n",
-      "comments": "<p>If the provided committish cannot be found in the repository, the HEAD is unaltered and GIT_ENOTFOUND is returned.</p>\n\n<p>If the provided commitish cannot be peeled into a commit, the HEAD is unaltered and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will eventually be detached and will directly point to the peeled Commit.</p>\n",
+      "comments": "<p>If the provided committish cannot be found in the repository, the HEAD\n is unaltered and GIT_ENOTFOUND is returned.</p>\n\n<p>If the provided commitish cannot be peeled into a commit, the HEAD\n is unaltered and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will eventually be detached and will directly point to\n the peeled Commit.</p>\n",
       "group": "repository"
     },
     "git_repository_set_head_detached_from_annotated": {
       "type": "function",
-      "file": "repository.h",
-      "line": 754,
-      "lineto": 756,
+      "file": "git2/repository.h",
+      "line": 756,
+      "lineto": 758,
       "args": [
         {
           "name": "repo",
@@ -18467,14 +19286,19 @@
         "comment": null
       },
       "description": "<p>Make the repository HEAD directly point to the Commit.</p>\n",
-      "comments": "<p>This behaves like <code>git_repository_set_head_detached()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_repository_set_head_detached()</code>.</p>\n",
-      "group": "repository"
+      "comments": "<p>This behaves like <code>git_repository_set_head_detached()</code> but takes an\n annotated commit, which lets you specify which extended sha syntax\n string was specified by a user, allowing for more exact reflog\n messages.</p>\n\n<p>See the documentation for <code>git_repository_set_head_detached()</code>.</p>\n",
+      "group": "repository",
+      "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_repository_set_head_detached_from_annotated-17"
+        ]
+      }
     },
     "git_repository_detach_head": {
       "type": "function",
-      "file": "repository.h",
-      "line": 775,
-      "lineto": 776,
+      "file": "git2/repository.h",
+      "line": 777,
+      "lineto": 778,
       "args": [
         {
           "name": "repo",
@@ -18489,14 +19313,14 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing\n branch or an error code"
       },
       "description": "<p>Detach the HEAD.</p>\n",
-      "comments": "<p>If the HEAD is already detached and points to a Commit, 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a Tag, the HEAD is updated into making it point to the peeled Commit, and 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a non commitish, the HEAD is unaltered, and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will be detached and point to the peeled Commit.</p>\n",
+      "comments": "<p>If the HEAD is already detached and points to a Commit, 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a Tag, the HEAD is\n updated into making it point to the peeled Commit, and 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a non commitish, the HEAD is\n unaltered, and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will be detached and point to the peeled Commit.</p>\n",
       "group": "repository"
     },
     "git_repository_state": {
       "type": "function",
-      "file": "repository.h",
-      "line": 806,
-      "lineto": 806,
+      "file": "git2/repository.h",
+      "line": 808,
+      "lineto": 808,
       "args": [
         {
           "name": "repo",
@@ -18514,16 +19338,19 @@
       "comments": "",
       "group": "repository",
       "examples": {
+        "checkout.c": [
+          "ex/HEAD/checkout.html#git_repository_state-18"
+        ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_state-44"
+          "ex/HEAD/merge.html#git_repository_state-39"
         ]
       }
     },
     "git_repository_set_namespace": {
       "type": "function",
-      "file": "repository.h",
-      "line": 820,
-      "lineto": 820,
+      "file": "git2/repository.h",
+      "line": 822,
+      "lineto": 822,
       "args": [
         {
           "name": "repo",
@@ -18543,14 +19370,14 @@
         "comment": " 0 on success, -1 on error"
       },
       "description": "<p>Sets the active namespace for this Git Repository</p>\n",
-      "comments": "<p>This namespace affects all reference operations for the repo. See <code>man gitnamespaces</code></p>\n",
+      "comments": "<p>This namespace affects all reference operations for the repo.\n See <code>man gitnamespaces</code></p>\n",
       "group": "repository"
     },
     "git_repository_get_namespace": {
       "type": "function",
-      "file": "repository.h",
-      "line": 828,
-      "lineto": 828,
+      "file": "git2/repository.h",
+      "line": 830,
+      "lineto": 830,
       "args": [
         {
           "name": "repo",
@@ -18570,9 +19397,9 @@
     },
     "git_repository_is_shallow": {
       "type": "function",
-      "file": "repository.h",
-      "line": 837,
-      "lineto": 837,
+      "file": "git2/repository.h",
+      "line": 839,
+      "lineto": 839,
       "args": [
         {
           "name": "repo",
@@ -18592,9 +19419,9 @@
     },
     "git_repository_ident": {
       "type": "function",
-      "file": "repository.h",
-      "line": 849,
-      "lineto": 849,
+      "file": "git2/repository.h",
+      "line": 851,
+      "lineto": 851,
       "args": [
         {
           "name": "name",
@@ -18619,14 +19446,14 @@
         "comment": null
       },
       "description": "<p>Retrieve the configured identity to use for reflogs</p>\n",
-      "comments": "<p>The memory is owned by the repository and must not be freed by the user.</p>\n",
+      "comments": "<p>The memory is owned by the repository and must not be freed by the\n user.</p>\n",
       "group": "repository"
     },
     "git_repository_set_ident": {
       "type": "function",
-      "file": "repository.h",
-      "line": 862,
-      "lineto": 862,
+      "file": "git2/repository.h",
+      "line": 864,
+      "lineto": 864,
       "args": [
         {
           "name": "repo",
@@ -18651,12 +19478,12 @@
         "comment": null
       },
       "description": "<p>Set the identity to be used for writing reflogs</p>\n",
-      "comments": "<p>If both are set, this name and email will be used to write to the reflog. Pass NULL to unset. When unset, the identity will be taken from the repository&#39;s configuration.</p>\n",
+      "comments": "<p>If both are set, this name and email will be used to write to the\n reflog. Pass NULL to unset. When unset, the identity will be taken\n from the repository&#39;s configuration.</p>\n",
       "group": "repository"
     },
     "git_reset": {
       "type": "function",
-      "file": "reset.h",
+      "file": "git2/reset.h",
       "line": 62,
       "lineto": 66,
       "args": [
@@ -18688,12 +19515,12 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Sets the current head to the specified commit oid and optionally\n resets the index and working tree to match.</p>\n",
-      "comments": "<p>SOFT reset means the Head will be moved to the commit.</p>\n\n<p>MIXED reset will trigger a SOFT reset, plus the index will be replaced with the content of the commit tree.</p>\n\n<p>HARD reset will trigger a MIXED reset and the working directory will be replaced with the content of the index.  (Untracked and ignored files will be left alone, however.)</p>\n\n<p>TODO: Implement remaining kinds of resets.</p>\n",
+      "comments": "<p>SOFT reset means the Head will be moved to the commit.</p>\n\n<p>MIXED reset will trigger a SOFT reset, plus the index will be replaced\n with the content of the commit tree.</p>\n\n<p>HARD reset will trigger a MIXED reset and the working directory will be\n replaced with the content of the index.  (Untracked and ignored files\n will be left alone, however.)</p>\n\n<p>TODO: Implement remaining kinds of resets.</p>\n",
       "group": "reset"
     },
     "git_reset_from_annotated": {
       "type": "function",
-      "file": "reset.h",
+      "file": "git2/reset.h",
       "line": 80,
       "lineto": 84,
       "args": [
@@ -18725,12 +19552,12 @@
         "comment": null
       },
       "description": "<p>Sets the current head to the specified commit oid and optionally\n resets the index and working tree to match.</p>\n",
-      "comments": "<p>This behaves like <code>git_reset()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_reset()</code>.</p>\n",
+      "comments": "<p>This behaves like <code>git_reset()</code> but takes an annotated commit,\n which lets you specify which extended sha syntax string was\n specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_reset()</code>.</p>\n",
       "group": "reset"
     },
     "git_reset_default": {
       "type": "function",
-      "file": "reset.h",
+      "file": "git2/reset.h",
       "line": 104,
       "lineto": 107,
       "args": [
@@ -18757,24 +19584,24 @@
         "comment": " 0 on success or an error code \n<\n 0"
       },
       "description": "<p>Updates some entries in the index from the target commit tree.</p>\n",
-      "comments": "<p>The scope of the updated entries is determined by the paths being passed in the <code>pathspec</code> parameters.</p>\n\n<p>Passing a NULL <code>target</code> will result in removing entries in the index matching the provided pathspecs.</p>\n",
+      "comments": "<p>The scope of the updated entries is determined by the paths\n being passed in the <code>pathspec</code> parameters.</p>\n\n<p>Passing a NULL <code>target</code> will result in removing\n entries in the index matching the provided pathspecs.</p>\n",
       "group": "reset"
     },
     "git_revert_init_options": {
       "type": "function",
-      "file": "revert.h",
-      "line": 47,
-      "lineto": 49,
+      "file": "git2/revert.h",
+      "line": 49,
+      "lineto": 51,
       "args": [
         {
           "name": "opts",
           "type": "git_revert_options *",
-          "comment": "the `git_revert_options` struct to initialize"
+          "comment": "The `git_revert_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_REVERT_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_REVERT_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_revert_options *opts, unsigned int version",
@@ -18783,15 +19610,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_revert_options</code> with default values. Equivalent to\n creating an instance with GIT_REVERT_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_revert_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_revert_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REVERT_OPTIONS_INIT</code>.</p>\n",
       "group": "revert"
     },
     "git_revert_commit": {
       "type": "function",
-      "file": "revert.h",
-      "line": 65,
-      "lineto": 71,
+      "file": "git2/revert.h",
+      "line": 67,
+      "lineto": 73,
       "args": [
         {
           "name": "out",
@@ -18836,9 +19663,9 @@
     },
     "git_revert": {
       "type": "function",
-      "file": "revert.h",
-      "line": 81,
-      "lineto": 84,
+      "file": "git2/revert.h",
+      "line": 83,
+      "lineto": 86,
       "args": [
         {
           "name": "repo",
@@ -18868,7 +19695,7 @@
     },
     "git_revparse_single": {
       "type": "function",
-      "file": "revparse.h",
+      "file": "git2/revparse.h",
       "line": 37,
       "lineto": 38,
       "args": [
@@ -18895,7 +19722,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EAMBIGUOUS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Find a single object, as specified by a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> when no longer needed.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> when no\n longer needed.</p>\n",
       "group": "revparse",
       "examples": {
         "blame.c": [
@@ -18905,7 +19732,7 @@
           "ex/HEAD/cat-file.html#git_revparse_single-34"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_revparse_single-8"
+          "ex/HEAD/describe.html#git_revparse_single-10"
         ],
         "log.c": [
           "ex/HEAD/log.html#git_revparse_single-48"
@@ -18920,7 +19747,7 @@
     },
     "git_revparse_ext": {
       "type": "function",
-      "file": "revparse.h",
+      "file": "git2/revparse.h",
       "line": 61,
       "lineto": 65,
       "args": [
@@ -18952,12 +19779,12 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EAMBIGUOUS, GIT_EINVALIDSPEC\n or an error code"
       },
       "description": "<p>Find a single object and intermediate reference by a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n\n<p>In some cases (<code>@{&lt;-n&gt;}</code> or <code>&lt;branchname&gt;@{upstream}</code>), the expression may point to an intermediate reference. When such expressions are being passed in, <code>reference_out</code> will be valued as well.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> and the returned reference with <code>git_reference_free</code> when no longer needed.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n\n<p>In some cases (<code>\n@\n{\n&lt;\n-n&gt;}</code> or `\n&lt;branchname</p>\n\n<blockquote>\n<p>@\n{upstream}<code>), the expression may\n point to an intermediate reference. When such expressions are being passed\n in,</code>reference_out` will be valued as well.</p>\n</blockquote>\n\n<p>The returned object should be released with <code>git_object_free</code> and the\n returned reference with <code>git_reference_free</code> when no longer needed.</p>\n",
       "group": "revparse"
     },
     "git_revparse": {
       "type": "function",
-      "file": "revparse.h",
+      "file": "git2/revparse.h",
       "line": 105,
       "lineto": 108,
       "args": [
@@ -18984,7 +19811,7 @@
         "comment": " 0 on success, GIT_INVALIDSPEC, GIT_ENOTFOUND, GIT_EAMBIGUOUS or an error code"
       },
       "description": "<p>Parse a revision string for <code>from</code>, <code>to</code>, and intent.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code> or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code> or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n",
       "group": "revparse",
       "examples": {
         "blame.c": [
@@ -19001,7 +19828,7 @@
     },
     "git_revwalk_new": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 73,
       "lineto": 73,
       "args": [
@@ -19023,7 +19850,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Allocate a new revision walker to iterate through a repo.</p>\n",
-      "comments": "<p>This revision walker uses a custom memory pool and an internal commit cache, so it is relatively expensive to allocate.</p>\n\n<p>For maximum performance, this revision walker should be reused for different walks.</p>\n\n<p>This revision walker is <em>not</em> thread safe: it may only be used to walk a repository on a single thread; however, it is possible to have several revision walkers in several different threads walking the same repository.</p>\n",
+      "comments": "<p>This revision walker uses a custom memory pool and an internal\n commit cache, so it is relatively expensive to allocate.</p>\n\n<p>For maximum performance, this revision walker should be\n reused for different walks.</p>\n\n<p>This revision walker is <em>not</em> thread safe: it may only be\n used to walk a repository on a single thread; however,\n it is possible to have several revision walkers in\n several different threads walking the same repository.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
@@ -19037,7 +19864,7 @@
     },
     "git_revwalk_reset": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 88,
       "lineto": 88,
       "args": [
@@ -19054,12 +19881,12 @@
         "comment": null
       },
       "description": "<p>Reset the revision walker for reuse.</p>\n",
-      "comments": "<p>This will clear all the pushed and hidden commits, and leave the walker in a blank state (just like at creation) ready to receive new commit pushes and start a new walk.</p>\n\n<p>The revision walk is automatically reset when a walk is over.</p>\n",
+      "comments": "<p>This will clear all the pushed and hidden commits, and\n leave the walker in a blank state (just like at\n creation) ready to receive new commit pushes and\n start a new walk.</p>\n\n<p>The revision walk is automatically reset when a walk\n is over.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_push": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 107,
       "lineto": 107,
       "args": [
@@ -19081,7 +19908,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a new root for the traversal</p>\n",
-      "comments": "<p>The pushed commit will be marked as one of the roots from which to start the walk. This commit may not be walked if it or a child is hidden.</p>\n\n<p>At least one commit must be pushed onto the walker before a walk can be started.</p>\n\n<p>The given id must belong to a committish on the walked repository.</p>\n",
+      "comments": "<p>The pushed commit will be marked as one of the roots from which to\n start the walk. This commit may not be walked if it or a child is\n hidden.</p>\n\n<p>At least one commit must be pushed onto the walker before a walk\n can be started.</p>\n\n<p>The given id must belong to a committish on the walked\n repository.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
@@ -19094,7 +19921,7 @@
     },
     "git_revwalk_push_glob": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 125,
       "lineto": 125,
       "args": [
@@ -19116,12 +19943,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Push matching references</p>\n",
-      "comments": "<p>The OIDs pointed to by the references that match the given glob pattern will be pushed to the revision walker.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing &#39;/*&#39; if the glob lacks &#39;?&#39;, &#39;*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a committish will be ignored.</p>\n",
+      "comments": "<p>The OIDs pointed to by the references that match the given glob\n pattern will be pushed to the revision walker.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing\n &#39;/\n\\\n*&#39; if the glob lacks &#39;?&#39;, &#39;\n\\\n*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a\n committish will be ignored.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_push_head": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 133,
       "lineto": 133,
       "args": [
@@ -19148,7 +19975,7 @@
     },
     "git_revwalk_hide": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 148,
       "lineto": 148,
       "args": [
@@ -19170,7 +19997,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Mark a commit (and its ancestors) uninteresting for the output.</p>\n",
-      "comments": "<p>The given id must belong to a committish on the walked repository.</p>\n\n<p>The resolved commit and all its parents will be hidden from the output on the revision walk.</p>\n",
+      "comments": "<p>The given id must belong to a committish on the walked\n repository.</p>\n\n<p>The resolved commit and all its parents will be hidden from the\n output on the revision walk.</p>\n",
       "group": "revwalk",
       "examples": {
         "log.c": [
@@ -19180,7 +20007,7 @@
     },
     "git_revwalk_hide_glob": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 167,
       "lineto": 167,
       "args": [
@@ -19202,12 +20029,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Hide matching references.</p>\n",
-      "comments": "<p>The OIDs pointed to by the references that match the given glob pattern and their ancestors will be hidden from the output on the revision walk.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing &#39;/*&#39; if the glob lacks &#39;?&#39;, &#39;*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a committish will be ignored.</p>\n",
+      "comments": "<p>The OIDs pointed to by the references that match the given glob\n pattern and their ancestors will be hidden from the output on the\n revision walk.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing\n &#39;/\n\\\n*&#39; if the glob lacks &#39;?&#39;, &#39;\n\\\n*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a\n committish will be ignored.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_hide_head": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 175,
       "lineto": 175,
       "args": [
@@ -19229,7 +20056,7 @@
     },
     "git_revwalk_push_ref": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 186,
       "lineto": 186,
       "args": [
@@ -19256,7 +20083,7 @@
     },
     "git_revwalk_hide_ref": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 197,
       "lineto": 197,
       "args": [
@@ -19283,7 +20110,7 @@
     },
     "git_revwalk_next": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 217,
       "lineto": 217,
       "args": [
@@ -19305,7 +20132,7 @@
         "comment": " 0 if the next commit was found;\n\tGIT_ITEROVER if there are no commits left to iterate"
       },
       "description": "<p>Get the next commit from the revision walk.</p>\n",
-      "comments": "<p>The initial call to this method is <em>not</em> blocking when iterating through a repo with a time-sorting mode.</p>\n\n<p>Iterating with Topological or inverted modes makes the initial call blocking to preprocess the commit list, but this block should be mostly unnoticeable on most repositories (topological preprocessing times at 0.3s on the git.git repo).</p>\n\n<p>The revision walker is reset when the walk is over.</p>\n",
+      "comments": "<p>The initial call to this method is <em>not</em> blocking when\n iterating through a repo with a time-sorting mode.</p>\n\n<p>Iterating with Topological or inverted modes makes the initial\n call blocking to preprocess the commit list, but this block should be\n mostly unnoticeable on most repositories (topological preprocessing\n times at 0.3s on the git.git repo).</p>\n\n<p>The revision walker is reset when the walk is over.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
@@ -19318,7 +20145,7 @@
     },
     "git_revwalk_sorting": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 228,
       "lineto": 228,
       "args": [
@@ -19354,7 +20181,7 @@
     },
     "git_revwalk_push_range": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 243,
       "lineto": 243,
       "args": [
@@ -19376,12 +20203,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Push and hide the respective endpoints of the given range.</p>\n",
-      "comments": "<p>The range should be of the form   <commit>..<commit> where each <commit> is in the form accepted by &#39;git_revparse_single&#39;. The left-hand commit will be hidden and the right-hand commit pushed.</p>\n",
+      "comments": "<p>The range should be of the form</p>\n\n<p>&lt;commit</p>\n\n<blockquote>\n<p>..\n&lt;commit</p>\n\n<p>where each \n&lt;commit\nis in the form accepted by &#39;git_revparse_single&#39;.\n The left-hand commit will be hidden and the right-hand commit pushed.</p>\n</blockquote>\n",
       "group": "revwalk"
     },
     "git_revwalk_simplify_first_parent": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 250,
       "lineto": 250,
       "args": [
@@ -19403,7 +20230,7 @@
     },
     "git_revwalk_free": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 258,
       "lineto": 258,
       "args": [
@@ -19433,7 +20260,7 @@
     },
     "git_revwalk_repository": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 267,
       "lineto": 267,
       "args": [
@@ -19455,7 +20282,7 @@
     },
     "git_revwalk_add_hide_cb": {
       "type": "function",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 288,
       "lineto": 291,
       "args": [
@@ -19487,7 +20314,7 @@
     },
     "git_signature_new": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 37,
       "lineto": 37,
       "args": [
@@ -19524,7 +20351,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new action signature.</p>\n",
-      "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n\n<p>Note: angle brackets (&#39;&lt;&#39; and &#39;&gt;&#39;) characters are not allowed to be used in either the <code>name</code> or the <code>email</code> parameter.</p>\n",
+      "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n\n<p>Note: angle brackets (&#39;\n&lt;\n&#39; and &#39;&gt;&#39;) characters are not allowed\n to be used in either the <code>name</code> or the <code>email</code> parameter.</p>\n",
       "group": "signature",
       "examples": {
         "general.c": [
@@ -19535,7 +20362,7 @@
     },
     "git_signature_now": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 49,
       "lineto": 49,
       "args": [
@@ -19566,13 +20393,13 @@
       "group": "signature",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_signature_now-45"
+          "ex/HEAD/merge.html#git_signature_now-40"
         ]
       }
     },
     "git_signature_default": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 63,
       "lineto": 63,
       "args": [
@@ -19594,7 +20421,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if config is missing, or error code"
       },
       "description": "<p>Create a new action signature with default user and now timestamp.</p>\n",
-      "comments": "<p>This looks up the user.name and user.email from the configuration and uses the current time as the timestamp, and creates a new signature based on that information.  It will return GIT_ENOTFOUND if either the user.name or user.email are not set.</p>\n",
+      "comments": "<p>This looks up the user.name and user.email from the configuration and\n uses the current time as the timestamp, and creates a new signature\n based on that information.  It will return GIT_ENOTFOUND if either the\n user.name or user.email are not set.</p>\n",
       "group": "signature",
       "examples": {
         "init.c": [
@@ -19607,7 +20434,7 @@
     },
     "git_signature_from_buffer": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 76,
       "lineto": 76,
       "args": [
@@ -19634,7 +20461,7 @@
     },
     "git_signature_dup": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 88,
       "lineto": 88,
       "args": [
@@ -19661,7 +20488,7 @@
     },
     "git_signature_free": {
       "type": "function",
-      "file": "signature.h",
+      "file": "git2/signature.h",
       "line": 99,
       "lineto": 99,
       "args": [
@@ -19678,7 +20505,7 @@
         "comment": null
       },
       "description": "<p>Free an existing signature.</p>\n",
-      "comments": "<p>Because the signature is not an opaque structure, it is legal to free it manually, but be sure to free the &quot;name&quot; and &quot;email&quot; strings in addition to the structure itself.</p>\n",
+      "comments": "<p>Because the signature is not an opaque structure, it is legal to free it\n manually, but be sure to free the &quot;name&quot; and &quot;email&quot; strings in addition\n to the structure itself.</p>\n",
       "group": "signature",
       "examples": {
         "general.c": [
@@ -19693,21 +20520,63 @@
         ]
       }
     },
+    "git_stash_save": {
+      "type": "function",
+      "file": "git2/stash.h",
+      "line": 67,
+      "lineto": 72,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_oid *",
+          "comment": "Object id of the commit containing the stashed state.\n This commit is also the target of the direct reference refs/stash."
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "The owning repository."
+        },
+        {
+          "name": "stasher",
+          "type": "const git_signature *",
+          "comment": "The identity of the person performing the stashing."
+        },
+        {
+          "name": "message",
+          "type": "const char *",
+          "comment": "Optional description along with the stashed state."
+        },
+        {
+          "name": "flags",
+          "type": "uint32_t",
+          "comment": "Flags to control the stashing process. (see GIT_STASH_* above)"
+        }
+      ],
+      "argline": "git_oid *out, git_repository *repo, const git_signature *stasher, const char *message, uint32_t flags",
+      "sig": "git_oid *::git_repository *::const git_signature *::const char *::uint32_t",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, GIT_ENOTFOUND where there's nothing to stash,\n or error code."
+      },
+      "description": "<p>Save the local modifications to a new stash.</p>\n",
+      "comments": "",
+      "group": "stash"
+    },
     "git_stash_apply_init_options": {
       "type": "function",
-      "file": "stash.h",
-      "line": 153,
-      "lineto": 154,
+      "file": "git2/stash.h",
+      "line": 156,
+      "lineto": 157,
       "args": [
         {
           "name": "opts",
           "type": "git_stash_apply_options *",
-          "comment": "the `git_stash_apply_options` instance to initialize."
+          "comment": "The `git_stash_apply_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "the version of the struct; you should pass\n        `GIT_STASH_APPLY_OPTIONS_INIT` here."
+          "comment": "The struct version; pass `GIT_STASH_APPLY_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_stash_apply_options *opts, unsigned int version",
@@ -19716,15 +20585,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_stash_apply_options</code> with default values. Equivalent to\n creating an instance with GIT_STASH_APPLY_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_stash_apply_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_stash_apply_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>.</p>\n",
       "group": "stash"
     },
     "git_stash_apply": {
       "type": "function",
-      "file": "stash.h",
-      "line": 182,
-      "lineto": 185,
+      "file": "git2/stash.h",
+      "line": 185,
+      "lineto": 188,
       "args": [
         {
           "name": "repo",
@@ -19749,14 +20618,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND if there's no stashed state for the\n         given index, GIT_EMERGECONFLICT if changes exist in the working\n         directory, or an error code"
       },
       "description": "<p>Apply a single stashed state from the stash list.</p>\n",
-      "comments": "<p>If local changes in the working directory conflict with changes in the stash then GIT_EMERGECONFLICT will be returned.  In this case, the index will always remain unmodified and all files in the working directory will remain unmodified.  However, if you are restoring untracked files or ignored files and there is a conflict when applying the modified files, then those files will remain in the working directory.</p>\n\n<p>If passing the GIT_STASH_APPLY_REINSTATE_INDEX flag and there would be conflicts when reinstating the index, the function will return GIT_EMERGECONFLICT and both the working directory and index will be left unmodified.</p>\n\n<p>Note that a minimum checkout strategy of <code>GIT_CHECKOUT_SAFE</code> is implied.</p>\n",
+      "comments": "<p>If local changes in the working directory conflict with changes in the\n stash then GIT_EMERGECONFLICT will be returned.  In this case, the index\n will always remain unmodified and all files in the working directory will\n remain unmodified.  However, if you are restoring untracked files or\n ignored files and there is a conflict when applying the modified files,\n then those files will remain in the working directory.</p>\n\n<p>If passing the GIT_STASH_APPLY_REINSTATE_INDEX flag and there would be\n conflicts when reinstating the index, the function will return\n GIT_EMERGECONFLICT and both the working directory and index will be left\n unmodified.</p>\n\n<p>Note that a minimum checkout strategy of <code>GIT_CHECKOUT_SAFE</code> is implied.</p>\n",
       "group": "stash"
     },
     "git_stash_foreach": {
       "type": "function",
-      "file": "stash.h",
-      "line": 218,
-      "lineto": 221,
+      "file": "git2/stash.h",
+      "line": 221,
+      "lineto": 224,
       "args": [
         {
           "name": "repo",
@@ -19786,9 +20655,9 @@
     },
     "git_stash_drop": {
       "type": "function",
-      "file": "stash.h",
-      "line": 234,
-      "lineto": 236,
+      "file": "git2/stash.h",
+      "line": 237,
+      "lineto": 239,
       "args": [
         {
           "name": "repo",
@@ -19813,9 +20682,9 @@
     },
     "git_stash_pop": {
       "type": "function",
-      "file": "stash.h",
-      "line": 250,
-      "lineto": 253,
+      "file": "git2/stash.h",
+      "line": 253,
+      "lineto": 256,
       "args": [
         {
           "name": "repo",
@@ -19845,19 +20714,19 @@
     },
     "git_status_init_options": {
       "type": "function",
-      "file": "status.h",
-      "line": 199,
-      "lineto": 201,
+      "file": "git2/status.h",
+      "line": 203,
+      "lineto": 205,
       "args": [
         {
           "name": "opts",
           "type": "git_status_options *",
-          "comment": "The `git_status_options` instance to initialize."
+          "comment": "The `git_status_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_STATUS_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_STATUS_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_status_options *opts, unsigned int version",
@@ -19866,15 +20735,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_status_options</code> with default values. Equivalent to\n creating an instance with GIT_STATUS_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_status_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_status_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_STATUS_OPTIONS_INIT</code>.</p>\n",
       "group": "status"
     },
     "git_status_foreach": {
       "type": "function",
-      "file": "status.h",
-      "line": 239,
-      "lineto": 242,
+      "file": "git2/status.h",
+      "line": 243,
+      "lineto": 246,
       "args": [
         {
           "name": "repo",
@@ -19899,7 +20768,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Gather file statuses and run a callback for each one.</p>\n",
-      "comments": "<p>The callback is passed the path of the file, the status (a combination of the <code>git_status_t</code> values above) and the <code>payload</code> data pointer passed into this function.</p>\n\n<p>If the callback returns a non-zero value, this function will stop looping and return that value to caller.</p>\n",
+      "comments": "<p>The callback is passed the path of the file, the status (a combination of\n the <code>git_status_t</code> values above) and the <code>payload</code> data pointer passed\n into this function.</p>\n\n<p>If the callback returns a non-zero value, this function will stop looping\n and return that value to caller.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
@@ -19909,9 +20778,9 @@
     },
     "git_status_foreach_ext": {
       "type": "function",
-      "file": "status.h",
-      "line": 263,
-      "lineto": 267,
+      "file": "git2/status.h",
+      "line": 267,
+      "lineto": 271,
       "args": [
         {
           "name": "repo",
@@ -19941,7 +20810,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Gather file status information and run callbacks as requested.</p>\n",
-      "comments": "<p>This is an extended version of the <code>git_status_foreach()</code> API that allows for more granular control over which paths will be processed and in what order.  See the <code>git_status_options</code> structure for details about the additional controls that this makes available.</p>\n\n<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter the status, then the results from rename detection (if you enable it) may not be accurate.  To do rename detection properly, this must be called with no <code>pathspec</code> so that all files can be considered.</p>\n",
+      "comments": "<p>This is an extended version of the <code>git_status_foreach()</code> API that\n allows for more granular control over which paths will be processed and\n in what order.  See the <code>git_status_options</code> structure for details\n about the additional controls that this makes available.</p>\n\n<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter\n the status, then the results from rename detection (if you enable it) may\n not be accurate.  To do rename detection properly, this must be called\n with no <code>pathspec</code> so that all files can be considered.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
@@ -19951,9 +20820,9 @@
     },
     "git_status_file": {
       "type": "function",
-      "file": "status.h",
-      "line": 295,
-      "lineto": 298,
+      "file": "git2/status.h",
+      "line": 299,
+      "lineto": 302,
       "args": [
         {
           "name": "status_flags",
@@ -19978,14 +20847,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the file is not found in the HEAD,\n      index, and work tree, GIT_EAMBIGUOUS if `path` matches multiple files\n      or if it refers to a folder, and -1 on other errors."
       },
       "description": "<p>Get file status for a single file.</p>\n",
-      "comments": "<p>This tries to get status for the filename that you give.  If no files match that name (in either the HEAD, index, or working directory), this returns GIT_ENOTFOUND.</p>\n\n<p>If the name matches multiple files (for example, if the <code>path</code> names a directory or if running on a case- insensitive filesystem and yet the HEAD has two entries that both match the path), then this returns GIT_EAMBIGUOUS because it cannot give correct results.</p>\n\n<p>This does not do any sort of rename detection.  Renames require a set of targets and because of the path filtering, there is not enough information to check renames correctly.  To check file status with rename detection, there is no choice but to do a full <code>git_status_list_new</code> and scan through looking for the path that you are interested in.</p>\n",
+      "comments": "<p>This tries to get status for the filename that you give.  If no files\n match that name (in either the HEAD, index, or working directory), this\n returns GIT_ENOTFOUND.</p>\n\n<p>If the name matches multiple files (for example, if the <code>path</code> names a\n directory or if running on a case- insensitive filesystem and yet the\n HEAD has two entries that both match the path), then this returns\n GIT_EAMBIGUOUS because it cannot give correct results.</p>\n\n<p>This does not do any sort of rename detection.  Renames require a set of\n targets and because of the path filtering, there is not enough\n information to check renames correctly.  To check file status with rename\n detection, there is no choice but to do a full <code>git_status_list_new</code> and\n scan through looking for the path that you are interested in.</p>\n",
       "group": "status"
     },
     "git_status_list_new": {
       "type": "function",
-      "file": "status.h",
-      "line": 313,
-      "lineto": 316,
+      "file": "git2/status.h",
+      "line": 317,
+      "lineto": 320,
       "args": [
         {
           "name": "out",
@@ -20010,7 +20879,7 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Gather file status information and populate the <code>git_status_list</code>.</p>\n",
-      "comments": "<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter the status, then the results from rename detection (if you enable it) may not be accurate.  To do rename detection properly, this must be called with no <code>pathspec</code> so that all files can be considered.</p>\n",
+      "comments": "<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter\n the status, then the results from rename detection (if you enable it) may\n not be accurate.  To do rename detection properly, this must be called\n with no <code>pathspec</code> so that all files can be considered.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
@@ -20021,9 +20890,9 @@
     },
     "git_status_list_entrycount": {
       "type": "function",
-      "file": "status.h",
-      "line": 327,
-      "lineto": 328,
+      "file": "git2/status.h",
+      "line": 331,
+      "lineto": 332,
       "args": [
         {
           "name": "statuslist",
@@ -20038,7 +20907,7 @@
         "comment": " the number of status entries"
       },
       "description": "<p>Gets the count of status entries in this list.</p>\n",
-      "comments": "<p>If there are no changes in status (at least according the options given when the status list was created), this can return 0.</p>\n",
+      "comments": "<p>If there are no changes in status (at least according the options given\n when the status list was created), this can return 0.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
@@ -20049,9 +20918,9 @@
     },
     "git_status_byindex": {
       "type": "function",
-      "file": "status.h",
-      "line": 339,
-      "lineto": 341,
+      "file": "git2/status.h",
+      "line": 343,
+      "lineto": 345,
       "args": [
         {
           "name": "statuslist",
@@ -20086,9 +20955,9 @@
     },
     "git_status_list_free": {
       "type": "function",
-      "file": "status.h",
-      "line": 348,
-      "lineto": 349,
+      "file": "git2/status.h",
+      "line": 352,
+      "lineto": 353,
       "args": [
         {
           "name": "statuslist",
@@ -20113,9 +20982,9 @@
     },
     "git_status_should_ignore": {
       "type": "function",
-      "file": "status.h",
-      "line": 367,
-      "lineto": 370,
+      "file": "git2/status.h",
+      "line": 371,
+      "lineto": 374,
       "args": [
         {
           "name": "ignored",
@@ -20140,12 +21009,12 @@
         "comment": " 0 if ignore rules could be processed for the file (regardless\n         of whether it exists or not), or an error \n<\n 0 if they could not."
       },
       "description": "<p>Test if the ignore rules apply to a given file.</p>\n",
-      "comments": "<p>This function checks the ignore rules to see if they would apply to the given file.  This indicates if the file would be ignored regardless of whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git add .&quot; on the directory containing the file, would it be added or not?</p>\n",
+      "comments": "<p>This function checks the ignore rules to see if they would apply to the\n given file.  This indicates if the file would be ignored regardless of\n whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git add .&quot; on the\n directory containing the file, would it be added or not?</p>\n",
       "group": "status"
     },
     "git_strarray_free": {
       "type": "function",
-      "file": "strarray.h",
+      "file": "git2/strarray.h",
       "line": 41,
       "lineto": 41,
       "args": [
@@ -20162,7 +21031,7 @@
         "comment": null
       },
       "description": "<p>Close a string array object</p>\n",
-      "comments": "<p>This method should be called on <code>git_strarray</code> objects where the strings array is allocated and contains allocated strings, such as what you would get from <code>git_strarray_copy()</code>.  Not doing so, will result in a memory leak.</p>\n\n<p>This does not free the <code>git_strarray</code> itself, since the library will never allocate that object directly itself (it is more commonly embedded inside another struct or created on the stack).</p>\n",
+      "comments": "<p>This method should be called on <code>git_strarray</code> objects where the strings\n array is allocated and contains allocated strings, such as what you\n would get from <code>git_strarray_copy()</code>.  Not doing so, will result in a\n memory leak.</p>\n\n<p>This does not free the <code>git_strarray</code> itself, since the library will\n never allocate that object directly itself (it is more commonly embedded\n inside another struct or created on the stack).</p>\n",
       "group": "strarray",
       "examples": {
         "general.c": [
@@ -20179,7 +21048,7 @@
     },
     "git_strarray_copy": {
       "type": "function",
-      "file": "strarray.h",
+      "file": "git2/strarray.h",
       "line": 53,
       "lineto": 53,
       "args": [
@@ -20201,24 +21070,24 @@
         "comment": " 0 on success, \n<\n 0 on allocation failure"
       },
       "description": "<p>Copy a string array object from source to target.</p>\n",
-      "comments": "<p>Note: target is overwritten and hence should be empty, otherwise its contents are leaked.  Call git_strarray_free() if necessary.</p>\n",
+      "comments": "<p>Note: target is overwritten and hence should be empty, otherwise its\n contents are leaked.  Call git_strarray_free() if necessary.</p>\n",
       "group": "strarray"
     },
     "git_submodule_update_init_options": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 170,
-      "lineto": 171,
+      "file": "git2/submodule.h",
+      "line": 171,
+      "lineto": 172,
       "args": [
         {
           "name": "opts",
           "type": "git_submodule_update_options *",
-          "comment": "The `git_submodule_update_options` instance to initialize."
+          "comment": "The `git_submodule_update_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_SUBMODULE_UPDATE_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_SUBMODULE_UPDATE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_submodule_update_options *opts, unsigned int version",
@@ -20227,15 +21096,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_submodule_update_options</code> with default values.\n Equivalent to creating an instance with GIT_SUBMODULE_UPDATE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_submodule_update_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_submodule_update_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>.</p>\n",
       "group": "submodule"
     },
     "git_submodule_update": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 191,
-      "lineto": 191,
+      "file": "git2/submodule.h",
+      "line": 192,
+      "lineto": 192,
       "args": [
         {
           "name": "submodule",
@@ -20265,9 +21134,9 @@
     },
     "git_submodule_lookup": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 220,
-      "lineto": 223,
+      "file": "git2/submodule.h",
+      "line": 221,
+      "lineto": 224,
       "args": [
         {
           "name": "out",
@@ -20292,14 +21161,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND if submodule does not exist,\n         GIT_EEXISTS if a repository is found in working directory only,\n         -1 on other errors."
       },
       "description": "<p>Lookup submodule information by name or path.</p>\n",
-      "comments": "<p>Given either the submodule name or path (they are usually the same), this returns a structure describing the submodule.</p>\n\n<p>There are two expected error scenarios:</p>\n\n<ul>\n<li>The submodule is not mentioned in the HEAD, the index, and the config,   but does &quot;exist&quot; in the working directory (i.e. there is a subdirectory   that appears to be a Git repository).  In this case, this function   returns GIT_EEXISTS to indicate a sub-repository exists but not in a   state where a git_submodule can be instantiated. - The submodule is not mentioned in the HEAD, index, or config and the   working directory doesn&#39;t contain a value git repo at that path.   There may or may not be anything else at that path, but nothing that   looks like a submodule.  In this case, this returns GIT_ENOTFOUND.</li>\n</ul>\n\n<p>You must call <code>git_submodule_free</code> when done with the submodule.</p>\n",
+      "comments": "<p>Given either the submodule name or path (they are usually the same), this\n returns a structure describing the submodule.</p>\n\n<p>There are two expected error scenarios:</p>\n\n<ul>\n<li>The submodule is not mentioned in the HEAD, the index, and the config,\nbut does &quot;exist&quot; in the working directory (i.e. there is a subdirectory\nthat appears to be a Git repository).  In this case, this function\nreturns GIT_EEXISTS to indicate a sub-repository exists but not in a\nstate where a git_submodule can be instantiated.</li>\n<li>The submodule is not mentioned in the HEAD, index, or config and the\nworking directory doesn&#39;t contain a value git repo at that path.\nThere may or may not be anything else at that path, but nothing that\nlooks like a submodule.  In this case, this returns GIT_ENOTFOUND.</li>\n</ul>\n\n<p>You must call <code>git_submodule_free</code> when done with the submodule.</p>\n",
       "group": "submodule"
     },
     "git_submodule_free": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 230,
-      "lineto": 230,
+      "file": "git2/submodule.h",
+      "line": 231,
+      "lineto": 231,
       "args": [
         {
           "name": "submodule",
@@ -20319,9 +21188,9 @@
     },
     "git_submodule_foreach": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 250,
-      "lineto": 253,
+      "file": "git2/submodule.h",
+      "line": 251,
+      "lineto": 254,
       "args": [
         {
           "name": "repo",
@@ -20346,7 +21215,7 @@
         "comment": " 0 on success, -1 on error, or non-zero return value of callback"
       },
       "description": "<p>Iterate over all tracked submodules of a repository.</p>\n",
-      "comments": "<p>See the note on <code>git_submodule</code> above.  This iterates over the tracked submodules as described therein.</p>\n\n<p>If you are concerned about items in the working directory that look like submodules but are not tracked, the diff API will generate a diff record for workdir items that look like submodules but are not tracked, showing them as added in the workdir.  Also, the status API will treat the entire subdirectory of a contained git repo as a single GIT_STATUS_WT_NEW item.</p>\n",
+      "comments": "<p>See the note on <code>git_submodule</code> above.  This iterates over the tracked\n submodules as described therein.</p>\n\n<p>If you are concerned about items in the working directory that look like\n submodules but are not tracked, the diff API will generate a diff record\n for workdir items that look like submodules but are not tracked, showing\n them as added in the workdir.  Also, the status API will treat the entire\n subdirectory of a contained git repo as a single GIT_STATUS_WT_NEW item.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
@@ -20356,9 +21225,9 @@
     },
     "git_submodule_add_setup": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 280,
-      "lineto": 285,
+      "file": "git2/submodule.h",
+      "line": 281,
+      "lineto": 286,
       "args": [
         {
           "name": "out",
@@ -20393,14 +21262,14 @@
         "comment": " 0 on success, GIT_EEXISTS if submodule already exists,\n         -1 on other errors."
       },
       "description": "<p>Set up a new git submodule for checkout.</p>\n",
-      "comments": "<p>This does &quot;git submodule add&quot; up to the fetch and checkout of the submodule contents.  It preps a new submodule, creates an entry in .gitmodules and creates an empty initialized repository either at the given path in the working directory or in .git/modules with a gitlink from the working directory to the new repo.</p>\n\n<p>To fully emulate &quot;git submodule add&quot; call this function, then open the submodule repo and perform the clone step as needed.  Lastly, call <code>git_submodule_add_finalize()</code> to wrap up adding the new submodule and .gitmodules to the index to be ready to commit.</p>\n\n<p>You must call <code>git_submodule_free</code> on the submodule object when done.</p>\n",
+      "comments": "<p>This does &quot;git submodule add&quot; up to the fetch and checkout of the\n submodule contents.  It preps a new submodule, creates an entry in\n .gitmodules and creates an empty initialized repository either at the\n given path in the working directory or in .git/modules with a gitlink\n from the working directory to the new repo.</p>\n\n<p>To fully emulate &quot;git submodule add&quot; call this function, then open the\n submodule repo and perform the clone step as needed.  Lastly, call\n <code>git_submodule_add_finalize()</code> to wrap up adding the new submodule and\n .gitmodules to the index to be ready to commit.</p>\n\n<p>You must call <code>git_submodule_free</code> on the submodule object when done.</p>\n",
       "group": "submodule"
     },
     "git_submodule_add_finalize": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 297,
-      "lineto": 297,
+      "file": "git2/submodule.h",
+      "line": 298,
+      "lineto": 298,
       "args": [
         {
           "name": "submodule",
@@ -20415,14 +21284,14 @@
         "comment": null
       },
       "description": "<p>Resolve the setup of a new git submodule.</p>\n",
-      "comments": "<p>This should be called on a submodule once you have called add setup and done the clone of the submodule.  This adds the .gitmodules file and the newly cloned submodule to the index to be ready to be committed (but doesn&#39;t actually do the commit).</p>\n",
+      "comments": "<p>This should be called on a submodule once you have called add setup\n and done the clone of the submodule.  This adds the .gitmodules file\n and the newly cloned submodule to the index to be ready to be committed\n (but doesn&#39;t actually do the commit).</p>\n",
       "group": "submodule"
     },
     "git_submodule_add_to_index": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 309,
-      "lineto": 311,
+      "file": "git2/submodule.h",
+      "line": 310,
+      "lineto": 312,
       "args": [
         {
           "name": "submodule",
@@ -20447,9 +21316,9 @@
     },
     "git_submodule_owner": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 324,
-      "lineto": 324,
+      "file": "git2/submodule.h",
+      "line": 325,
+      "lineto": 325,
       "args": [
         {
           "name": "submodule",
@@ -20464,14 +21333,14 @@
         "comment": " Pointer to `git_repository`"
       },
       "description": "<p>Get the containing repository for a submodule.</p>\n",
-      "comments": "<p>This returns a pointer to the repository that contains the submodule. This is a just a reference to the repository that was passed to the original <code>git_submodule_lookup()</code> call, so if that repository has been freed, then this may be a dangling reference.</p>\n",
+      "comments": "<p>This returns a pointer to the repository that contains the submodule.\n This is a just a reference to the repository that was passed to the\n original <code>git_submodule_lookup()</code> call, so if that repository has been\n freed, then this may be a dangling reference.</p>\n",
       "group": "submodule"
     },
     "git_submodule_name": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 332,
-      "lineto": 332,
+      "file": "git2/submodule.h",
+      "line": 333,
+      "lineto": 333,
       "args": [
         {
           "name": "submodule",
@@ -20496,9 +21365,9 @@
     },
     "git_submodule_path": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 343,
-      "lineto": 343,
+      "file": "git2/submodule.h",
+      "line": 344,
+      "lineto": 344,
       "args": [
         {
           "name": "submodule",
@@ -20513,7 +21382,7 @@
         "comment": " Pointer to the submodule path"
       },
       "description": "<p>Get the path to the submodule.</p>\n",
-      "comments": "<p>The path is almost always the same as the submodule name, but the two are actually not required to match.</p>\n",
+      "comments": "<p>The path is almost always the same as the submodule name, but the\n two are actually not required to match.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
@@ -20523,9 +21392,9 @@
     },
     "git_submodule_url": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 351,
-      "lineto": 351,
+      "file": "git2/submodule.h",
+      "line": 352,
+      "lineto": 352,
       "args": [
         {
           "name": "submodule",
@@ -20545,9 +21414,9 @@
     },
     "git_submodule_resolve_url": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 361,
-      "lineto": 361,
+      "file": "git2/submodule.h",
+      "line": 362,
+      "lineto": 362,
       "args": [
         {
           "name": "out",
@@ -20577,9 +21446,9 @@
     },
     "git_submodule_branch": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 369,
-      "lineto": 369,
+      "file": "git2/submodule.h",
+      "line": 370,
+      "lineto": 370,
       "args": [
         {
           "name": "submodule",
@@ -20599,9 +21468,9 @@
     },
     "git_submodule_set_branch": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 382,
-      "lineto": 382,
+      "file": "git2/submodule.h",
+      "line": 383,
+      "lineto": 383,
       "args": [
         {
           "name": "repo",
@@ -20626,14 +21495,14 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set the branch for the submodule in the configuration</p>\n",
-      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to write the changes to the checked out submodule repository.</p>\n",
+      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to\n write the changes to the checked out submodule repository.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_url": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 396,
-      "lineto": 396,
+      "file": "git2/submodule.h",
+      "line": 397,
+      "lineto": 397,
       "args": [
         {
           "name": "repo",
@@ -20658,14 +21527,14 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set the URL for the submodule in the configuration</p>\n",
-      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to write the changes to the checked out submodule repository.</p>\n",
+      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to\n write the changes to the checked out submodule repository.</p>\n",
       "group": "submodule"
     },
     "git_submodule_index_id": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 404,
-      "lineto": 404,
+      "file": "git2/submodule.h",
+      "line": 405,
+      "lineto": 405,
       "args": [
         {
           "name": "submodule",
@@ -20685,9 +21554,9 @@
     },
     "git_submodule_head_id": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 412,
-      "lineto": 412,
+      "file": "git2/submodule.h",
+      "line": 413,
+      "lineto": 413,
       "args": [
         {
           "name": "submodule",
@@ -20707,9 +21576,9 @@
     },
     "git_submodule_wd_id": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 425,
-      "lineto": 425,
+      "file": "git2/submodule.h",
+      "line": 426,
+      "lineto": 426,
       "args": [
         {
           "name": "submodule",
@@ -20724,14 +21593,14 @@
         "comment": " Pointer to git_oid or NULL if submodule is not checked out."
       },
       "description": "<p>Get the OID for the submodule in the current working directory.</p>\n",
-      "comments": "<p>This returns the OID that corresponds to looking up &#39;HEAD&#39; in the checked out submodule.  If there are pending changes in the index or anything else, this won&#39;t notice that.  You should call <code>git_submodule_status()</code> for a more complete picture about the state of the working directory.</p>\n",
+      "comments": "<p>This returns the OID that corresponds to looking up &#39;HEAD&#39; in the checked\n out submodule.  If there are pending changes in the index or anything\n else, this won&#39;t notice that.  You should call <code>git_submodule_status()</code>\n for a more complete picture about the state of the working directory.</p>\n",
       "group": "submodule"
     },
     "git_submodule_ignore": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 450,
-      "lineto": 451,
+      "file": "git2/submodule.h",
+      "line": 451,
+      "lineto": 452,
       "args": [
         {
           "name": "submodule",
@@ -20746,14 +21615,14 @@
         "comment": " The current git_submodule_ignore_t valyue what will be used for\n         this submodule."
       },
       "description": "<p>Get the ignore rule that will be used for the submodule.</p>\n",
-      "comments": "<p>These values control the behavior of <code>git_submodule_status()</code> for this submodule.  There are four ignore values:</p>\n\n<ul>\n<li><strong>GIT_SUBMODULE_IGNORE_NONE</strong> will consider any change to the contents    of the submodule from a clean checkout to be dirty, including the    addition of untracked files.  This is the default if unspecified.  - <strong>GIT_SUBMODULE_IGNORE_UNTRACKED</strong> examines the contents of the    working tree (i.e. call <code>git_status_foreach()</code> on the submodule) but    UNTRACKED files will not count as making the submodule dirty.  - <strong>GIT_SUBMODULE_IGNORE_DIRTY</strong> means to only check if the HEAD of the    submodule has moved for status.  This is fast since it does not need to    scan the working tree of the submodule at all.  - <strong>GIT_SUBMODULE_IGNORE_ALL</strong> means not to open the submodule repo.    The working directory will be consider clean so long as there is a    checked out version present.</li>\n</ul>\n",
+      "comments": "<p>These values control the behavior of <code>git_submodule_status()</code> for this\n submodule.  There are four ignore values:</p>\n\n<ul>\n<li><strong>GIT_SUBMODULE_IGNORE_NONE</strong> will consider any change to the contents\nof the submodule from a clean checkout to be dirty, including the\naddition of untracked files.  This is the default if unspecified.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_UNTRACKED</strong> examines the contents of the\nworking tree (i.e. call <code>git_status_foreach()</code> on the submodule) but\nUNTRACKED files will not count as making the submodule dirty.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_DIRTY</strong> means to only check if the HEAD of the\nsubmodule has moved for status.  This is fast since it does not need to\nscan the working tree of the submodule at all.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_ALL</strong> means not to open the submodule repo.\nThe working directory will be consider clean so long as there is a\nchecked out version present.</li>\n</ul>\n",
       "group": "submodule"
     },
     "git_submodule_set_ignore": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 463,
-      "lineto": 466,
+      "file": "git2/submodule.h",
+      "line": 464,
+      "lineto": 467,
       "args": [
         {
           "name": "repo",
@@ -20783,9 +21652,9 @@
     },
     "git_submodule_update_strategy": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 478,
-      "lineto": 479,
+      "file": "git2/submodule.h",
+      "line": 479,
+      "lineto": 480,
       "args": [
         {
           "name": "submodule",
@@ -20800,14 +21669,14 @@
         "comment": " The current git_submodule_update_t value that will be used\n         for this submodule."
       },
       "description": "<p>Get the update rule that will be used for the submodule.</p>\n",
-      "comments": "<p>This value controls the behavior of the <code>git submodule update</code> command. There are four useful values documented with <code>git_submodule_update_t</code>.</p>\n",
+      "comments": "<p>This value controls the behavior of the <code>git submodule update</code> command.\n There are four useful values documented with <code>git_submodule_update_t</code>.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_update": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 491,
-      "lineto": 494,
+      "file": "git2/submodule.h",
+      "line": 492,
+      "lineto": 495,
       "args": [
         {
           "name": "repo",
@@ -20837,9 +21706,9 @@
     },
     "git_submodule_fetch_recurse_submodules": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 507,
-      "lineto": 508,
+      "file": "git2/submodule.h",
+      "line": 508,
+      "lineto": 509,
       "args": [
         {
           "name": "submodule",
@@ -20854,14 +21723,14 @@
         "comment": " 0 if fetchRecurseSubmodules is false, 1 if true"
       },
       "description": "<p>Read the fetchRecurseSubmodules rule for a submodule.</p>\n",
-      "comments": "<p>This accesses the submodule.<name>.fetchRecurseSubmodules value for the submodule that controls fetching behavior for the submodule.</p>\n\n<p>Note that at this time, libgit2 does not honor this setting and the fetch functionality current ignores submodules.</p>\n",
+      "comments": "<p>This accesses the submodule.\n&lt;name</p>\n\n<blockquote>\n<p>.fetchRecurseSubmodules value for\n the submodule that controls fetching behavior for the submodule.</p>\n</blockquote>\n\n<p>Note that at this time, libgit2 does not honor this setting and the\n fetch functionality current ignores submodules.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_fetch_recurse_submodules": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 520,
-      "lineto": 523,
+      "file": "git2/submodule.h",
+      "line": 521,
+      "lineto": 524,
       "args": [
         {
           "name": "repo",
@@ -20891,9 +21760,9 @@
     },
     "git_submodule_init": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 538,
-      "lineto": 538,
+      "file": "git2/submodule.h",
+      "line": 539,
+      "lineto": 539,
       "args": [
         {
           "name": "submodule",
@@ -20913,14 +21782,14 @@
         "comment": " 0 on success, \n<\n0 on failure."
       },
       "description": "<p>Copy submodule info into &quot;.git/config&quot; file.</p>\n",
-      "comments": "<p>Just like &quot;git submodule init&quot;, this copies information about the submodule into &quot;.git/config&quot;.  You can use the accessor functions above to alter the in-memory git_submodule object and control what is written to the config, overriding what is in .gitmodules.</p>\n",
+      "comments": "<p>Just like &quot;git submodule init&quot;, this copies information about the\n submodule into &quot;.git/config&quot;.  You can use the accessor functions\n above to alter the in-memory git_submodule object and control what\n is written to the config, overriding what is in .gitmodules.</p>\n",
       "group": "submodule"
     },
     "git_submodule_repo_init": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 553,
-      "lineto": 556,
+      "file": "git2/submodule.h",
+      "line": 554,
+      "lineto": 557,
       "args": [
         {
           "name": "out",
@@ -20945,14 +21814,14 @@
         "comment": " 0 on success, \n<\n0 on failure."
       },
       "description": "<p>Set up the subrepository for a submodule in preparation for clone.</p>\n",
-      "comments": "<p>This function can be called to init and set up a submodule repository from a submodule in preparation to clone it from its remote.</p>\n",
+      "comments": "<p>This function can be called to init and set up a submodule\n repository from a submodule in preparation to clone it from\n its remote.</p>\n",
       "group": "submodule"
     },
     "git_submodule_sync": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 566,
-      "lineto": 566,
+      "file": "git2/submodule.h",
+      "line": 567,
+      "lineto": 567,
       "args": [
         {
           "name": "submodule",
@@ -20967,14 +21836,14 @@
         "comment": null
       },
       "description": "<p>Copy submodule remote info into submodule repo.</p>\n",
-      "comments": "<p>This copies the information about the submodules URL into the checked out submodule config, acting like &quot;git submodule sync&quot;.  This is useful if you have altered the URL for the submodule (or it has been altered by a fetch of upstream changes) and you need to update your local repo.</p>\n",
+      "comments": "<p>This copies the information about the submodules URL into the checked out\n submodule config, acting like &quot;git submodule sync&quot;.  This is useful if\n you have altered the URL for the submodule (or it has been altered by a\n fetch of upstream changes) and you need to update your local repo.</p>\n",
       "group": "submodule"
     },
     "git_submodule_open": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 580,
-      "lineto": 582,
+      "file": "git2/submodule.h",
+      "line": 581,
+      "lineto": 583,
       "args": [
         {
           "name": "repo",
@@ -20994,14 +21863,14 @@
         "comment": " 0 on success, \n<\n0 if submodule repo could not be opened."
       },
       "description": "<p>Open the repository for a submodule.</p>\n",
-      "comments": "<p>This is a newly opened repository object.  The caller is responsible for calling <code>git_repository_free()</code> on it when done.  Multiple calls to this function will return distinct <code>git_repository</code> objects.  This will only work if the submodule is checked out into the working directory.</p>\n",
+      "comments": "<p>This is a newly opened repository object.  The caller is responsible for\n calling <code>git_repository_free()</code> on it when done.  Multiple calls to this\n function will return distinct <code>git_repository</code> objects.  This will only\n work if the submodule is checked out into the working directory.</p>\n",
       "group": "submodule"
     },
     "git_submodule_reload": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 594,
-      "lineto": 594,
+      "file": "git2/submodule.h",
+      "line": 595,
+      "lineto": 595,
       "args": [
         {
           "name": "submodule",
@@ -21021,14 +21890,14 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Reread submodule info from config, index, and HEAD.</p>\n",
-      "comments": "<p>Call this to reread cached submodule information for this submodule if you have reason to believe that it has changed.</p>\n",
+      "comments": "<p>Call this to reread cached submodule information for this submodule if\n you have reason to believe that it has changed.</p>\n",
       "group": "submodule"
     },
     "git_submodule_status": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 610,
-      "lineto": 614,
+      "file": "git2/submodule.h",
+      "line": 611,
+      "lineto": 615,
       "args": [
         {
           "name": "status",
@@ -21058,7 +21927,7 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get the status for a submodule.</p>\n",
-      "comments": "<p>This looks at a submodule and tries to determine the status.  It will return a combination of the <code>GIT_SUBMODULE_STATUS</code> values above. How deeply it examines the working directory to do this will depend on the <code>git_submodule_ignore_t</code> value for the submodule.</p>\n",
+      "comments": "<p>This looks at a submodule and tries to determine the status.  It\n will return a combination of the <code>GIT_SUBMODULE_STATUS</code> values above.\n How deeply it examines the working directory to do this will depend\n on the <code>git_submodule_ignore_t</code> value for the submodule.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
@@ -21068,9 +21937,9 @@
     },
     "git_submodule_location": {
       "type": "function",
-      "file": "submodule.h",
-      "line": 630,
-      "lineto": 632,
+      "file": "git2/submodule.h",
+      "line": 631,
+      "lineto": 633,
       "args": [
         {
           "name": "location_status",
@@ -21090,12 +21959,56 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get the locations of submodule information.</p>\n",
-      "comments": "<p>This is a bit like a very lightweight version of <code>git_submodule_status</code>. It just returns a made of the first four submodule status values (i.e. the ones like GIT_SUBMODULE_STATUS_IN_HEAD, etc) that tell you where the submodule data comes from (i.e. the HEAD commit, gitmodules file, etc.). This can be useful if you want to know if the submodule is present in the working directory at this point in time, etc.</p>\n",
+      "comments": "<p>This is a bit like a very lightweight version of <code>git_submodule_status</code>.\n It just returns a made of the first four submodule status values (i.e.\n the ones like GIT_SUBMODULE_STATUS_IN_HEAD, etc) that tell you where the\n submodule data comes from (i.e. the HEAD commit, gitmodules file, etc.).\n This can be useful if you want to know if the submodule is present in the\n working directory at this point in time, etc.</p>\n",
       "group": "submodule"
+    },
+    "git_stdalloc_init_allocator": {
+      "type": "function",
+      "file": "git2/sys/alloc.h",
+      "line": 85,
+      "lineto": 85,
+      "args": [
+        {
+          "name": "allocator",
+          "type": "git_allocator *",
+          "comment": "The allocator that is to be initialized."
+        }
+      ],
+      "argline": "git_allocator *allocator",
+      "sig": "git_allocator *",
+      "return": {
+        "type": "int",
+        "comment": " An error code or 0."
+      },
+      "description": "<p>Initialize the allocator structure to use the <code>stdalloc</code> pointer.</p>\n",
+      "comments": "<p>Set up the structure so that all of its members are using the standard\n &quot;stdalloc&quot; allocator functions. The structure can then be used with\n <code>git_allocator_setup</code>.</p>\n",
+      "group": "stdalloc"
+    },
+    "git_win32_crtdbg_init_allocator": {
+      "type": "function",
+      "file": "git2/sys/alloc.h",
+      "line": 97,
+      "lineto": 97,
+      "args": [
+        {
+          "name": "allocator",
+          "type": "git_allocator *",
+          "comment": "The allocator that is to be initialized."
+        }
+      ],
+      "argline": "git_allocator *allocator",
+      "sig": "git_allocator *",
+      "return": {
+        "type": "int",
+        "comment": " An error code or 0."
+      },
+      "description": "<p>Initialize the allocator structure to use the <code>crtdbg</code> pointer.</p>\n",
+      "comments": "<p>Set up the structure so that all of its members are using the &quot;crtdbg&quot;\n allocator functions. Note that this allocator is only available on Windows\n platforms and only if libgit2 is being compiled with &quot;-DMSVC_CRTDBG&quot;.</p>\n",
+      "group": "win32"
     },
     "git_commit_create_from_ids": {
       "type": "function",
-      "file": "sys/commit.h",
+      "file": "git2/sys/commit.h",
       "line": 34,
       "lineto": 44,
       "args": [
@@ -21157,12 +22070,12 @@
         "comment": null
       },
       "description": "<p>Create new commit in the repository from a list of <code>git_oid</code> values.</p>\n",
-      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the parameters, as the meaning is identical excepting that <code>tree</code> and <code>parents</code> now take <code>git_oid</code>.  This is a dangerous API in that nor the <code>tree</code>, neither the <code>parents</code> list of <code>git_oid</code>s are checked for validity.</p>\n",
+      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the\n parameters, as the meaning is identical excepting that <code>tree</code> and\n <code>parents</code> now take <code>git_oid</code>.  This is a dangerous API in that nor\n the <code>tree</code>, neither the <code>parents</code> list of <code>git_oid</code>s are checked for\n validity.</p>\n",
       "group": "commit"
     },
     "git_commit_create_from_callback": {
       "type": "function",
-      "file": "sys/commit.h",
+      "file": "git2/sys/commit.h",
       "line": 66,
       "lineto": 76,
       "args": [
@@ -21224,12 +22137,12 @@
         "comment": null
       },
       "description": "<p>Create a new commit in the repository with an callback to supply parents.</p>\n",
-      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the parameters, as the meaning is identical excepting that <code>tree</code> takes a <code>git_oid</code> and doesn&#39;t check for validity, and <code>parent_cb</code> is invoked with <code>parent_payload</code> and should return <code>git_oid</code> values or NULL to indicate that all parents are accounted for.</p>\n",
+      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the\n parameters, as the meaning is identical excepting that <code>tree</code> takes a\n <code>git_oid</code> and doesn&#39;t check for validity, and <code>parent_cb</code> is invoked\n with <code>parent_payload</code> and should return <code>git_oid</code> values or NULL to\n indicate that all parents are accounted for.</p>\n",
       "group": "commit"
     },
     "git_config_init_backend": {
       "type": "function",
-      "file": "sys/config.h",
+      "file": "git2/sys/config.h",
       "line": 97,
       "lineto": 99,
       "args": [
@@ -21256,7 +22169,7 @@
     },
     "git_config_add_backend": {
       "type": "function",
-      "file": "sys/config.h",
+      "file": "git2/sys/config.h",
       "line": 121,
       "lineto": 126,
       "args": [
@@ -21293,12 +22206,12 @@
         "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0), or error code"
       },
       "description": "<p>Add a generic config file instance to an existing config</p>\n",
-      "comments": "<p>Note that the configuration object will free the file automatically.</p>\n\n<p>Further queries on this config object will access each of the config file instances in order (instances with a higher priority level will be accessed first).</p>\n",
+      "comments": "<p>Note that the configuration object will free the file\n automatically.</p>\n\n<p>Further queries on this config object will access each\n of the config file instances in order (instances with\n a higher priority level will be accessed first).</p>\n",
       "group": "config"
     },
     "git_diff_print_callback__to_buf": {
       "type": "function",
-      "file": "sys/diff.h",
+      "file": "git2/sys/diff.h",
       "line": 37,
       "lineto": 41,
       "args": [
@@ -21330,12 +22243,12 @@
         "comment": null
       },
       "description": "<p>Diff print callback that writes to a git_buf.</p>\n",
-      "comments": "<p>This function is provided not for you to call it directly, but instead so you can use it as a function pointer to the <code>git_diff_print</code> or <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a <code>git_buf</code> buffer.  You must pass a <code>git_buf *</code> value as the payload to the <code>git_diff_print</code> and/or <code>git_patch_print</code> function.  The data will be appended to the buffer (after any existing content).</p>\n",
+      "comments": "<p>This function is provided not for you to call it directly, but instead\n so you can use it as a function pointer to the <code>git_diff_print</code> or\n <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback\n to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a <code>git_buf</code> buffer.  You\n must pass a <code>git_buf *</code> value as the payload to the <code>git_diff_print</code>\n and/or <code>git_patch_print</code> function.  The data will be appended to the\n buffer (after any existing content).</p>\n",
       "group": "diff"
     },
     "git_diff_print_callback__to_file_handle": {
       "type": "function",
-      "file": "sys/diff.h",
+      "file": "git2/sys/diff.h",
       "line": 57,
       "lineto": 61,
       "args": [
@@ -21367,12 +22280,12 @@
         "comment": null
       },
       "description": "<p>Diff print callback that writes to stdio FILE handle.</p>\n",
-      "comments": "<p>This function is provided not for you to call it directly, but instead so you can use it as a function pointer to the <code>git_diff_print</code> or <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a stdio FILE handle.  You must pass a <code>FILE *</code> value (such as <code>stdout</code> or <code>stderr</code> or the return value from <code>fopen()</code>) as the payload to the <code>git_diff_print</code> and/or <code>git_patch_print</code> function.  If you pass NULL, this will write data to <code>stdout</code>.</p>\n",
+      "comments": "<p>This function is provided not for you to call it directly, but instead\n so you can use it as a function pointer to the <code>git_diff_print</code> or\n <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback\n to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a stdio FILE handle.  You\n must pass a <code>FILE *</code> value (such as <code>stdout</code> or <code>stderr</code> or the return\n value from <code>fopen()</code>) as the payload to the <code>git_diff_print</code>\n and/or <code>git_patch_print</code> function.  If you pass NULL, this will write\n data to <code>stdout</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_get_perfdata": {
       "type": "function",
-      "file": "sys/diff.h",
+      "file": "git2/sys/diff.h",
       "line": 83,
       "lineto": 84,
       "args": [
@@ -21399,7 +22312,7 @@
     },
     "git_status_list_get_perfdata": {
       "type": "function",
-      "file": "sys/diff.h",
+      "file": "git2/sys/diff.h",
       "line": 89,
       "lineto": 90,
       "args": [
@@ -21426,7 +22339,7 @@
     },
     "git_filter_lookup": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 27,
       "lineto": 27,
       "args": [
@@ -21448,7 +22361,7 @@
     },
     "git_filter_list_new": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 57,
       "lineto": 61,
       "args": [
@@ -21480,12 +22393,12 @@
         "comment": null
       },
       "description": "<p>Create a new empty filter list</p>\n",
-      "comments": "<p>Normally you won&#39;t use this because <code>git_filter_list_load</code> will create the filter list for you, but you can use this in combination with the <code>git_filter_lookup</code> and <code>git_filter_list_push</code> functions to assemble your own chains of filters.</p>\n",
+      "comments": "<p>Normally you won&#39;t use this because <code>git_filter_list_load</code> will create\n the filter list for you, but you can use this in combination with the\n <code>git_filter_lookup</code> and <code>git_filter_list_push</code> functions to assemble\n your own chains of filters.</p>\n",
       "group": "filter"
     },
     "git_filter_list_push": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 76,
       "lineto": 77,
       "args": [
@@ -21512,12 +22425,12 @@
         "comment": null
       },
       "description": "<p>Add a filter to a filter list with the given payload.</p>\n",
-      "comments": "<p>Normally you won&#39;t have to do this because the filter list is created by calling the &quot;check&quot; function on registered filters when the filter attributes are set, but this does allow more direct manipulation of filter lists when desired.</p>\n\n<p>Note that normally the &quot;check&quot; function can set up a payload for the filter.  Using this function, you can either pass in a payload if you know the expected payload format, or you can pass NULL.  Some filters may fail with a NULL payload.  Good luck!</p>\n",
+      "comments": "<p>Normally you won&#39;t have to do this because the filter list is created\n by calling the &quot;check&quot; function on registered filters when the filter\n attributes are set, but this does allow more direct manipulation of\n filter lists when desired.</p>\n\n<p>Note that normally the &quot;check&quot; function can set up a payload for the\n filter.  Using this function, you can either pass in a payload if you\n know the expected payload format, or you can pass NULL.  Some filters\n may fail with a NULL payload.  Good luck!</p>\n",
       "group": "filter"
     },
     "git_filter_list_length": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 90,
       "lineto": 90,
       "args": [
@@ -21534,12 +22447,12 @@
         "comment": " The number of filters in the list"
       },
       "description": "<p>Look up how many filters are in the list</p>\n",
-      "comments": "<p>We will attempt to apply all of these filters to any data passed in, but note that the filter apply action still has the option of skipping data that is passed in (for example, the CRLF filter will skip data that appears to be binary).</p>\n",
+      "comments": "<p>We will attempt to apply all of these filters to any data passed in,\n but note that the filter apply action still has the option of skipping\n data that is passed in (for example, the CRLF filter will skip data\n that appears to be binary).</p>\n",
       "group": "filter"
     },
     "git_filter_source_repo": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 100,
       "lineto": 100,
       "args": [
@@ -21561,7 +22474,7 @@
     },
     "git_filter_source_path": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 105,
       "lineto": 105,
       "args": [
@@ -21583,7 +22496,7 @@
     },
     "git_filter_source_filemode": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 111,
       "lineto": 111,
       "args": [
@@ -21605,7 +22518,7 @@
     },
     "git_filter_source_id": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 118,
       "lineto": 118,
       "args": [
@@ -21627,7 +22540,7 @@
     },
     "git_filter_source_mode": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 123,
       "lineto": 123,
       "args": [
@@ -21649,7 +22562,7 @@
     },
     "git_filter_source_flags": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 128,
       "lineto": 128,
       "args": [
@@ -21671,7 +22584,7 @@
     },
     "git_filter_init": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 284,
       "lineto": 284,
       "args": [
@@ -21698,7 +22611,7 @@
     },
     "git_filter_register": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 312,
       "lineto": 313,
       "args": [
@@ -21725,12 +22638,12 @@
         "comment": " 0 on successful registry, error code \n<\n0 on failure"
       },
       "description": "<p>Register a filter under a given name with a given priority.</p>\n",
-      "comments": "<p>As mentioned elsewhere, the initialize callback will not be invoked immediately.  It is deferred until the filter is used in some way.</p>\n\n<p>A filter&#39;s attribute checks and <code>check</code> and <code>apply</code> callbacks will be issued in order of <code>priority</code> on smudge (to workdir), and in reverse order of <code>priority</code> on clean (to odb).</p>\n\n<p>Two filters are preregistered with libgit2: - GIT_FILTER_CRLF with priority 0 - GIT_FILTER_IDENT with priority 100</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or deregistering of filters must be done outside of any possible usage of the filters (i.e. during application setup or shutdown).</p>\n",
+      "comments": "<p>As mentioned elsewhere, the initialize callback will not be invoked\n immediately.  It is deferred until the filter is used in some way.</p>\n\n<p>A filter&#39;s attribute checks and <code>check</code> and <code>apply</code> callbacks will be\n issued in order of <code>priority</code> on smudge (to workdir), and in reverse\n order of <code>priority</code> on clean (to odb).</p>\n\n<p>Two filters are preregistered with libgit2:\n - GIT_FILTER_CRLF with priority 0\n - GIT_FILTER_IDENT with priority 100</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or\n deregistering of filters must be done outside of any possible usage of\n the filters (i.e. during application setup or shutdown).</p>\n",
       "group": "filter"
     },
     "git_filter_unregister": {
       "type": "function",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 328,
       "lineto": 328,
       "args": [
@@ -21747,12 +22660,12 @@
         "comment": " 0 on success, error code \n<\n0 on failure"
       },
       "description": "<p>Remove the filter with the given name</p>\n",
-      "comments": "<p>Attempting to remove the builtin libgit2 filters is not permitted and will return an error.</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or deregistering of filters must be done outside of any possible usage of the filters (i.e. during application setup or shutdown).</p>\n",
+      "comments": "<p>Attempting to remove the builtin libgit2 filters is not permitted and\n will return an error.</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or\n deregistering of filters must be done outside of any possible usage of\n the filters (i.e. during application setup or shutdown).</p>\n",
       "group": "filter"
     },
     "git_hashsig_create": {
       "type": "function",
-      "file": "sys/hashsig.h",
+      "file": "git2/sys/hashsig.h",
       "line": 62,
       "lineto": 66,
       "args": [
@@ -21784,12 +22697,12 @@
         "comment": " 0 on success, GIT_EBUFS if the buffer doesn't contain enough data to\n compute a valid signature (unless GIT_HASHSIG_ALLOW_SMALL_FILES is set), or\n error code."
       },
       "description": "<p>Compute a similarity signature for a text buffer</p>\n",
-      "comments": "<p>If you have passed the option GIT_HASHSIG_IGNORE_WHITESPACE, then the whitespace will be removed from the buffer while it is being processed, modifying the buffer in place. Sorry about that!</p>\n",
+      "comments": "<p>If you have passed the option GIT_HASHSIG_IGNORE_WHITESPACE, then the\n whitespace will be removed from the buffer while it is being processed,\n modifying the buffer in place. Sorry about that!</p>\n",
       "group": "hashsig"
     },
     "git_hashsig_create_fromfile": {
       "type": "function",
-      "file": "sys/hashsig.h",
+      "file": "git2/sys/hashsig.h",
       "line": 81,
       "lineto": 84,
       "args": [
@@ -21816,12 +22729,12 @@
         "comment": " 0 on success, GIT_EBUFS if the buffer doesn't contain enough data to\n compute a valid signature (unless GIT_HASHSIG_ALLOW_SMALL_FILES is set), or\n error code."
       },
       "description": "<p>Compute a similarity signature for a text file</p>\n",
-      "comments": "<p>This walks through the file, only loading a maximum of 4K of file data at a time. Otherwise, it acts just like <code>git_hashsig_create</code>.</p>\n",
+      "comments": "<p>This walks through the file, only loading a maximum of 4K of file data at\n a time. Otherwise, it acts just like <code>git_hashsig_create</code>.</p>\n",
       "group": "hashsig"
     },
     "git_hashsig_free": {
       "type": "function",
-      "file": "sys/hashsig.h",
+      "file": "git2/sys/hashsig.h",
       "line": 91,
       "lineto": 91,
       "args": [
@@ -21843,7 +22756,7 @@
     },
     "git_hashsig_compare": {
       "type": "function",
-      "file": "sys/hashsig.h",
+      "file": "git2/sys/hashsig.h",
       "line": 100,
       "lineto": 102,
       "args": [
@@ -21868,9 +22781,331 @@
       "comments": "",
       "group": "hashsig"
     },
+    "git_index_name_entrycount": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 48,
+      "lineto": 48,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        }
+      ],
+      "argline": "git_index *index",
+      "sig": "git_index *",
+      "return": {
+        "type": "size_t",
+        "comment": " integer of count of current filename conflict entries"
+      },
+      "description": "<p>Get the count of filename conflict entries currently in the index.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_name_get_byindex": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 60,
+      "lineto": 61,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "n",
+          "type": "size_t",
+          "comment": "the position of the entry"
+        }
+      ],
+      "argline": "git_index *index, size_t n",
+      "sig": "git_index *::size_t",
+      "return": {
+        "type": "const git_index_name_entry *",
+        "comment": " a pointer to the filename conflict entry; NULL if out of bounds"
+      },
+      "description": "<p>Get a filename conflict entry from the index.</p>\n",
+      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
+      "group": "index"
+    },
+    "git_index_name_add": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 71,
+      "lineto": 72,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "ancestor",
+          "type": "const char *",
+          "comment": "the path of the file as it existed in the ancestor"
+        },
+        {
+          "name": "ours",
+          "type": "const char *",
+          "comment": "the path of the file as it existed in our tree"
+        },
+        {
+          "name": "theirs",
+          "type": "const char *",
+          "comment": "the path of the file as it existed in their tree"
+        }
+      ],
+      "argline": "git_index *index, const char *ancestor, const char *ours, const char *theirs",
+      "sig": "git_index *::const char *::const char *::const char *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Record the filenames involved in a rename conflict.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_name_clear": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 79,
+      "lineto": 79,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        }
+      ],
+      "argline": "git_index *index",
+      "sig": "git_index *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Remove all filename conflict entries.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_reuc_entrycount": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 96,
+      "lineto": 96,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        }
+      ],
+      "argline": "git_index *index",
+      "sig": "git_index *",
+      "return": {
+        "type": "size_t",
+        "comment": " integer of count of current resolve undo entries"
+      },
+      "description": "<p>Get the count of resolve undo entries currently in the index.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_reuc_find": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 107,
+      "lineto": 107,
+      "args": [
+        {
+          "name": "at_pos",
+          "type": "size_t *",
+          "comment": "the address to which the position of the reuc entry is written (optional)"
+        },
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "path",
+          "type": "const char *",
+          "comment": "path to search"
+        }
+      ],
+      "argline": "size_t *at_pos, git_index *index, const char *path",
+      "sig": "size_t *::git_index *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 if found, \n<\n 0 otherwise (GIT_ENOTFOUND)"
+      },
+      "description": "<p>Finds the resolve undo entry that points to the given path in the Git\n index.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_reuc_get_bypath": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 119,
+      "lineto": 119,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "path",
+          "type": "const char *",
+          "comment": "path to search"
+        }
+      ],
+      "argline": "git_index *index, const char *path",
+      "sig": "git_index *::const char *",
+      "return": {
+        "type": "const git_index_reuc_entry *",
+        "comment": " the resolve undo entry; NULL if not found"
+      },
+      "description": "<p>Get a resolve undo entry from the index.</p>\n",
+      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
+      "group": "index"
+    },
+    "git_index_reuc_get_byindex": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 131,
+      "lineto": 131,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "n",
+          "type": "size_t",
+          "comment": "the position of the entry"
+        }
+      ],
+      "argline": "git_index *index, size_t n",
+      "sig": "git_index *::size_t",
+      "return": {
+        "type": "const git_index_reuc_entry *",
+        "comment": " a pointer to the resolve undo entry; NULL if out of bounds"
+      },
+      "description": "<p>Get a resolve undo entry from the index.</p>\n",
+      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
+      "group": "index"
+    },
+    "git_index_reuc_add": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 155,
+      "lineto": 158,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "path",
+          "type": "const char *",
+          "comment": "filename to add"
+        },
+        {
+          "name": "ancestor_mode",
+          "type": "int",
+          "comment": "mode of the ancestor file"
+        },
+        {
+          "name": "ancestor_id",
+          "type": "const git_oid *",
+          "comment": "oid of the ancestor file"
+        },
+        {
+          "name": "our_mode",
+          "type": "int",
+          "comment": "mode of our file"
+        },
+        {
+          "name": "our_id",
+          "type": "const git_oid *",
+          "comment": "oid of our file"
+        },
+        {
+          "name": "their_mode",
+          "type": "int",
+          "comment": "mode of their file"
+        },
+        {
+          "name": "their_id",
+          "type": "const git_oid *",
+          "comment": "oid of their file"
+        }
+      ],
+      "argline": "git_index *index, const char *path, int ancestor_mode, const git_oid *ancestor_id, int our_mode, const git_oid *our_id, int their_mode, const git_oid *their_id",
+      "sig": "git_index *::const char *::int::const git_oid *::int::const git_oid *::int::const git_oid *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Adds a resolve undo entry for a file based on the given parameters.</p>\n",
+      "comments": "<p>The resolve undo entry contains the OIDs of files that were involved\n in a merge conflict after the conflict has been resolved.  This allows\n conflicts to be re-resolved later.</p>\n\n<p>If there exists a resolve undo entry for the given path in the index,\n it will be removed.</p>\n\n<p>This method will fail in bare index instances.</p>\n",
+      "group": "index"
+    },
+    "git_index_reuc_remove": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 167,
+      "lineto": 167,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        },
+        {
+          "name": "n",
+          "type": "size_t",
+          "comment": "position of the resolve undo entry to remove"
+        }
+      ],
+      "argline": "git_index *index, size_t n",
+      "sig": "git_index *::size_t",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Remove an resolve undo entry from the index</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_reuc_clear": {
+      "type": "function",
+      "file": "git2/sys/index.h",
+      "line": 174,
+      "lineto": 174,
+      "args": [
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "an existing index object"
+        }
+      ],
+      "argline": "git_index *index",
+      "sig": "git_index *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Remove all resolve undo entries from the index</p>\n",
+      "comments": "",
+      "group": "index"
+    },
     "git_mempack_new": {
       "type": "function",
-      "file": "sys/mempack.h",
+      "file": "git2/sys/mempack.h",
       "line": 45,
       "lineto": 45,
       "args": [
@@ -21886,13 +23121,13 @@
         "type": "int",
         "comment": " 0 on success; error code otherwise"
       },
-      "description": "<pre><code>Instantiate a new mempack backend.\n</code></pre>\n",
-      "comments": "<pre><code>The backend must be added to an existing ODB with the highest   priority.\n\n    git_mempack_new(&amp;mempacker);        git_repository_odb(&amp;odb, repository);       git_odb_add_backend(odb, mempacker, 999);\n\nOnce the backend has been loaded, all writes to the ODB will    instead be queued in memory, and can be finalized with  `git_mempack_dump`.\n\nSubsequent reads will also be served from the in-memory store   to ensure consistency, until the memory store is dumped.\n</code></pre>\n",
+      "description": "<p>Instantiate a new mempack backend.</p>\n",
+      "comments": "<p>The backend must be added to an existing ODB with the highest\n priority.</p>\n\n<pre><code> git_mempack_new(\n</code></pre>\n\n<p>&amp;mempacker\n);\n     git_repository_odb(\n&amp;odb\n, repository);\n     git_odb_add_backend(odb, mempacker, 999);</p>\n\n<p>Once the backend has been loaded, all writes to the ODB will\n instead be queued in memory, and can be finalized with\n <code>git_mempack_dump</code>.</p>\n\n<p>Subsequent reads will also be served from the in-memory store\n to ensure consistency, until the memory store is dumped.</p>\n",
       "group": "mempack"
     },
     "git_mempack_dump": {
       "type": "function",
-      "file": "sys/mempack.h",
+      "file": "git2/sys/mempack.h",
       "line": 68,
       "lineto": 68,
       "args": [
@@ -21918,13 +23153,13 @@
         "type": "int",
         "comment": " 0 on success; error code otherwise"
       },
-      "description": "<pre><code>Dump all the queued in-memory writes to a packfile.\n</code></pre>\n",
-      "comments": "<pre><code>The contents of the packfile will be stored in the given buffer.    It is the caller&#39;s responsibility to ensure that the generated  packfile is available to the repository (e.g. by writing it to disk, or doing something crazy like distributing it across   several copies of the repository over a network).\n\nOnce the generated packfile is available to the repository, call `git_mempack_reset` to cleanup the memory store.\n\nCalling `git_mempack_reset` before the packfile has been    written to disk will result in an inconsistent repository   (the objects in the memory store won&#39;t be accessible).\n</code></pre>\n",
+      "description": "<p>Dump all the queued in-memory writes to a packfile.</p>\n",
+      "comments": "<p>The contents of the packfile will be stored in the given buffer.\n It is the caller&#39;s responsibility to ensure that the generated\n packfile is available to the repository (e.g. by writing it\n to disk, or doing something crazy like distributing it across\n several copies of the repository over a network).</p>\n\n<p>Once the generated packfile is available to the repository,\n call <code>git_mempack_reset</code> to cleanup the memory store.</p>\n\n<p>Calling <code>git_mempack_reset</code> before the packfile has been\n written to disk will result in an inconsistent repository\n (the objects in the memory store won&#39;t be accessible).</p>\n",
       "group": "mempack"
     },
     "git_mempack_reset": {
       "type": "function",
-      "file": "sys/mempack.h",
+      "file": "git2/sys/mempack.h",
       "line": 82,
       "lineto": 82,
       "args": [
@@ -21940,13 +23175,194 @@
         "type": "void",
         "comment": null
       },
-      "description": "<pre><code>Reset the memory packer by clearing all the queued objects.\n</code></pre>\n",
-      "comments": "<pre><code>This assumes that `git_mempack_dump` has been called before to  store all the queued objects into a single packfile.\n\nAlternatively, call `reset` without a previous dump to &quot;undo&quot;   all the recently written objects, giving transaction-like   semantics to the Git repository.\n</code></pre>\n",
+      "description": "<p>Reset the memory packer by clearing all the queued objects.</p>\n",
+      "comments": "<p>This assumes that <code>git_mempack_dump</code> has been called before to\n store all the queued objects into a single packfile.</p>\n\n<p>Alternatively, call <code>reset</code> without a previous dump to &quot;undo&quot;\n all the recently written objects, giving transaction-like\n semantics to the Git repository.</p>\n",
       "group": "mempack"
+    },
+    "git_merge_driver_lookup": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 32,
+      "lineto": 32,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "The name of the merge driver"
+        }
+      ],
+      "argline": "const char *name",
+      "sig": "const char *",
+      "return": {
+        "type": "git_merge_driver *",
+        "comment": " Pointer to the merge driver object or NULL if not found"
+      },
+      "description": "<p>Look up a merge driver by name</p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_source_repo": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 44,
+      "lineto": 45,
+      "args": [
+        {
+          "name": "src",
+          "type": "const git_merge_driver_source *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_merge_driver_source *src",
+      "sig": "const git_merge_driver_source *",
+      "return": {
+        "type": "const git_repository *",
+        "comment": null
+      },
+      "description": "<p>Get the repository that the source data is coming from. </p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_source_ancestor": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 48,
+      "lineto": 49,
+      "args": [
+        {
+          "name": "src",
+          "type": "const git_merge_driver_source *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_merge_driver_source *src",
+      "sig": "const git_merge_driver_source *",
+      "return": {
+        "type": "const git_index_entry *",
+        "comment": null
+      },
+      "description": "<p>Gets the ancestor of the file to merge. </p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_source_ours": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 52,
+      "lineto": 53,
+      "args": [
+        {
+          "name": "src",
+          "type": "const git_merge_driver_source *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_merge_driver_source *src",
+      "sig": "const git_merge_driver_source *",
+      "return": {
+        "type": "const git_index_entry *",
+        "comment": null
+      },
+      "description": "<p>Gets the ours side of the file to merge. </p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_source_theirs": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 56,
+      "lineto": 57,
+      "args": [
+        {
+          "name": "src",
+          "type": "const git_merge_driver_source *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_merge_driver_source *src",
+      "sig": "const git_merge_driver_source *",
+      "return": {
+        "type": "const git_index_entry *",
+        "comment": null
+      },
+      "description": "<p>Gets the theirs side of the file to merge. </p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_source_file_options": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 60,
+      "lineto": 61,
+      "args": [
+        {
+          "name": "src",
+          "type": "const git_merge_driver_source *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_merge_driver_source *src",
+      "sig": "const git_merge_driver_source *",
+      "return": {
+        "type": "const git_merge_file_options *",
+        "comment": null
+      },
+      "description": "<p>Gets the merge file options that the merge was invoked with </p>\n",
+      "comments": "",
+      "group": "merge"
+    },
+    "git_merge_driver_register": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 162,
+      "lineto": 163,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "The name of this driver to match an attribute.  Attempting\n \t\t\tto register with an in-use name will return GIT_EEXISTS."
+        },
+        {
+          "name": "driver",
+          "type": "git_merge_driver *",
+          "comment": "The merge driver definition.  This pointer will be stored\n\t\t\tas is by libgit2 so it must be a durable allocation (either\n\t\t\tstatic or on the heap)."
+        }
+      ],
+      "argline": "const char *name, git_merge_driver *driver",
+      "sig": "const char *::git_merge_driver *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on successful registry, error code \n<\n0 on failure"
+      },
+      "description": "<p>Register a merge driver under a given name.</p>\n",
+      "comments": "<p>As mentioned elsewhere, the initialize callback will not be invoked\n immediately.  It is deferred until the driver is used in some way.</p>\n\n<p>Currently the merge driver registry is not thread safe, so any\n registering or deregistering of merge drivers must be done outside of\n any possible usage of the drivers (i.e. during application setup or\n shutdown).</p>\n",
+      "group": "merge"
+    },
+    "git_merge_driver_unregister": {
+      "type": "function",
+      "file": "git2/sys/merge.h",
+      "line": 178,
+      "lineto": 178,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "The name under which the merge driver was registered"
+        }
+      ],
+      "argline": "const char *name",
+      "sig": "const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, error code \n<\n0 on failure"
+      },
+      "description": "<p>Remove the merge driver with the given name.</p>\n",
+      "comments": "<p>Attempting to remove the builtin libgit2 merge drivers is not permitted\n and will return an error.</p>\n\n<p>Currently the merge driver registry is not thread safe, so any\n registering or deregistering of drivers must be done outside of any\n possible usage of the drivers (i.e. during application setup or shutdown).</p>\n",
+      "group": "merge"
     },
     "git_odb_init_backend": {
       "type": "function",
-      "file": "sys/odb_backend.h",
+      "file": "git2/sys/odb_backend.h",
       "line": 116,
       "lineto": 118,
       "args": [
@@ -21971,9 +23387,36 @@
       "comments": "",
       "group": "odb"
     },
+    "git_odb_backend_malloc": {
+      "type": "function",
+      "file": "git2/sys/odb_backend.h",
+      "line": 120,
+      "lineto": 120,
+      "args": [
+        {
+          "name": "backend",
+          "type": "git_odb_backend *",
+          "comment": null
+        },
+        {
+          "name": "len",
+          "type": "size_t",
+          "comment": null
+        }
+      ],
+      "argline": "git_odb_backend *backend, size_t len",
+      "sig": "git_odb_backend *::size_t",
+      "return": {
+        "type": "void *",
+        "comment": null
+      },
+      "description": "",
+      "comments": "",
+      "group": "odb"
+    },
     "git_openssl_set_locking": {
       "type": "function",
-      "file": "sys/openssl.h",
+      "file": "git2/sys/openssl.h",
       "line": 34,
       "lineto": 34,
       "args": [],
@@ -21984,12 +23427,49 @@
         "comment": " 0 on success, -1 if there are errors or if libgit2 was not\n built with OpenSSL and threading support."
       },
       "description": "<p>Initialize the OpenSSL locks</p>\n",
-      "comments": "<p>OpenSSL requires the application to determine how it performs locking.</p>\n\n<p>This is a last-resort convenience function which libgit2 provides for allocating and initializing the locks as well as setting the locking function to use the system&#39;s native locking functions.</p>\n\n<p>The locking function will be cleared and the memory will be freed when you call git_threads_sutdown().</p>\n\n<p>If your programming language has an OpenSSL package/bindings, it likely sets up locking. You should very strongly prefer that over this function.</p>\n",
+      "comments": "<p>OpenSSL requires the application to determine how it performs\n locking.</p>\n\n<p>This is a last-resort convenience function which libgit2 provides for\n allocating and initializing the locks as well as setting the\n locking function to use the system&#39;s native locking functions.</p>\n\n<p>The locking function will be cleared and the memory will be freed\n when you call git_threads_sutdown().</p>\n\n<p>If your programming language has an OpenSSL package/bindings, it\n likely sets up locking. You should very strongly prefer that over\n this function.</p>\n",
       "group": "openssl"
+    },
+    "git_path_is_gitfile": {
+      "type": "function",
+      "file": "git2/sys/path.h",
+      "line": 60,
+      "lineto": 60,
+      "args": [
+        {
+          "name": "path",
+          "type": "const char *",
+          "comment": "the path component to check"
+        },
+        {
+          "name": "pathlen",
+          "type": "size_t",
+          "comment": "the length of `path` that is to be checked"
+        },
+        {
+          "name": "gitfile",
+          "type": "git_path_gitfile",
+          "comment": "which file to check against"
+        },
+        {
+          "name": "fs",
+          "type": "git_path_fs",
+          "comment": "which filesystem-specific checks to use"
+        }
+      ],
+      "argline": "const char *path, size_t pathlen, git_path_gitfile gitfile, git_path_fs fs",
+      "sig": "const char *::size_t::git_path_gitfile::git_path_fs",
+      "return": {
+        "type": "int",
+        "comment": " 0 in case the file does not match, a positive value if\n         it does; -1 in case of an error"
+      },
+      "description": "<p>Check whether a path component corresponds to a .git$SUFFIX\n file.</p>\n",
+      "comments": "<p>As some filesystems do special things to filenames when\n writing files to disk, you cannot always do a plain string\n comparison to verify whether a file name matches an expected\n path or not. This function can do the comparison for you,\n depending on the filesystem you&#39;re on.</p>\n",
+      "group": "path"
     },
     "git_refdb_init_backend": {
       "type": "function",
-      "file": "sys/refdb_backend.h",
+      "file": "git2/sys/refdb_backend.h",
       "line": 183,
       "lineto": 185,
       "args": [
@@ -22016,7 +23496,7 @@
     },
     "git_refdb_backend_fs": {
       "type": "function",
-      "file": "sys/refdb_backend.h",
+      "file": "git2/sys/refdb_backend.h",
       "line": 198,
       "lineto": 200,
       "args": [
@@ -22038,12 +23518,12 @@
         "comment": " 0 on success, \n<\n0 error code on failure"
       },
       "description": "<p>Constructors for default filesystem-based refdb backend</p>\n",
-      "comments": "<p>Under normal usage, this is called for you when the repository is opened / created, but you can use this to explicitly construct a filesystem refdb backend for a repository.</p>\n",
+      "comments": "<p>Under normal usage, this is called for you when the repository is\n opened / created, but you can use this to explicitly construct a\n filesystem refdb backend for a repository.</p>\n",
       "group": "refdb"
     },
     "git_refdb_set_backend": {
       "type": "function",
-      "file": "sys/refdb_backend.h",
+      "file": "git2/sys/refdb_backend.h",
       "line": 212,
       "lineto": 214,
       "args": [
@@ -22065,12 +23545,50 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Sets the custom backend to an existing reference DB</p>\n",
-      "comments": "<p>The <code>git_refdb</code> will take ownership of the <code>git_refdb_backend</code> so you should NOT free it after calling this function.</p>\n",
+      "comments": "<p>The <code>git_refdb</code> will take ownership of the <code>git_refdb_backend</code> so you\n should NOT free it after calling this function.</p>\n",
       "group": "refdb"
+    },
+    "git_reflog_entry__alloc": {
+      "type": "function",
+      "file": "git2/sys/reflog.h",
+      "line": 16,
+      "lineto": 16,
+      "args": [],
+      "argline": "",
+      "sig": "",
+      "return": {
+        "type": "git_reflog_entry *",
+        "comment": null
+      },
+      "description": "",
+      "comments": "",
+      "group": "reflog"
+    },
+    "git_reflog_entry__free": {
+      "type": "function",
+      "file": "git2/sys/reflog.h",
+      "line": 17,
+      "lineto": 17,
+      "args": [
+        {
+          "name": "entry",
+          "type": "git_reflog_entry *",
+          "comment": null
+        }
+      ],
+      "argline": "git_reflog_entry *entry",
+      "sig": "git_reflog_entry *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "",
+      "comments": "",
+      "group": "reflog"
     },
     "git_reference__alloc": {
       "type": "function",
-      "file": "sys/refs.h",
+      "file": "git2/sys/refs.h",
       "line": 31,
       "lineto": 34,
       "args": [
@@ -22102,7 +23620,7 @@
     },
     "git_reference__alloc_symbolic": {
       "type": "function",
-      "file": "sys/refs.h",
+      "file": "git2/sys/refs.h",
       "line": 43,
       "lineto": 45,
       "args": [
@@ -22129,7 +23647,7 @@
     },
     "git_repository_new": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 31,
       "lineto": 31,
       "args": [
@@ -22146,12 +23664,12 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Create a new repository with neither backends nor config object</p>\n",
-      "comments": "<p>Note that this is only useful if you wish to associate the repository with a non-filesystem-backed object database and config store.</p>\n",
+      "comments": "<p>Note that this is only useful if you wish to associate the repository\n with a non-filesystem-backed object database and config store.</p>\n",
       "group": "repository"
     },
     "git_repository__cleanup": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 44,
       "lineto": 44,
       "args": [
@@ -22168,12 +23686,12 @@
         "comment": null
       },
       "description": "<p>Reset all the internal state in a repository.</p>\n",
-      "comments": "<p>This will free all the mapped memory and internal objects of the repository and leave it in a &quot;blank&quot; state.</p>\n\n<p>There&#39;s no need to call this function directly unless you&#39;re trying to aggressively cleanup the repo before its deallocation. <code>git_repository_free</code> already performs this operation before deallocation the repo.</p>\n",
+      "comments": "<p>This will free all the mapped memory and internal objects\n of the repository and leave it in a &quot;blank&quot; state.</p>\n\n<p>There&#39;s no need to call this function directly unless you&#39;re\n trying to aggressively cleanup the repo before its\n deallocation. <code>git_repository_free</code> already performs this operation\n before deallocation the repo.</p>\n",
       "group": "repository"
     },
     "git_repository_reinit_filesystem": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 61,
       "lineto": 63,
       "args": [
@@ -22195,12 +23713,12 @@
         "comment": " 0 on success, \n<\n 0 on error"
       },
       "description": "<p>Update the filesystem config settings for an open repository</p>\n",
-      "comments": "<p>When a repository is initialized, config values are set based on the properties of the filesystem that the repository is on, such as &quot;core.ignorecase&quot;, &quot;core.filemode&quot;, &quot;core.symlinks&quot;, etc.  If the repository is moved to a new filesystem, these properties may no longer be correct and API calls may not behave as expected.  This call reruns the phase of repository initialization that sets those properties to compensate for the current filesystem of the repo.</p>\n",
+      "comments": "<p>When a repository is initialized, config values are set based on the\n properties of the filesystem that the repository is on, such as\n &quot;core.ignorecase&quot;, &quot;core.filemode&quot;, &quot;core.symlinks&quot;, etc.  If the\n repository is moved to a new filesystem, these properties may no\n longer be correct and API calls may not behave as expected.  This\n call reruns the phase of repository initialization that sets those\n properties to compensate for the current filesystem of the repo.</p>\n",
       "group": "repository"
     },
     "git_repository_set_config": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 78,
       "lineto": 78,
       "args": [
@@ -22222,12 +23740,12 @@
         "comment": null
       },
       "description": "<p>Set the configuration file for this repository</p>\n",
-      "comments": "<p>This configuration file will be used for all configuration queries involving this repository.</p>\n\n<p>The repository will keep a reference to the config file; the user must still free the config after setting it to the repository, or it will leak.</p>\n",
+      "comments": "<p>This configuration file will be used for all configuration\n queries involving this repository.</p>\n\n<p>The repository will keep a reference to the config file;\n the user must still free the config after setting it\n to the repository, or it will leak.</p>\n",
       "group": "repository"
     },
     "git_repository_set_odb": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 93,
       "lineto": 93,
       "args": [
@@ -22249,12 +23767,12 @@
         "comment": null
       },
       "description": "<p>Set the Object Database for this repository</p>\n",
-      "comments": "<p>The ODB will be used for all object-related operations involving this repository.</p>\n\n<p>The repository will keep a reference to the ODB; the user must still free the ODB object after setting it to the repository, or it will leak.</p>\n",
+      "comments": "<p>The ODB will be used for all object-related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the ODB; the user\n must still free the ODB object after setting it to the\n repository, or it will leak.</p>\n",
       "group": "repository"
     },
     "git_repository_set_refdb": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 108,
       "lineto": 108,
       "args": [
@@ -22276,12 +23794,12 @@
         "comment": null
       },
       "description": "<p>Set the Reference Database Backend for this repository</p>\n",
-      "comments": "<p>The refdb will be used for all reference related operations involving this repository.</p>\n\n<p>The repository will keep a reference to the refdb; the user must still free the refdb object after setting it to the repository, or it will leak.</p>\n",
+      "comments": "<p>The refdb will be used for all reference related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the refdb; the user\n must still free the refdb object after setting it to the\n repository, or it will leak.</p>\n",
       "group": "repository"
     },
     "git_repository_set_index": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 123,
       "lineto": 123,
       "args": [
@@ -22303,12 +23821,12 @@
         "comment": null
       },
       "description": "<p>Set the index file for this repository</p>\n",
-      "comments": "<p>This index will be used for all index-related operations involving this repository.</p>\n\n<p>The repository will keep a reference to the index file; the user must still free the index after setting it to the repository, or it will leak.</p>\n",
+      "comments": "<p>This index will be used for all index-related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the index file;\n the user must still free the index after setting it\n to the repository, or it will leak.</p>\n",
       "group": "repository"
     },
     "git_repository_set_bare": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 136,
       "lineto": 136,
       "args": [
@@ -22325,12 +23843,12 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set a repository to be bare.</p>\n",
-      "comments": "<p>Clear the working directory and set core.bare to true.  You may also want to call <code>git_repository_set_index(repo, NULL)</code> since a bare repo typically does not have an index, but this function will not do that for you.</p>\n",
+      "comments": "<p>Clear the working directory and set core.bare to true.  You may also\n want to call <code>git_repository_set_index(repo, NULL)</code> since a bare repo\n typically does not have an index, but this function will not do that\n for you.</p>\n",
       "group": "repository"
     },
     "git_repository_submodule_cache_all": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 149,
       "lineto": 150,
       "args": [
@@ -22347,12 +23865,12 @@
         "comment": null
       },
       "description": "<p>Load and cache all submodules.</p>\n",
-      "comments": "<p>Because the <code>.gitmodules</code> file is unstructured, loading submodules is an O(N) operation.  Any operation (such as <code>git_rebase_init</code>) that requires accessing all submodules is O(N^2) in the number of submodules, if it has to look each one up individually.  This function loads all submodules and caches them so that subsequent calls to <code>git_submodule_lookup</code> are O(1).</p>\n",
+      "comments": "<p>Because the <code>.gitmodules</code> file is unstructured, loading submodules is an\n O(N) operation.  Any operation (such as <code>git_rebase_init</code>) that requires\n accessing all submodules is O(N^2) in the number of submodules, if it\n has to look each one up individually.  This function loads all submodules\n and caches them so that subsequent calls to <code>git_submodule_lookup</code> are O(1).</p>\n",
       "group": "repository"
     },
     "git_repository_submodule_cache_clear": {
       "type": "function",
-      "file": "sys/repository.h",
+      "file": "git2/sys/repository.h",
       "line": 164,
       "lineto": 165,
       "args": [
@@ -22369,12 +23887,12 @@
         "comment": null
       },
       "description": "<p>Clear the submodule cache.</p>\n",
-      "comments": "<p>Clear the submodule cache populated by <code>git_repository_submodule_cache_all</code>. If there is no cache, do nothing.</p>\n\n<p>The cache incorporates data from the repository&#39;s configuration, as well as the state of the working tree, the index, and HEAD.  So any time any of these has changed, the cache might become invalid.</p>\n",
+      "comments": "<p>Clear the submodule cache populated by <code>git_repository_submodule_cache_all</code>.\n If there is no cache, do nothing.</p>\n\n<p>The cache incorporates data from the repository&#39;s configuration, as well\n as the state of the working tree, the index, and HEAD.  So any time any\n of these has changed, the cache might become invalid.</p>\n",
       "group": "repository"
     },
     "git_stream_register_tls": {
       "type": "function",
-      "file": "sys/stream.h",
+      "file": "git2/sys/stream.h",
       "line": 54,
       "lineto": 54,
       "args": [
@@ -22391,12 +23909,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Register a TLS stream constructor for the library to use</p>\n",
-      "comments": "<p>If a constructor is already set, it will be overwritten. Pass <code>NULL</code> in order to deregister the current constructor.</p>\n",
+      "comments": "<p>If a constructor is already set, it will be overwritten. Pass\n <code>NULL</code> in order to deregister the current constructor.</p>\n",
       "group": "stream"
     },
     "git_time_monotonic": {
       "type": "function",
-      "file": "sys/time.h",
+      "file": "git2/sys/time.h",
       "line": 27,
       "lineto": 27,
       "args": [],
@@ -22407,12 +23925,12 @@
         "comment": null
       },
       "description": "<p>Return a monotonic time value, useful for measuring running time\n and setting up timeouts.</p>\n",
-      "comments": "<p>The returned value is an arbitrary point in time -- it can only be used when comparing it to another <code>git_time_monotonic</code> call.</p>\n\n<p>The time is returned in seconds, with a decimal fraction that differs on accuracy based on the underlying system, but should be least accurate to Nanoseconds.</p>\n\n<p>This function cannot fail.</p>\n",
+      "comments": "<p>The returned value is an arbitrary point in time -- it can only be\n used when comparing it to another <code>git_time_monotonic</code> call.</p>\n\n<p>The time is returned in seconds, with a decimal fraction that differs\n on accuracy based on the underlying system, but should be least\n accurate to Nanoseconds.</p>\n\n<p>This function cannot fail.</p>\n",
       "group": "time"
     },
     "git_transport_init": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 119,
       "lineto": 121,
       "args": [
@@ -22439,7 +23957,7 @@
     },
     "git_transport_new": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 133,
       "lineto": 133,
       "args": [
@@ -22471,7 +23989,7 @@
     },
     "git_transport_ssh_with_paths": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 149,
       "lineto": 149,
       "args": [
@@ -22498,12 +24016,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create an ssh transport with custom git command paths</p>\n",
-      "comments": "<p>This is a factory function suitable for setting as the transport callback in a remote (or for a clone in the options).</p>\n\n<p>The payload argument must be a strarray pointer with the paths for the <code>git-upload-pack</code> and <code>git-receive-pack</code> at index 0 and 1.</p>\n",
+      "comments": "<p>This is a factory function suitable for setting as the transport\n callback in a remote (or for a clone in the options).</p>\n\n<p>The payload argument must be a strarray pointer with the paths for\n the <code>git-upload-pack</code> and <code>git-receive-pack</code> at index 0 and 1.</p>\n",
       "group": "transport"
     },
     "git_transport_register": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 164,
       "lineto": 167,
       "args": [
@@ -22530,12 +24048,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a custom transport definition, to be used in addition to the built-in\n set of transports that come with libgit2.</p>\n",
-      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register and git_transport_unregister with other calls to the library that instantiate transports.</p>\n",
+      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register\n and git_transport_unregister with other calls to the library that\n instantiate transports.</p>\n",
       "group": "transport"
     },
     "git_transport_unregister": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 177,
       "lineto": 178,
       "args": [
@@ -22557,7 +24075,7 @@
     },
     "git_transport_dummy": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 191,
       "lineto": 194,
       "args": [
@@ -22589,7 +24107,7 @@
     },
     "git_transport_local": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 204,
       "lineto": 207,
       "args": [
@@ -22621,7 +24139,7 @@
     },
     "git_transport_smart": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 217,
       "lineto": 220,
       "args": [
@@ -22653,7 +24171,7 @@
     },
     "git_transport_smart_certificate_check": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 231,
       "lineto": 231,
       "args": [
@@ -22690,7 +24208,7 @@
     },
     "git_transport_smart_credentials": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 242,
       "lineto": 242,
       "args": [
@@ -22727,7 +24245,7 @@
     },
     "git_transport_smart_proxy_options": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 252,
       "lineto": 252,
       "args": [
@@ -22754,7 +24272,7 @@
     },
     "git_smart_subtransport_http": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 362,
       "lineto": 365,
       "args": [
@@ -22786,7 +24304,7 @@
     },
     "git_smart_subtransport_git": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 374,
       "lineto": 377,
       "args": [
@@ -22818,7 +24336,7 @@
     },
     "git_smart_subtransport_ssh": {
       "type": "function",
-      "file": "sys/transport.h",
+      "file": "git2/sys/transport.h",
       "line": 386,
       "lineto": 389,
       "args": [
@@ -22850,7 +24368,7 @@
     },
     "git_tag_lookup": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 33,
       "lineto": 34,
       "args": [
@@ -22887,7 +24405,7 @@
     },
     "git_tag_lookup_prefix": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 48,
       "lineto": 49,
       "args": [
@@ -22924,7 +24442,7 @@
     },
     "git_tag_free": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 61,
       "lineto": 61,
       "args": [
@@ -22941,7 +24459,7 @@
         "comment": null
       },
       "description": "<p>Close an open tag</p>\n",
-      "comments": "<p>You can no longer use the git_tag pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you are through with a tag to release memory. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>You can no longer use the git_tag pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you are through with a tag to\n release memory. Failure to do so will cause a memory leak.</p>\n",
       "group": "tag",
       "examples": {
         "general.c": [
@@ -22951,7 +24469,7 @@
     },
     "git_tag_id": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 69,
       "lineto": 69,
       "args": [
@@ -22973,7 +24491,7 @@
     },
     "git_tag_owner": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 77,
       "lineto": 77,
       "args": [
@@ -22995,7 +24513,7 @@
     },
     "git_tag_target": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 89,
       "lineto": 89,
       "args": [
@@ -23017,7 +24535,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the tagged object of a tag</p>\n",
-      "comments": "<p>This method performs a repository lookup for the given object and returns it</p>\n",
+      "comments": "<p>This method performs a repository lookup for the\n given object and returns it</p>\n",
       "group": "tag",
       "examples": {
         "general.c": [
@@ -23027,7 +24545,7 @@
     },
     "git_tag_target_id": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 97,
       "lineto": 97,
       "args": [
@@ -23054,7 +24572,7 @@
     },
     "git_tag_target_type": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 105,
       "lineto": 105,
       "args": [
@@ -23084,7 +24602,7 @@
     },
     "git_tag_name": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 113,
       "lineto": 113,
       "args": [
@@ -23117,7 +24635,7 @@
     },
     "git_tag_tagger": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 121,
       "lineto": 121,
       "args": [
@@ -23144,7 +24662,7 @@
     },
     "git_tag_message": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 129,
       "lineto": 129,
       "args": [
@@ -23178,7 +24696,7 @@
     },
     "git_tag_create": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 171,
       "lineto": 178,
       "args": [
@@ -23225,7 +24743,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code\n\tA tag object is written to the ODB, and a proper reference\n\tis written in the /refs/tags folder, pointing to it"
       },
       "description": "<p>Create a new tag in the repository from an object</p>\n",
-      "comments": "<p>A new reference will also be created pointing to this tag object. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The message will not be cleaned up. This can be achieved through <code>git_message_prettify()</code>.</p>\n\n<p>The tag name will be checked for validity. You must avoid the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</p>\n",
+      "comments": "<p>A new reference will also be created pointing to\n this tag object. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The message will not be cleaned up. This can be achieved\n through <code>git_message_prettify()</code>.</p>\n\n<p>The tag name will be checked for validity. You must avoid\n the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\n sequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
@@ -23235,7 +24753,7 @@
     },
     "git_tag_annotation_create": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 203,
       "lineto": 209,
       "args": [
@@ -23277,12 +24795,12 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Create a new tag in the object database pointing to a git_object</p>\n",
-      "comments": "<p>The message will not be cleaned up. This can be achieved through <code>git_message_prettify()</code>.</p>\n",
+      "comments": "<p>The message will not be cleaned up. This can be achieved\n through <code>git_message_prettify()</code>.</p>\n",
       "group": "tag"
     },
     "git_tag_create_frombuffer": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 220,
       "lineto": 224,
       "args": [
@@ -23319,7 +24837,7 @@
     },
     "git_tag_create_lightweight": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 256,
       "lineto": 261,
       "args": [
@@ -23356,7 +24874,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code\n\tA proper reference is written in the /refs/tags folder,\n pointing to the provided target object"
       },
       "description": "<p>Create a new lightweight tag pointing at a target object</p>\n",
-      "comments": "<p>A new direct reference will be created pointing to this target object. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The tag name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>A new direct reference will be created pointing to\n this target object. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The tag name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
@@ -23366,7 +24884,7 @@
     },
     "git_tag_delete": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 276,
       "lineto": 278,
       "args": [
@@ -23388,7 +24906,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Delete an existing tag reference.</p>\n",
-      "comments": "<p>The tag name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The tag name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
@@ -23398,7 +24916,7 @@
     },
     "git_tag_list": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 293,
       "lineto": 295,
       "args": [
@@ -23420,12 +24938,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the tags in the Repository</p>\n",
-      "comments": "<p>The string array will be filled with the names of the matching tags; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The string array will be filled with the names of the\n matching tags; these values are owned by the user and\n should be free&#39;d manually when no longer needed, using\n <code>git_strarray_free</code>.</p>\n",
       "group": "tag"
     },
     "git_tag_list_match": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 315,
       "lineto": 318,
       "args": [
@@ -23452,7 +24970,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the tags in the Repository\n which name match a defined pattern</p>\n",
-      "comments": "<p>If an empty pattern is provided, all the tags will be returned.</p>\n\n<p>The string array will be filled with the names of the matching tags; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>If an empty pattern is provided, all the tags\n will be returned.</p>\n\n<p>The string array will be filled with the names of the\n matching tags; these values are owned by the user and\n should be free&#39;d manually when no longer needed, using\n <code>git_strarray_free</code>.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
@@ -23462,7 +24980,7 @@
     },
     "git_tag_foreach": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 330,
       "lineto": 333,
       "args": [
@@ -23494,7 +25012,7 @@
     },
     "git_tag_peel": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 346,
       "lineto": 348,
       "args": [
@@ -23516,12 +25034,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Recursively peel a tag until a non tag git_object is found</p>\n",
-      "comments": "<p>The retrieved <code>tag_target</code> object is owned by the repository and should be closed with the <code>git_object_free</code> method.</p>\n",
+      "comments": "<p>The retrieved <code>tag_target</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n",
       "group": "tag"
     },
     "git_tag_dup": {
       "type": "function",
-      "file": "tag.h",
+      "file": "git2/tag.h",
       "line": 357,
       "lineto": 357,
       "args": [
@@ -23548,7 +25066,7 @@
     },
     "git_trace_set": {
       "type": "function",
-      "file": "trace.h",
+      "file": "git2/trace.h",
       "line": 63,
       "lineto": 63,
       "args": [
@@ -23573,11 +25091,252 @@
       "comments": "",
       "group": "trace"
     },
+    "git_transaction_new": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 32,
+      "lineto": 32,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_transaction **",
+          "comment": "the resulting transaction"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository in which to lock"
+        }
+      ],
+      "argline": "git_transaction **out, git_repository *repo",
+      "sig": "git_transaction **::git_repository *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Create a new transaction object</p>\n",
+      "comments": "<p>This does not lock anything, but sets up the transaction object to\n know from which repository to lock.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_lock_ref": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 44,
+      "lineto": 44,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "the reference to lock"
+        }
+      ],
+      "argline": "git_transaction *tx, const char *refname",
+      "sig": "git_transaction *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error message"
+      },
+      "description": "<p>Lock a reference</p>\n",
+      "comments": "<p>Lock the specified reference. This is the first step to updating a\n reference.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_set_target": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 59,
+      "lineto": 59,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "reference to update"
+        },
+        {
+          "name": "target",
+          "type": "const git_oid *",
+          "comment": "target to set the reference to"
+        },
+        {
+          "name": "sig",
+          "type": "const git_signature *",
+          "comment": "signature to use in the reflog; pass NULL to read the identity from the config"
+        },
+        {
+          "name": "msg",
+          "type": "const char *",
+          "comment": "message to use in the reflog"
+        }
+      ],
+      "argline": "git_transaction *tx, const char *refname, const git_oid *target, const git_signature *sig, const char *msg",
+      "sig": "git_transaction *::const char *::const git_oid *::const git_signature *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
+      },
+      "description": "<p>Set the target of a reference</p>\n",
+      "comments": "<p>Set the target of the specified reference. This reference must be\n locked.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_set_symbolic_target": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 74,
+      "lineto": 74,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "reference to update"
+        },
+        {
+          "name": "target",
+          "type": "const char *",
+          "comment": "target to set the reference to"
+        },
+        {
+          "name": "sig",
+          "type": "const git_signature *",
+          "comment": "signature to use in the reflog; pass NULL to read the identity from the config"
+        },
+        {
+          "name": "msg",
+          "type": "const char *",
+          "comment": "message to use in the reflog"
+        }
+      ],
+      "argline": "git_transaction *tx, const char *refname, const char *target, const git_signature *sig, const char *msg",
+      "sig": "git_transaction *::const char *::const char *::const git_signature *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
+      },
+      "description": "<p>Set the target of a reference</p>\n",
+      "comments": "<p>Set the target of the specified reference. This reference must be\n locked.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_set_reflog": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 87,
+      "lineto": 87,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "the reference whose reflog to set"
+        },
+        {
+          "name": "reflog",
+          "type": "const git_reflog *",
+          "comment": "the reflog as it should be written out"
+        }
+      ],
+      "argline": "git_transaction *tx, const char *refname, const git_reflog *reflog",
+      "sig": "git_transaction *::const char *::const git_reflog *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
+      },
+      "description": "<p>Set the reflog of a reference</p>\n",
+      "comments": "<p>Set the specified reference&#39;s reflog. If this is combined with\n setting the target, that update won&#39;t be written to the reflog.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_remove": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 96,
+      "lineto": 96,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        },
+        {
+          "name": "refname",
+          "type": "const char *",
+          "comment": "the reference to remove"
+        }
+      ],
+      "argline": "git_transaction *tx, const char *refname",
+      "sig": "git_transaction *::const char *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
+      },
+      "description": "<p>Remove a reference</p>\n",
+      "comments": "",
+      "group": "transaction"
+    },
+    "git_transaction_commit": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 107,
+      "lineto": 107,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        }
+      ],
+      "argline": "git_transaction *tx",
+      "sig": "git_transaction *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Commit the changes from the transaction</p>\n",
+      "comments": "<p>Perform the changes that have been queued. The updates will be made\n one by one, and the first failure will stop the processing.</p>\n",
+      "group": "transaction"
+    },
+    "git_transaction_free": {
+      "type": "function",
+      "file": "git2/transaction.h",
+      "line": 117,
+      "lineto": 117,
+      "args": [
+        {
+          "name": "tx",
+          "type": "git_transaction *",
+          "comment": "the transaction"
+        }
+      ],
+      "argline": "git_transaction *tx",
+      "sig": "git_transaction *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free the resources allocated by this transaction</p>\n",
+      "comments": "<p>If any references remain locked, they will be unlocked without any\n changes made to them.</p>\n",
+      "group": "transaction"
+    },
     "git_cred_has_username": {
       "type": "function",
-      "file": "transport.h",
-      "line": 190,
-      "lineto": 190,
+      "file": "git2/transport.h",
+      "line": 219,
+      "lineto": 219,
       "args": [
         {
           "name": "cred",
@@ -23597,9 +25356,9 @@
     },
     "git_cred_userpass_plaintext_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 201,
-      "lineto": 204,
+      "file": "git2/transport.h",
+      "line": 230,
+      "lineto": 233,
       "args": [
         {
           "name": "out",
@@ -23629,9 +25388,9 @@
     },
     "git_cred_ssh_key_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 217,
-      "lineto": 222,
+      "file": "git2/transport.h",
+      "line": 246,
+      "lineto": 251,
       "args": [
         {
           "name": "out",
@@ -23671,9 +25430,9 @@
     },
     "git_cred_ssh_interactive_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 233,
-      "lineto": 237,
+      "file": "git2/transport.h",
+      "line": 262,
+      "lineto": 266,
       "args": [
         {
           "name": "out",
@@ -23708,9 +25467,9 @@
     },
     "git_cred_ssh_key_from_agent": {
       "type": "function",
-      "file": "transport.h",
-      "line": 247,
-      "lineto": 249,
+      "file": "git2/transport.h",
+      "line": 276,
+      "lineto": 278,
       "args": [
         {
           "name": "out",
@@ -23735,9 +25494,9 @@
     },
     "git_cred_ssh_custom_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 269,
-      "lineto": 275,
+      "file": "git2/transport.h",
+      "line": 298,
+      "lineto": 304,
       "args": [
         {
           "name": "out",
@@ -23777,14 +25536,14 @@
         "comment": " 0 for success or an error code for failure"
       },
       "description": "<p>Create an ssh key credential with a custom signing function.</p>\n",
-      "comments": "<p>This lets you use your own function to sign the challenge.</p>\n\n<p>This function and its credential type is provided for completeness and wraps <code>libssh2_userauth_publickey()</code>, which is undocumented.</p>\n\n<p>The supplied credential parameter will be internally duplicated.</p>\n",
+      "comments": "<p>This lets you use your own function to sign the challenge.</p>\n\n<p>This function and its credential type is provided for completeness\n and wraps <code>libssh2_userauth_publickey()</code>, which is undocumented.</p>\n\n<p>The supplied credential parameter will be internally duplicated.</p>\n",
       "group": "cred"
     },
     "git_cred_default_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 283,
-      "lineto": 283,
+      "file": "git2/transport.h",
+      "line": 312,
+      "lineto": 312,
       "args": [
         {
           "name": "out",
@@ -23804,9 +25563,9 @@
     },
     "git_cred_username_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 291,
-      "lineto": 291,
+      "file": "git2/transport.h",
+      "line": 320,
+      "lineto": 320,
       "args": [
         {
           "name": "cred",
@@ -23826,14 +25585,14 @@
         "comment": null
       },
       "description": "<p>Create a credential to specify a username.</p>\n",
-      "comments": "<p>This is used with ssh authentication to query for the username if none is specified in the url.</p>\n",
+      "comments": "<p>This is used with ssh authentication to query for the username if\n none is specified in the url.</p>\n",
       "group": "cred"
     },
     "git_cred_ssh_key_memory_new": {
       "type": "function",
-      "file": "transport.h",
-      "line": 303,
-      "lineto": 308,
+      "file": "git2/transport.h",
+      "line": 332,
+      "lineto": 337,
       "args": [
         {
           "name": "out",
@@ -23873,9 +25632,9 @@
     },
     "git_cred_free": {
       "type": "function",
-      "file": "transport.h",
-      "line": 319,
-      "lineto": 319,
+      "file": "git2/transport.h",
+      "line": 348,
+      "lineto": 348,
       "args": [
         {
           "name": "cred",
@@ -23890,12 +25649,12 @@
         "comment": null
       },
       "description": "<p>Free a credential.</p>\n",
-      "comments": "<p>This is only necessary if you own the object; that is, if you are a transport.</p>\n",
+      "comments": "<p>This is only necessary if you own the object; that is, if you are a\n transport.</p>\n",
       "group": "cred"
     },
     "git_tree_lookup": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 32,
       "lineto": 33,
       "args": [
@@ -23933,13 +25692,13 @@
           "ex/HEAD/init.html#git_tree_lookup-14"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_tree_lookup-46"
+          "ex/HEAD/merge.html#git_tree_lookup-41"
         ]
       }
     },
     "git_tree_lookup_prefix": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 47,
       "lineto": 51,
       "args": [
@@ -23976,7 +25735,7 @@
     },
     "git_tree_free": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 63,
       "lineto": 63,
       "args": [
@@ -23993,7 +25752,7 @@
         "comment": null
       },
       "description": "<p>Close an open tree</p>\n",
-      "comments": "<p>You can no longer use the git_tree pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you stop using a tree to release memory. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>You can no longer use the git_tree pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you stop using a tree to\n release memory. Failure to do so will cause a memory leak.</p>\n",
       "group": "tree",
       "examples": {
         "diff.c": [
@@ -24018,7 +25777,7 @@
     },
     "git_tree_id": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 71,
       "lineto": 71,
       "args": [
@@ -24040,7 +25799,7 @@
     },
     "git_tree_owner": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 79,
       "lineto": 79,
       "args": [
@@ -24062,7 +25821,7 @@
     },
     "git_tree_entrycount": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 87,
       "lineto": 87,
       "args": [
@@ -24092,7 +25851,7 @@
     },
     "git_tree_entry_byname": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 99,
       "lineto": 100,
       "args": [
@@ -24114,7 +25873,7 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by its filename</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n",
       "group": "tree",
       "examples": {
         "general.c": [
@@ -24124,7 +25883,7 @@
     },
     "git_tree_entry_byindex": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 112,
       "lineto": 113,
       "args": [
@@ -24146,7 +25905,7 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by its position in the tree</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n",
       "group": "tree",
       "examples": {
         "cat-file.c": [
@@ -24159,7 +25918,7 @@
     },
     "git_tree_entry_byid": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 127,
       "lineto": 128,
       "args": [
@@ -24181,12 +25940,12 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by SHA value.</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n\n<p>Warning: this must examine every entry in the tree, so it is not fast.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n\n<p>Warning: this must examine every entry in the tree, so it is not fast.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_bypath": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 142,
       "lineto": 145,
       "args": [
@@ -24213,12 +25972,12 @@
         "comment": " 0 on success; GIT_ENOTFOUND if the path does not exist"
       },
       "description": "<p>Retrieve a tree entry contained in a tree or in any of its subtrees,\n given its relative path.</p>\n",
-      "comments": "<p>Unlike the other lookup functions, the returned tree entry is owned by the user and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
+      "comments": "<p>Unlike the other lookup functions, the returned tree entry is owned by\n the user and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_dup": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 157,
       "lineto": 157,
       "args": [
@@ -24240,12 +25999,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Duplicate a tree entry</p>\n",
-      "comments": "<p>Create a copy of a tree entry. The returned copy is owned by the user, and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
+      "comments": "<p>Create a copy of a tree entry. The returned copy is owned by the user,\n and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_free": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 168,
       "lineto": 168,
       "args": [
@@ -24262,12 +26021,12 @@
         "comment": null
       },
       "description": "<p>Free a user-owned tree entry</p>\n",
-      "comments": "<p>IMPORTANT: This function is only needed for tree entries owned by the user, such as the ones returned by <code>git_tree_entry_dup()</code> or <code>git_tree_entry_bypath()</code>.</p>\n",
+      "comments": "<p>IMPORTANT: This function is only needed for tree entries owned by the\n user, such as the ones returned by <code>git_tree_entry_dup()</code> or\n <code>git_tree_entry_bypath()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_name": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 176,
       "lineto": 176,
       "args": [
@@ -24298,7 +26057,7 @@
     },
     "git_tree_entry_id": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 184,
       "lineto": 184,
       "args": [
@@ -24325,7 +26084,7 @@
     },
     "git_tree_entry_type": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 192,
       "lineto": 192,
       "args": [
@@ -24352,7 +26111,7 @@
     },
     "git_tree_entry_filemode": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 200,
       "lineto": 200,
       "args": [
@@ -24379,7 +26138,7 @@
     },
     "git_tree_entry_filemode_raw": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 212,
       "lineto": 212,
       "args": [
@@ -24396,12 +26155,12 @@
         "comment": " filemode as an integer"
       },
       "description": "<p>Get the raw UNIX file attributes of a tree entry</p>\n",
-      "comments": "<p>This function does not perform any normalization and is only useful if you need to be able to recreate the original tree object.</p>\n",
+      "comments": "<p>This function does not perform any normalization and is only useful\n if you need to be able to recreate the original tree object.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_cmp": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 220,
       "lineto": 220,
       "args": [
@@ -24428,7 +26187,7 @@
     },
     "git_tree_entry_to_object": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 232,
       "lineto": 235,
       "args": [
@@ -24465,7 +26224,7 @@
     },
     "git_treebuilder_new": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 254,
       "lineto": 255,
       "args": [
@@ -24492,12 +26251,12 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Create a new tree builder.</p>\n",
-      "comments": "<p>The tree builder can be used to create or modify trees in memory and write them as tree objects to the database.</p>\n\n<p>If the <code>source</code> parameter is not NULL, the tree builder will be initialized with the entries of the given tree.</p>\n\n<p>If the <code>source</code> parameter is NULL, the tree builder will start with no entries and will have to be filled manually.</p>\n",
+      "comments": "<p>The tree builder can be used to create or modify trees in memory and\n write them as tree objects to the database.</p>\n\n<p>If the <code>source</code> parameter is not NULL, the tree builder will be\n initialized with the entries of the given tree.</p>\n\n<p>If the <code>source</code> parameter is NULL, the tree builder will start with no\n entries and will have to be filled manually.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_clear": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 262,
       "lineto": 262,
       "args": [
@@ -24519,7 +26278,7 @@
     },
     "git_treebuilder_entrycount": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 270,
       "lineto": 270,
       "args": [
@@ -24541,7 +26300,7 @@
     },
     "git_treebuilder_free": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 281,
       "lineto": 281,
       "args": [
@@ -24558,12 +26317,12 @@
         "comment": null
       },
       "description": "<p>Free a tree builder</p>\n",
-      "comments": "<p>This will clear all the entries and free to builder. Failing to free the builder after you&#39;re done using it will result in a memory leak</p>\n",
+      "comments": "<p>This will clear all the entries and free to builder.\n Failing to free the builder after you&#39;re done using it\n will result in a memory leak</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_get": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 293,
       "lineto": 294,
       "args": [
@@ -24585,12 +26344,12 @@
         "comment": " pointer to the entry; NULL if not found"
       },
       "description": "<p>Get an entry from the builder from its filename</p>\n",
-      "comments": "<p>The returned entry is owned by the builder and should not be freed manually.</p>\n",
+      "comments": "<p>The returned entry is owned by the builder and should\n not be freed manually.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_insert": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 324,
       "lineto": 329,
       "args": [
@@ -24627,12 +26386,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an entry to the builder</p>\n",
-      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the newly created/updated entry.  Pass NULL if you do not need it. The pointer may not be valid past the next operation in this builder. Duplicate the entry if you want to keep it.</p>\n\n<p>By default the entry that you are inserting will be checked for validity; that it exists in the object database and is of the correct type.  If you do not want this behavior, set the <code>GIT_OPT_ENABLE_STRICT_OBJECT_CREATION</code> library option to false.</p>\n",
+      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the\n given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes\n will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the\n newly created/updated entry.  Pass NULL if you do not need it. The\n pointer may not be valid past the next operation in this\n builder. Duplicate the entry if you want to keep it.</p>\n\n<p>By default the entry that you are inserting will be checked for\n validity; that it exists in the object database and is of the\n correct type.  If you do not want this behavior, set the\n <code>GIT_OPT_ENABLE_STRICT_OBJECT_CREATION</code> library option to false.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_remove": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 337,
       "lineto": 338,
       "args": [
@@ -24659,7 +26418,7 @@
     },
     "git_treebuilder_filter": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 361,
       "lineto": 364,
       "args": [
@@ -24686,12 +26445,12 @@
         "comment": null
       },
       "description": "<p>Selectively remove entries in the tree</p>\n",
-      "comments": "<p>The <code>filter</code> callback will be called for each entry in the tree with a pointer to the entry and the provided <code>payload</code>; if the callback returns non-zero, the entry will be filtered (removed from the builder).</p>\n",
+      "comments": "<p>The <code>filter</code> callback will be called for each entry in the tree with a\n pointer to the entry and the provided <code>payload</code>; if the callback returns\n non-zero, the entry will be filtered (removed from the builder).</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_write": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 376,
       "lineto": 377,
       "args": [
@@ -24713,12 +26472,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Write the contents of the tree builder as a tree object</p>\n",
-      "comments": "<p>The tree builder will be written to the given <code>repo</code>, and its identifying SHA1 hash will be stored in the <code>id</code> pointer.</p>\n",
+      "comments": "<p>The tree builder will be written to the given <code>repo</code>, and its\n identifying SHA1 hash will be stored in the <code>id</code> pointer.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_write_with_buffer": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 390,
       "lineto": 391,
       "args": [
@@ -24750,7 +26509,7 @@
     },
     "git_tree_walk": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 420,
       "lineto": 424,
       "args": [
@@ -24782,12 +26541,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Traverse the entries in a tree and its subtrees in post or pre order.</p>\n",
-      "comments": "<p>The entries will be traversed in the specified order, children subtrees will be automatically loaded as required, and the <code>callback</code> will be called once per entry with the current (relative) root for the entry and the entry data itself.</p>\n\n<p>If the callback returns a positive value, the passed entry will be skipped on the traversal (in pre mode). A negative value stops the walk.</p>\n",
+      "comments": "<p>The entries will be traversed in the specified order, children subtrees\n will be automatically loaded as required, and the <code>callback</code> will be\n called once per entry with the current (relative) root for the entry and\n the entry data itself.</p>\n\n<p>If the callback returns a positive value, the passed entry will be\n skipped on the traversal (in pre mode). A negative value stops the walk.</p>\n",
       "group": "tree"
     },
     "git_tree_dup": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 433,
       "lineto": 433,
       "args": [
@@ -24814,7 +26573,7 @@
     },
     "git_tree_create_updated": {
       "type": "function",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 479,
       "lineto": 479,
       "args": [
@@ -24851,12 +26610,12 @@
         "comment": null
       },
       "description": "<p>Create a tree based on another one with the specified modifications</p>\n",
-      "comments": "<p>Given the <code>baseline</code> perform the changes described in the list of <code>updates</code> and create a new tree.</p>\n\n<p>This function is optimized for common file/directory addition, removal and replacement in trees. It is much more efficient than reading the tree into a <code>git_index</code> and modifying that, but in exchange it is not as flexible.</p>\n\n<p>Deleting and adding the same entry is undefined behaviour, changing a tree to a blob or viceversa is not supported.</p>\n",
+      "comments": "<p>Given the <code>baseline</code> perform the changes described in the list of\n <code>updates</code> and create a new tree.</p>\n\n<p>This function is optimized for common file/directory addition, removal and\n replacement in trees. It is much more efficient than reading the tree into a\n <code>git_index</code> and modifying that, but in exchange it is not as flexible.</p>\n\n<p>Deleting and adding the same entry is undefined behaviour, changing\n a tree to a blob or viceversa is not supported.</p>\n",
       "group": "tree"
     },
     "git_worktree_list": {
       "type": "function",
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "line": 34,
       "lineto": 34,
       "args": [
@@ -24878,12 +26637,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>List names of linked working trees</p>\n",
-      "comments": "<p>The returned list should be released with <code>git_strarray_free</code> when no longer needed.</p>\n",
+      "comments": "<p>The returned list should be released with <code>git_strarray_free</code>\n when no longer needed.</p>\n",
       "group": "worktree"
     },
     "git_worktree_lookup": {
       "type": "function",
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "line": 44,
       "lineto": 44,
       "args": [
@@ -24915,7 +26674,7 @@
     },
     "git_worktree_open_from_repository": {
       "type": "function",
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "line": 56,
       "lineto": 56,
       "args": [
@@ -24937,12 +26696,12 @@
         "comment": null
       },
       "description": "<p>Open a worktree of a given repository</p>\n",
-      "comments": "<p>If a repository is not the main tree but a worktree, this function will look up the worktree inside the parent repository and create a new <code>git_worktree</code> structure.</p>\n",
+      "comments": "<p>If a repository is not the main tree but a worktree, this\n function will look up the worktree inside the parent\n repository and create a new <code>git_worktree</code> structure.</p>\n",
       "group": "worktree"
     },
     "git_worktree_free": {
       "type": "function",
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "line": 63,
       "lineto": 63,
       "args": [
@@ -24964,7 +26723,7 @@
     },
     "git_worktree_validate": {
       "type": "function",
-      "file": "worktree.h",
+      "file": "git2/worktree.h",
       "line": 75,
       "lineto": 75,
       "args": [
@@ -24981,24 +26740,24 @@
         "comment": " 0 when worktree is valid, error-code otherwise"
       },
       "description": "<p>Check if worktree is valid</p>\n",
-      "comments": "<p>A valid worktree requires both the git data structures inside the linked parent repository and the linked working copy to be present.</p>\n",
+      "comments": "<p>A valid worktree requires both the git data structures inside\n the linked parent repository and the linked working copy to be\n present.</p>\n",
       "group": "worktree"
     },
     "git_worktree_add_init_options": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 95,
-      "lineto": 96,
+      "file": "git2/worktree.h",
+      "line": 104,
+      "lineto": 105,
       "args": [
         {
           "name": "opts",
           "type": "git_worktree_add_options *",
-          "comment": "the struct to initialize"
+          "comment": "The `git_worktree_add_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Verison of struct; pass `GIT_WORKTREE_ADD_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_WORKTREE_ADD_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_worktree_add_options *opts, unsigned int version",
@@ -25007,15 +26766,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_worktree_add_options</code> with default vaules.\n Equivalent to creating an instance with\n GIT_WORKTREE_ADD_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_worktree_add_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_worktree_add_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>.</p>\n",
       "group": "worktree"
     },
     "git_worktree_add": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 112,
-      "lineto": 114,
+      "file": "git2/worktree.h",
+      "line": 121,
+      "lineto": 123,
       "args": [
         {
           "name": "out",
@@ -25050,14 +26809,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a new working tree</p>\n",
-      "comments": "<p>Add a new working tree for the repository, that is create the required data structures inside the repository and check out the current HEAD at <code>path</code></p>\n",
+      "comments": "<p>Add a new working tree for the repository, that is create the\n required data structures inside the repository and check out\n the current HEAD at <code>path</code></p>\n",
       "group": "worktree"
     },
     "git_worktree_lock": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 126,
-      "lineto": 126,
+      "file": "git2/worktree.h",
+      "line": 135,
+      "lineto": 135,
       "args": [
         {
           "name": "wt",
@@ -25077,14 +26836,14 @@
         "comment": " 0 on success, non-zero otherwise"
       },
       "description": "<p>Lock worktree if not already locked</p>\n",
-      "comments": "<p>Lock a worktree, optionally specifying a reason why the linked working tree is being locked.</p>\n",
+      "comments": "<p>Lock a worktree, optionally specifying a reason why the linked\n working tree is being locked.</p>\n",
       "group": "worktree"
     },
     "git_worktree_unlock": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 135,
-      "lineto": 135,
+      "file": "git2/worktree.h",
+      "line": 144,
+      "lineto": 144,
       "args": [
         {
           "name": "wt",
@@ -25104,9 +26863,9 @@
     },
     "git_worktree_is_locked": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 149,
-      "lineto": 149,
+      "file": "git2/worktree.h",
+      "line": 158,
+      "lineto": 158,
       "args": [
         {
           "name": "reason",
@@ -25126,24 +26885,68 @@
         "comment": " 0 when the working tree not locked, a value greater\n  than zero if it is locked, less than zero if there was an\n  error"
       },
       "description": "<p>Check if worktree is locked</p>\n",
-      "comments": "<p>A worktree may be locked if the linked working tree is stored on a portable device which is not available.</p>\n",
+      "comments": "<p>A worktree may be locked if the linked working tree is stored\n on a portable device which is not available.</p>\n",
+      "group": "worktree"
+    },
+    "git_worktree_name": {
+      "type": "function",
+      "file": "git2/worktree.h",
+      "line": 167,
+      "lineto": 167,
+      "args": [
+        {
+          "name": "wt",
+          "type": "const git_worktree *",
+          "comment": "Worktree to get the name for"
+        }
+      ],
+      "argline": "const git_worktree *wt",
+      "sig": "const git_worktree *",
+      "return": {
+        "type": "const char *",
+        "comment": " The worktree's name. The pointer returned is valid for the\n  lifetime of the git_worktree"
+      },
+      "description": "<p>Retrieve the name of the worktree</p>\n",
+      "comments": "",
+      "group": "worktree"
+    },
+    "git_worktree_path": {
+      "type": "function",
+      "file": "git2/worktree.h",
+      "line": 176,
+      "lineto": 176,
+      "args": [
+        {
+          "name": "wt",
+          "type": "const git_worktree *",
+          "comment": "Worktree to get the path for"
+        }
+      ],
+      "argline": "const git_worktree *wt",
+      "sig": "const git_worktree *",
+      "return": {
+        "type": "const char *",
+        "comment": " The worktree's filesystem path. The pointer returned\n  is valid for the lifetime of the git_worktree."
+      },
+      "description": "<p>Retrieve the filesystem path for the worktree</p>\n",
+      "comments": "",
       "group": "worktree"
     },
     "git_worktree_prune_init_options": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 182,
-      "lineto": 184,
+      "file": "git2/worktree.h",
+      "line": 217,
+      "lineto": 219,
       "args": [
         {
           "name": "opts",
           "type": "git_worktree_prune_options *",
-          "comment": "the struct to initialize"
+          "comment": "The `git_worktree_prune_options` struct to initialize."
         },
         {
           "name": "version",
           "type": "unsigned int",
-          "comment": "Verison of struct; pass `GIT_WORKTREE_PRUNE_OPTIONS_VERSION`"
+          "comment": "The struct version; pass `GIT_WORKTREE_PRUNE_OPTIONS_VERSION`."
         }
       ],
       "argline": "git_worktree_prune_options *opts, unsigned int version",
@@ -25152,15 +26955,15 @@
         "type": "int",
         "comment": " Zero on success; -1 on failure."
       },
-      "description": "<p>Initializes a <code>git_worktree_prune_options</code> with default vaules.\n Equivalent to creating an instance with\n GIT_WORKTREE_PRUNE_OPTIONS_INIT.</p>\n",
-      "comments": "",
+      "description": "<p>Initialize git_worktree_prune_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_worktree_prune_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>.</p>\n",
       "group": "worktree"
     },
     "git_worktree_is_prunable": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 200,
-      "lineto": 201,
+      "file": "git2/worktree.h",
+      "line": 235,
+      "lineto": 236,
       "args": [
         {
           "name": "wt",
@@ -25180,14 +26983,14 @@
         "comment": null
       },
       "description": "<p>Is the worktree prunable with the given options?</p>\n",
-      "comments": "<p>A worktree is not prunable in the following scenarios:</p>\n\n<ul>\n<li>the worktree is linking to a valid on-disk worktree. The   <code>valid</code> member will cause this check to be ignored. - the worktree is locked. The <code>locked</code> flag will cause this   check to be ignored.</li>\n</ul>\n\n<p>If the worktree is not valid and not locked or if the above flags have been passed in, this function will return a positive value.</p>\n",
+      "comments": "<p>A worktree is not prunable in the following scenarios:</p>\n\n<ul>\n<li>the worktree is linking to a valid on-disk worktree. The\n<code>valid</code> member will cause this check to be ignored.</li>\n<li>the worktree is locked. The <code>locked</code> flag will cause this\ncheck to be ignored.</li>\n</ul>\n\n<p>If the worktree is not valid and not locked or if the above\n flags have been passed in, this function will return a\n positive value.</p>\n",
       "group": "worktree"
     },
     "git_worktree_prune": {
       "type": "function",
-      "file": "worktree.h",
-      "line": 215,
-      "lineto": 216,
+      "file": "git2/worktree.h",
+      "line": 250,
+      "lineto": 251,
       "args": [
         {
           "name": "wt",
@@ -25207,14 +27010,45 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Prune working tree</p>\n",
-      "comments": "<p>Prune the working tree, that is remove the git data structures on disk. The repository will only be pruned of <code>git_worktree_is_prunable</code> succeeds.</p>\n",
+      "comments": "<p>Prune the working tree, that is remove the git data\n structures on disk. The repository will only be pruned of\n <code>git_worktree_is_prunable</code> succeeds.</p>\n",
       "group": "worktree"
     }
   },
   "callbacks": {
+    "git_attr_foreach_cb": {
+      "type": "callback",
+      "file": "git2/attr.h",
+      "line": 205,
+      "lineto": 205,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": "The attribute name."
+        },
+        {
+          "name": "value",
+          "type": "const char *",
+          "comment": "The attribute value. May be NULL if the attribute is explicitly\n              set to UNSPECIFIED using the '!' sign."
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": "A user-specified pointer."
+        }
+      ],
+      "argline": "const char *name, const char *value, void *payload",
+      "sig": "const char *::const char *::void *",
+      "return": {
+        "type": "int",
+        "comment": " 0 to continue looping, non-zero to stop. This value will be returned\n         from git_attr_foreach."
+      },
+      "description": "<p>The callback used with git_attr_foreach.</p>\n",
+      "comments": "<p>This callback will be invoked only once per attribute name, even if there\n are multiple rules for a given file. The highest priority rule will be\n used.</p>\n"
+    },
     "git_checkout_notify_cb": {
       "type": "callback",
-      "file": "checkout.h",
+      "file": "git2/checkout.h",
       "line": 223,
       "lineto": 229,
       "args": [
@@ -25260,7 +27094,7 @@
     },
     "git_checkout_progress_cb": {
       "type": "callback",
-      "file": "checkout.h",
+      "file": "git2/checkout.h",
       "line": 232,
       "lineto": 236,
       "args": [
@@ -25296,7 +27130,7 @@
     },
     "git_checkout_perfdata_cb": {
       "type": "callback",
-      "file": "checkout.h",
+      "file": "git2/checkout.h",
       "line": 239,
       "lineto": 241,
       "args": [
@@ -25322,7 +27156,7 @@
     },
     "git_remote_create_cb": {
       "type": "callback",
-      "file": "clone.h",
+      "file": "git2/clone.h",
       "line": 69,
       "lineto": 74,
       "args": [
@@ -25359,11 +27193,11 @@
         "comment": " 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>The signature of a function matching git_remote_create, with an additional\n void* as a callback payload.</p>\n",
-      "comments": "<p>Callers of git_clone may provide a function matching this signature to override the remote creation and customization process during a clone operation.</p>\n"
+      "comments": "<p>Callers of git_clone may provide a function matching this signature to override\n the remote creation and customization process during a clone operation.</p>\n"
     },
     "git_repository_create_cb": {
       "type": "callback",
-      "file": "clone.h",
+      "file": "git2/clone.h",
       "line": 90,
       "lineto": 94,
       "args": [
@@ -25395,13 +27229,39 @@
         "comment": " 0, or a negative value to indicate error"
       },
       "description": "<p>The signature of a function matchin git_repository_init, with an\n aditional void * as callback payload.</p>\n",
-      "comments": "<p>Callers of git_clone my provide a function matching this signature to override the repository creation and customization process during a clone operation.</p>\n"
+      "comments": "<p>Callers of git_clone my provide a function matching this signature\n to override the repository creation and customization process\n during a clone operation.</p>\n"
+    },
+    "git_config_foreach_cb": {
+      "type": "callback",
+      "file": "git2/config.h",
+      "line": 84,
+      "lineto": 84,
+      "args": [
+        {
+          "name": "entry",
+          "type": "const git_config_entry *",
+          "comment": "the entry currently being enumerated"
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": "a user-specified pointer"
+        }
+      ],
+      "argline": "const git_config_entry *entry, void *payload",
+      "sig": "const git_config_entry *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>A config enumeration callback</p>\n",
+      "comments": ""
     },
     "git_diff_notify_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 359,
-      "lineto": 363,
+      "file": "git2/diff.h",
+      "line": 331,
+      "lineto": 335,
       "args": [
         {
           "name": "diff_so_far",
@@ -25431,13 +27291,13 @@
         "comment": null
       },
       "description": "<p>Diff notification callback function.</p>\n",
-      "comments": "<p>The callback will be called for each file, just before the <code>git_delta_t</code> gets inserted into the diff.</p>\n\n<p>When the callback: - returns &lt; 0, the diff process will be aborted. - returns &gt; 0, the delta will not be inserted into the diff, but the       diff process continues. - returns 0, the delta is inserted into the diff, and the diff process      continues.</p>\n"
+      "comments": "<p>The callback will be called for each file, just before the <code>git_diff_delta</code>\n gets inserted into the diff.</p>\n\n<p>When the callback:\n - returns \n&lt;\n 0, the diff process will be aborted.\n - returns &gt; 0, the delta will not be inserted into the diff, but the\n        diff process continues.\n - returns 0, the delta is inserted into the diff, and the diff process\n        continues.</p>\n"
     },
     "git_diff_progress_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 375,
-      "lineto": 379,
+      "file": "git2/diff.h",
+      "line": 347,
+      "lineto": 351,
       "args": [
         {
           "name": "diff_so_far",
@@ -25471,9 +27331,9 @@
     },
     "git_diff_file_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 458,
-      "lineto": 461,
+      "file": "git2/diff.h",
+      "line": 465,
+      "lineto": 468,
       "args": [
         {
           "name": "delta",
@@ -25502,9 +27362,9 @@
     },
     "git_diff_binary_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 515,
-      "lineto": 518,
+      "file": "git2/diff.h",
+      "line": 531,
+      "lineto": 534,
       "args": [
         {
           "name": "delta",
@@ -25533,9 +27393,9 @@
     },
     "git_diff_hunk_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 535,
-      "lineto": 538,
+      "file": "git2/diff.h",
+      "line": 557,
+      "lineto": 560,
       "args": [
         {
           "name": "delta",
@@ -25564,9 +27424,9 @@
     },
     "git_diff_line_cb": {
       "type": "callback",
-      "file": "diff.h",
-      "line": 588,
-      "lineto": 592,
+      "file": "git2/diff.h",
+      "line": 618,
+      "lineto": 622,
       "args": [
         {
           "name": "delta",
@@ -25596,11 +27456,11 @@
         "comment": null
       },
       "description": "<p>When iterating over a diff, callback that will be made per text diff\n line. In this context, the provided range will be NULL.</p>\n",
-      "comments": "<p>When printing a diff, callback that will be made to output each line of text.  This uses some extra GIT_DIFF_LINE_... constants for output of lines of file and hunk headers.</p>\n"
+      "comments": "<p>When printing a diff, callback that will be made to output each line\n of text.  This uses some extra GIT_DIFF_LINE_... constants for output\n of lines of file and hunk headers.</p>\n"
     },
     "git_index_matched_path_cb": {
       "type": "callback",
-      "file": "index.h",
+      "file": "git2/index.h",
       "line": 146,
       "lineto": 147,
       "args": [
@@ -25631,7 +27491,7 @@
     },
     "git_headlist_cb": {
       "type": "callback",
-      "file": "net.h",
+      "file": "git2/net.h",
       "line": 55,
       "lineto": 55,
       "args": [
@@ -25657,7 +27517,7 @@
     },
     "git_note_foreach_cb": {
       "type": "callback",
-      "file": "notes.h",
+      "file": "git2/notes.h",
       "line": 29,
       "lineto": 30,
       "args": [
@@ -25684,11 +27544,11 @@
         "comment": null
       },
       "description": "<p>Callback for git_note_foreach.</p>\n",
-      "comments": "<p>Receives: - blob_id: Oid of the blob containing the message - annotated_object_id: Oid of the git object being annotated - payload: Payload data passed to <code>git_note_foreach</code></p>\n"
+      "comments": "<p>Receives:\n - blob_id: Oid of the blob containing the message\n - annotated_object_id: Oid of the git object being annotated\n - payload: Payload data passed to <code>git_note_foreach</code></p>\n"
     },
     "git_odb_foreach_cb": {
       "type": "callback",
-      "file": "odb.h",
+      "file": "git2/odb.h",
       "line": 27,
       "lineto": 27,
       "args": [
@@ -25712,9 +27572,40 @@
       "description": "<p>Function type for callbacks from git_odb_foreach.</p>\n",
       "comments": ""
     },
+    "git_packbuilder_foreach_cb": {
+      "type": "callback",
+      "file": "git2/pack.h",
+      "line": 181,
+      "lineto": 181,
+      "args": [
+        {
+          "name": "buf",
+          "type": "void *",
+          "comment": null
+        },
+        {
+          "name": "size",
+          "type": "size_t",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "void *buf, size_t size, void *payload",
+      "sig": "void *::size_t::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
     "git_packbuilder_progress": {
       "type": "callback",
-      "file": "pack.h",
+      "file": "git2/pack.h",
       "line": 210,
       "lineto": 214,
       "args": [
@@ -25748,9 +27639,61 @@
       "description": "<p>Packbuilder progress notification function </p>\n",
       "comments": ""
     },
+    "git_reference_foreach_cb": {
+      "type": "callback",
+      "file": "git2/refs.h",
+      "line": 425,
+      "lineto": 425,
+      "args": [
+        {
+          "name": "reference",
+          "type": "git_reference *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "git_reference *reference, void *payload",
+      "sig": "git_reference *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
+    "git_reference_foreach_name_cb": {
+      "type": "callback",
+      "file": "git2/refs.h",
+      "line": 426,
+      "lineto": 426,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "const char *name, void *payload",
+      "sig": "const char *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
     "git_push_transfer_progress": {
       "type": "callback",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 351,
       "lineto": 355,
       "args": [
@@ -25786,7 +27729,7 @@
     },
     "git_push_negotiation": {
       "type": "callback",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 386,
       "lineto": 386,
       "args": [
@@ -25817,7 +27760,7 @@
     },
     "git_push_update_reference_cb": {
       "type": "callback",
-      "file": "remote.h",
+      "file": "git2/remote.h",
       "line": 400,
       "lineto": 400,
       "args": [
@@ -25844,11 +27787,78 @@
         "comment": " 0 on success, otherwise an error"
       },
       "description": "<p>Callback used to inform of the update status from the remote.</p>\n",
-      "comments": "<p>Called for each updated reference on push. If <code>status</code> is not <code>NULL</code>, the update was rejected by the remote server and <code>status</code> contains the reason given.</p>\n"
+      "comments": "<p>Called for each updated reference on push. If <code>status</code> is\n not <code>NULL</code>, the update was rejected by the remote server\n and <code>status</code> contains the reason given.</p>\n"
+    },
+    "git_repository_fetchhead_foreach_cb": {
+      "type": "callback",
+      "file": "git2/repository.h",
+      "line": 630,
+      "lineto": 634,
+      "args": [
+        {
+          "name": "ref_name",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "remote_url",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": null
+        },
+        {
+          "name": "is_merge",
+          "type": "unsigned int",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "const char *ref_name, const char *remote_url, const git_oid *oid, unsigned int is_merge, void *payload",
+      "sig": "const char *::const char *::const git_oid *::unsigned int::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
+    "git_repository_mergehead_foreach_cb": {
+      "type": "callback",
+      "file": "git2/repository.h",
+      "line": 652,
+      "lineto": 653,
+      "args": [
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_oid *oid, void *payload",
+      "sig": "const git_oid *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
     },
     "git_revwalk_hide_cb": {
       "type": "callback",
-      "file": "revwalk.h",
+      "file": "git2/revwalk.h",
       "line": 277,
       "lineto": 279,
       "args": [
@@ -25874,9 +27884,9 @@
     },
     "git_stash_apply_progress_cb": {
       "type": "callback",
-      "file": "stash.h",
-      "line": 113,
-      "lineto": 115,
+      "file": "git2/stash.h",
+      "line": 115,
+      "lineto": 117,
       "args": [
         {
           "name": "progress",
@@ -25900,9 +27910,9 @@
     },
     "git_stash_cb": {
       "type": "callback",
-      "file": "stash.h",
-      "line": 198,
-      "lineto": 202,
+      "file": "git2/stash.h",
+      "line": 201,
+      "lineto": 205,
       "args": [
         {
           "name": "index",
@@ -25916,7 +27926,7 @@
         },
         {
           "name": "stash_id",
-          "type": "const int *",
+          "type": "const git_oid *",
           "comment": "The commit oid of the stashed state."
         },
         {
@@ -25925,8 +27935,8 @@
           "comment": "Extra parameter to callback function."
         }
       ],
-      "argline": "size_t index, const char *message, const int *stash_id, void *payload",
-      "sig": "size_t::const char *::const int *::void *",
+      "argline": "size_t index, const char *message, const git_oid *stash_id, void *payload",
+      "sig": "size_t::const char *::const git_oid *::void *",
       "return": {
         "type": "int",
         "comment": " 0 to continue iterating or non-zero to stop."
@@ -25936,9 +27946,9 @@
     },
     "git_status_cb": {
       "type": "callback",
-      "file": "status.h",
-      "line": 61,
-      "lineto": 62,
+      "file": "git2/status.h",
+      "line": 63,
+      "lineto": 64,
       "args": [
         {
           "name": "path",
@@ -25967,7 +27977,7 @@
     },
     "git_submodule_cb": {
       "type": "callback",
-      "file": "submodule.h",
+      "file": "git2/submodule.h",
       "line": 118,
       "lineto": 119,
       "args": [
@@ -25998,7 +28008,7 @@
     },
     "git_filter_init_fn": {
       "type": "callback",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 141,
       "lineto": 141,
       "args": [
@@ -26015,11 +28025,11 @@
         "comment": null
       },
       "description": "<p>Initialize callback on filter</p>\n",
-      "comments": "<p>Specified as <code>filter.initialize</code>, this is an optional callback invoked before a filter is first used.  It will be called once at most.</p>\n\n<p>If non-NULL, the filter&#39;s <code>initialize</code> callback will be invoked right before the first use of the filter, so you can defer expensive initialization operations (in case libgit2 is being used in a way that doesn&#39;t need the filter).</p>\n"
+      "comments": "<p>Specified as <code>filter.initialize</code>, this is an optional callback invoked\n before a filter is first used.  It will be called once at most.</p>\n\n<p>If non-NULL, the filter&#39;s <code>initialize</code> callback will be invoked right\n before the first use of the filter, so you can defer expensive\n initialization operations (in case libgit2 is being used in a way that\n doesn&#39;t need the filter).</p>\n"
     },
     "git_filter_shutdown_fn": {
       "type": "callback",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 153,
       "lineto": 153,
       "args": [
@@ -26036,11 +28046,11 @@
         "comment": null
       },
       "description": "<p>Shutdown callback on filter</p>\n",
-      "comments": "<p>Specified as <code>filter.shutdown</code>, this is an optional callback invoked when the filter is unregistered or when libgit2 is shutting down.  It will be called once at most and should release resources as needed. This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_filter</code> object itself.</p>\n"
+      "comments": "<p>Specified as <code>filter.shutdown</code>, this is an optional callback invoked\n when the filter is unregistered or when libgit2 is shutting down.  It\n will be called once at most and should release resources as needed.\n This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_filter</code> object itself.</p>\n"
     },
     "git_filter_check_fn": {
       "type": "callback",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 175,
       "lineto": 179,
       "args": [
@@ -26072,11 +28082,11 @@
         "comment": null
       },
       "description": "<p>Callback to decide if a given source needs this filter</p>\n",
-      "comments": "<p>Specified as <code>filter.check</code>, this is an optional callback that checks if filtering is needed for a given source.</p>\n\n<p>It should return 0 if the filter should be applied (i.e. success), GIT_PASSTHROUGH if the filter should not be applied, or an error code to fail out of the filter processing pipeline and return to the caller.</p>\n\n<p>The <code>attr_values</code> will be set to the values of any attributes given in the filter definition.  See <code>git_filter</code> below for more detail.</p>\n\n<p>The <code>payload</code> will be a pointer to a reference payload for the filter. This will start as NULL, but <code>check</code> can assign to this pointer for later use by the <code>apply</code> callback.  Note that the value should be heap allocated (not stack), so that it doesn&#39;t go away before the <code>apply</code> callback can use it.  If a filter allocates and assigns a value to the <code>payload</code>, it will need a <code>cleanup</code> callback to free the payload.</p>\n"
+      "comments": "<p>Specified as <code>filter.check</code>, this is an optional callback that checks\n if filtering is needed for a given source.</p>\n\n<p>It should return 0 if the filter should be applied (i.e. success),\n GIT_PASSTHROUGH if the filter should not be applied, or an error code\n to fail out of the filter processing pipeline and return to the caller.</p>\n\n<p>The <code>attr_values</code> will be set to the values of any attributes given in\n the filter definition.  See <code>git_filter</code> below for more detail.</p>\n\n<p>The <code>payload</code> will be a pointer to a reference payload for the filter.\n This will start as NULL, but <code>check</code> can assign to this pointer for\n later use by the <code>apply</code> callback.  Note that the value should be heap\n allocated (not stack), so that it doesn&#39;t go away before the <code>apply</code>\n callback can use it.  If a filter allocates and assigns a value to the\n <code>payload</code>, it will need a <code>cleanup</code> callback to free the payload.</p>\n"
     },
     "git_filter_apply_fn": {
       "type": "callback",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 193,
       "lineto": 198,
       "args": [
@@ -26113,11 +28123,52 @@
         "comment": null
       },
       "description": "<p>Callback to actually perform the data filtering</p>\n",
-      "comments": "<p>Specified as <code>filter.apply</code>, this is the callback that actually filters data.  If it successfully writes the output, it should return 0.  Like <code>check</code>, it can return GIT_PASSTHROUGH to indicate that the filter doesn&#39;t want to run.  Other error codes will stop filter processing and return to the caller.</p>\n\n<p>The <code>payload</code> value will refer to any payload that was set by the <code>check</code> callback.  It may be read from or written to as needed.</p>\n"
+      "comments": "<p>Specified as <code>filter.apply</code>, this is the callback that actually filters\n data.  If it successfully writes the output, it should return 0.  Like\n <code>check</code>, it can return GIT_PASSTHROUGH to indicate that the filter\n doesn&#39;t want to run.  Other error codes will stop filter processing and\n return to the caller.</p>\n\n<p>The <code>payload</code> value will refer to any payload that was set by the\n <code>check</code> callback.  It may be read from or written to as needed.</p>\n"
+    },
+    "git_filter_stream_fn": {
+      "type": "callback",
+      "file": "git2/sys/filter.h",
+      "line": 200,
+      "lineto": 205,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_writestream **",
+          "comment": null
+        },
+        {
+          "name": "self",
+          "type": "git_filter *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void **",
+          "comment": null
+        },
+        {
+          "name": "src",
+          "type": "const git_filter_source *",
+          "comment": null
+        },
+        {
+          "name": "next",
+          "type": "git_writestream *",
+          "comment": null
+        }
+      ],
+      "argline": "git_writestream **out, git_filter *self, void **payload, const git_filter_source *src, git_writestream *next",
+      "sig": "git_writestream **::git_filter *::void **::const git_filter_source *::git_writestream *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
     },
     "git_filter_cleanup_fn": {
       "type": "callback",
-      "file": "sys/filter.h",
+      "file": "git2/sys/filter.h",
       "line": 215,
       "lineto": 217,
       "args": [
@@ -26139,59 +28190,59 @@
         "comment": null
       },
       "description": "<p>Callback to clean up after filtering has been applied</p>\n",
-      "comments": "<p>Specified as <code>filter.cleanup</code>, this is an optional callback invoked after the filter has been applied.  If the <code>check</code> or <code>apply</code> callbacks allocated a <code>payload</code> to keep per-source filter state, use this callback to free that payload and release resources as required.</p>\n"
+      "comments": "<p>Specified as <code>filter.cleanup</code>, this is an optional callback invoked\n after the filter has been applied.  If the <code>check</code> or <code>apply</code> callbacks\n allocated a <code>payload</code> to keep per-source filter state, use this\n callback to free that payload and release resources as required.</p>\n"
     },
     "git_merge_driver_init_fn": {
       "type": "callback",
-      "file": "sys/merge.h",
-      "line": 71,
-      "lineto": 71,
+      "file": "git2/sys/merge.h",
+      "line": 76,
+      "lineto": 76,
       "args": [
         {
           "name": "self",
-          "type": "int *",
+          "type": "git_merge_driver *",
           "comment": null
         }
       ],
-      "argline": "int *self",
-      "sig": "int *",
+      "argline": "git_merge_driver *self",
+      "sig": "git_merge_driver *",
       "return": {
         "type": "int",
         "comment": null
       },
       "description": "<p>Initialize callback on merge driver</p>\n",
-      "comments": "<p>Specified as <code>driver.initialize</code>, this is an optional callback invoked before a merge driver is first used.  It will be called once at most per library lifetime.</p>\n\n<p>If non-NULL, the merge driver&#39;s <code>initialize</code> callback will be invoked right before the first use of the driver, so you can defer expensive initialization operations (in case libgit2 is being used in a way that doesn&#39;t need the merge driver).</p>\n"
+      "comments": "<p>Specified as <code>driver.initialize</code>, this is an optional callback invoked\n before a merge driver is first used.  It will be called once at most\n per library lifetime.</p>\n\n<p>If non-NULL, the merge driver&#39;s <code>initialize</code> callback will be invoked\n right before the first use of the driver, so you can defer expensive\n initialization operations (in case libgit2 is being used in a way that\n doesn&#39;t need the merge driver).</p>\n"
     },
     "git_merge_driver_shutdown_fn": {
       "type": "callback",
-      "file": "sys/merge.h",
-      "line": 83,
-      "lineto": 83,
+      "file": "git2/sys/merge.h",
+      "line": 88,
+      "lineto": 88,
       "args": [
         {
           "name": "self",
-          "type": "int *",
+          "type": "git_merge_driver *",
           "comment": null
         }
       ],
-      "argline": "int *self",
-      "sig": "int *",
+      "argline": "git_merge_driver *self",
+      "sig": "git_merge_driver *",
       "return": {
         "type": "void",
         "comment": null
       },
       "description": "<p>Shutdown callback on merge driver</p>\n",
-      "comments": "<p>Specified as <code>driver.shutdown</code>, this is an optional callback invoked when the merge driver is unregistered or when libgit2 is shutting down. It will be called once at most and should release resources as needed. This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_merge_driver</code> object itself.</p>\n"
+      "comments": "<p>Specified as <code>driver.shutdown</code>, this is an optional callback invoked\n when the merge driver is unregistered or when libgit2 is shutting down.\n It will be called once at most and should release resources as needed.\n This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_merge_driver</code> object itself.</p>\n"
     },
     "git_merge_driver_apply_fn": {
       "type": "callback",
-      "file": "sys/merge.h",
-      "line": 103,
-      "lineto": 109,
+      "file": "git2/sys/merge.h",
+      "line": 108,
+      "lineto": 114,
       "args": [
         {
           "name": "self",
-          "type": "int *",
+          "type": "git_merge_driver *",
           "comment": null
         },
         {
@@ -26201,12 +28252,12 @@
         },
         {
           "name": "mode_out",
-          "type": "int *",
+          "type": "uint32_t *",
           "comment": null
         },
         {
           "name": "merged_out",
-          "type": "int *",
+          "type": "git_buf *",
           "comment": null
         },
         {
@@ -26220,18 +28271,111 @@
           "comment": null
         }
       ],
-      "argline": "int *self, const char **path_out, int *mode_out, int *merged_out, const char *filter_name, const git_merge_driver_source *src",
-      "sig": "int *::const char **::int *::int *::const char *::const git_merge_driver_source *",
+      "argline": "git_merge_driver *self, const char **path_out, uint32_t *mode_out, git_buf *merged_out, const char *filter_name, const git_merge_driver_source *src",
+      "sig": "git_merge_driver *::const char **::uint32_t *::git_buf *::const char *::const git_merge_driver_source *",
       "return": {
         "type": "int",
         "comment": null
       },
       "description": "<p>Callback to perform the merge.</p>\n",
-      "comments": "<p>Specified as <code>driver.apply</code>, this is the callback that actually does the merge.  If it can successfully perform a merge, it should populate <code>path_out</code> with a pointer to the filename to accept, <code>mode_out</code> with the resultant mode, and <code>merged_out</code> with the buffer of the merged file and then return 0.  If the driver returns <code>GIT_PASSTHROUGH</code>, then the default merge driver should instead be run.  It can also return <code>GIT_EMERGECONFLICT</code> if the driver is not able to produce a merge result, and the file will remain conflicted.  Any other errors will fail and return to the caller.</p>\n\n<p>The <code>filter_name</code> contains the name of the filter that was invoked, as specified by the file&#39;s attributes.</p>\n\n<p>The <code>src</code> contains the data about the file to be merged.</p>\n"
+      "comments": "<p>Specified as <code>driver.apply</code>, this is the callback that actually does the\n merge.  If it can successfully perform a merge, it should populate\n <code>path_out</code> with a pointer to the filename to accept, <code>mode_out</code> with\n the resultant mode, and <code>merged_out</code> with the buffer of the merged file\n and then return 0.  If the driver returns <code>GIT_PASSTHROUGH</code>, then the\n default merge driver should instead be run.  It can also return\n <code>GIT_EMERGECONFLICT</code> if the driver is not able to produce a merge result,\n and the file will remain conflicted.  Any other errors will fail and\n return to the caller.</p>\n\n<p>The <code>filter_name</code> contains the name of the filter that was invoked, as\n specified by the file&#39;s attributes.</p>\n\n<p>The <code>src</code> contains the data about the file to be merged.</p>\n"
+    },
+    "git_stream_cb": {
+      "type": "callback",
+      "file": "git2/sys/stream.h",
+      "line": 43,
+      "lineto": 43,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_stream **",
+          "comment": null
+        },
+        {
+          "name": "host",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "port",
+          "type": "const char *",
+          "comment": null
+        }
+      ],
+      "argline": "git_stream **out, const char *host, const char *port",
+      "sig": "git_stream **::const char *::const char *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
+    "git_smart_subtransport_cb": {
+      "type": "callback",
+      "file": "git2/sys/transport.h",
+      "line": 325,
+      "lineto": 328,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_smart_subtransport **",
+          "comment": null
+        },
+        {
+          "name": "owner",
+          "type": "git_transport *",
+          "comment": null
+        },
+        {
+          "name": "param",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "git_smart_subtransport **out, git_transport *owner, void *param",
+      "sig": "git_smart_subtransport **::git_transport *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
+    "git_tag_foreach_cb": {
+      "type": "callback",
+      "file": "git2/tag.h",
+      "line": 321,
+      "lineto": 321,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "oid",
+          "type": "git_oid *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "const char *name, git_oid *oid, void *payload",
+      "sig": "const char *::git_oid *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
     },
     "git_trace_callback": {
       "type": "callback",
-      "file": "trace.h",
+      "file": "git2/trace.h",
       "line": 52,
       "lineto": 52,
       "args": [
@@ -26257,7 +28401,7 @@
     },
     "git_transport_cb": {
       "type": "callback",
-      "file": "transport.h",
+      "file": "git2/transport.h",
       "line": 24,
       "lineto": 24,
       "args": [
@@ -26286,11 +28430,113 @@
       "description": "<p>Signature of a function which creates a transport </p>\n",
       "comments": ""
     },
+    "git_cred_sign_callback": {
+      "type": "callback",
+      "file": "git2/transport.h",
+      "line": 168,
+      "lineto": 168,
+      "args": [
+        {
+          "name": "session",
+          "type": "LIBSSH2_SESSION *",
+          "comment": null
+        },
+        {
+          "name": "sig",
+          "type": "unsigned char **",
+          "comment": null
+        },
+        {
+          "name": "sig_len",
+          "type": "size_t *",
+          "comment": null
+        },
+        {
+          "name": "data",
+          "type": "const unsigned char *",
+          "comment": null
+        },
+        {
+          "name": "data_len",
+          "type": "size_t",
+          "comment": null
+        },
+        {
+          "name": "abstract",
+          "type": "void **",
+          "comment": null
+        }
+      ],
+      "argline": "LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract",
+      "sig": "LIBSSH2_SESSION *::unsigned char **::size_t *::const unsigned char *::size_t::void **",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
+    "git_cred_ssh_interactive_callback": {
+      "type": "callback",
+      "file": "git2/transport.h",
+      "line": 169,
+      "lineto": 169,
+      "args": [
+        {
+          "name": "name",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "name_len",
+          "type": "int",
+          "comment": null
+        },
+        {
+          "name": "instruction",
+          "type": "const char *",
+          "comment": null
+        },
+        {
+          "name": "instruction_len",
+          "type": "int",
+          "comment": null
+        },
+        {
+          "name": "num_prompts",
+          "type": "int",
+          "comment": null
+        },
+        {
+          "name": "prompts",
+          "type": "const LIBSSH2_USERAUTH_KBDINT_PROMPT *",
+          "comment": null
+        },
+        {
+          "name": "responses",
+          "type": "LIBSSH2_USERAUTH_KBDINT_RESPONSE *",
+          "comment": null
+        },
+        {
+          "name": "abstract",
+          "type": "void **",
+          "comment": null
+        }
+      ],
+      "argline": "const char *name, int name_len, const char *instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract",
+      "sig": "const char *::int::const char *::int::int::const LIBSSH2_USERAUTH_KBDINT_PROMPT *::LIBSSH2_USERAUTH_KBDINT_RESPONSE *::void **",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "",
+      "comments": ""
+    },
     "git_cred_acquire_cb": {
       "type": "callback",
-      "file": "transport.h",
-      "line": 333,
-      "lineto": 338,
+      "file": "git2/transport.h",
+      "line": 362,
+      "lineto": 367,
       "args": [
         {
           "name": "cred",
@@ -26329,7 +28575,7 @@
     },
     "git_treebuilder_filter_cb": {
       "type": "callback",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 347,
       "lineto": 348,
       "args": [
@@ -26351,11 +28597,11 @@
         "comment": null
       },
       "description": "<p>Callback for git_treebuilder_filter</p>\n",
-      "comments": "<p>The return value is treated as a boolean, with zero indicating that the entry should be left alone and any non-zero value meaning that the entry should be removed from the treebuilder list (i.e. filtered out).</p>\n"
+      "comments": "<p>The return value is treated as a boolean, with zero indicating that the\n entry should be left alone and any non-zero value meaning that the\n entry should be removed from the treebuilder list (i.e. filtered out).</p>\n"
     },
     "git_treewalk_cb": {
       "type": "callback",
-      "file": "tree.h",
+      "file": "git2/tree.h",
       "line": 394,
       "lineto": 395,
       "args": [
@@ -26386,7 +28632,7 @@
     },
     "git_transfer_progress_cb": {
       "type": "callback",
-      "file": "types.h",
+      "file": "git2/types.h",
       "line": 274,
       "lineto": 274,
       "args": [
@@ -26412,7 +28658,7 @@
     },
     "git_transport_message_cb": {
       "type": "callback",
-      "file": "types.h",
+      "file": "git2/types.h",
       "line": 284,
       "lineto": 284,
       "args": [
@@ -26443,7 +28689,7 @@
     },
     "git_transport_certificate_check_cb": {
       "type": "callback",
-      "file": "types.h",
+      "file": "git2/types.h",
       "line": 334,
       "lineto": 334,
       "args": [
@@ -26481,17 +28727,214 @@
   "globals": {},
   "types": [
     [
+      "LIBSSH2_SESSION",
+      {
+        "decl": "LIBSSH2_SESSION",
+        "type": "struct",
+        "value": "LIBSSH2_SESSION",
+        "file": "git2/transport.h",
+        "line": 163,
+        "lineto": 163,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_cred_sign_callback"
+          ]
+        }
+      }
+    ],
+    [
+      "LIBSSH2_USERAUTH_KBDINT_PROMPT",
+      {
+        "decl": "LIBSSH2_USERAUTH_KBDINT_PROMPT",
+        "type": "struct",
+        "value": "LIBSSH2_USERAUTH_KBDINT_PROMPT",
+        "file": "git2/transport.h",
+        "line": 164,
+        "lineto": 164,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_cred_ssh_interactive_callback"
+          ]
+        }
+      }
+    ],
+    [
+      "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
+      {
+        "decl": "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
+        "type": "struct",
+        "value": "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
+        "file": "git2/transport.h",
+        "line": 165,
+        "lineto": 165,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_cred_ssh_interactive_callback"
+          ]
+        }
+      }
+    ],
+    [
+      "_LIBSSH2_SESSION",
+      {
+        "decl": [],
+        "type": "struct",
+        "value": "_LIBSSH2_SESSION",
+        "file": "git2/transport.h",
+        "line": 163,
+        "lineto": 163,
+        "tdef": null,
+        "description": "",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "_LIBSSH2_USERAUTH_KBDINT_PROMPT",
+      {
+        "decl": [],
+        "type": "struct",
+        "value": "_LIBSSH2_USERAUTH_KBDINT_PROMPT",
+        "file": "git2/transport.h",
+        "line": 164,
+        "lineto": 164,
+        "tdef": null,
+        "description": "",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "_LIBSSH2_USERAUTH_KBDINT_RESPONSE",
+      {
+        "decl": [],
+        "type": "struct",
+        "value": "_LIBSSH2_USERAUTH_KBDINT_RESPONSE",
+        "file": "git2/transport.h",
+        "line": 165,
+        "lineto": 165,
+        "tdef": null,
+        "description": "",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_allocator",
+      {
+        "decl": [
+          "void *(*)(size_t, const char *, int) gmalloc",
+          "void *(*)(size_t, size_t, const char *, int) gcalloc",
+          "char *(*)(const char *, const char *, int) gstrdup",
+          "char *(*)(const char *, size_t, const char *, int) gstrndup",
+          "char *(*)(const char *, size_t, const char *, int) gsubstrdup",
+          "void *(*)(void *, size_t, const char *, int) grealloc",
+          "void *(*)(void *, size_t, size_t, const char *, int) greallocarray",
+          "void *(*)(size_t, size_t, const char *, int) gmallocarray",
+          "void (*)(void *) gfree"
+        ],
+        "type": "struct",
+        "value": "git_allocator",
+        "file": "git2/sys/alloc.h",
+        "line": 23,
+        "lineto": 73,
+        "block": "void *(*)(size_t, const char *, int) gmalloc\nvoid *(*)(size_t, size_t, const char *, int) gcalloc\nchar *(*)(const char *, const char *, int) gstrdup\nchar *(*)(const char *, size_t, const char *, int) gstrndup\nchar *(*)(const char *, size_t, const char *, int) gsubstrdup\nvoid *(*)(void *, size_t, const char *, int) grealloc\nvoid *(*)(void *, size_t, size_t, const char *, int) greallocarray\nvoid *(*)(size_t, size_t, const char *, int) gmallocarray\nvoid (*)(void *) gfree",
+        "tdef": "typedef",
+        "description": " An instance for a custom memory allocator",
+        "comments": "<p>Setting the pointers of this structure allows the developer to implement\n custom memory allocators. The global memory allocator can be set by using\n &quot;GIT_OPT_SET_ALLOCATOR&quot; with the <code>git_libgit2_opts</code> function. Keep in mind\n that all fields need to be set to a proper function.</p>\n",
+        "fields": [
+          {
+            "type": "void *(*)(size_t, const char *, int)",
+            "name": "gmalloc",
+            "comments": ""
+          },
+          {
+            "type": "void *(*)(size_t, size_t, const char *, int)",
+            "name": "gcalloc",
+            "comments": ""
+          },
+          {
+            "type": "char *(*)(const char *, const char *, int)",
+            "name": "gstrdup",
+            "comments": ""
+          },
+          {
+            "type": "char *(*)(const char *, size_t, const char *, int)",
+            "name": "gstrndup",
+            "comments": ""
+          },
+          {
+            "type": "char *(*)(const char *, size_t, const char *, int)",
+            "name": "gsubstrdup",
+            "comments": ""
+          },
+          {
+            "type": "void *(*)(void *, size_t, const char *, int)",
+            "name": "grealloc",
+            "comments": ""
+          },
+          {
+            "type": "void *(*)(void *, size_t, size_t, const char *, int)",
+            "name": "greallocarray",
+            "comments": ""
+          },
+          {
+            "type": "void *(*)(size_t, size_t, const char *, int)",
+            "name": "gmallocarray",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(void *)",
+            "name": "gfree",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_stdalloc_init_allocator",
+            "git_win32_crtdbg_init_allocator"
+          ]
+        }
+      }
+    ],
+    [
       "git_annotated_commit",
       {
         "decl": "git_annotated_commit",
         "type": "struct",
         "value": "git_annotated_commit",
-        "file": "types.h",
-        "line": 182,
-        "lineto": 182,
+        "file": "git2/types.h",
+        "line": 185,
+        "lineto": 185,
         "tdef": "typedef",
         "description": " Annotated commits, the input to merge and rebase. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -26501,6 +28944,7 @@
             "git_annotated_commit_from_revspec",
             "git_annotated_commit_id",
             "git_annotated_commit_lookup",
+            "git_annotated_commit_ref",
             "git_branch_create_from_annotated",
             "git_merge",
             "git_merge_analysis",
@@ -26521,7 +28965,7 @@
           "GIT_ATTR_VALUE_T"
         ],
         "type": "enum",
-        "file": "attr.h",
+        "file": "git2/attr.h",
         "line": 82,
         "lineto": 87,
         "block": "GIT_ATTR_UNSPECIFIED_T\nGIT_ATTR_TRUE_T\nGIT_ATTR_FALSE_T\nGIT_ATTR_VALUE_T",
@@ -26563,6 +29007,36 @@
       }
     ],
     [
+      "git_blame",
+      {
+        "decl": "git_blame",
+        "type": "struct",
+        "value": "git_blame",
+        "file": "git2/blame.h",
+        "line": 149,
+        "lineto": 149,
+        "tdef": "typedef",
+        "description": " Opaque structure to hold blame results ",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [
+            "git_blame_get_hunk_byindex",
+            "git_blame_get_hunk_byline"
+          ],
+          "needs": [
+            "git_blame_buffer",
+            "git_blame_file",
+            "git_blame_free",
+            "git_blame_get_hunk_byindex",
+            "git_blame_get_hunk_byline",
+            "git_blame_get_hunk_count",
+            "git_blame_init_options"
+          ]
+        }
+      }
+    ],
+    [
       "git_blame_flag_t",
       {
         "decl": [
@@ -26571,13 +29045,14 @@
           "GIT_BLAME_TRACK_COPIES_SAME_COMMIT_MOVES",
           "GIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES",
           "GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES",
-          "GIT_BLAME_FIRST_PARENT"
+          "GIT_BLAME_FIRST_PARENT",
+          "GIT_BLAME_USE_MAILMAP"
         ],
         "type": "enum",
-        "file": "blame.h",
+        "file": "git2/blame.h",
         "line": 26,
-        "lineto": 46,
-        "block": "GIT_BLAME_NORMAL\nGIT_BLAME_TRACK_COPIES_SAME_FILE\nGIT_BLAME_TRACK_COPIES_SAME_COMMIT_MOVES\nGIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES\nGIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES\nGIT_BLAME_FIRST_PARENT",
+        "lineto": 50,
+        "block": "GIT_BLAME_NORMAL\nGIT_BLAME_TRACK_COPIES_SAME_FILE\nGIT_BLAME_TRACK_COPIES_SAME_COMMIT_MOVES\nGIT_BLAME_TRACK_COPIES_SAME_COMMIT_COPIES\nGIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES\nGIT_BLAME_FIRST_PARENT\nGIT_BLAME_USE_MAILMAP",
         "tdef": "typedef",
         "description": " Flags for indicating option behavior for git_blame APIs.",
         "comments": "",
@@ -26617,6 +29092,12 @@
             "name": "GIT_BLAME_FIRST_PARENT",
             "comments": "<p>Restrict the search of commits to those reachable following only the\n first parents. </p>\n",
             "value": 16
+          },
+          {
+            "type": "int",
+            "name": "GIT_BLAME_USE_MAILMAP",
+            "comments": "<p>Use mailmap file to map author and committer names and email addresses\n to canonical real names and email addresses. The mailmap will be read\n from the working directory, or HEAD in a bare repository. </p>\n",
+            "value": 32
           }
         ],
         "used": {
@@ -26641,13 +29122,13 @@
         ],
         "type": "struct",
         "value": "git_blame_hunk",
-        "file": "blame.h",
-        "line": 115,
-        "lineto": 128,
+        "file": "git2/blame.h",
+        "line": 132,
+        "lineto": 145,
         "block": "size_t lines_in_hunk\ngit_oid final_commit_id\nsize_t final_start_line_number\ngit_signature * final_signature\ngit_oid orig_commit_id\nconst char * orig_path\nsize_t orig_start_line_number\ngit_signature * orig_signature\nchar boundary",
         "tdef": "typedef",
         "description": " Structure that represents a blame hunk.",
-        "comments": "<ul>\n<li><code>lines_in_hunk</code> is the number of lines in this hunk - <code>final_commit_id</code> is the OID of the commit where this line was last   changed. - <code>final_start_line_number</code> is the 1-based line number where this hunk   begins, in the final version of the file - <code>orig_commit_id</code> is the OID of the commit where this hunk was found.  This   will usually be the same as <code>final_commit_id</code>, except when   <code>GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES</code> has been specified. - <code>orig_path</code> is the path to the file where this hunk originated, as of the   commit specified by <code>orig_commit_id</code>. - <code>orig_start_line_number</code> is the 1-based line number where this hunk begins   in the file named by <code>orig_path</code> in the commit specified by   <code>orig_commit_id</code>. - <code>boundary</code> is 1 iff the hunk has been tracked to a boundary commit (the   root, or the commit specified in git_blame_options.oldest_commit)</li>\n</ul>\n",
+        "comments": "<ul>\n<li><code>lines_in_hunk</code> is the number of lines in this hunk</li>\n<li><code>final_commit_id</code> is the OID of the commit where this line was last\nchanged.</li>\n<li><code>final_start_line_number</code> is the 1-based line number where this hunk\nbegins, in the final version of the file</li>\n<li><code>final_signature</code> is the author of <code>final_commit_id</code>. If\n<code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical\nreal name and email address.</li>\n<li><code>orig_commit_id</code> is the OID of the commit where this hunk was found.  This\nwill usually be the same as <code>final_commit_id</code>, except when\n<code>GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES</code> has been specified.</li>\n<li><code>orig_path</code> is the path to the file where this hunk originated, as of the\ncommit specified by <code>orig_commit_id</code>.</li>\n<li><code>orig_start_line_number</code> is the 1-based line number where this hunk begins\nin the file named by <code>orig_path</code> in the commit specified by\n<code>orig_commit_id</code>.</li>\n<li><code>orig_signature</code> is the author of <code>orig_commit_id</code>. If\n<code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical\nreal name and email address.</li>\n<li><code>boundary</code> is 1 iff the hunk has been tracked to a boundary commit (the\nroot, or the commit specified in git_blame_options.oldest_commit)</li>\n</ul>\n",
         "fields": [
           {
             "type": "size_t",
@@ -26718,13 +29199,13 @@
         ],
         "type": "struct",
         "value": "git_blame_options",
-        "file": "blame.h",
-        "line": 70,
-        "lineto": 79,
+        "file": "git2/blame.h",
+        "line": 59,
+        "lineto": 88,
         "block": "unsigned int version\nuint32_t flags\nuint16_t min_match_characters\ngit_oid newest_commit\ngit_oid oldest_commit\nsize_t min_line\nsize_t max_line",
         "tdef": "typedef",
         "description": " Blame options structure",
-        "comments": "<p>Use zeros to indicate default settings.  It&#39;s easiest to use the <code>GIT_BLAME_OPTIONS_INIT</code> macro:     git_blame_options opts = GIT_BLAME_OPTIONS_INIT;</p>\n\n<ul>\n<li><code>flags</code> is a combination of the <code>git_blame_flag_t</code> values above. - <code>min_match_characters</code> is the lower bound on the number of alphanumeric   characters that must be detected as moving/copying within a file for it to   associate those lines with the parent commit. The default value is 20.   This value only takes effect if any of the <code>GIT_BLAME_TRACK_COPIES_*</code>   flags are specified. - <code>newest_commit</code> is the id of the newest commit to consider.  The default                   is HEAD. - <code>oldest_commit</code> is the id of the oldest commit to consider.  The default                   is the first commit encountered with a NULL parent.   - <code>min_line</code> is the first line in the file to blame.  The default is 1 (line                 numbers start with 1). - <code>max_line</code> is the last line in the file to blame.  The default is the last                 line of the file.</li>\n</ul>\n",
+        "comments": "<p>Initialize with <code>GIT_BLAME_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_blame_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -26734,32 +29215,32 @@
           {
             "type": "uint32_t",
             "name": "flags",
-            "comments": ""
+            "comments": " A combination of `git_blame_flag_t` "
           },
           {
             "type": "uint16_t",
             "name": "min_match_characters",
-            "comments": ""
+            "comments": " The lower bound on the number of alphanumeric\n   characters that must be detected as moving/copying within a file for it to\n   associate those lines with the parent commit. The default value is 20.\n   This value only takes effect if any of the `GIT_BLAME_TRACK_COPIES_*`\n   flags are specified."
           },
           {
             "type": "git_oid",
             "name": "newest_commit",
-            "comments": ""
+            "comments": " The id of the newest commit to consider. The default is HEAD. "
           },
           {
             "type": "git_oid",
             "name": "oldest_commit",
-            "comments": ""
+            "comments": " The id of the oldest commit to consider.\n The default is the first commit encountered with a NULL parent."
           },
           {
             "type": "size_t",
             "name": "min_line",
-            "comments": ""
+            "comments": " The first line in the file to blame.\n The default is 1 (line numbers start with 1)."
           },
           {
             "type": "size_t",
             "name": "max_line",
-            "comments": ""
+            "comments": " The last line in the file to blame.\n The default is the last line of the file."
           }
         ],
         "used": {
@@ -26777,12 +29258,13 @@
         "decl": "git_blob",
         "type": "struct",
         "value": "git_blob",
-        "file": "types.h",
-        "line": 120,
-        "lineto": 120,
+        "file": "git2/types.h",
+        "line": 123,
+        "lineto": 123,
         "tdef": "typedef",
         "description": " In-memory representation of a blob object. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -26813,12 +29295,13 @@
         "decl": "git_branch_iterator",
         "type": "struct",
         "value": "git_branch_iterator",
-        "file": "branch.h",
+        "file": "git2/branch.h",
         "line": 88,
         "lineto": 88,
         "tdef": "typedef",
         "description": " Iterator type for branches ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -26838,7 +29321,7 @@
           "GIT_BRANCH_ALL"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 202,
         "lineto": 206,
         "block": "GIT_BRANCH_LOCAL\nGIT_BRANCH_REMOTE\nGIT_BRANCH_ALL",
@@ -26885,13 +29368,13 @@
         ],
         "type": "struct",
         "value": "git_buf",
-        "file": "buffer.h",
+        "file": "git2/buffer.h",
         "line": 52,
         "lineto": 55,
         "block": "char * ptr\nsize_t asize\nsize_t size",
         "tdef": "typedef",
         "description": " A data buffer for exporting data from libgit2",
-        "comments": "<p>Sometimes libgit2 wants to return an allocated data buffer to the caller and have the caller take responsibility for freeing that memory. This can be awkward if the caller does not have easy access to the same allocation functions that libgit2 is using.  In those cases, libgit2 will fill in a <code>git_buf</code> and the caller can use <code>git_buf_free()</code> to release it when they are done.</p>\n\n<p>A <code>git_buf</code> may also be used for the caller to pass in a reference to a block of memory they hold.  In this case, libgit2 will not resize or free the memory, but will read from it as needed.</p>\n\n<p>A <code>git_buf</code> is a public structure with three fields:</p>\n\n<ul>\n<li><p><code>ptr</code> points to the start of the allocated memory.  If it is NULL,   then the <code>git_buf</code> is considered empty and libgit2 will feel free   to overwrite it with new data.</p></li>\n<li><p><code>size</code> holds the size (in bytes) of the data that is actually used.</p></li>\n<li><p><code>asize</code> holds the known total amount of allocated memory if the <code>ptr</code>    was allocated by libgit2.  It may be larger than <code>size</code>.  If <code>ptr</code>    was not allocated by libgit2 and should not be resized and/or freed,    then <code>asize</code> will be set to zero.</p></li>\n</ul>\n\n<p>Some APIs may occasionally do something slightly unusual with a buffer, such as setting <code>ptr</code> to a value that was passed in by the user.  In those cases, the behavior will be clearly documented by the API.</p>\n",
+        "comments": "<p>Sometimes libgit2 wants to return an allocated data buffer to the\n caller and have the caller take responsibility for freeing that memory.\n This can be awkward if the caller does not have easy access to the same\n allocation functions that libgit2 is using.  In those cases, libgit2\n will fill in a <code>git_buf</code> and the caller can use <code>git_buf_dispose()</code> to\n release it when they are done.</p>\n\n<p>A <code>git_buf</code> may also be used for the caller to pass in a reference to\n a block of memory they hold.  In this case, libgit2 will not resize or\n free the memory, but will read from it as needed.</p>\n\n<p>A <code>git_buf</code> is a public structure with three fields:</p>\n\n<ul>\n<li><p><code>ptr</code> points to the start of the allocated memory.  If it is NULL,\nthen the <code>git_buf</code> is considered empty and libgit2 will feel free\nto overwrite it with new data.</p></li>\n<li><p><code>size</code> holds the size (in bytes) of the data that is actually used.</p></li>\n<li><p><code>asize</code> holds the known total amount of allocated memory if the <code>ptr</code>\nwas allocated by libgit2.  It may be larger than <code>size</code>.  If <code>ptr</code>\nwas not allocated by libgit2 and should not be resized and/or freed,\nthen <code>asize</code> will be set to zero.</p></li>\n</ul>\n\n<p>Some APIs may occasionally do something slightly unusual with a buffer,\n such as setting <code>ptr</code> to a value that was passed in by the user.  In\n those cases, the behavior will be clearly documented by the API.</p>\n",
         "fields": [
           {
             "type": "char *",
@@ -26913,7 +29396,11 @@
           "returns": [],
           "needs": [
             "git_blob_filtered_content",
+            "git_branch_remote_name",
+            "git_branch_upstream_name",
+            "git_branch_upstream_remote",
             "git_buf_contains_nul",
+            "git_buf_dispose",
             "git_buf_free",
             "git_buf_grow",
             "git_buf_is_binary",
@@ -26939,8 +29426,11 @@
             "git_filter_list_apply_to_file",
             "git_filter_list_stream_data",
             "git_mempack_dump",
+            "git_merge_driver_apply_fn",
             "git_message_prettify",
+            "git_note_default_ref",
             "git_object_short_id",
+            "git_packbuilder_write_buf",
             "git_patch_to_buf",
             "git_refspec_rtransform",
             "git_refspec_transform",
@@ -26963,7 +29453,7 @@
         ],
         "type": "struct",
         "value": "git_cert",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 318,
         "lineto": 323,
         "block": "git_cert_t cert_type",
@@ -26997,7 +29487,7 @@
         ],
         "type": "struct",
         "value": "git_cert_hostkey",
-        "file": "transport.h",
+        "file": "git2/transport.h",
         "line": 39,
         "lineto": 59,
         "block": "git_cert parent\ngit_cert_ssh_t type\nunsigned char [16] hash_md5\nunsigned char [20] hash_sha1",
@@ -27040,7 +29530,7 @@
           "GIT_CERT_SSH_SHA1"
         ],
         "type": "enum",
-        "file": "transport.h",
+        "file": "git2/transport.h",
         "line": 29,
         "lineto": 34,
         "block": "GIT_CERT_SSH_MD5\nGIT_CERT_SSH_SHA1",
@@ -27077,7 +29567,7 @@
           "GIT_CERT_STRARRAY"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 290,
         "lineto": 313,
         "block": "GIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY\nGIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY",
@@ -27126,7 +29616,7 @@
         ],
         "type": "struct",
         "value": "git_cert_x509",
-        "file": "transport.h",
+        "file": "git2/transport.h",
         "line": 64,
         "lineto": 74,
         "block": "git_cert parent\nvoid * data\nsize_t len",
@@ -27169,13 +29659,13 @@
           "GIT_CHECKOUT_NOTIFY_ALL"
         ],
         "type": "enum",
-        "file": "checkout.h",
+        "file": "git2/checkout.h",
         "line": 205,
         "lineto": 214,
         "block": "GIT_CHECKOUT_NOTIFY_NONE\nGIT_CHECKOUT_NOTIFY_CONFLICT\nGIT_CHECKOUT_NOTIFY_DIRTY\nGIT_CHECKOUT_NOTIFY_UPDATED\nGIT_CHECKOUT_NOTIFY_UNTRACKED\nGIT_CHECKOUT_NOTIFY_IGNORED\nGIT_CHECKOUT_NOTIFY_ALL",
         "tdef": "typedef",
         "description": " Checkout notification flags",
-        "comments": "<p>Checkout will invoke an options notification callback (<code>notify_cb</code>) for certain cases - you pick which ones via <code>notify_flags</code>:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_NOTIFY_CONFLICT invokes checkout on conflicting paths.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_DIRTY notifies about &quot;dirty&quot; files, i.e. those that   do not need an update but no longer match the baseline.  Core git   displays these files when checkout runs, but won&#39;t stop the checkout.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UPDATED sends notification for any file changed.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UNTRACKED notifies about untracked files.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_IGNORED notifies about ignored files.</p></li>\n</ul>\n\n<p>Returning a non-zero value from this callback will cancel the checkout. The non-zero return value will be propagated back and returned by the git_checkout_... call.</p>\n\n<p>Notification callbacks are made prior to modifying any files on disk, so canceling on any notification will still happen prior to any files being modified.</p>\n",
+        "comments": "<p>Checkout will invoke an options notification callback (<code>notify_cb</code>) for\n certain cases - you pick which ones via <code>notify_flags</code>:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_NOTIFY_CONFLICT invokes checkout on conflicting paths.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_DIRTY notifies about &quot;dirty&quot; files, i.e. those that\ndo not need an update but no longer match the baseline.  Core git\ndisplays these files when checkout runs, but won&#39;t stop the checkout.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UPDATED sends notification for any file changed.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UNTRACKED notifies about untracked files.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_IGNORED notifies about ignored files.</p></li>\n</ul>\n\n<p>Returning a non-zero value from this callback will cancel the checkout.\n The non-zero return value will be propagated back and returned by the\n git_checkout_... call.</p>\n\n<p>Notification callbacks are made prior to modifying any files on disk,\n so canceling on any notification will still happen prior to any files\n being modified.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -27255,13 +29745,13 @@
         ],
         "type": "struct",
         "value": "git_checkout_options",
-        "file": "checkout.h",
-        "line": 251,
-        "lineto": 295,
+        "file": "git2/checkout.h",
+        "line": 250,
+        "lineto": 294,
         "block": "unsigned int version\nunsigned int checkout_strategy\nint disable_filters\nunsigned int dir_mode\nunsigned int file_mode\nint file_open_flags\nunsigned int notify_flags\ngit_checkout_notify_cb notify_cb\nvoid * notify_payload\ngit_checkout_progress_cb progress_cb\nvoid * progress_payload\ngit_strarray paths\ngit_tree * baseline\ngit_index * baseline_index\nconst char * target_directory\nconst char * ancestor_label\nconst char * our_label\nconst char * their_label\ngit_checkout_perfdata_cb perfdata_cb\nvoid * perfdata_payload",
         "tdef": "typedef",
         "description": " Checkout options structure",
-        "comments": "<p>Zero out for defaults.  Initialize with <code>GIT_CHECKOUT_OPTIONS_INIT</code> macro to correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;\n</code></pre>\n",
+        "comments": "<p>Initialize with <code>GIT_CHECKOUT_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_checkout_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -27271,7 +29761,7 @@
           {
             "type": "unsigned int",
             "name": "checkout_strategy",
-            "comments": " default will be a dry run "
+            "comments": " default will be a safe checkout "
           },
           {
             "type": "int",
@@ -27379,6 +29869,48 @@
       }
     ],
     [
+      "git_checkout_perfdata",
+      {
+        "decl": [
+          "size_t mkdir_calls",
+          "size_t stat_calls",
+          "size_t chmod_calls"
+        ],
+        "type": "struct",
+        "value": "git_checkout_perfdata",
+        "file": "git2/checkout.h",
+        "line": 216,
+        "lineto": 220,
+        "block": "size_t mkdir_calls\nsize_t stat_calls\nsize_t chmod_calls",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "size_t",
+            "name": "mkdir_calls",
+            "comments": ""
+          },
+          {
+            "type": "size_t",
+            "name": "stat_calls",
+            "comments": ""
+          },
+          {
+            "type": "size_t",
+            "name": "chmod_calls",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_checkout_perfdata_cb"
+          ]
+        }
+      }
+    ],
+    [
       "git_checkout_strategy_t",
       {
         "decl": [
@@ -27406,13 +29938,13 @@
           "GIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED"
         ],
         "type": "enum",
-        "file": "checkout.h",
+        "file": "git2/checkout.h",
         "line": 106,
         "lineto": 177,
         "block": "GIT_CHECKOUT_NONE\nGIT_CHECKOUT_SAFE\nGIT_CHECKOUT_FORCE\nGIT_CHECKOUT_RECREATE_MISSING\nGIT_CHECKOUT_ALLOW_CONFLICTS\nGIT_CHECKOUT_REMOVE_UNTRACKED\nGIT_CHECKOUT_REMOVE_IGNORED\nGIT_CHECKOUT_UPDATE_ONLY\nGIT_CHECKOUT_DONT_UPDATE_INDEX\nGIT_CHECKOUT_NO_REFRESH\nGIT_CHECKOUT_SKIP_UNMERGED\nGIT_CHECKOUT_USE_OURS\nGIT_CHECKOUT_USE_THEIRS\nGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH\nGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES\nGIT_CHECKOUT_DONT_OVERWRITE_IGNORED\nGIT_CHECKOUT_CONFLICT_STYLE_MERGE\nGIT_CHECKOUT_CONFLICT_STYLE_DIFF3\nGIT_CHECKOUT_DONT_REMOVE_EXISTING\nGIT_CHECKOUT_DONT_WRITE_INDEX\nGIT_CHECKOUT_UPDATE_SUBMODULES\nGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED",
         "tdef": "typedef",
         "description": " Checkout behavior flags",
-        "comments": "<p>In libgit2, checkout is used to update the working directory and index to match a target tree.  Unlike git checkout, it does not move the HEAD commit for you - use <code>git_repository_set_head</code> or the like to do that.</p>\n\n<p>Checkout looks at (up to) four things: the &quot;target&quot; tree you want to check out, the &quot;baseline&quot; tree of what was checked out previously, the working directory for actual files, and the index for staged changes.</p>\n\n<p>You give checkout one of three strategies for update:</p>\n\n<ul>\n<li><p><code>GIT_CHECKOUT_NONE</code> is a dry-run strategy that checks for conflicts,   etc., but doesn&#39;t make any actual changes.</p></li>\n<li><p><code>GIT_CHECKOUT_FORCE</code> is at the opposite extreme, taking any action to   make the working directory match the target (including potentially   discarding modified files).</p></li>\n<li><p><code>GIT_CHECKOUT_SAFE</code> is between these two options, it will only make   modifications that will not lose changes.</p>\n\n<pre><code>                 |  target == baseline   |  target != baseline  |    ---------------------|-----------------------|----------------------|     workdir == baseline |       no action       |  create, update, or  |                         |                       |     delete file      |    ---------------------|-----------------------|----------------------|     workdir exists and  |       no action       |   conflict (notify   |       is != baseline    | notify dirty MODIFIED | and cancel checkout) |    ---------------------|-----------------------|----------------------|      workdir missing,   | notify dirty DELETED  |     create file      |      baseline present   |                       |                      |    ---------------------|-----------------------|----------------------|\n</code></pre></li>\n</ul>\n\n<p>To emulate <code>git checkout</code>, use <code>GIT_CHECKOUT_SAFE</code> with a checkout notification callback (see below) that displays information about dirty files.  The default behavior will cancel checkout on conflicts.</p>\n\n<p>To emulate <code>git checkout-index</code>, use <code>GIT_CHECKOUT_SAFE</code> with a notification callback that cancels the operation if a dirty-but-existing file is found in the working directory.  This core git command isn&#39;t quite &quot;force&quot; but is sensitive about some types of changes.</p>\n\n<p>To emulate <code>git checkout -f</code>, use <code>GIT_CHECKOUT_FORCE</code>.</p>\n\n<p>There are some additional flags to modified the behavior of checkout:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_ALLOW_CONFLICTS makes SAFE mode apply safe file updates   even if there are conflicts (instead of cancelling the checkout).</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_UNTRACKED means remove untracked files (i.e. not   in target, baseline, or index, and not ignored) from the working dir.</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_IGNORED means remove ignored files (that are also   untracked) from the working directory as well.</p></li>\n<li><p>GIT_CHECKOUT_UPDATE_ONLY means to only update the content of files that   already exist.  Files will not be created nor deleted.  This just skips   applying adds, deletes, and typechanges.</p></li>\n<li><p>GIT_CHECKOUT_DONT_UPDATE_INDEX prevents checkout from writing the   updated files&#39; information to the index.</p></li>\n<li><p>Normally, checkout will reload the index and git attributes from disk   before any operations.  GIT_CHECKOUT_NO_REFRESH prevents this reload.</p></li>\n<li><p>Unmerged index entries are conflicts.  GIT_CHECKOUT_SKIP_UNMERGED skips   files with unmerged index entries instead.  GIT_CHECKOUT_USE_OURS and   GIT_CHECKOUT_USE_THEIRS to proceed with the checkout using either the   stage 2 (&quot;ours&quot;) or stage 3 (&quot;theirs&quot;) version of files in the index.</p></li>\n<li><p>GIT_CHECKOUT_DONT_OVERWRITE_IGNORED prevents ignored files from being   overwritten.  Normally, files that are ignored in the working directory   are not considered &quot;precious&quot; and may be overwritten if the checkout   target contains that file.</p></li>\n<li><p>GIT_CHECKOUT_DONT_REMOVE_EXISTING prevents checkout from removing   files or folders that fold to the same name on case insensitive   filesystems.  This can cause files to retain their existing names   and write through existing symbolic links.</p></li>\n</ul>\n",
+        "comments": "<p>In libgit2, checkout is used to update the working directory and index\n to match a target tree.  Unlike git checkout, it does not move the HEAD\n commit for you - use <code>git_repository_set_head</code> or the like to do that.</p>\n\n<p>Checkout looks at (up to) four things: the &quot;target&quot; tree you want to\n check out, the &quot;baseline&quot; tree of what was checked out previously, the\n working directory for actual files, and the index for staged changes.</p>\n\n<p>You give checkout one of three strategies for update:</p>\n\n<ul>\n<li><p><code>GIT_CHECKOUT_NONE</code> is a dry-run strategy that checks for conflicts,\netc., but doesn&#39;t make any actual changes.</p></li>\n<li><p><code>GIT_CHECKOUT_FORCE</code> is at the opposite extreme, taking any action to\nmake the working directory match the target (including potentially\ndiscarding modified files).</p></li>\n<li><p><code>GIT_CHECKOUT_SAFE</code> is between these two options, it will only make\nmodifications that will not lose changes.</p>\n\n<pre><code>                 |  target == baseline   |  target != baseline  |\n</code></pre>\n\n<p>---------------------|-----------------------|----------------------|\n workdir == baseline |       no action       |  create, update, or  |\n                     |                       |     delete file      |\n---------------------|-----------------------|----------------------|\n workdir exists and  |       no action       |   conflict (notify   |\n   is != baseline    | notify dirty MODIFIED | and cancel checkout) |\n---------------------|-----------------------|----------------------|\n  workdir missing,   | notify dirty DELETED  |     create file      |\n  baseline present   |                       |                      |\n---------------------|-----------------------|----------------------|</p></li>\n</ul>\n\n<p>To emulate <code>git checkout</code>, use <code>GIT_CHECKOUT_SAFE</code> with a checkout\n notification callback (see below) that displays information about dirty\n files.  The default behavior will cancel checkout on conflicts.</p>\n\n<p>To emulate <code>git checkout-index</code>, use <code>GIT_CHECKOUT_SAFE</code> with a\n notification callback that cancels the operation if a dirty-but-existing\n file is found in the working directory.  This core git command isn&#39;t\n quite &quot;force&quot; but is sensitive about some types of changes.</p>\n\n<p>To emulate <code>git checkout -f</code>, use <code>GIT_CHECKOUT_FORCE</code>.</p>\n\n<p>There are some additional flags to modify the behavior of checkout:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_ALLOW_CONFLICTS makes SAFE mode apply safe file updates\neven if there are conflicts (instead of cancelling the checkout).</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_UNTRACKED means remove untracked files (i.e. not\nin target, baseline, or index, and not ignored) from the working dir.</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_IGNORED means remove ignored files (that are also\nuntracked) from the working directory as well.</p></li>\n<li><p>GIT_CHECKOUT_UPDATE_ONLY means to only update the content of files that\nalready exist.  Files will not be created nor deleted.  This just skips\napplying adds, deletes, and typechanges.</p></li>\n<li><p>GIT_CHECKOUT_DONT_UPDATE_INDEX prevents checkout from writing the\nupdated files&#39; information to the index.</p></li>\n<li><p>Normally, checkout will reload the index and git attributes from disk\nbefore any operations.  GIT_CHECKOUT_NO_REFRESH prevents this reload.</p></li>\n<li><p>Unmerged index entries are conflicts.  GIT_CHECKOUT_SKIP_UNMERGED skips\nfiles with unmerged index entries instead.  GIT_CHECKOUT_USE_OURS and\nGIT_CHECKOUT_USE_THEIRS to proceed with the checkout using either the\nstage 2 (&quot;ours&quot;) or stage 3 (&quot;theirs&quot;) version of files in the index.</p></li>\n<li><p>GIT_CHECKOUT_DONT_OVERWRITE_IGNORED prevents ignored files from being\noverwritten.  Normally, files that are ignored in the working directory\nare not considered &quot;precious&quot; and may be overwritten if the checkout\ntarget contains that file.</p></li>\n<li><p>GIT_CHECKOUT_DONT_REMOVE_EXISTING prevents checkout from removing\nfiles or folders that fold to the same name on case insensitive\nfilesystems.  This can cause files to retain their existing names\nand write through existing symbolic links.</p></li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -27564,7 +30096,7 @@
         ],
         "type": "struct",
         "value": "git_cherrypick_options",
-        "file": "cherrypick.h",
+        "file": "git2/cherrypick.h",
         "line": 26,
         "lineto": 34,
         "block": "unsigned int version\nunsigned int mainline\ngit_merge_options merge_opts\ngit_checkout_options checkout_opts",
@@ -27612,7 +30144,7 @@
           "GIT_CLONE_LOCAL_NO_LINKS"
         ],
         "type": "enum",
-        "file": "clone.h",
+        "file": "git2/clone.h",
         "line": 33,
         "lineto": 53,
         "block": "GIT_CLONE_LOCAL_AUTO\nGIT_CLONE_LOCAL\nGIT_CLONE_NO_LOCAL\nGIT_CLONE_LOCAL_NO_LINKS",
@@ -27668,13 +30200,13 @@
         ],
         "type": "struct",
         "value": "git_clone_options",
-        "file": "clone.h",
+        "file": "git2/clone.h",
         "line": 103,
         "lineto": 164,
         "block": "unsigned int version\ngit_checkout_options checkout_opts\ngit_fetch_options fetch_opts\nint bare\ngit_clone_local_t local\nconst char * checkout_branch\ngit_repository_create_cb repository_cb\nvoid * repository_cb_payload\ngit_remote_create_cb remote_cb\nvoid * remote_cb_payload",
         "tdef": "typedef",
         "description": " Clone options structure",
-        "comments": "<p>Use the GIT_CLONE_OPTIONS_INIT to get the default settings, like this:</p>\n\n<pre><code>    git_clone_options opts = GIT_CLONE_OPTIONS_INIT;\n</code></pre>\n",
+        "comments": "<p>Initialize with <code>GIT_CLONE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_clone_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -27742,12 +30274,13 @@
         "decl": "git_commit",
         "type": "struct",
         "value": "git_commit",
-        "file": "types.h",
-        "line": 123,
-        "lineto": 123,
+        "file": "git2/types.h",
+        "line": 126,
+        "lineto": 126,
         "tdef": "typedef",
         "description": " Parsed representation of a commit object. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -27756,8 +30289,10 @@
             "git_cherrypick_commit",
             "git_commit_amend",
             "git_commit_author",
+            "git_commit_author_with_mailmap",
             "git_commit_body",
             "git_commit_committer",
+            "git_commit_committer_with_mailmap",
             "git_commit_create",
             "git_commit_create_buffer",
             "git_commit_create_from_callback",
@@ -27799,12 +30334,13 @@
         "decl": "git_config",
         "type": "struct",
         "value": "git_config",
-        "file": "types.h",
-        "line": 141,
-        "lineto": 141,
+        "file": "git2/types.h",
+        "line": 144,
+        "lineto": 144,
         "tdef": "typedef",
         "description": " Memory representation of a set of config files ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -27815,6 +30351,7 @@
             "git_config_delete_multivar",
             "git_config_entry_free",
             "git_config_foreach",
+            "git_config_foreach_cb",
             "git_config_foreach_match",
             "git_config_free",
             "git_config_get_bool",
@@ -27857,9 +30394,9 @@
         "decl": "git_config_backend",
         "type": "struct",
         "value": "git_config_backend",
-        "file": "types.h",
-        "line": 144,
-        "lineto": 144,
+        "file": "git2/types.h",
+        "line": 147,
+        "lineto": 147,
         "block": "unsigned int version\nint readonly\nstruct git_config * cfg\nint (*)(struct git_config_backend *, git_config_level_t, const git_repository *) open\nint (*)(struct git_config_backend *, const char *, git_config_entry **) get\nint (*)(struct git_config_backend *, const char *, const char *) set\nint (*)(git_config_backend *, const char *, const char *, const char *) set_multivar\nint (*)(struct git_config_backend *, const char *) del\nint (*)(struct git_config_backend *, const char *, const char *) del_multivar\nint (*)(git_config_iterator **, struct git_config_backend *) iterator\nint (*)(struct git_config_backend **, struct git_config_backend *) snapshot\nint (*)(struct git_config_backend *) lock\nint (*)(struct git_config_backend *, int) unlock\nvoid (*)(struct git_config_backend *) free",
         "tdef": "typedef",
         "description": " Interface to access a configuration file ",
@@ -27952,16 +30489,17 @@
         "decl": [
           "const char * name",
           "const char * value",
+          "unsigned int include_depth",
           "git_config_level_t level",
           "void (*)(struct git_config_entry *) free",
           "void * payload"
         ],
         "type": "struct",
         "value": "git_config_entry",
-        "file": "config.h",
+        "file": "git2/config.h",
         "line": 64,
-        "lineto": 70,
-        "block": "const char * name\nconst char * value\ngit_config_level_t level\nvoid (*)(struct git_config_entry *) free\nvoid * payload",
+        "lineto": 71,
+        "block": "const char * name\nconst char * value\nunsigned int include_depth\ngit_config_level_t level\nvoid (*)(struct git_config_entry *) free\nvoid * payload",
         "tdef": "typedef",
         "description": " An entry in a configuration file",
         "comments": "",
@@ -27975,6 +30513,11 @@
             "type": "const char *",
             "name": "value",
             "comments": " String value of the entry "
+          },
+          {
+            "type": "unsigned int",
+            "name": "include_depth",
+            "comments": " Depth of includes where this variable was found "
           },
           {
             "type": "git_config_level_t",
@@ -27996,6 +30539,7 @@
           "returns": [],
           "needs": [
             "git_config_entry_free",
+            "git_config_foreach_cb",
             "git_config_get_entry",
             "git_config_next"
           ]
@@ -28005,21 +30549,15 @@
     [
       "git_config_iterator",
       {
-        "decl": [
-          "git_config_backend * backend",
-          "unsigned int flags",
-          "int (*)(git_config_entry **, git_config_iterator *) next",
-          "void (*)(git_config_iterator *) free"
-        ],
+        "decl": "git_config_iterator",
         "type": "struct",
         "value": "git_config_iterator",
-        "file": "sys/config.h",
-        "line": 34,
-        "lineto": 48,
-        "block": "git_config_backend * backend\nunsigned int flags\nint (*)(git_config_entry **, git_config_iterator *) next\nvoid (*)(git_config_iterator *) free",
-        "tdef": null,
-        "description": " Every iterator must have this struct as its first element, so the\n API can talk to it. You'd define your iterator as",
-        "comments": "<pre><code> struct my_iterator {             git_config_iterator parent;             ...     }\n</code></pre>\n\n<p>and assign <code>iter-&gt;parent.backend</code> to your <code>git_config_backend</code>.</p>\n",
+        "file": "git2/config.h",
+        "line": 89,
+        "lineto": 89,
+        "tdef": "typedef",
+        "description": " An opaque structure for a configuration iterator",
+        "comments": "",
         "fields": [
           {
             "type": "git_config_backend *",
@@ -28067,13 +30605,13 @@
           "GIT_CONFIG_HIGHEST_LEVEL"
         ],
         "type": "enum",
-        "file": "config.h",
+        "file": "git2/config.h",
         "line": 31,
         "lineto": 59,
         "block": "GIT_CONFIG_LEVEL_PROGRAMDATA\nGIT_CONFIG_LEVEL_SYSTEM\nGIT_CONFIG_LEVEL_XDG\nGIT_CONFIG_LEVEL_GLOBAL\nGIT_CONFIG_LEVEL_LOCAL\nGIT_CONFIG_LEVEL_APP\nGIT_CONFIG_HIGHEST_LEVEL",
         "tdef": "typedef",
         "description": " Priority level of a config file.\n These priority levels correspond to the natural escalation logic\n (from higher to lower) when searching for config entries in git.git.",
-        "comments": "<p>git_config_open_default() and git_repository_config() honor those priority levels as well.</p>\n",
+        "comments": "<p>git_config_open_default() and git_repository_config() honor those\n priority levels as well.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -28129,14 +30667,58 @@
       }
     ],
     [
+      "git_cred",
+      {
+        "decl": "git_cred",
+        "type": "struct",
+        "value": "git_cred",
+        "file": "git2/transport.h",
+        "line": 140,
+        "lineto": 140,
+        "tdef": "typedef",
+        "description": " The base structure for all credential types",
+        "comments": "",
+        "fields": [
+          {
+            "type": "git_credtype_t",
+            "name": "credtype",
+            "comments": " A type of credential "
+          },
+          {
+            "type": "void (*)(git_cred *)",
+            "name": "free",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_cred_acquire_cb",
+            "git_cred_default_new",
+            "git_cred_free",
+            "git_cred_has_username",
+            "git_cred_ssh_custom_new",
+            "git_cred_ssh_interactive_new",
+            "git_cred_ssh_key_from_agent",
+            "git_cred_ssh_key_memory_new",
+            "git_cred_ssh_key_new",
+            "git_cred_username_new",
+            "git_cred_userpass",
+            "git_cred_userpass_plaintext_new",
+            "git_transport_smart_credentials"
+          ]
+        }
+      }
+    ],
+    [
       "git_cred_default",
       {
         "decl": "git_cred_default",
         "type": "struct",
         "value": "git_cred_default",
-        "file": "transport.h",
-        "line": 176,
-        "lineto": 176,
+        "file": "git2/transport.h",
+        "line": 205,
+        "lineto": 205,
         "tdef": "typedef",
         "description": " A key for NTLM/Kerberos \"default\" credentials ",
         "comments": "",
@@ -28159,9 +30741,9 @@
         ],
         "type": "struct",
         "value": "git_cred_ssh_custom",
-        "file": "transport.h",
-        "line": 166,
-        "lineto": 173,
+        "file": "git2/transport.h",
+        "line": 195,
+        "lineto": 202,
         "block": "git_cred parent\nchar * username\nchar * publickey\nsize_t publickey_len\ngit_cred_sign_callback sign_callback\nvoid * payload",
         "tdef": "typedef",
         "description": " A key with a custom signature function",
@@ -28215,9 +30797,9 @@
         ],
         "type": "struct",
         "value": "git_cred_ssh_interactive",
-        "file": "transport.h",
-        "line": 156,
-        "lineto": 161,
+        "file": "git2/transport.h",
+        "line": 185,
+        "lineto": 190,
         "block": "git_cred parent\nchar * username\ngit_cred_ssh_interactive_callback prompt_callback\nvoid * payload",
         "tdef": "typedef",
         "description": " Keyboard-interactive based ssh authentication",
@@ -28264,9 +30846,9 @@
         ],
         "type": "struct",
         "value": "git_cred_ssh_key",
-        "file": "transport.h",
-        "line": 145,
-        "lineto": 151,
+        "file": "git2/transport.h",
+        "line": 174,
+        "lineto": 180,
         "block": "git_cred parent\nchar * username\nchar * publickey\nchar * privatekey\nchar * passphrase",
         "tdef": "typedef",
         "description": " A ssh key from disk",
@@ -28313,9 +30895,9 @@
         ],
         "type": "struct",
         "value": "git_cred_username",
-        "file": "transport.h",
-        "line": 179,
-        "lineto": 182,
+        "file": "git2/transport.h",
+        "line": 208,
+        "lineto": 211,
         "block": "git_cred parent\nchar [1] username",
         "tdef": "typedef",
         "description": " Username-only credential information ",
@@ -28347,7 +30929,7 @@
         ],
         "type": "struct",
         "value": "git_cred_userpass_payload",
-        "file": "cred_helpers.h",
+        "file": "git2/cred_helpers.h",
         "line": 24,
         "lineto": 27,
         "block": "const char * username\nconst char * password",
@@ -28382,9 +30964,9 @@
         ],
         "type": "struct",
         "value": "git_cred_userpass_plaintext",
-        "file": "transport.h",
-        "line": 122,
-        "lineto": 126,
+        "file": "git2/transport.h",
+        "line": 151,
+        "lineto": 155,
         "block": "git_cred parent\nchar * username\nchar * password",
         "tdef": "typedef",
         "description": " A plaintext username and password ",
@@ -28425,54 +31007,54 @@
           "GIT_CREDTYPE_SSH_MEMORY"
         ],
         "type": "enum",
-        "file": "transport.h",
-        "line": 81,
-        "lineto": 111,
+        "file": "git2/transport.h",
+        "line": 86,
+        "lineto": 138,
         "block": "GIT_CREDTYPE_USERPASS_PLAINTEXT\nGIT_CREDTYPE_SSH_KEY\nGIT_CREDTYPE_SSH_CUSTOM\nGIT_CREDTYPE_DEFAULT\nGIT_CREDTYPE_SSH_INTERACTIVE\nGIT_CREDTYPE_USERNAME\nGIT_CREDTYPE_SSH_MEMORY",
         "tdef": "typedef",
-        "description": " Authentication type requested ",
-        "comments": "",
+        "description": " Supported credential types",
+        "comments": "<p>This represents the various types of authentication methods supported by\n the library.</p>\n",
         "fields": [
           {
             "type": "int",
             "name": "GIT_CREDTYPE_USERPASS_PLAINTEXT",
-            "comments": "",
+            "comments": "<p>A vanilla user/password request</p>\n",
             "value": 1
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_SSH_KEY",
-            "comments": "",
+            "comments": "<p>An SSH key-based authentication request</p>\n",
             "value": 2
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_SSH_CUSTOM",
-            "comments": "",
+            "comments": "<p>An SSH key-based authentication request, with a custom signature</p>\n",
             "value": 4
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_DEFAULT",
-            "comments": "",
+            "comments": "<p>An NTLM/Negotiate-based authentication request.</p>\n",
             "value": 8
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_SSH_INTERACTIVE",
-            "comments": "",
+            "comments": "<p>An SSH interactive authentication request</p>\n",
             "value": 16
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_USERNAME",
-            "comments": "<p>Username-only information</p>\n\n<p>If the SSH transport does not know which username to use,\n it will ask via this credential type.</p>\n",
+            "comments": "<p>Username-only authentication request</p>\n\n<p>Used as a pre-authentication step if the underlying transport\n (eg. SSH, with no username in its URL) does not know which username\n to use.</p>\n",
             "value": 32
           },
           {
             "type": "int",
             "name": "GIT_CREDTYPE_SSH_MEMORY",
-            "comments": "<p>Credentials read from memory.</p>\n\n<p>Only available for libssh2+OpenSSL for now.</p>\n",
+            "comments": "<p>An SSH key-based authentication request</p>\n\n<p>Allows credentials to be read from memory instead of files.\n Note that because of differences in crypto backend support, it might\n not be functional.</p>\n",
             "value": 64
           }
         ],
@@ -28492,9 +31074,9 @@
         ],
         "type": "struct",
         "value": "git_cvar_map",
-        "file": "config.h",
-        "line": 93,
-        "lineto": 97,
+        "file": "git2/config.h",
+        "line": 104,
+        "lineto": 108,
         "block": "git_cvar_t cvar_type\nconst char * str_match\nint map_value",
         "tdef": "typedef",
         "description": " Mapping from config variables to values.",
@@ -28535,9 +31117,9 @@
           "GIT_CVAR_STRING"
         ],
         "type": "enum",
-        "file": "config.h",
-        "line": 83,
-        "lineto": 88,
+        "file": "git2/config.h",
+        "line": 94,
+        "lineto": 99,
         "block": "GIT_CVAR_FALSE\nGIT_CVAR_TRUE\nGIT_CVAR_INT32\nGIT_CVAR_STRING",
         "tdef": "typedef",
         "description": " Config var type",
@@ -28591,13 +31173,13 @@
           "GIT_DELTA_CONFLICTED"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 252,
-        "lineto": 264,
+        "file": "git2/diff.h",
+        "line": 220,
+        "lineto": 232,
         "block": "GIT_DELTA_UNMODIFIED\nGIT_DELTA_ADDED\nGIT_DELTA_DELETED\nGIT_DELTA_MODIFIED\nGIT_DELTA_RENAMED\nGIT_DELTA_COPIED\nGIT_DELTA_IGNORED\nGIT_DELTA_UNTRACKED\nGIT_DELTA_TYPECHANGE\nGIT_DELTA_UNREADABLE\nGIT_DELTA_CONFLICTED",
         "tdef": "typedef",
         "description": " What type of change is described by a git_diff_delta?",
-        "comments": "<p><code>GIT_DELTA_RENAMED</code> and <code>GIT_DELTA_COPIED</code> will only show up if you run <code>git_diff_find_similar()</code> on the diff object.</p>\n\n<p><code>GIT_DELTA_TYPECHANGE</code> only shows up given <code>GIT_DIFF_INCLUDE_TYPECHANGE</code> in the option flags (otherwise type changes will be split into ADDED / DELETED pairs).</p>\n",
+        "comments": "<p><code>GIT_DELTA_RENAMED</code> and <code>GIT_DELTA_COPIED</code> will only show up if you run\n <code>git_diff_find_similar()</code> on the diff object.</p>\n\n<p><code>GIT_DELTA_TYPECHANGE</code> only shows up given <code>GIT_DIFF_INCLUDE_TYPECHANGE</code>\n in the option flags (otherwise type changes will be split into ADDED /\n DELETED pairs).</p>\n",
         "fields": [
           {
             "type": "int",
@@ -28686,13 +31268,13 @@
         ],
         "type": "struct",
         "value": "git_describe_format_options",
-        "file": "describe.h",
-        "line": 78,
-        "lineto": 98,
+        "file": "git2/describe.h",
+        "line": 91,
+        "lineto": 111,
         "block": "unsigned int version\nunsigned int abbreviated_size\nint always_use_long_format\nconst char * dirty_suffix",
         "tdef": "typedef",
-        "description": " Options for formatting the describe string",
-        "comments": "",
+        "description": " Describe format options structure",
+        "comments": "<p>Initialize with <code>GIT_DESCRIBE_FORMAT_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_describe_format_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -28718,7 +31300,8 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_describe_format"
+            "git_describe_format",
+            "git_describe_init_format_options"
           ]
         }
       }
@@ -28736,13 +31319,13 @@
         ],
         "type": "struct",
         "value": "git_describe_options",
-        "file": "describe.h",
-        "line": 44,
-        "lineto": 62,
+        "file": "git2/describe.h",
+        "line": 43,
+        "lineto": 61,
         "block": "unsigned int version\nunsigned int max_candidates_tags\nunsigned int describe_strategy\nconst char * pattern\nint only_follow_first_parent\nint show_commit_oid_as_fallback",
         "tdef": "typedef",
         "description": " Describe options structure",
-        "comments": "<p>Initialize with <code>GIT_DESCRIBE_OPTIONS_INIT</code> macro to correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_describe_options opts = GIT_DESCRIBE_OPTIONS_INIT;\n</code></pre>\n",
+        "comments": "<p>Initialize with <code>GIT_DESCRIBE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_describe_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -28779,6 +31362,7 @@
           "returns": [],
           "needs": [
             "git_describe_commit",
+            "git_describe_init_options",
             "git_describe_workdir"
           ]
         }
@@ -28790,12 +31374,13 @@
         "decl": "git_describe_result",
         "type": "struct",
         "value": "git_describe_result",
-        "file": "describe.h",
-        "line": 111,
-        "lineto": 111,
+        "file": "git2/describe.h",
+        "line": 134,
+        "lineto": 134,
         "tdef": "typedef",
         "description": " A struct that stores the result of a describe operation.",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -28816,13 +31401,13 @@
           "GIT_DESCRIBE_ALL"
         ],
         "type": "enum",
-        "file": "describe.h",
+        "file": "git2/describe.h",
         "line": 30,
         "lineto": 34,
         "block": "GIT_DESCRIBE_DEFAULT\nGIT_DESCRIBE_TAGS\nGIT_DESCRIBE_ALL",
         "tdef": "typedef",
         "description": " Reference lookup strategy",
-        "comments": "<p>These behave like the --tags and --all options to git-describe, namely they say to look for any reference in either refs/tags/ or refs/ respectively.</p>\n",
+        "comments": "<p>These behave like the --tags and --all options to git-describe,\n namely they say to look for any reference in either refs/tags/ or\n refs/ respectively.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -28855,12 +31440,13 @@
         "decl": "git_diff",
         "type": "struct",
         "value": "git_diff",
-        "file": "diff.h",
-        "line": 225,
-        "lineto": 225,
+        "file": "git2/diff.h",
+        "line": 193,
+        "lineto": 193,
         "tdef": "typedef",
         "description": " The diff object that contains all individual file deltas.",
-        "comments": "<p>This is an opaque structure which will be allocated by one of the diff generator functions below (such as <code>git_diff_tree_to_tree</code>).  You are responsible for releasing the object memory when done, using the <code>git_diff_free()</code> function.</p>\n",
+        "comments": "<p>A <code>diff</code> represents the cumulative list of differences between two\n snapshots of a repository (possibly filtered by a set of file name\n patterns).</p>\n\n<p>Calculating diffs is generally done in two phases: building a list of\n diffs then traversing it. This makes is easier to share logic across\n the various types of diffs (tree vs tree, workdir vs index, etc.), and\n also allows you to insert optional diff post-processing phases,\n such as rename detection, in between the steps. When you are done with\n a diff object, it must be freed.</p>\n\n<p>This is an opaque structure which will be allocated by one of the diff\n generator functions below (such as <code>git_diff_tree_to_tree</code>). You are\n responsible for releasing the object memory when done, using the\n <code>git_diff_free()</code> function.</p>\n",
+        "fields": [],
         "used": {
           "returns": [
             "git_diff_get_delta",
@@ -28934,18 +31520,18 @@
         ],
         "type": "struct",
         "value": "git_diff_binary",
-        "file": "diff.h",
-        "line": 498,
-        "lineto": 509,
+        "file": "git2/diff.h",
+        "line": 513,
+        "lineto": 525,
         "block": "unsigned int contains_data\ngit_diff_binary_file old_file\ngit_diff_binary_file new_file",
         "tdef": "typedef",
-        "description": " Structure describing the binary contents of a diff. ",
-        "comments": "",
+        "description": " Structure describing the binary contents of a diff.",
+        "comments": "<p>A <code>binary</code> file / delta is a file (or pair) for which no text diffs\n should be generated. A diff can contain delta entries that are\n binary, but no diff content will be output for those files. There is\n a base heuristic for binary detection and you can further tune the\n behavior with git attributes or diff flags and option settings.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
             "name": "contains_data",
-            "comments": " Whether there is data in this binary structure or not.  If this\n is `1`, then this was produced and included binary content.  If\n this is `0` then this was generated knowing only that a binary\n file changed but without providing the data, probably from a patch\n that said `Binary files a/file.txt and b/file.txt differ`."
+            "comments": " Whether there is data in this binary structure or not.\n\n If this is `1`, then this was produced and included binary content.\n If this is `0` then this was generated knowing only that a binary\n file changed but without providing the data, probably from a patch\n that said `Binary files a/file.txt and b/file.txt differ`."
           },
           {
             "type": "git_diff_binary_file",
@@ -28981,9 +31567,9 @@
         ],
         "type": "struct",
         "value": "git_diff_binary_file",
-        "file": "diff.h",
-        "line": 483,
-        "lineto": 495,
+        "file": "git2/diff.h",
+        "line": 490,
+        "lineto": 502,
         "block": "git_diff_binary_t type\nconst char * data\nsize_t datalen\nsize_t inflatedlen",
         "tdef": "typedef",
         "description": " The contents of one of the files in a binary diff. ",
@@ -29025,9 +31611,9 @@
           "GIT_DIFF_BINARY_DELTA"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 471,
-        "lineto": 480,
+        "file": "git2/diff.h",
+        "line": 478,
+        "lineto": 487,
         "block": "GIT_DIFF_BINARY_NONE\nGIT_DIFF_BINARY_LITERAL\nGIT_DIFF_BINARY_DELTA",
         "tdef": "typedef",
         "description": " When producing a binary diff, the binary data returned will be\n either the deflated full (\"literal\") contents of the file, or\n the deflated binary delta between the two sides (whichever is\n smaller).",
@@ -29071,13 +31657,13 @@
         ],
         "type": "struct",
         "value": "git_diff_delta",
-        "file": "diff.h",
-        "line": 337,
-        "lineto": 344,
+        "file": "git2/diff.h",
+        "line": 309,
+        "lineto": 316,
         "block": "git_delta_t status\nuint32_t flags\nuint16_t similarity\nuint16_t nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
         "tdef": "typedef",
         "description": " Description of changes to one entry.",
-        "comments": "<p>When iterating over a diff, this will be passed to most callbacks and you can use the contents to understand exactly what has changed.</p>\n\n<p>The <code>old_file</code> represents the &quot;from&quot; side of the diff and the <code>new_file</code> represents to &quot;to&quot; side of the diff.  What those means depend on the function that was used to generate the diff and will be documented below. You can also use the <code>GIT_DIFF_REVERSE</code> flag to flip it around.</p>\n\n<p>Although the two sides of the delta are named &quot;old_file&quot; and &quot;new_file&quot;, they actually may correspond to entries that represent a file, a symbolic link, a submodule commit id, or even a tree (if you are tracking type changes or ignored/untracked directories).</p>\n\n<p>Under some circumstances, in the name of efficiency, not all fields will be filled in, but we generally try to fill in as much as possible.  One example is that the &quot;flags&quot; field may not have either the <code>BINARY</code> or the <code>NOT_BINARY</code> flag set to avoid examining file contents if you do not pass in hunk and/or line callbacks to the diff foreach iteration function.  It will just use the git attributes for those files.</p>\n\n<p>The similarity score is zero unless you call <code>git_diff_find_similar()</code> which does a similarity analysis of files in the diff.  Use that function to do rename and copy detection, and to split heavily modified files in add/delete pairs.  After that call, deltas with a status of GIT_DELTA_RENAMED or GIT_DELTA_COPIED will have a similarity score between 0 and 100 indicating how similar the old and new sides are.</p>\n\n<p>If you ask <code>git_diff_find_similar</code> to find heavily modified files to break, but to not <em>actually</em> break the records, then GIT_DELTA_MODIFIED records may have a non-zero similarity score if the self-similarity is below the split threshold.  To display this value like core Git, invert the score (a la <code>printf(&quot;M%03d&quot;, 100 - delta-&gt;similarity)</code>).</p>\n",
+        "comments": "<p>A <code>delta</code> is a file pair with an old and new revision.  The old version\n may be absent if the file was just created and the new version may be\n absent if the file was deleted.  A diff is mostly just a list of deltas.</p>\n\n<p>When iterating over a diff, this will be passed to most callbacks and\n you can use the contents to understand exactly what has changed.</p>\n\n<p>The <code>old_file</code> represents the &quot;from&quot; side of the diff and the <code>new_file</code>\n represents to &quot;to&quot; side of the diff.  What those means depend on the\n function that was used to generate the diff and will be documented below.\n You can also use the <code>GIT_DIFF_REVERSE</code> flag to flip it around.</p>\n\n<p>Although the two sides of the delta are named &quot;old_file&quot; and &quot;new_file&quot;,\n they actually may correspond to entries that represent a file, a symbolic\n link, a submodule commit id, or even a tree (if you are tracking type\n changes or ignored/untracked directories).</p>\n\n<p>Under some circumstances, in the name of efficiency, not all fields will\n be filled in, but we generally try to fill in as much as possible.  One\n example is that the &quot;flags&quot; field may not have either the <code>BINARY</code> or the\n <code>NOT_BINARY</code> flag set to avoid examining file contents if you do not pass\n in hunk and/or line callbacks to the diff foreach iteration function.  It\n will just use the git attributes for those files.</p>\n\n<p>The similarity score is zero unless you call <code>git_diff_find_similar()</code>\n which does a similarity analysis of files in the diff.  Use that\n function to do rename and copy detection, and to split heavily modified\n files in add/delete pairs.  After that call, deltas with a status of\n GIT_DELTA_RENAMED or GIT_DELTA_COPIED will have a similarity score\n between 0 and 100 indicating how similar the old and new sides are.</p>\n\n<p>If you ask <code>git_diff_find_similar</code> to find heavily modified files to\n break, but to not <em>actually</em> break the records, then GIT_DELTA_MODIFIED\n records may have a non-zero similarity score if the self-similarity is\n below the split threshold.  To display this value like core Git, invert\n the score (a la <code>printf(&quot;M%03d&quot;, 100 - delta-&gt;similarity)</code>).</p>\n",
         "fields": [
           {
             "type": "git_delta_t",
@@ -29141,13 +31727,13 @@
         ],
         "type": "struct",
         "value": "git_diff_file",
-        "file": "diff.h",
-        "line": 292,
-        "lineto": 299,
+        "file": "git2/diff.h",
+        "line": 260,
+        "lineto": 267,
         "block": "git_oid id\nconst char * path\ngit_off_t size\nuint32_t flags\nuint16_t mode\nuint16_t id_abbrev",
         "tdef": "typedef",
         "description": " Description of one side of a delta.",
-        "comments": "<p>Although this is called a &quot;file&quot;, it could represent a file, a symbolic link, a submodule commit id, or even a tree (although that only if you are tracking type changes or ignored/untracked directories).</p>\n\n<p>The <code>id</code> is the <code>git_oid</code> of the item.  If the entry represents an absent side of a diff (e.g. the <code>old_file</code> of a <code>GIT_DELTA_ADDED</code> delta), then the oid will be zeroes.</p>\n\n<p><code>path</code> is the NUL-terminated path to the entry relative to the working directory of the repository.</p>\n\n<p><code>size</code> is the size of the entry in bytes.</p>\n\n<p><code>flags</code> is a combination of the <code>git_diff_flag_t</code> types</p>\n\n<p><code>mode</code> is, roughly, the stat() <code>st_mode</code> value for the item.  This will be restricted to one of the <code>git_filemode_t</code> values.</p>\n\n<p>The <code>id_abbrev</code> represents the known length of the <code>id</code> field, when converted to a hex string.  It is generally <code>GIT_OID_HEXSZ</code>, unless this delta was created from reading a patch file, in which case it may be abbreviated to something reasonable, like 7 characters.</p>\n",
+        "comments": "<p>Although this is called a &quot;file&quot;, it could represent a file, a symbolic\n link, a submodule commit id, or even a tree (although that only if you\n are tracking type changes or ignored/untracked directories).</p>\n\n<p>The <code>id</code> is the <code>git_oid</code> of the item.  If the entry represents an\n absent side of a diff (e.g. the <code>old_file</code> of a <code>GIT_DELTA_ADDED</code> delta),\n then the oid will be zeroes.</p>\n\n<p><code>path</code> is the NUL-terminated path to the entry relative to the working\n directory of the repository.</p>\n\n<p><code>size</code> is the size of the entry in bytes.</p>\n\n<p><code>flags</code> is a combination of the <code>git_diff_flag_t</code> types</p>\n\n<p><code>mode</code> is, roughly, the stat() <code>st_mode</code> value for the item.  This will\n be restricted to one of the <code>git_filemode_t</code> values.</p>\n\n<p>The <code>id_abbrev</code> represents the known length of the <code>id</code> field, when\n converted to a hex string.  It is generally <code>GIT_OID_HEXSZ</code>, unless this\n delta was created from reading a patch file, in which case it may be\n abbreviated to something reasonable, like 7 characters.</p>\n",
         "fields": [
           {
             "type": "git_oid",
@@ -29207,13 +31793,13 @@
         ],
         "type": "struct",
         "value": "git_diff_find_options",
-        "file": "diff.h",
-        "line": 703,
-        "lineto": 729,
+        "file": "git2/diff.h",
+        "line": 718,
+        "lineto": 772,
         "block": "unsigned int version\nuint32_t flags\nuint16_t rename_threshold\nuint16_t rename_from_rewrite_threshold\nuint16_t copy_threshold\nuint16_t break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
         "tdef": "typedef",
         "description": " Control behavior of rename and copy detection",
-        "comments": "<p>These options mostly mimic parameters that can be passed to git-diff.</p>\n\n<ul>\n<li><code>rename_threshold</code> is the same as the -M option with a value - <code>copy_threshold</code> is the same as the -C option with a value - <code>rename_from_rewrite_threshold</code> matches the top of the -B option - <code>break_rewrite_threshold</code> matches the bottom of the -B option - <code>rename_limit</code> is the maximum number of matches to consider for   a particular file.  This is a little different from the <code>-l</code> option   to regular Git because we will still process up to this many matches   before abandoning the search.</li>\n</ul>\n\n<p>The <code>metric</code> option allows you to plug in a custom similarity metric. Set it to NULL for the default internal metric which is based on sampling hashes of ranges of data in the file.  The default metric is a pretty good similarity approximation that should work fairly well for both text and binary data, and is pretty fast with fixed memory overhead.</p>\n",
+        "comments": "<p>These options mostly mimic parameters that can be passed to git-diff.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -29228,32 +31814,32 @@
           {
             "type": "uint16_t",
             "name": "rename_threshold",
-            "comments": " Similarity to consider a file renamed (default 50) "
+            "comments": " Threshold above which similar files will be considered renames.\n This is equivalent to the -M option. Defaults to 50."
           },
           {
             "type": "uint16_t",
             "name": "rename_from_rewrite_threshold",
-            "comments": " Similarity of modified to be eligible rename source (default 50) "
+            "comments": " Threshold below which similar files will be eligible to be a rename source.\n This is equivalent to the first part of the -B option. Defaults to 50."
           },
           {
             "type": "uint16_t",
             "name": "copy_threshold",
-            "comments": " Similarity to consider a file a copy (default 50) "
+            "comments": " Threshold above which similar files will be considered copies.\n This is equivalent to the -C option. Defaults to 50."
           },
           {
             "type": "uint16_t",
             "name": "break_rewrite_threshold",
-            "comments": " Similarity to split modify into delete/add pair (default 60) "
+            "comments": " Treshold below which similar files will be split into a delete/add pair.\n This is equivalent to the last part of the -B option. Defaults to 60."
           },
           {
             "type": "size_t",
             "name": "rename_limit",
-            "comments": " Maximum similarity sources to examine for a file (somewhat like\n  git-diff's `-l` option or `diff.renameLimit` config) (default 200)"
+            "comments": " Maximum number of matches to consider for a particular file.\n\n This is a little different from the `-l` option from Git because we\n will still process up to this many matches before abandoning the search.\n Defaults to 200."
           },
           {
             "type": "git_diff_similarity_metric *",
             "name": "metric",
-            "comments": " Pluggable similarity metric; pass NULL to use internal metric "
+            "comments": " The `metric` option allows you to plug in a custom similarity metric.\n\n Set it to NULL to use the default internal metric.\n\n The default metric is based on sampling hashes of ranges of data in\n the file, which is a pretty good similarity approximation that should\n work fairly well for both text and binary data while still being\n pretty fast with a fixed memory overhead."
           }
         ],
         "used": {
@@ -29287,9 +31873,9 @@
           "GIT_DIFF_FIND_REMOVE_UNMODIFIED"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 597,
-        "lineto": 666,
+        "file": "git2/diff.h",
+        "line": 627,
+        "lineto": 696,
         "block": "GIT_DIFF_FIND_BY_CONFIG\nGIT_DIFF_FIND_RENAMES\nGIT_DIFF_FIND_RENAMES_FROM_REWRITES\nGIT_DIFF_FIND_COPIES\nGIT_DIFF_FIND_COPIES_FROM_UNMODIFIED\nGIT_DIFF_FIND_REWRITES\nGIT_DIFF_BREAK_REWRITES\nGIT_DIFF_FIND_AND_BREAK_REWRITES\nGIT_DIFF_FIND_FOR_UNTRACKED\nGIT_DIFF_FIND_ALL\nGIT_DIFF_FIND_IGNORE_LEADING_WHITESPACE\nGIT_DIFF_FIND_IGNORE_WHITESPACE\nGIT_DIFF_FIND_DONT_IGNORE_WHITESPACE\nGIT_DIFF_FIND_EXACT_MATCH_ONLY\nGIT_DIFF_BREAK_REWRITES_FOR_RENAMES_ONLY\nGIT_DIFF_FIND_REMOVE_UNMODIFIED",
         "tdef": "typedef",
         "description": " Flags to control the behavior of diff rename/copy detection.",
@@ -29408,13 +31994,13 @@
           "GIT_DIFF_FLAG_EXISTS"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 235,
-        "lineto": 240,
+        "file": "git2/diff.h",
+        "line": 203,
+        "lineto": 208,
         "block": "GIT_DIFF_FLAG_BINARY\nGIT_DIFF_FLAG_NOT_BINARY\nGIT_DIFF_FLAG_VALID_ID\nGIT_DIFF_FLAG_EXISTS",
         "tdef": "typedef",
         "description": " Flags for the delta object and the file objects on each side.",
-        "comments": "<p>These flags are used for both the <code>flags</code> value of the <code>git_diff_delta</code> and the flags for the <code>git_diff_file</code> objects representing the old and new sides of the delta.  Values outside of this public range should be considered reserved for internal or future use.</p>\n",
+        "comments": "<p>These flags are used for both the <code>flags</code> value of the <code>git_diff_delta</code>\n and the flags for the <code>git_diff_file</code> objects representing the old and\n new sides of the delta.  Values outside of this public range should be\n considered reserved for internal or future use.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -29455,9 +32041,9 @@
           "GIT_DIFF_FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 1321,
-        "lineto": 1328,
+        "file": "git2/diff.h",
+        "line": 1366,
+        "lineto": 1373,
         "block": "GIT_DIFF_FORMAT_EMAIL_NONE\nGIT_DIFF_FORMAT_EMAIL_EXCLUDE_SUBJECT_PATCH_MARKER",
         "tdef": "typedef",
         "description": " Formatting options for diff e-mail generation",
@@ -29499,9 +32085,9 @@
         ],
         "type": "struct",
         "value": "git_diff_format_email_options",
-        "file": "diff.h",
-        "line": 1333,
-        "lineto": 1355,
+        "file": "git2/diff.h",
+        "line": 1378,
+        "lineto": 1400,
         "block": "unsigned int version\ngit_diff_format_email_flags_t flags\nsize_t patch_no\nsize_t total_patches\nconst git_oid * id\nconst char * summary\nconst char * body\nconst git_signature * author",
         "tdef": "typedef",
         "description": " Options for controlling the formatting of the generated e-mail.",
@@ -29568,9 +32154,9 @@
           "GIT_DIFF_FORMAT_NAME_STATUS"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 1045,
-        "lineto": 1051,
+        "file": "git2/diff.h",
+        "line": 1090,
+        "lineto": 1096,
         "block": "GIT_DIFF_FORMAT_PATCH\nGIT_DIFF_FORMAT_PATCH_HEADER\nGIT_DIFF_FORMAT_RAW\nGIT_DIFF_FORMAT_NAME_ONLY\nGIT_DIFF_FORMAT_NAME_STATUS",
         "tdef": "typedef",
         "description": " Possible output formats for diff data",
@@ -29629,13 +32215,13 @@
         ],
         "type": "struct",
         "value": "git_diff_hunk",
-        "file": "diff.h",
-        "line": 523,
-        "lineto": 530,
+        "file": "git2/diff.h",
+        "line": 545,
+        "lineto": 552,
         "block": "int old_start\nint old_lines\nint new_start\nint new_lines\nsize_t header_len\nchar [128] header",
         "tdef": "typedef",
         "description": " Structure describing a hunk of a diff.",
-        "comments": "",
+        "comments": "<p>A <code>hunk</code> is a span of modified lines in a delta along with some stable\n surrounding context. You can configure the amount of context and other\n properties of how hunks are generated. Each hunk also comes with a\n header that described where it starts and ends in both the old and new\n versions in the delta.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -29698,13 +32284,13 @@
         ],
         "type": "struct",
         "value": "git_diff_line",
-        "file": "diff.h",
-        "line": 570,
-        "lineto": 578,
+        "file": "git2/diff.h",
+        "line": 600,
+        "lineto": 608,
         "block": "char origin\nint old_lineno\nint new_lineno\nint num_lines\nsize_t content_len\ngit_off_t content_offset\nconst char * content",
         "tdef": "typedef",
         "description": " Structure describing a line (or data span) of a diff.",
-        "comments": "",
+        "comments": "<p>A <code>line</code> is a range of characters inside a hunk.  It could be a context\n line (i.e. in both old and new versions), an added line (i.e. only in\n the new version), or a removed line (i.e. only in the old version).\n Unfortunately, we don&#39;t know anything about the encoding of data in the\n file being diffed, so we cannot tell you much about the line content.\n Line data will not be NUL-byte terminated, however, because it will be\n just a span of bytes inside the larger file.</p>\n",
         "fields": [
           {
             "type": "char",
@@ -29774,13 +32360,13 @@
           "GIT_DIFF_LINE_BINARY"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 549,
-        "lineto": 565,
+        "file": "git2/diff.h",
+        "line": 571,
+        "lineto": 587,
         "block": "GIT_DIFF_LINE_CONTEXT\nGIT_DIFF_LINE_ADDITION\nGIT_DIFF_LINE_DELETION\nGIT_DIFF_LINE_CONTEXT_EOFNL\nGIT_DIFF_LINE_ADD_EOFNL\nGIT_DIFF_LINE_DEL_EOFNL\nGIT_DIFF_LINE_FILE_HDR\nGIT_DIFF_LINE_HUNK_HDR\nGIT_DIFF_LINE_BINARY",
         "tdef": "typedef",
         "description": " Line origin constants.",
-        "comments": "<p>These values describe where a line came from and will be passed to the git_diff_line_cb when iterating over a diff.  There are some special origin constants at the end that are used for the text output callbacks to demarcate lines that are actually part of the file or hunk headers.</p>\n",
+        "comments": "<p>These values describe where a line came from and will be passed to\n the git_diff_line_cb when iterating over a diff.  There are some\n special origin constants at the end that are used for the text\n output callbacks to demarcate lines that are actually part of\n the file or hunk headers.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -29866,6 +32452,7 @@
           "GIT_DIFF_UPDATE_INDEX",
           "GIT_DIFF_INCLUDE_UNREADABLE",
           "GIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED",
+          "GIT_DIFF_INDENT_HEURISTIC",
           "GIT_DIFF_FORCE_TEXT",
           "GIT_DIFF_FORCE_BINARY",
           "GIT_DIFF_IGNORE_WHITESPACE",
@@ -29875,14 +32462,13 @@
           "GIT_DIFF_SHOW_UNMODIFIED",
           "GIT_DIFF_PATIENCE",
           "GIT_DIFF_MINIMAL",
-          "GIT_DIFF_SHOW_BINARY",
-          "GIT_DIFF_INDENT_HEURISTIC"
+          "GIT_DIFF_SHOW_BINARY"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 72,
-        "lineto": 215,
-        "block": "GIT_DIFF_NORMAL\nGIT_DIFF_REVERSE\nGIT_DIFF_INCLUDE_IGNORED\nGIT_DIFF_RECURSE_IGNORED_DIRS\nGIT_DIFF_INCLUDE_UNTRACKED\nGIT_DIFF_RECURSE_UNTRACKED_DIRS\nGIT_DIFF_INCLUDE_UNMODIFIED\nGIT_DIFF_INCLUDE_TYPECHANGE\nGIT_DIFF_INCLUDE_TYPECHANGE_TREES\nGIT_DIFF_IGNORE_FILEMODE\nGIT_DIFF_IGNORE_SUBMODULES\nGIT_DIFF_IGNORE_CASE\nGIT_DIFF_INCLUDE_CASECHANGE\nGIT_DIFF_DISABLE_PATHSPEC_MATCH\nGIT_DIFF_SKIP_BINARY_CHECK\nGIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS\nGIT_DIFF_UPDATE_INDEX\nGIT_DIFF_INCLUDE_UNREADABLE\nGIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED\nGIT_DIFF_FORCE_TEXT\nGIT_DIFF_FORCE_BINARY\nGIT_DIFF_IGNORE_WHITESPACE\nGIT_DIFF_IGNORE_WHITESPACE_CHANGE\nGIT_DIFF_IGNORE_WHITESPACE_EOL\nGIT_DIFF_SHOW_UNTRACKED_CONTENT\nGIT_DIFF_SHOW_UNMODIFIED\nGIT_DIFF_PATIENCE\nGIT_DIFF_MINIMAL\nGIT_DIFF_SHOW_BINARY\nGIT_DIFF_INDENT_HEURISTIC",
+        "file": "git2/diff.h",
+        "line": 28,
+        "lineto": 171,
+        "block": "GIT_DIFF_NORMAL\nGIT_DIFF_REVERSE\nGIT_DIFF_INCLUDE_IGNORED\nGIT_DIFF_RECURSE_IGNORED_DIRS\nGIT_DIFF_INCLUDE_UNTRACKED\nGIT_DIFF_RECURSE_UNTRACKED_DIRS\nGIT_DIFF_INCLUDE_UNMODIFIED\nGIT_DIFF_INCLUDE_TYPECHANGE\nGIT_DIFF_INCLUDE_TYPECHANGE_TREES\nGIT_DIFF_IGNORE_FILEMODE\nGIT_DIFF_IGNORE_SUBMODULES\nGIT_DIFF_IGNORE_CASE\nGIT_DIFF_INCLUDE_CASECHANGE\nGIT_DIFF_DISABLE_PATHSPEC_MATCH\nGIT_DIFF_SKIP_BINARY_CHECK\nGIT_DIFF_ENABLE_FAST_UNTRACKED_DIRS\nGIT_DIFF_UPDATE_INDEX\nGIT_DIFF_INCLUDE_UNREADABLE\nGIT_DIFF_INCLUDE_UNREADABLE_AS_UNTRACKED\nGIT_DIFF_INDENT_HEURISTIC\nGIT_DIFF_FORCE_TEXT\nGIT_DIFF_FORCE_BINARY\nGIT_DIFF_IGNORE_WHITESPACE\nGIT_DIFF_IGNORE_WHITESPACE_CHANGE\nGIT_DIFF_IGNORE_WHITESPACE_EOL\nGIT_DIFF_SHOW_UNTRACKED_CONTENT\nGIT_DIFF_SHOW_UNMODIFIED\nGIT_DIFF_PATIENCE\nGIT_DIFF_MINIMAL\nGIT_DIFF_SHOW_BINARY",
         "tdef": "typedef",
         "description": " Flags for diff options.  A combination of these flags can be passed\n in via the `flags` value in the `git_diff_options`.",
         "comments": "",
@@ -30003,6 +32589,12 @@
           },
           {
             "type": "int",
+            "name": "GIT_DIFF_INDENT_HEURISTIC",
+            "comments": "<p>Use a heuristic that takes indentation and whitespace into account\n which generally can produce better diffs when dealing with ambiguous\n diff hunks.</p>\n",
+            "value": 262144
+          },
+          {
+            "type": "int",
             "name": "GIT_DIFF_FORCE_TEXT",
             "comments": "<p>Treat all files as text, disabling binary attributes \n&amp;\n detection </p>\n",
             "value": 1048576
@@ -30060,12 +32652,6 @@
             "name": "GIT_DIFF_SHOW_BINARY",
             "comments": "<p>Include the necessary deflate / delta information so that <code>git-apply</code>\n  can apply given diff information to binary files.</p>\n",
             "value": 1073741824
-          },
-          {
-            "type": "unsigned int",
-            "name": "GIT_DIFF_INDENT_HEURISTIC",
-            "comments": "<p>Use a heuristic that takes indentation and whitespace into account\n which generally can produce better diffs when dealing with ambiguous\n diff hunks.</p>\n",
-            "value": -2147483648
           }
         ],
         "used": {
@@ -30094,13 +32680,13 @@
         ],
         "type": "struct",
         "value": "git_diff_options",
-        "file": "diff.h",
-        "line": 408,
-        "lineto": 428,
+        "file": "git2/diff.h",
+        "line": 361,
+        "lineto": 433,
         "block": "unsigned int version\nuint32_t flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nuint32_t context_lines\nuint32_t interhunk_lines\nuint16_t id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
         "tdef": "typedef",
         "description": " Structure describing options about how the diff should be executed.",
-        "comments": "<p>Setting all values of the structure to zero will yield the default values.  Similarly, passing NULL for the options structure will give the defaults.  The default values are marked below.</p>\n\n<ul>\n<li><code>flags</code> is a combination of the <code>git_diff_option_t</code> values above - <code>context_lines</code> is the number of unchanged lines that define the    boundary of a hunk (and to display before and after) - <code>interhunk_lines</code> is the maximum number of unchanged lines between    hunk boundaries before the hunks will be merged into a one. - <code>old_prefix</code> is the virtual &quot;directory&quot; to prefix to old file names   in hunk headers (default &quot;a&quot;) - <code>new_prefix</code> is the virtual &quot;directory&quot; to prefix to new file names   in hunk headers (default &quot;b&quot;) - <code>pathspec</code> is an array of paths / fnmatch patterns to constrain diff - <code>max_size</code> is a file size (in bytes) above which a blob will be marked   as binary automatically; pass a negative value to disable. - <code>notify_cb</code> is an optional callback function, notifying the consumer of   changes to the diff as new deltas are added. - <code>progress_cb</code> is an optional callback function, notifying the consumer of   which files are being examined as the diff is generated. - <code>payload</code> is the payload to pass to the callback functions. - <code>ignore_submodules</code> overrides the submodule ignore setting for all   submodules in the diff.</li>\n</ul>\n",
+        "comments": "<p>Setting all values of the structure to zero will yield the default\n values.  Similarly, passing NULL for the options structure will\n give the defaults.  The default values are marked below.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -30110,62 +32696,62 @@
           {
             "type": "uint32_t",
             "name": "flags",
-            "comments": " defaults to GIT_DIFF_NORMAL "
+            "comments": " A combination of `git_diff_option_t` values above.\n Defaults to GIT_DIFF_NORMAL"
           },
           {
             "type": "git_submodule_ignore_t",
             "name": "ignore_submodules",
-            "comments": " submodule ignore rule "
+            "comments": " Overrides the submodule ignore setting for all submodules in the diff. "
           },
           {
             "type": "git_strarray",
             "name": "pathspec",
-            "comments": " defaults to include all paths "
+            "comments": " An array of paths / fnmatch patterns to constrain diff.\n All paths are included by default."
           },
           {
             "type": "git_diff_notify_cb",
             "name": "notify_cb",
-            "comments": ""
+            "comments": " An optional callback function, notifying the consumer of changes to\n the diff as new deltas are added."
           },
           {
             "type": "git_diff_progress_cb",
             "name": "progress_cb",
-            "comments": ""
+            "comments": " An optional callback function, notifying the consumer of which files\n are being examined as the diff is generated."
           },
           {
             "type": "void *",
             "name": "payload",
-            "comments": ""
+            "comments": " The payload to pass to the callback functions. "
           },
           {
             "type": "uint32_t",
             "name": "context_lines",
-            "comments": " defaults to 3 "
+            "comments": " The number of unchanged lines that define the boundary of a hunk\n (and to display before and after). Defaults to 3."
           },
           {
             "type": "uint32_t",
             "name": "interhunk_lines",
-            "comments": " defaults to 0 "
+            "comments": " The maximum number of unchanged lines between hunk boundaries before\n the hunks will be merged into one. Defaults to 0."
           },
           {
             "type": "uint16_t",
             "name": "id_abbrev",
-            "comments": " default 'core.abbrev' or 7 if unset "
+            "comments": " The abbreviation length to use when formatting object ids.\n Defaults to the value of 'core.abbrev' from the config, or 7 if unset."
           },
           {
             "type": "git_off_t",
             "name": "max_size",
-            "comments": " defaults to 512MB "
+            "comments": " A size (in bytes) above which a blob will be marked as binary\n automatically; pass a negative value to disable.\n Defaults to 512MB."
           },
           {
             "type": "const char *",
             "name": "old_prefix",
-            "comments": " defaults to \"a\" "
+            "comments": " The virtual \"directory\" prefix for old file names in hunk headers.\n Default is \"a\"."
           },
           {
             "type": "const char *",
             "name": "new_prefix",
-            "comments": " defaults to \"b\" "
+            "comments": " The virtual \"directory\" prefix for new file names in hunk headers.\n Defaults to \"b\"."
           }
         ],
         "used": {
@@ -30197,13 +32783,13 @@
         ],
         "type": "struct",
         "value": "git_diff_patchid_options",
-        "file": "diff.h",
-        "line": 1415,
-        "lineto": 1417,
+        "file": "git2/diff.h",
+        "line": 1462,
+        "lineto": 1464,
         "block": "unsigned int version",
         "tdef": "typedef",
         "description": " Patch ID options structure",
-        "comments": "<p>Initialize with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code> macro to correctly set the default values and version.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_PATCHID_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_patchid_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -30230,7 +32816,7 @@
         ],
         "type": "struct",
         "value": "git_diff_perfdata",
-        "file": "sys/diff.h",
+        "file": "git2/sys/diff.h",
         "line": 67,
         "lineto": 71,
         "block": "unsigned int version\nsize_t stat_calls\nsize_t oid_calculations",
@@ -30275,9 +32861,9 @@
         ],
         "type": "struct",
         "value": "git_diff_similarity_metric",
-        "file": "diff.h",
-        "line": 671,
-        "lineto": 681,
+        "file": "git2/diff.h",
+        "line": 701,
+        "lineto": 711,
         "block": "int (*)(void **, const git_diff_file *, const char *, void *) file_signature\nint (*)(void **, const git_diff_file *, const char *, size_t, void *) buffer_signature\nvoid (*)(void *, void *) free_signature\nint (*)(int *, void *, void *, void *) similarity\nvoid * payload",
         "tdef": "typedef",
         "description": " Pluggable similarity metric",
@@ -30321,12 +32907,13 @@
         "decl": "git_diff_stats",
         "type": "struct",
         "value": "git_diff_stats",
-        "file": "diff.h",
-        "line": 1235,
-        "lineto": 1235,
+        "file": "git2/diff.h",
+        "line": 1280,
+        "lineto": 1280,
         "tdef": "typedef",
         "description": " This is an opaque structure which is allocated by `git_diff_get_stats`.\n You are responsible for releasing the object memory when done, using the\n `git_diff_stats_free()` function.",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -30351,9 +32938,9 @@
           "GIT_DIFF_STATS_INCLUDE_SUMMARY"
         ],
         "type": "enum",
-        "file": "diff.h",
-        "line": 1240,
-        "lineto": 1255,
+        "file": "git2/diff.h",
+        "line": 1285,
+        "lineto": 1300,
         "block": "GIT_DIFF_STATS_NONE\nGIT_DIFF_STATS_FULL\nGIT_DIFF_STATS_SHORT\nGIT_DIFF_STATS_NUMBER\nGIT_DIFF_STATS_INCLUDE_SUMMARY",
         "tdef": "typedef",
         "description": " Formatting options for diff stats",
@@ -30406,13 +32993,13 @@
           "GIT_DIRECTION_PUSH"
         ],
         "type": "enum",
-        "file": "net.h",
+        "file": "git2/net.h",
         "line": 31,
         "lineto": 34,
         "block": "GIT_DIRECTION_FETCH\nGIT_DIRECTION_PUSH",
         "tdef": "typedef",
         "description": " Direction of the connection.",
-        "comments": "<p>We need this because we need to know whether we should call git-upload-pack or git-receive-pack on the remote end when get_refs gets called.</p>\n",
+        "comments": "<p>We need this because we need to know whether we should call\n git-upload-pack or git-receive-pack on the remote end when get_refs\n gets called.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -30446,13 +33033,13 @@
         ],
         "type": "struct",
         "value": "git_error",
-        "file": "errors.h",
-        "line": 66,
-        "lineto": 69,
+        "file": "git2/errors.h",
+        "line": 68,
+        "lineto": 71,
         "block": "char * message\nint klass",
         "tdef": "typedef",
         "description": " Structure to store extra details of the last error that occurred.",
-        "comments": "<p>This is kept on a per-thread basis if GIT_THREADS was defined when the library was build, otherwise one is kept globally for the library</p>\n",
+        "comments": "<p>This is kept on a per-thread basis if GIT_THREADS was defined when the\n library was build, otherwise one is kept globally for the library</p>\n",
         "fields": [
           {
             "type": "char *",
@@ -30504,13 +33091,14 @@
           "GIT_PASSTHROUGH",
           "GIT_ITEROVER",
           "GIT_RETRY",
-          "GIT_EMISMATCH"
+          "GIT_EMISMATCH",
+          "GIT_EINDEXDIRTY"
         ],
         "type": "enum",
-        "file": "errors.h",
+        "file": "git2/errors.h",
         "line": 21,
-        "lineto": 58,
-        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER\nGIT_RETRY\nGIT_EMISMATCH",
+        "lineto": 60,
+        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER\nGIT_RETRY\nGIT_EMISMATCH\nGIT_EINDEXDIRTY",
         "tdef": "typedef",
         "description": " Generic return codes ",
         "comments": "",
@@ -30554,7 +33142,7 @@
           {
             "type": "int",
             "name": "GIT_EUSER",
-            "comments": "",
+            "comments": "<p>GIT_EUSER is a special error that is never generated by libgit2\n code.  You can return it from a callback (e.g to stop an iteration)\n to know that it was generated by the callback and not by libgit2.</p>\n",
             "value": -7
           },
           {
@@ -30682,6 +33270,12 @@
             "name": "GIT_EMISMATCH",
             "comments": "<p>Hashsum mismatch in object </p>\n",
             "value": -33
+          },
+          {
+            "type": "int",
+            "name": "GIT_EINDEXDIRTY",
+            "comments": "<p>Unsaved changes in the index would be overwritten </p>\n",
+            "value": -34
           }
         ],
         "used": {
@@ -30730,9 +33324,9 @@
           "GITERR_SHA1"
         ],
         "type": "enum",
-        "file": "errors.h",
-        "line": 72,
-        "lineto": 107,
+        "file": "git2/errors.h",
+        "line": 74,
+        "lineto": 109,
         "block": "GITERR_NONE\nGITERR_NOMEMORY\nGITERR_OS\nGITERR_INVALID\nGITERR_REFERENCE\nGITERR_ZLIB\nGITERR_REPOSITORY\nGITERR_CONFIG\nGITERR_REGEX\nGITERR_ODB\nGITERR_INDEX\nGITERR_OBJECT\nGITERR_NET\nGITERR_TAG\nGITERR_TREE\nGITERR_INDEXER\nGITERR_SSL\nGITERR_SUBMODULE\nGITERR_THREAD\nGITERR_STASH\nGITERR_CHECKOUT\nGITERR_FETCHHEAD\nGITERR_MERGE\nGITERR_SSH\nGITERR_FILTER\nGITERR_REVERT\nGITERR_CALLBACK\nGITERR_CHERRYPICK\nGITERR_DESCRIBE\nGITERR_REBASE\nGITERR_FILESYSTEM\nGITERR_PATCH\nGITERR_WORKTREE\nGITERR_SHA1",
         "tdef": "typedef",
         "description": " Error classes ",
@@ -30959,9 +33553,9 @@
           "GIT_FEATURE_NSEC"
         ],
         "type": "enum",
-        "file": "common.h",
-        "line": 111,
-        "lineto": 134,
+        "file": "git2/common.h",
+        "line": 122,
+        "lineto": 145,
         "block": "GIT_FEATURE_THREADS\nGIT_FEATURE_HTTPS\nGIT_FEATURE_SSH\nGIT_FEATURE_NSEC",
         "tdef": "typedef",
         "description": " Combinations of these values describe the features with which libgit2\n was compiled",
@@ -31012,13 +33606,13 @@
         ],
         "type": "struct",
         "value": "git_fetch_options",
-        "file": "remote.h",
+        "file": "git2/remote.h",
         "line": 555,
         "lineto": 592,
         "block": "int version\ngit_remote_callbacks callbacks\ngit_fetch_prune_t prune\nint update_fetchhead\ngit_remote_autotag_option_t download_tags\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Fetch options structure.",
-        "comments": "<p>Zero out for defaults.  Initialize with <code>GIT_FETCH_OPTIONS_INIT</code> macro to correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;\n</code></pre>\n",
+        "comments": "<p>Zero out for defaults.  Initialize with <code>GIT_FETCH_OPTIONS_INIT</code> macro to\n correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;\n</code></pre>\n",
         "fields": [
           {
             "type": "int",
@@ -31067,6 +33661,48 @@
       }
     ],
     [
+      "git_fetch_prune_t",
+      {
+        "decl": [
+          "GIT_FETCH_PRUNE_UNSPECIFIED",
+          "GIT_FETCH_PRUNE",
+          "GIT_FETCH_NO_PRUNE"
+        ],
+        "type": "enum",
+        "file": "git2/remote.h",
+        "line": 507,
+        "lineto": 520,
+        "block": "GIT_FETCH_PRUNE_UNSPECIFIED\nGIT_FETCH_PRUNE\nGIT_FETCH_NO_PRUNE",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_FETCH_PRUNE_UNSPECIFIED",
+            "comments": "<p>Use the setting from the configuration</p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_FETCH_PRUNE",
+            "comments": "<p>Force pruning on</p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_FETCH_NO_PRUNE",
+            "comments": "<p>Force pruning off</p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_filemode_t",
       {
         "decl": [
@@ -31078,7 +33714,7 @@
           "GIT_FILEMODE_COMMIT"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 209,
         "lineto": 216,
         "block": "GIT_FILEMODE_UNREADABLE\nGIT_FILEMODE_TREE\nGIT_FILEMODE_BLOB\nGIT_FILEMODE_BLOB_EXECUTABLE\nGIT_FILEMODE_LINK\nGIT_FILEMODE_COMMIT",
@@ -31137,25 +33773,15 @@
     [
       "git_filter",
       {
-        "decl": [
-          "unsigned int version",
-          "const char * attributes",
-          "git_filter_init_fn initialize",
-          "git_filter_shutdown_fn shutdown",
-          "git_filter_check_fn check",
-          "git_filter_apply_fn apply",
-          "git_filter_stream_fn stream",
-          "git_filter_cleanup_fn cleanup"
-        ],
+        "decl": "git_filter",
         "type": "struct",
         "value": "git_filter",
-        "file": "sys/filter.h",
-        "line": 226,
-        "lineto": 271,
-        "tdef": null,
-        "description": " Filter structure used to register custom filters.",
-        "comments": "<p>To associate extra data with a filter, allocate extra data and put the <code>git_filter</code> struct at the start of your data buffer, then cast the <code>self</code> pointer to your larger structure when your callback is invoked.</p>\n",
-        "block": "unsigned int version\nconst char * attributes\ngit_filter_init_fn initialize\ngit_filter_shutdown_fn shutdown\ngit_filter_check_fn check\ngit_filter_apply_fn apply\ngit_filter_stream_fn stream\ngit_filter_cleanup_fn cleanup",
+        "file": "git2/filter.h",
+        "line": 61,
+        "lineto": 61,
+        "tdef": "typedef",
+        "description": " A filter that can transform file data",
+        "comments": "<p>This represents a filter that can be used to transform or even replace\n file data.  Libgit2 includes one built in filter and it is possible to\n write your own (see git2/sys/filter.h for information on that).</p>\n\n<p>The two builtin filters are:</p>\n\n<ul>\n<li>&quot;crlf&quot; which uses the complex rules with the &quot;text&quot;, &quot;eol&quot;, and\n&quot;crlf&quot; file attributes to decide how to convert between LF and CRLF\nline endings</li>\n<li>&quot;ident&quot; which replaces &quot;$Id$&quot; in a blob with &quot;$Id: \n<blob\nOID>$&quot; upon\ncheckout and replaced &quot;$Id: \n<anything\n>$&quot; with &quot;$Id$&quot; on checkin.</li>\n</ul>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -31228,7 +33854,8 @@
             "git_filter_source_id",
             "git_filter_source_mode",
             "git_filter_source_path",
-            "git_filter_source_repo"
+            "git_filter_source_repo",
+            "git_filter_stream_fn"
           ]
         }
       }
@@ -31241,7 +33868,7 @@
           "GIT_FILTER_ALLOW_UNSAFE"
         ],
         "type": "enum",
-        "file": "filter.h",
+        "file": "git2/filter.h",
         "line": 41,
         "lineto": 44,
         "block": "GIT_FILTER_DEFAULT\nGIT_FILTER_ALLOW_UNSAFE",
@@ -31274,12 +33901,13 @@
         "decl": "git_filter_list",
         "type": "struct",
         "value": "git_filter_list",
-        "file": "filter.h",
+        "file": "git2/filter.h",
         "line": 73,
         "lineto": 73,
         "tdef": "typedef",
         "description": " List of filters to be applied",
-        "comments": "<p>This represents a list of filters to be applied to a file / blob.  You can build the list with one call, apply it with another, and dispose it with a third.  In typical usage, there are not many occasions where a git_filter_list is needed directly since the library will generally handle conversions for you, but it can be convenient to be able to build and apply the list sometimes.</p>\n",
+        "comments": "<p>This represents a list of filters to be applied to a file / blob.  You\n can build the list with one call, apply it with another, and dispose it\n with a third.  In typical usage, there are not many occasions where a\n git_filter_list is needed directly since the library will generally\n handle conversions for you, but it can be convenient to be able to\n build and apply the list sometimes.</p>\n",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -31309,7 +33937,7 @@
           "GIT_FILTER_CLEAN"
         ],
         "type": "enum",
-        "file": "filter.h",
+        "file": "git2/filter.h",
         "line": 31,
         "lineto": 36,
         "block": "GIT_FILTER_TO_WORKTREE\nGIT_FILTER_SMUDGE\nGIT_FILTER_TO_ODB\nGIT_FILTER_CLEAN",
@@ -31359,12 +33987,13 @@
         "decl": "git_filter_source",
         "type": "struct",
         "value": "git_filter_source",
-        "file": "sys/filter.h",
+        "file": "git2/sys/filter.h",
         "line": 95,
         "lineto": 95,
         "tdef": "typedef",
         "description": " A filter source represents a file/blob to be processed",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -31375,7 +34004,8 @@
             "git_filter_source_id",
             "git_filter_source_mode",
             "git_filter_source_path",
-            "git_filter_source_repo"
+            "git_filter_source_repo",
+            "git_filter_stream_fn"
           ]
         }
       }
@@ -31386,12 +34016,13 @@
         "decl": "git_hashsig",
         "type": "struct",
         "value": "git_hashsig",
-        "file": "sys/hashsig.h",
+        "file": "git2/sys/hashsig.h",
         "line": 17,
         "lineto": 17,
         "tdef": "typedef",
         "description": " Similarity signature of arbitrary text content based on line hashes",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -31413,13 +34044,13 @@
           "GIT_HASHSIG_ALLOW_SMALL_FILES"
         ],
         "type": "enum",
-        "file": "sys/hashsig.h",
+        "file": "git2/sys/hashsig.h",
         "line": 25,
         "lineto": 45,
         "block": "GIT_HASHSIG_NORMAL\nGIT_HASHSIG_IGNORE_WHITESPACE\nGIT_HASHSIG_SMART_WHITESPACE\nGIT_HASHSIG_ALLOW_SMALL_FILES",
         "tdef": "typedef",
         "description": " Options for hashsig computation",
-        "comments": "<p>The options GIT_HASHSIG_NORMAL, GIT_HASHSIG_IGNORE_WHITESPACE, GIT_HASHSIG_SMART_WHITESPACE are exclusive and should not be combined.</p>\n",
+        "comments": "<p>The options GIT_HASHSIG_NORMAL, GIT_HASHSIG_IGNORE_WHITESPACE,\n GIT_HASHSIG_SMART_WHITESPACE are exclusive and should not be combined.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31475,13 +34106,13 @@
           "GIT_IDXENTRY_NEW_SKIP_WORKTREE"
         ],
         "type": "enum",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 115,
         "lineto": 135,
         "block": "GIT_IDXENTRY_INTENT_TO_ADD\nGIT_IDXENTRY_SKIP_WORKTREE\nGIT_IDXENTRY_EXTENDED2\nGIT_IDXENTRY_EXTENDED_FLAGS\nGIT_IDXENTRY_UPDATE\nGIT_IDXENTRY_REMOVE\nGIT_IDXENTRY_UPTODATE\nGIT_IDXENTRY_ADDED\nGIT_IDXENTRY_HASHED\nGIT_IDXENTRY_UNHASHED\nGIT_IDXENTRY_WT_REMOVE\nGIT_IDXENTRY_CONFLICTED\nGIT_IDXENTRY_UNPACKED\nGIT_IDXENTRY_NEW_SKIP_WORKTREE",
         "tdef": "typedef",
         "description": " Bitmasks for on-disk fields of `git_index_entry`'s `flags_extended`",
-        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the fields that are read from and written to disk, and other fields that in-memory only and used by libgit2.  Only the flags in <code>GIT_IDXENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code> <code>flags_extended</code> value that are only used in-memory by libgit2. You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
+        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the\n fields that are read from and written to disk, and other fields that\n in-memory only and used by libgit2.  Only the flags in\n <code>GIT_IDXENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the\n <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You\n can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code>\n <code>flags_extended</code> value that are only used in-memory by libgit2.\n You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31580,16 +34211,23 @@
         "decl": "git_index",
         "type": "struct",
         "value": "git_index",
-        "file": "types.h",
-        "line": 135,
-        "lineto": 135,
+        "file": "git2/types.h",
+        "line": 138,
+        "lineto": 138,
         "tdef": "typedef",
         "description": " Memory representation of an index file. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_index_get_byindex",
-            "git_index_get_bypath"
+            "git_index_get_bypath",
+            "git_index_name_get_byindex",
+            "git_index_reuc_get_byindex",
+            "git_index_reuc_get_bypath",
+            "git_merge_driver_source_ancestor",
+            "git_merge_driver_source_ours",
+            "git_merge_driver_source_theirs"
           ],
           "needs": [
             "git_checkout_index",
@@ -31620,6 +34258,10 @@
             "git_index_get_byindex",
             "git_index_get_bypath",
             "git_index_has_conflicts",
+            "git_index_name_add",
+            "git_index_name_clear",
+            "git_index_name_entrycount",
+            "git_index_name_get_byindex",
             "git_index_new",
             "git_index_open",
             "git_index_owner",
@@ -31630,6 +34272,13 @@
             "git_index_remove_all",
             "git_index_remove_bypath",
             "git_index_remove_directory",
+            "git_index_reuc_add",
+            "git_index_reuc_clear",
+            "git_index_reuc_entrycount",
+            "git_index_reuc_find",
+            "git_index_reuc_get_byindex",
+            "git_index_reuc_get_bypath",
+            "git_index_reuc_remove",
             "git_index_set_caps",
             "git_index_set_version",
             "git_index_update_all",
@@ -31641,6 +34290,7 @@
             "git_indexer_commit",
             "git_indexer_free",
             "git_indexer_hash",
+            "git_indexer_init_options",
             "git_indexer_new",
             "git_merge_commits",
             "git_merge_file_from_index",
@@ -31664,7 +34314,7 @@
           "GIT_INDEX_ADD_CHECK_PATHSPEC"
         ],
         "type": "enum",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 150,
         "lineto": 155,
         "block": "GIT_INDEX_ADD_DEFAULT\nGIT_INDEX_ADD_FORCE\nGIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH\nGIT_INDEX_ADD_CHECK_PATHSPEC",
@@ -31709,12 +34359,13 @@
         "decl": "git_index_conflict_iterator",
         "type": "struct",
         "value": "git_index_conflict_iterator",
-        "file": "types.h",
-        "line": 138,
-        "lineto": 138,
+        "file": "git2/types.h",
+        "line": 141,
+        "lineto": 141,
         "tdef": "typedef",
         "description": " An iterator for conflicts in the index. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -31744,13 +34395,13 @@
         ],
         "type": "struct",
         "value": "git_index_entry",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 53,
         "lineto": 70,
         "block": "git_index_time ctime\ngit_index_time mtime\nuint32_t dev\nuint32_t ino\nuint32_t mode\nuint32_t uid\nuint32_t gid\nuint32_t file_size\ngit_oid id\nuint16_t flags\nuint16_t flags_extended\nconst char * path",
         "tdef": "typedef",
         "description": " In-memory representation of a file entry in the index.",
-        "comments": "<p>This is a public structure that represents a file entry in the index. The meaning of the fields corresponds to core Git&#39;s documentation (in &quot;Documentation/technical/index-format.txt&quot;).</p>\n\n<p>The <code>flags</code> field consists of a number of bit fields which can be accessed via the first set of <code>GIT_IDXENTRY_...</code> bitmasks below.  These flags are all read from and persisted to disk.</p>\n\n<p>The <code>flags_extended</code> field also has a number of bit fields which can be accessed via the later <code>GIT_IDXENTRY_...</code> bitmasks below.  Some of these flags are read from and written to disk, but some are set aside for in-memory only reference.</p>\n\n<p>Note that the time and size fields are truncated to 32 bits. This is enough to detect changes, which is enough for the index to function as a cache, but it should not be taken as an authoritative source for that data.</p>\n",
+        "comments": "<p>This is a public structure that represents a file entry in the index.\n The meaning of the fields corresponds to core Git&#39;s documentation (in\n &quot;Documentation/technical/index-format.txt&quot;).</p>\n\n<p>The <code>flags</code> field consists of a number of bit fields which can be\n accessed via the first set of <code>GIT_IDXENTRY_...</code> bitmasks below.  These\n flags are all read from and persisted to disk.</p>\n\n<p>The <code>flags_extended</code> field also has a number of bit fields which can be\n accessed via the later <code>GIT_IDXENTRY_...</code> bitmasks below.  Some of\n these flags are read from and written to disk, but some are set aside\n for in-memory only reference.</p>\n\n<p>Note that the time and size fields are truncated to 32 bits. This\n is enough to detect changes, which is enough for the index to\n function as a cache, but it should not be taken as an authoritative\n source for that data.</p>\n",
         "fields": [
           {
             "type": "git_index_time",
@@ -31816,7 +34467,10 @@
         "used": {
           "returns": [
             "git_index_get_byindex",
-            "git_index_get_bypath"
+            "git_index_get_bypath",
+            "git_merge_driver_source_ancestor",
+            "git_merge_driver_source_ours",
+            "git_merge_driver_source_theirs"
           ],
           "needs": [
             "git_index_add",
@@ -31832,6 +34486,147 @@
       }
     ],
     [
+      "git_index_name_entry",
+      {
+        "decl": [
+          "char * ancestor",
+          "char * ours",
+          "char * theirs"
+        ],
+        "type": "struct",
+        "value": "git_index_name_entry",
+        "file": "git2/sys/index.h",
+        "line": 23,
+        "lineto": 27,
+        "block": "char * ancestor\nchar * ours\nchar * theirs",
+        "tdef": "typedef",
+        "description": " Representation of a rename conflict entry in the index. ",
+        "comments": "",
+        "fields": [
+          {
+            "type": "char *",
+            "name": "ancestor",
+            "comments": ""
+          },
+          {
+            "type": "char *",
+            "name": "ours",
+            "comments": ""
+          },
+          {
+            "type": "char *",
+            "name": "theirs",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [
+            "git_index_name_get_byindex"
+          ],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_index_reuc_entry",
+      {
+        "decl": [
+          "uint32_t [3] mode",
+          "git_oid [3] oid",
+          "char * path"
+        ],
+        "type": "struct",
+        "value": "git_index_reuc_entry",
+        "file": "git2/sys/index.h",
+        "line": 30,
+        "lineto": 34,
+        "block": "uint32_t [3] mode\ngit_oid [3] oid\nchar * path",
+        "tdef": "typedef",
+        "description": " Representation of a resolve undo entry in the index. ",
+        "comments": "",
+        "fields": [
+          {
+            "type": "uint32_t [3]",
+            "name": "mode",
+            "comments": ""
+          },
+          {
+            "type": "git_oid [3]",
+            "name": "oid",
+            "comments": ""
+          },
+          {
+            "type": "char *",
+            "name": "path",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [
+            "git_index_reuc_get_byindex",
+            "git_index_reuc_get_bypath"
+          ],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_index_stage_t",
+      {
+        "decl": [
+          "GIT_INDEX_STAGE_ANY",
+          "GIT_INDEX_STAGE_NORMAL",
+          "GIT_INDEX_STAGE_ANCESTOR",
+          "GIT_INDEX_STAGE_OURS",
+          "GIT_INDEX_STAGE_THEIRS"
+        ],
+        "type": "enum",
+        "file": "git2/index.h",
+        "line": 157,
+        "lineto": 177,
+        "block": "GIT_INDEX_STAGE_ANY\nGIT_INDEX_STAGE_NORMAL\nGIT_INDEX_STAGE_ANCESTOR\nGIT_INDEX_STAGE_OURS\nGIT_INDEX_STAGE_THEIRS",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_INDEX_STAGE_ANY",
+            "comments": "<p>Match any index stage.</p>\n\n<p>Some index APIs take a stage to match; pass this value to match\n any entry matching the path regardless of stage.</p>\n",
+            "value": -1
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_STAGE_NORMAL",
+            "comments": "<p>A normal staged file in the index. </p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_STAGE_ANCESTOR",
+            "comments": "<p>The ancestor side of a conflict. </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_STAGE_OURS",
+            "comments": "<p>The &quot;ours&quot; side of a conflict. </p>\n",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_STAGE_THEIRS",
+            "comments": "<p>The &quot;theirs&quot; side of a conflict. </p>\n",
+            "value": 3
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_index_time",
       {
         "decl": [
@@ -31840,7 +34635,7 @@
         ],
         "type": "struct",
         "value": "git_index_time",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 26,
         "lineto": 30,
         "block": "int32_t seconds\nuint32_t nanoseconds",
@@ -31875,7 +34670,7 @@
           "GIT_INDEXCAP_FROM_OWNER"
         ],
         "type": "enum",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 138,
         "lineto": 143,
         "block": "GIT_INDEXCAP_IGNORE_CASE\nGIT_INDEXCAP_NO_FILEMODE\nGIT_INDEXCAP_NO_SYMLINKS\nGIT_INDEXCAP_FROM_OWNER",
@@ -31915,6 +34710,81 @@
       }
     ],
     [
+      "git_indexer",
+      {
+        "decl": "git_indexer",
+        "type": "struct",
+        "value": "git_indexer",
+        "file": "git2/indexer.h",
+        "line": 16,
+        "lineto": 16,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_indexer_append",
+            "git_indexer_commit",
+            "git_indexer_free",
+            "git_indexer_hash",
+            "git_indexer_init_options",
+            "git_indexer_new"
+          ]
+        }
+      }
+    ],
+    [
+      "git_indexer_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "git_transfer_progress_cb progress_cb",
+          "void * progress_cb_payload",
+          "unsigned char verify"
+        ],
+        "type": "struct",
+        "value": "git_indexer_options",
+        "file": "git2/indexer.h",
+        "line": 18,
+        "lineto": 28,
+        "block": "unsigned int version\ngit_transfer_progress_cb progress_cb\nvoid * progress_cb_payload\nunsigned char verify",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "git_transfer_progress_cb",
+            "name": "progress_cb",
+            "comments": " progress_cb function to call with progress information "
+          },
+          {
+            "type": "void *",
+            "name": "progress_cb_payload",
+            "comments": " progress_cb_payload payload for the progress callback "
+          },
+          {
+            "type": "unsigned char",
+            "name": "verify",
+            "comments": " Do connectivity checks for the received pack "
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_indexer_init_options",
+            "git_indexer_new"
+          ]
+        }
+      }
+    ],
+    [
       "git_indxentry_flag_t",
       {
         "decl": [
@@ -31922,7 +34792,7 @@
           "GIT_IDXENTRY_VALID"
         ],
         "type": "enum",
-        "file": "index.h",
+        "file": "git2/index.h",
         "line": 86,
         "lineto": 89,
         "block": "GIT_IDXENTRY_EXTENDED\nGIT_IDXENTRY_VALID",
@@ -31943,6 +34813,25 @@
             "value": 32768
           }
         ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_iterator",
+      {
+        "decl": [],
+        "type": "struct",
+        "value": "git_iterator",
+        "file": "git2/notes.h",
+        "line": 35,
+        "lineto": 35,
+        "tdef": null,
+        "description": "",
+        "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": []
@@ -31975,16 +34864,20 @@
           "GIT_OPT_ENABLE_FSYNC_GITDIR",
           "GIT_OPT_GET_WINDOWS_SHAREMODE",
           "GIT_OPT_SET_WINDOWS_SHAREMODE",
-          "GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION"
+          "GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION",
+          "GIT_OPT_SET_ALLOCATOR",
+          "GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY",
+          "GIT_OPT_GET_PACK_MAX_OBJECTS",
+          "GIT_OPT_SET_PACK_MAX_OBJECTS"
         ],
         "type": "enum",
-        "file": "common.h",
-        "line": 162,
-        "lineto": 186,
-        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION",
+        "file": "git2/common.h",
+        "line": 173,
+        "lineto": 201,
+        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION\nGIT_OPT_SET_ALLOCATOR\nGIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY\nGIT_OPT_GET_PACK_MAX_OBJECTS\nGIT_OPT_SET_PACK_MAX_OBJECTS",
         "tdef": "typedef",
         "description": " Global library options",
-        "comments": "<p>These are used to select which global option to set or get and are used in <code>git_libgit2_opts()</code>.</p>\n",
+        "comments": "<p>These are used to select which global option to set or get and are\n used in <code>git_libgit2_opts()</code>.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -32123,11 +35016,64 @@
             "name": "GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION",
             "comments": "",
             "value": 22
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_SET_ALLOCATOR",
+            "comments": "",
+            "value": 23
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY",
+            "comments": "",
+            "value": 24
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_GET_PACK_MAX_OBJECTS",
+            "comments": "",
+            "value": 25
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_SET_PACK_MAX_OBJECTS",
+            "comments": "",
+            "value": 26
           }
         ],
         "used": {
           "returns": [],
           "needs": []
+        }
+      }
+    ],
+    [
+      "git_mailmap",
+      {
+        "decl": "git_mailmap",
+        "type": "struct",
+        "value": "git_mailmap",
+        "file": "git2/types.h",
+        "line": 438,
+        "lineto": 438,
+        "tdef": "typedef",
+        "description": " Representation of .mailmap file state. ",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_commit_author_with_mailmap",
+            "git_commit_committer_with_mailmap",
+            "git_mailmap_add_entry",
+            "git_mailmap_free",
+            "git_mailmap_from_buffer",
+            "git_mailmap_from_repository",
+            "git_mailmap_new",
+            "git_mailmap_resolve",
+            "git_mailmap_resolve_signature"
+          ]
         }
       }
     ],
@@ -32142,9 +35088,9 @@
           "GIT_MERGE_ANALYSIS_UNBORN"
         ],
         "type": "enum",
-        "file": "merge.h",
-        "line": 318,
-        "lineto": 347,
+        "file": "git2/merge.h",
+        "line": 320,
+        "lineto": 349,
         "block": "GIT_MERGE_ANALYSIS_NONE\nGIT_MERGE_ANALYSIS_NORMAL\nGIT_MERGE_ANALYSIS_UP_TO_DATE\nGIT_MERGE_ANALYSIS_FASTFORWARD\nGIT_MERGE_ANALYSIS_UNBORN",
         "tdef": "typedef",
         "description": " The results of `git_merge_analysis` indicate the merge opportunities.",
@@ -32192,21 +35138,15 @@
     [
       "git_merge_driver",
       {
-        "decl": [
-          "unsigned int version",
-          "git_merge_driver_init_fn initialize",
-          "git_merge_driver_shutdown_fn shutdown",
-          "git_merge_driver_apply_fn apply"
-        ],
+        "decl": "git_merge_driver",
         "type": "struct",
         "value": "git_merge_driver",
-        "file": "sys/merge.h",
-        "line": 118,
-        "lineto": 135,
-        "block": "unsigned int version\ngit_merge_driver_init_fn initialize\ngit_merge_driver_shutdown_fn shutdown\ngit_merge_driver_apply_fn apply",
-        "tdef": null,
-        "description": " Merge driver structure used to register custom merge drivers.",
-        "comments": "<p>To associate extra data with a driver, allocate extra data and put the <code>git_merge_driver</code> struct at the start of your data buffer, then cast the <code>self</code> pointer to your larger structure when your callback is invoked.</p>\n",
+        "file": "git2/sys/merge.h",
+        "line": 24,
+        "lineto": 24,
+        "tdef": "typedef",
+        "description": " \n\n git2/sys/merge.h\n ",
+        "comments": "<p>@\n{</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -32230,9 +35170,19 @@
           }
         ],
         "used": {
-          "returns": [],
+          "returns": [
+            "git_merge_driver_lookup"
+          ],
           "needs": [
-            "git_merge_driver_apply_fn"
+            "git_merge_driver_apply_fn",
+            "git_merge_driver_init_fn",
+            "git_merge_driver_register",
+            "git_merge_driver_shutdown_fn",
+            "git_merge_driver_source_ancestor",
+            "git_merge_driver_source_file_options",
+            "git_merge_driver_source_ours",
+            "git_merge_driver_source_repo",
+            "git_merge_driver_source_theirs"
           ]
         }
       }
@@ -32243,16 +35193,22 @@
         "decl": "git_merge_driver_source",
         "type": "struct",
         "value": "git_merge_driver_source",
-        "file": "sys/merge.h",
-        "line": 36,
-        "lineto": 36,
+        "file": "git2/sys/merge.h",
+        "line": 41,
+        "lineto": 41,
         "tdef": "typedef",
         "description": " A merge driver source represents the file to be merged",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
-            "git_merge_driver_apply_fn"
+            "git_merge_driver_apply_fn",
+            "git_merge_driver_source_ancestor",
+            "git_merge_driver_source_file_options",
+            "git_merge_driver_source_ours",
+            "git_merge_driver_source_repo",
+            "git_merge_driver_source_theirs"
           ]
         }
       }
@@ -32267,7 +35223,7 @@
           "GIT_MERGE_FILE_FAVOR_UNION"
         ],
         "type": "enum",
-        "file": "merge.h",
+        "file": "git2/merge.h",
         "line": 101,
         "lineto": 131,
         "block": "GIT_MERGE_FILE_FAVOR_NORMAL\nGIT_MERGE_FILE_FAVOR_OURS\nGIT_MERGE_FILE_FAVOR_THEIRS\nGIT_MERGE_FILE_FAVOR_UNION",
@@ -32321,7 +35277,7 @@
           "GIT_MERGE_FILE_DIFF_MINIMAL"
         ],
         "type": "enum",
-        "file": "merge.h",
+        "file": "git2/merge.h",
         "line": 136,
         "lineto": 163,
         "block": "GIT_MERGE_FILE_DEFAULT\nGIT_MERGE_FILE_STYLE_MERGE\nGIT_MERGE_FILE_STYLE_DIFF3\nGIT_MERGE_FILE_SIMPLIFY_ALNUM\nGIT_MERGE_FILE_IGNORE_WHITESPACE\nGIT_MERGE_FILE_IGNORE_WHITESPACE_CHANGE\nGIT_MERGE_FILE_IGNORE_WHITESPACE_EOL\nGIT_MERGE_FILE_DIFF_PATIENCE\nGIT_MERGE_FILE_DIFF_MINIMAL",
@@ -32402,7 +35358,7 @@
         ],
         "type": "struct",
         "value": "git_merge_file_input",
-        "file": "merge.h",
+        "file": "git2/merge.h",
         "line": 32,
         "lineto": 46,
         "block": "unsigned int version\nconst char * ptr\nsize_t size\nconst char * path\nunsigned int mode",
@@ -32459,7 +35415,7 @@
         ],
         "type": "struct",
         "value": "git_merge_file_options",
-        "file": "merge.h",
+        "file": "git2/merge.h",
         "line": 170,
         "lineto": 200,
         "block": "unsigned int version\nconst char * ancestor_label\nconst char * our_label\nconst char * their_label\ngit_merge_file_favor_t favor\ngit_merge_file_flag_t flags\nunsigned short marker_size",
@@ -32504,7 +35460,9 @@
           }
         ],
         "used": {
-          "returns": [],
+          "returns": [
+            "git_merge_driver_source_file_options"
+          ],
           "needs": [
             "git_merge_file",
             "git_merge_file_from_index",
@@ -32525,9 +35483,9 @@
         ],
         "type": "struct",
         "value": "git_merge_file_result",
-        "file": "merge.h",
-        "line": 221,
-        "lineto": 242,
+        "file": "git2/merge.h",
+        "line": 222,
+        "lineto": 243,
         "block": "unsigned int automergeable\nconst char * path\nunsigned int mode\nconst char * ptr\nsize_t len",
         "tdef": "typedef",
         "description": " Information about file-level merging",
@@ -32579,7 +35537,7 @@
           "GIT_MERGE_NO_RECURSIVE"
         ],
         "type": "enum",
-        "file": "merge.h",
+        "file": "git2/merge.h",
         "line": 68,
         "lineto": 95,
         "block": "GIT_MERGE_FIND_RENAMES\nGIT_MERGE_FAIL_ON_CONFLICT\nGIT_MERGE_SKIP_REUC\nGIT_MERGE_NO_RECURSIVE",
@@ -32634,9 +35592,9 @@
         ],
         "type": "struct",
         "value": "git_merge_options",
-        "file": "merge.h",
-        "line": 247,
-        "lineto": 296,
+        "file": "git2/merge.h",
+        "line": 248,
+        "lineto": 297,
         "block": "unsigned int version\ngit_merge_flag_t flags\nunsigned int rename_threshold\nunsigned int target_limit\ngit_diff_similarity_metric * metric\nunsigned int recursion_limit\nconst char * default_driver\ngit_merge_file_favor_t file_favor\ngit_merge_file_flag_t file_flags",
         "tdef": "typedef",
         "description": " Merging options",
@@ -32710,9 +35668,9 @@
           "GIT_MERGE_PREFERENCE_FASTFORWARD_ONLY"
         ],
         "type": "enum",
-        "file": "merge.h",
-        "line": 352,
-        "lineto": 370,
+        "file": "git2/merge.h",
+        "line": 354,
+        "lineto": 372,
         "block": "GIT_MERGE_PREFERENCE_NONE\nGIT_MERGE_PREFERENCE_NO_FASTFORWARD\nGIT_MERGE_PREFERENCE_FASTFORWARD_ONLY",
         "tdef": "typedef",
         "description": " The user's stated preference for merges.",
@@ -32746,24 +35704,6 @@
       }
     ],
     [
-      "git_merge_result",
-      {
-        "decl": "git_merge_result",
-        "type": "struct",
-        "value": "git_merge_result",
-        "file": "types.h",
-        "line": 185,
-        "lineto": 185,
-        "tdef": "typedef",
-        "description": " Merge result ",
-        "comments": "",
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
       "git_message_trailer",
       {
         "decl": [
@@ -32772,7 +35712,7 @@
         ],
         "type": "struct",
         "value": "git_message_trailer",
-        "file": "message.h",
+        "file": "git2/message.h",
         "line": 43,
         "lineto": 46,
         "block": "const char * key\nconst char * value",
@@ -32810,13 +35750,13 @@
         ],
         "type": "struct",
         "value": "git_message_trailer_array",
-        "file": "message.h",
+        "file": "git2/message.h",
         "line": 54,
         "lineto": 60,
         "block": "git_message_trailer * trailers\nsize_t count\nchar * _trailer_block",
         "tdef": "typedef",
         "description": " Represents an array of git message trailers.",
-        "comments": "<p>Struct members under the private comment are private, subject to change and should not be used by callers.</p>\n",
+        "comments": "<p>Struct members under the private comment are private, subject to change\n and should not be used by callers.</p>\n",
         "fields": [
           {
             "type": "git_message_trailer *",
@@ -32849,12 +35789,13 @@
         "decl": "git_note",
         "type": "struct",
         "value": "git_note",
-        "file": "types.h",
-        "line": 153,
-        "lineto": 153,
+        "file": "git2/types.h",
+        "line": 156,
+        "lineto": 156,
         "tdef": "typedef",
         "description": " Representation of a git note ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -32880,7 +35821,7 @@
         "decl": "git_note_iterator",
         "type": "struct",
         "value": "git_note_iterator",
-        "file": "notes.h",
+        "file": "git2/notes.h",
         "line": 35,
         "lineto": 35,
         "tdef": "typedef",
@@ -32903,12 +35844,13 @@
         "decl": "git_object",
         "type": "struct",
         "value": "git_object",
-        "file": "types.h",
-        "line": 111,
-        "lineto": 111,
+        "file": "git2/types.h",
+        "line": 114,
+        "lineto": 114,
         "tdef": "typedef",
         "description": " Representation of a generic object in a repository ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -32945,12 +35887,13 @@
         "decl": "git_odb",
         "type": "struct",
         "value": "git_odb",
-        "file": "types.h",
-        "line": 81,
-        "lineto": 81,
+        "file": "git2/types.h",
+        "line": 84,
+        "lineto": 84,
         "tdef": "typedef",
         "description": " An open object database handle. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -32962,6 +35905,7 @@
             "git_odb_add_backend",
             "git_odb_add_disk_alternate",
             "git_odb_backend_loose",
+            "git_odb_backend_malloc",
             "git_odb_backend_one_pack",
             "git_odb_backend_pack",
             "git_odb_exists",
@@ -33005,9 +35949,9 @@
         "decl": "git_odb_backend",
         "type": "struct",
         "value": "git_odb_backend",
-        "file": "types.h",
-        "line": 84,
-        "lineto": 84,
+        "file": "git2/types.h",
+        "line": 87,
+        "lineto": 87,
         "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_otype *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_otype *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_otype *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_otype) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_otype) writestream\nint (*)(git_odb_stream **, size_t *, git_otype *, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
         "tdef": "typedef",
         "description": " A custom backend in an ODB ",
@@ -33098,6 +36042,7 @@
             "git_odb_add_alternate",
             "git_odb_add_backend",
             "git_odb_backend_loose",
+            "git_odb_backend_malloc",
             "git_odb_backend_one_pack",
             "git_odb_backend_pack",
             "git_odb_get_backend",
@@ -33116,7 +36061,7 @@
         ],
         "type": "struct",
         "value": "git_odb_expand_id",
-        "file": "odb.h",
+        "file": "git2/odb.h",
         "line": 180,
         "lineto": 195,
         "block": "git_oid id\nunsigned short length\ngit_otype type",
@@ -33154,12 +36099,13 @@
         "decl": "git_odb_object",
         "type": "struct",
         "value": "git_odb_object",
-        "file": "types.h",
-        "line": 87,
-        "lineto": 87,
+        "file": "git2/types.h",
+        "line": 90,
+        "lineto": 90,
         "tdef": "typedef",
         "description": " An object read from the ODB ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33181,10 +36127,10 @@
         "decl": "git_odb_stream",
         "type": "struct",
         "value": "git_odb_stream",
-        "file": "types.h",
-        "line": 90,
-        "lineto": 90,
-        "block": "git_odb_backend * backend\nunsigned int mode\nvoid * hash_ctx\ngit_off_t declared_size\ngit_off_t received_bytes\nint (*)(git_odb_stream *, char *, size_t) read\nint (*)(git_odb_stream *, const char *, size_t) write\nint (*)(git_odb_stream *, const int *) finalize_write\nvoid (*)(git_odb_stream *) free",
+        "file": "git2/types.h",
+        "line": 93,
+        "lineto": 93,
+        "block": "git_odb_backend * backend\nunsigned int mode\nvoid * hash_ctx\ngit_off_t declared_size\ngit_off_t received_bytes\nint (*)(git_odb_stream *, char *, size_t) read\nint (*)(git_odb_stream *, const char *, size_t) write\nint (*)(git_odb_stream *, const git_oid *) finalize_write\nvoid (*)(git_odb_stream *) free",
         "tdef": "typedef",
         "description": " A stream to read/write from the ODB ",
         "comments": "",
@@ -33225,7 +36171,7 @@
             "comments": " Write `len` bytes from `buffer` into the stream."
           },
           {
-            "type": "int (*)(git_odb_stream *, const int *)",
+            "type": "int (*)(git_odb_stream *, const git_oid *)",
             "name": "finalize_write",
             "comments": " Store the contents of the stream as an object with the id\n specified in `oid`.\n\n This method might not be invoked if:\n - an error occurs earlier with the `write` callback,\n - the object referred to by `oid` already exists in any backend, or\n - the final number of received bytes differs from the size declared\n   with `git_odb_open_wstream()`"
           },
@@ -33257,7 +36203,7 @@
           "GIT_STREAM_RW"
         ],
         "type": "enum",
-        "file": "odb_backend.h",
+        "file": "git2/odb_backend.h",
         "line": 70,
         "lineto": 74,
         "block": "GIT_STREAM_RDONLY\nGIT_STREAM_WRONLY\nGIT_STREAM_RW",
@@ -33296,9 +36242,9 @@
         "decl": "git_odb_writepack",
         "type": "struct",
         "value": "git_odb_writepack",
-        "file": "types.h",
-        "line": 93,
-        "lineto": 93,
+        "file": "git2/types.h",
+        "line": 96,
+        "lineto": 96,
         "block": "git_odb_backend * backend\nint (*)(git_odb_writepack *, const void *, size_t, git_transfer_progress *) append\nint (*)(git_odb_writepack *, git_transfer_progress *) commit\nvoid (*)(git_odb_writepack *) free",
         "tdef": "typedef",
         "description": " A stream to write a packfile to the ODB ",
@@ -33341,7 +36287,7 @@
         ],
         "type": "struct",
         "value": "git_oid",
-        "file": "oid.h",
+        "file": "git2/oid.h",
         "line": 33,
         "lineto": 36,
         "block": "unsigned char [20] id",
@@ -33403,6 +36349,7 @@
             "git_diff_patchid",
             "git_graph_ahead_behind",
             "git_graph_descendant_of",
+            "git_index_reuc_add",
             "git_index_write_tree",
             "git_index_write_tree_to",
             "git_merge_base",
@@ -33461,18 +36408,24 @@
             "git_reference_name_to_id",
             "git_reference_set_target",
             "git_reflog_append",
+            "git_repository_fetchhead_foreach_cb",
             "git_repository_hashfile",
+            "git_repository_mergehead_foreach_cb",
             "git_repository_set_head_detached",
             "git_revwalk_hide",
             "git_revwalk_hide_cb",
             "git_revwalk_next",
             "git_revwalk_push",
+            "git_stash_cb",
+            "git_stash_save",
             "git_tag_annotation_create",
             "git_tag_create",
             "git_tag_create_frombuffer",
             "git_tag_create_lightweight",
+            "git_tag_foreach_cb",
             "git_tag_lookup",
             "git_tag_lookup_prefix",
+            "git_transaction_set_target",
             "git_tree_create_updated",
             "git_tree_entry_byid",
             "git_tree_lookup",
@@ -33490,12 +36443,13 @@
         "decl": "git_oid_shorten",
         "type": "struct",
         "value": "git_oid_shorten",
-        "file": "oid.h",
+        "file": "git2/oid.h",
         "line": 215,
         "lineto": 215,
         "tdef": "typedef",
         "description": " OID Shortener object",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_oid_shorten_new"
@@ -33516,7 +36470,7 @@
         ],
         "type": "struct",
         "value": "git_oidarray",
-        "file": "oidarray.h",
+        "file": "git2/oidarray.h",
         "line": 16,
         "lineto": 19,
         "block": "git_oid * ids\nsize_t count",
@@ -33561,9 +36515,9 @@
           "GIT_OBJ_REF_DELTA"
         ],
         "type": "enum",
-        "file": "types.h",
-        "line": 67,
-        "lineto": 78,
+        "file": "git2/types.h",
+        "line": 70,
+        "lineto": 81,
         "block": "GIT_OBJ_ANY\nGIT_OBJ_BAD\nGIT_OBJ__EXT1\nGIT_OBJ_COMMIT\nGIT_OBJ_TREE\nGIT_OBJ_BLOB\nGIT_OBJ_TAG\nGIT_OBJ__EXT2\nGIT_OBJ_OFS_DELTA\nGIT_OBJ_REF_DELTA",
         "tdef": "typedef",
         "description": " Basic type (loose or packed) of any Git object. ",
@@ -33664,12 +36618,13 @@
         "decl": "git_packbuilder",
         "type": "struct",
         "value": "git_packbuilder",
-        "file": "types.h",
-        "line": 156,
-        "lineto": 156,
+        "file": "git2/types.h",
+        "line": 159,
+        "lineto": 159,
         "tdef": "typedef",
         "description": " Representation of a git packbuilder ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33686,6 +36641,7 @@
             "git_packbuilder_set_callbacks",
             "git_packbuilder_set_threads",
             "git_packbuilder_write",
+            "git_packbuilder_write_buf",
             "git_packbuilder_written"
           ]
         }
@@ -33699,7 +36655,7 @@
           "GIT_PACKBUILDER_DELTAFICATION"
         ],
         "type": "enum",
-        "file": "pack.h",
+        "file": "git2/pack.h",
         "line": 51,
         "lineto": 54,
         "block": "GIT_PACKBUILDER_ADDING_OBJECTS\nGIT_PACKBUILDER_DELTAFICATION",
@@ -33732,12 +36688,13 @@
         "decl": "git_patch",
         "type": "struct",
         "value": "git_patch",
-        "file": "patch.h",
+        "file": "git2/patch.h",
         "line": 29,
         "lineto": 29,
         "tdef": "typedef",
         "description": " The diff patch is used to store all the text diffs for a delta.",
-        "comments": "<p>You can easily loop over the content of patches and get information about them.</p>\n",
+        "comments": "<p>You can easily loop over the content of patches and get information about\n them.</p>\n",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33760,17 +36717,106 @@
       }
     ],
     [
+      "git_path_fs",
+      {
+        "decl": [
+          "GIT_PATH_FS_GENERIC",
+          "GIT_PATH_FS_NTFS",
+          "GIT_PATH_FS_HFS"
+        ],
+        "type": "enum",
+        "file": "git2/sys/path.h",
+        "line": 34,
+        "lineto": 41,
+        "block": "GIT_PATH_FS_GENERIC\nGIT_PATH_FS_NTFS\nGIT_PATH_FS_HFS",
+        "tdef": "typedef",
+        "description": " The kinds of checks to perform according to which filesystem we are trying to\n protect.",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_PATH_FS_GENERIC",
+            "comments": "<p>Do both NTFS- and HFS-specific checks </p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_PATH_FS_NTFS",
+            "comments": "<p>Do NTFS-specific checks only </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_PATH_FS_HFS",
+            "comments": "<p>Do HFS-specific checks only </p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_path_is_gitfile"
+          ]
+        }
+      }
+    ],
+    [
+      "git_path_gitfile",
+      {
+        "decl": [
+          "GIT_PATH_GITFILE_GITIGNORE",
+          "GIT_PATH_GITFILE_GITMODULES",
+          "GIT_PATH_GITFILE_GITATTRIBUTES"
+        ],
+        "type": "enum",
+        "file": "git2/sys/path.h",
+        "line": 21,
+        "lineto": 28,
+        "block": "GIT_PATH_GITFILE_GITIGNORE\nGIT_PATH_GITFILE_GITMODULES\nGIT_PATH_GITFILE_GITATTRIBUTES",
+        "tdef": "typedef",
+        "description": " The kinds of git-specific files we know about.",
+        "comments": "<p>The order needs to stay the same to not break the <code>gitfiles</code>\n array in path.c</p>\n",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_PATH_GITFILE_GITIGNORE",
+            "comments": "<p>Check for the .gitignore file </p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_PATH_GITFILE_GITMODULES",
+            "comments": "<p>Check for the .gitmodules file </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_PATH_GITFILE_GITATTRIBUTES",
+            "comments": "<p>Check for the .gitattributes file </p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_path_is_gitfile"
+          ]
+        }
+      }
+    ],
+    [
       "git_pathspec",
       {
         "decl": "git_pathspec",
         "type": "struct",
         "value": "git_pathspec",
-        "file": "pathspec.h",
+        "file": "git2/pathspec.h",
         "line": 20,
         "lineto": 20,
         "tdef": "typedef",
         "description": " Compiled pathspec",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33804,7 +36850,7 @@
           "GIT_PATHSPEC_FAILURES_ONLY"
         ],
         "type": "enum",
-        "file": "pathspec.h",
+        "file": "git2/pathspec.h",
         "line": 30,
         "lineto": 73,
         "block": "GIT_PATHSPEC_DEFAULT\nGIT_PATHSPEC_IGNORE_CASE\nGIT_PATHSPEC_USE_CASE\nGIT_PATHSPEC_NO_GLOB\nGIT_PATHSPEC_NO_MATCH_ERROR\nGIT_PATHSPEC_FIND_FAILURES\nGIT_PATHSPEC_FAILURES_ONLY",
@@ -33867,12 +36913,13 @@
         "decl": "git_pathspec_match_list",
         "type": "struct",
         "value": "git_pathspec_match_list",
-        "file": "pathspec.h",
+        "file": "git2/pathspec.h",
         "line": 25,
         "lineto": 25,
         "tdef": "typedef",
         "description": " List of filenames matching a pathspec",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33903,13 +36950,13 @@
         ],
         "type": "struct",
         "value": "git_proxy_options",
-        "file": "proxy.h",
+        "file": "git2/proxy.h",
         "line": 42,
         "lineto": 77,
         "block": "unsigned int version\ngit_proxy_t type\nconst char * url\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\nvoid * payload",
         "tdef": "typedef",
         "description": " Options for connecting through a proxy",
-        "comments": "<p>Note that not all types may be supported, depending on the platform and compilation options.</p>\n",
+        "comments": "<p>Note that not all types may be supported, depending on the platform\n and compilation options.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -33934,7 +36981,7 @@
           {
             "type": "git_transport_certificate_check_cb",
             "name": "certificate_check",
-            "comments": " If cert verification fails, this will be called to let the\n user make the final decision of whether to allow the\n connection to proceed. Returns 1 to allow the connection, 0\n to disallow it or a negative value to indicate an error."
+            "comments": " If cert verification fails, this will be called to let the\n user make the final decision of whether to allow the\n connection to proceed. Returns 0 to allow the connection\n or a negative value to indicate an error."
           },
           {
             "type": "void *",
@@ -33961,7 +37008,7 @@
           "GIT_PROXY_SPECIFIED"
         ],
         "type": "enum",
-        "file": "proxy.h",
+        "file": "git2/proxy.h",
         "line": 18,
         "lineto": 34,
         "block": "GIT_PROXY_NONE\nGIT_PROXY_AUTO\nGIT_PROXY_SPECIFIED",
@@ -34000,12 +37047,13 @@
         "decl": "git_push",
         "type": "struct",
         "value": "git_push",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 240,
         "lineto": 240,
         "tdef": "typedef",
         "description": " Preparation for a push operation. Can be used to configure what to\n push and the level of parallelism of the packfile builder.",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -34029,9 +37077,9 @@
         ],
         "type": "struct",
         "value": "git_push_options",
-        "file": "remote.h",
-        "line": 615,
-        "lineto": 642,
+        "file": "git2/remote.h",
+        "line": 616,
+        "lineto": 643,
         "block": "unsigned int version\nunsigned int pb_parallelism\ngit_remote_callbacks callbacks\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Controls the behavior of a git_push object.",
@@ -34084,7 +37132,7 @@
         ],
         "type": "struct",
         "value": "git_push_update",
-        "file": "remote.h",
+        "file": "git2/remote.h",
         "line": 359,
         "lineto": 376,
         "block": "char * src_refname\nchar * dst_refname\ngit_oid src\ngit_oid dst",
@@ -34127,12 +37175,13 @@
         "decl": "git_rebase",
         "type": "struct",
         "value": "git_rebase",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 191,
         "lineto": 191,
         "tdef": "typedef",
         "description": " Representation of a rebase ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_rebase_operation_byindex"
@@ -34164,13 +37213,13 @@
         ],
         "type": "struct",
         "value": "git_rebase_operation",
-        "file": "rebase.h",
-        "line": 130,
-        "lineto": 145,
+        "file": "git2/rebase.h",
+        "line": 132,
+        "lineto": 147,
         "block": "git_rebase_operation_t type\nconst git_oid id\nconst char * exec",
         "tdef": "typedef",
         "description": " A rebase operation",
-        "comments": "<p>Describes a single instruction/operation to be performed during the rebase.</p>\n",
+        "comments": "<p>Describes a single instruction/operation to be performed during the\n rebase.</p>\n",
         "fields": [
           {
             "type": "git_rebase_operation_t",
@@ -34210,9 +37259,9 @@
           "GIT_REBASE_OPERATION_EXEC"
         ],
         "type": "enum",
-        "file": "rebase.h",
-        "line": 78,
-        "lineto": 114,
+        "file": "git2/rebase.h",
+        "line": 80,
+        "lineto": 116,
         "block": "GIT_REBASE_OPERATION_PICK\nGIT_REBASE_OPERATION_REWORD\nGIT_REBASE_OPERATION_EDIT\nGIT_REBASE_OPERATION_SQUASH\nGIT_REBASE_OPERATION_FIXUP\nGIT_REBASE_OPERATION_EXEC",
         "tdef": "typedef",
         "description": " Type of rebase operation in-progress after calling `git_rebase_next`.",
@@ -34262,6 +37311,68 @@
       }
     ],
     [
+      "git_rebase_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "int quiet",
+          "int inmemory",
+          "const char * rewrite_notes_ref",
+          "git_merge_options merge_options",
+          "git_checkout_options checkout_options"
+        ],
+        "type": "struct",
+        "value": "git_rebase_options",
+        "file": "git2/rebase.h",
+        "line": 31,
+        "lineto": 75,
+        "block": "unsigned int version\nint quiet\nint inmemory\nconst char * rewrite_notes_ref\ngit_merge_options merge_options\ngit_checkout_options checkout_options",
+        "tdef": "typedef",
+        "description": " Rebase options",
+        "comments": "<p>Use to tell the rebase machinery how to operate.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "int",
+            "name": "quiet",
+            "comments": " Used by `git_rebase_init`, this will instruct other clients working\n on this rebase that you want a quiet rebase experience, which they\n may choose to provide in an application-specific manner.  This has no\n effect upon libgit2 directly, but is provided for interoperability\n between Git tools."
+          },
+          {
+            "type": "int",
+            "name": "inmemory",
+            "comments": " Used by `git_rebase_init`, this will begin an in-memory rebase,\n which will allow callers to step through the rebase operations and\n commit the rebased changes, but will not rewind HEAD or update the\n repository to be in a rebasing state.  This will not interfere with\n the working directory (if there is one)."
+          },
+          {
+            "type": "const char *",
+            "name": "rewrite_notes_ref",
+            "comments": " Used by `git_rebase_finish`, this is the name of the notes reference\n used to rewrite notes for rebased commits when finishing the rebase;\n if NULL, the contents of the configuration option `notes.rewriteRef`\n is examined, unless the configuration option `notes.rewrite.rebase`\n is set to false.  If `notes.rewriteRef` is also NULL, notes will\n not be rewritten."
+          },
+          {
+            "type": "git_merge_options",
+            "name": "merge_options",
+            "comments": " Options to control how trees are merged during `git_rebase_next`."
+          },
+          {
+            "type": "git_checkout_options",
+            "name": "checkout_options",
+            "comments": " Options to control how files are written during `git_rebase_init`,\n `git_rebase_next` and `git_rebase_abort`.  Note that a minimum\n strategy of `GIT_CHECKOUT_SAFE` is defaulted in `init` and `next`,\n and a minimum strategy of `GIT_CHECKOUT_FORCE` is defaulted in\n `abort` to match git semantics."
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_rebase_init",
+            "git_rebase_init_options",
+            "git_rebase_open"
+          ]
+        }
+      }
+    ],
+    [
       "git_ref_t",
       {
         "decl": [
@@ -34271,7 +37382,7 @@
           "GIT_REF_LISTALL"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 194,
         "lineto": 199,
         "block": "GIT_REF_INVALID\nGIT_REF_OID\nGIT_REF_SYMBOLIC\nGIT_REF_LISTALL",
@@ -34318,12 +37429,13 @@
         "decl": "git_refdb",
         "type": "struct",
         "value": "git_refdb",
-        "file": "types.h",
-        "line": 96,
-        "lineto": 96,
+        "file": "git2/types.h",
+        "line": 99,
+        "lineto": 99,
         "tdef": "typedef",
         "description": " An open refs database handle. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -34346,9 +37458,9 @@
         "decl": "git_refdb_backend",
         "type": "struct",
         "value": "git_refdb_backend",
-        "file": "types.h",
-        "line": 99,
-        "lineto": 99,
+        "file": "git2/types.h",
+        "line": 102,
+        "lineto": 102,
         "block": "unsigned int version\nint (*)(int *, git_refdb_backend *, const char *) exists\nint (*)(git_reference **, git_refdb_backend *, const char *) lookup\nint (*)(git_reference_iterator **, struct git_refdb_backend *, const char *) iterator\nint (*)(git_refdb_backend *, const git_reference *, int, const git_signature *, const char *, const git_oid *, const char *) write\nint (*)(git_reference **, git_refdb_backend *, const char *, const char *, int, const git_signature *, const char *) rename\nint (*)(git_refdb_backend *, const char *, const git_oid *, const char *) del\nint (*)(git_refdb_backend *) compress\nint (*)(git_refdb_backend *, const char *) has_log\nint (*)(git_refdb_backend *, const char *) ensure_log\nvoid (*)(git_refdb_backend *) free\nint (*)(git_reflog **, git_refdb_backend *, const char *) reflog_read\nint (*)(git_refdb_backend *, git_reflog *) reflog_write\nint (*)(git_refdb_backend *, const char *, const char *) reflog_rename\nint (*)(git_refdb_backend *, const char *) reflog_delete\nint (*)(void **, git_refdb_backend *, const char *) lock\nint (*)(git_refdb_backend *, void *, int, int, const git_reference *, const git_signature *, const char *) unlock",
         "tdef": "typedef",
         "description": " A custom backend for refs ",
@@ -34456,12 +37568,13 @@
         "decl": "git_reference",
         "type": "struct",
         "value": "git_reference",
-        "file": "types.h",
-        "line": 173,
-        "lineto": 173,
+        "file": "git2/types.h",
+        "line": 176,
+        "lineto": 176,
         "tdef": "typedef",
         "description": " In-memory representation of a reference. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_reference__alloc",
@@ -34487,6 +37600,7 @@
             "git_reference_dup",
             "git_reference_dwim",
             "git_reference_foreach",
+            "git_reference_foreach_cb",
             "git_reference_foreach_glob",
             "git_reference_foreach_name",
             "git_reference_free",
@@ -34527,9 +37641,9 @@
         "decl": "git_reference_iterator",
         "type": "struct",
         "value": "git_reference_iterator",
-        "file": "types.h",
-        "line": 176,
-        "lineto": 176,
+        "file": "git2/types.h",
+        "line": 179,
+        "lineto": 179,
         "block": "git_refdb * db\nint (*)(git_reference **, git_reference_iterator *) next\nint (*)(const char **, git_reference_iterator *) next_name\nvoid (*)(git_reference_iterator *) free",
         "tdef": "typedef",
         "description": " Iterator for references ",
@@ -34578,7 +37692,7 @@
           "GIT_REF_FORMAT_REFSPEC_SHORTHAND"
         ],
         "type": "enum",
-        "file": "refs.h",
+        "file": "git2/refs.h",
         "line": 639,
         "lineto": 668,
         "block": "GIT_REF_FORMAT_NORMAL\nGIT_REF_FORMAT_ALLOW_ONELEVEL\nGIT_REF_FORMAT_REFSPEC_PATTERN\nGIT_REF_FORMAT_REFSPEC_SHORTHAND",
@@ -34623,19 +37737,22 @@
         "decl": "git_reflog",
         "type": "struct",
         "value": "git_reflog",
-        "file": "types.h",
-        "line": 150,
-        "lineto": 150,
+        "file": "git2/types.h",
+        "line": 153,
+        "lineto": 153,
         "tdef": "typedef",
         "description": " Representation of a reference log ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
+            "git_reflog_entry__alloc",
             "git_reflog_entry_byindex"
           ],
           "needs": [
             "git_reflog_append",
             "git_reflog_drop",
+            "git_reflog_entry__free",
             "git_reflog_entry_byindex",
             "git_reflog_entry_committer",
             "git_reflog_entry_id_new",
@@ -34644,7 +37761,8 @@
             "git_reflog_entrycount",
             "git_reflog_free",
             "git_reflog_read",
-            "git_reflog_write"
+            "git_reflog_write",
+            "git_transaction_set_reflog"
           ]
         }
       }
@@ -34655,21 +37773,57 @@
         "decl": "git_reflog_entry",
         "type": "struct",
         "value": "git_reflog_entry",
-        "file": "types.h",
-        "line": 147,
-        "lineto": 147,
+        "file": "git2/types.h",
+        "line": 150,
+        "lineto": 150,
         "tdef": "typedef",
         "description": " Representation of a reference log entry ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
+            "git_reflog_entry__alloc",
             "git_reflog_entry_byindex"
           ],
           "needs": [
+            "git_reflog_entry__free",
             "git_reflog_entry_committer",
             "git_reflog_entry_id_new",
             "git_reflog_entry_id_old",
             "git_reflog_entry_message"
+          ]
+        }
+      }
+    ],
+    [
+      "git_refspec",
+      {
+        "decl": "git_refspec",
+        "type": "struct",
+        "value": "git_refspec",
+        "file": "git2/types.h",
+        "line": 222,
+        "lineto": 222,
+        "tdef": "typedef",
+        "description": " A refspec specifies the mapping between remote and local reference\n names when fetch or pushing.",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [
+            "git_remote_get_refspec"
+          ],
+          "needs": [
+            "git_refspec_direction",
+            "git_refspec_dst",
+            "git_refspec_dst_matches",
+            "git_refspec_force",
+            "git_refspec_free",
+            "git_refspec_parse",
+            "git_refspec_rtransform",
+            "git_refspec_src",
+            "git_refspec_src_matches",
+            "git_refspec_string",
+            "git_refspec_transform"
           ]
         }
       }
@@ -34680,12 +37834,13 @@
         "decl": "git_remote",
         "type": "struct",
         "value": "git_remote",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 228,
         "lineto": 228,
         "tdef": "typedef",
         "description": " Git's idea of a remote repository. A remote can be anonymous (in\n which case it does not have backing configuration entires).",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_remote_autotag"
@@ -34745,7 +37900,7 @@
           "GIT_REMOTE_DOWNLOAD_TAGS_ALL"
         ],
         "type": "enum",
-        "file": "remote.h",
+        "file": "git2/remote.h",
         "line": 527,
         "lineto": 545,
         "block": "GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED\nGIT_REMOTE_DOWNLOAD_TAGS_AUTO\nGIT_REMOTE_DOWNLOAD_TAGS_NONE\nGIT_REMOTE_DOWNLOAD_TAGS_ALL",
@@ -34792,30 +37947,16 @@
     [
       "git_remote_callbacks",
       {
-        "decl": [
-          "unsigned int version",
-          "git_transport_message_cb sideband_progress",
-          "int (*)(git_remote_completion_type, void *) completion",
-          "git_cred_acquire_cb credentials",
-          "git_transport_certificate_check_cb certificate_check",
-          "git_transfer_progress_cb transfer_progress",
-          "int (*)(const char *, const git_oid *, const git_oid *, void *) update_tips",
-          "git_packbuilder_progress pack_progress",
-          "git_push_transfer_progress push_transfer_progress",
-          "git_push_update_reference_cb push_update_reference",
-          "git_push_negotiation push_negotiation",
-          "git_transport_cb transport",
-          "void * payload"
-        ],
+        "decl": "git_remote_callbacks",
         "type": "struct",
         "value": "git_remote_callbacks",
-        "file": "remote.h",
-        "line": 408,
-        "lineto": 490,
+        "file": "git2/types.h",
+        "line": 244,
+        "lineto": 244,
         "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_type, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_transfer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress push_transfer_progress\ngit_push_update_reference_cb push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload",
-        "tdef": null,
-        "description": " The callback settings structure",
-        "comments": "<p>Set the callbacks to be called by the remote when informing the user about the progress of the network operations.</p>\n",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -34840,7 +37981,7 @@
           {
             "type": "git_transport_certificate_check_cb",
             "name": "certificate_check",
-            "comments": " If cert verification fails, this will be called to let the\n user make the final decision of whether to allow the\n connection to proceed. Returns 1 to allow the connection, 0\n to disallow it or a negative value to indicate an error."
+            "comments": " If cert verification fails, this will be called to let the\n user make the final decision of whether to allow the\n connection to proceed. Returns 0 to allow the connection\n or a negative value to indicate an error."
           },
           {
             "type": "git_transfer_progress_cb",
@@ -34903,7 +38044,7 @@
           "GIT_REMOTE_COMPLETION_ERROR"
         ],
         "type": "enum",
-        "file": "remote.h",
+        "file": "git2/remote.h",
         "line": 344,
         "lineto": 348,
         "block": "GIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR\nGIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR",
@@ -34939,21 +38080,15 @@
     [
       "git_remote_head",
       {
-        "decl": [
-          "int local",
-          "git_oid oid",
-          "git_oid loid",
-          "char * name",
-          "char * symref_target"
-        ],
+        "decl": "git_remote_head",
         "type": "struct",
         "value": "git_remote_head",
-        "file": "net.h",
-        "line": 40,
-        "lineto": 50,
+        "file": "git2/types.h",
+        "line": 243,
+        "lineto": 243,
         "block": "int local\ngit_oid oid\ngit_oid loid\nchar * name\nchar * symref_target",
-        "tdef": null,
-        "description": " Description of a reference advertised by a remote server, given out\n on `ls` calls.",
+        "tdef": "typedef",
+        "description": "",
         "comments": "",
         "fields": [
           {
@@ -34997,18 +38132,20 @@
         "decl": "git_repository",
         "type": "struct",
         "value": "git_repository",
-        "file": "types.h",
-        "line": 105,
-        "lineto": 105,
+        "file": "git2/types.h",
+        "line": 108,
+        "lineto": 108,
         "tdef": "typedef",
         "description": " Representation of an existing git repository,\n including all its object contents",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_blob_owner",
             "git_commit_owner",
             "git_filter_source_repo",
             "git_index_owner",
+            "git_merge_driver_source_repo",
             "git_object_owner",
             "git_reference_owner",
             "git_remote_owner",
@@ -35038,6 +38175,9 @@
             "git_branch_create_from_annotated",
             "git_branch_iterator_new",
             "git_branch_lookup",
+            "git_branch_remote_name",
+            "git_branch_upstream_name",
+            "git_branch_upstream_remote",
             "git_checkout_head",
             "git_checkout_index",
             "git_checkout_tree",
@@ -35073,6 +38213,7 @@
             "git_ignore_clear_internal_rules",
             "git_ignore_path_is_ignored",
             "git_index_write_tree_to",
+            "git_mailmap_from_repository",
             "git_mempack_dump",
             "git_merge",
             "git_merge_analysis",
@@ -35088,6 +38229,7 @@
             "git_note_commit_read",
             "git_note_commit_remove",
             "git_note_create",
+            "git_note_default_ref",
             "git_note_foreach",
             "git_note_iterator_new",
             "git_note_read",
@@ -35145,6 +38287,7 @@
             "git_repository_hashfile",
             "git_repository_head",
             "git_repository_head_detached",
+            "git_repository_head_detached_for_worktree",
             "git_repository_head_for_worktree",
             "git_repository_head_unborn",
             "git_repository_ident",
@@ -35200,6 +38343,7 @@
             "git_stash_drop",
             "git_stash_foreach",
             "git_stash_pop",
+            "git_stash_save",
             "git_status_file",
             "git_status_foreach",
             "git_status_foreach_ext",
@@ -35227,6 +38371,7 @@
             "git_tag_list_match",
             "git_tag_lookup",
             "git_tag_lookup_prefix",
+            "git_transaction_new",
             "git_tree_create_updated",
             "git_tree_entry_to_object",
             "git_tree_lookup",
@@ -35253,13 +38398,13 @@
           "GIT_REPOSITORY_INIT_RELATIVE_GITLINK"
         ],
         "type": "enum",
-        "file": "repository.h",
+        "file": "git2/repository.h",
         "line": 232,
         "lineto": 240,
         "block": "GIT_REPOSITORY_INIT_BARE\nGIT_REPOSITORY_INIT_NO_REINIT\nGIT_REPOSITORY_INIT_NO_DOTGIT_DIR\nGIT_REPOSITORY_INIT_MKDIR\nGIT_REPOSITORY_INIT_MKPATH\nGIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE\nGIT_REPOSITORY_INIT_RELATIVE_GITLINK",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_init_ext`.",
-        "comments": "<p>These flags configure extra behaviors to <code>git_repository_init_ext</code>. In every case, the default behavior is the zero value (i.e. flag is not set).  Just OR the flag values together for the <code>flags</code> parameter when initializing a new repo.  Details of individual values are:</p>\n\n<ul>\n<li>BARE   - Create a bare repository with no working directory. * NO_REINIT - Return an GIT_EEXISTS error if the repo_path appears to        already be an git repository. * NO_DOTGIT_DIR - Normally a &quot;/.git/&quot; will be appended to the repo        path for non-bare repos (if it is not already there), but        passing this flag prevents that behavior. * MKDIR  - Make the repo_path (and workdir_path) as needed.  Init is        always willing to create the &quot;.git&quot; directory even without this        flag.  This flag tells init to create the trailing component of        the repo and workdir paths as needed. * MKPATH - Recursively make all components of the repo and workdir        paths as necessary. * EXTERNAL_TEMPLATE - libgit2 normally uses internal templates to        initialize a new repo.  This flags enables external templates,        looking the &quot;template_path&quot; from the options if set, or the        <code>init.templatedir</code> global config if not, or falling back on        &quot;/usr/share/git-core/templates&quot; if it exists. * GIT_REPOSITORY_INIT_RELATIVE_GITLINK - If an alternate workdir is        specified, use relative paths for the gitdir and core.worktree.</li>\n</ul>\n",
+        "comments": "<p>These flags configure extra behaviors to <code>git_repository_init_ext</code>.\n In every case, the default behavior is the zero value (i.e. flag is\n not set).  Just OR the flag values together for the <code>flags</code> parameter\n when initializing a new repo.  Details of individual values are:</p>\n\n<ul>\n<li>BARE   - Create a bare repository with no working directory.</li>\n<li>NO_REINIT - Return an GIT_EEXISTS error if the repo_path appears to\n    already be an git repository.</li>\n<li>NO_DOTGIT_DIR - Normally a &quot;/.git/&quot; will be appended to the repo\n    path for non-bare repos (if it is not already there), but\n    passing this flag prevents that behavior.</li>\n<li>MKDIR  - Make the repo_path (and workdir_path) as needed.  Init is\n    always willing to create the &quot;.git&quot; directory even without this\n    flag.  This flag tells init to create the trailing component of\n    the repo and workdir paths as needed.</li>\n<li>MKPATH - Recursively make all components of the repo and workdir\n    paths as necessary.</li>\n<li>EXTERNAL_TEMPLATE - libgit2 normally uses internal templates to\n    initialize a new repo.  This flags enables external templates,\n    looking the &quot;template_path&quot; from the options if set, or the\n    <code>init.templatedir</code> global config if not, or falling back on\n    &quot;/usr/share/git-core/templates&quot; if it exists.</li>\n<li>GIT_REPOSITORY_INIT_RELATIVE_GITLINK - If an alternate workdir is\n    specified, use relative paths for the gitdir and core.worktree.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -35319,13 +38464,13 @@
           "GIT_REPOSITORY_INIT_SHARED_ALL"
         ],
         "type": "enum",
-        "file": "repository.h",
+        "file": "git2/repository.h",
         "line": 255,
         "lineto": 259,
         "block": "GIT_REPOSITORY_INIT_SHARED_UMASK\nGIT_REPOSITORY_INIT_SHARED_GROUP\nGIT_REPOSITORY_INIT_SHARED_ALL",
         "tdef": "typedef",
         "description": " Mode options for `git_repository_init_ext`.",
-        "comments": "<p>Set the mode field of the <code>git_repository_init_options</code> structure either to the custom mode that you would like, or to one of the following modes:</p>\n\n<ul>\n<li>SHARED_UMASK - Use permissions configured by umask - the default. * SHARED_GROUP - Use &quot;--shared=group&quot; behavior, chmod&#39;ing the new repo        to be group writable and &quot;g+sx&quot; for sticky group assignment. * SHARED_ALL - Use &quot;--shared=all&quot; behavior, adding world readability. * Anything else - Set to custom value.</li>\n</ul>\n",
+        "comments": "<p>Set the mode field of the <code>git_repository_init_options</code> structure\n either to the custom mode that you would like, or to one of the\n following modes:</p>\n\n<ul>\n<li>SHARED_UMASK - Use permissions configured by umask - the default.</li>\n<li>SHARED_GROUP - Use &quot;--shared=group&quot; behavior, chmod&#39;ing the new repo\n    to be group writable and &quot;g+sx&quot; for sticky group assignment.</li>\n<li>SHARED_ALL - Use &quot;--shared=all&quot; behavior, adding world readability.</li>\n<li>Anything else - Set to custom value.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -35367,13 +38512,13 @@
         ],
         "type": "struct",
         "value": "git_repository_init_options",
-        "file": "repository.h",
+        "file": "git2/repository.h",
         "line": 289,
         "lineto": 298,
         "block": "unsigned int version\nuint32_t flags\nuint32_t mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
         "tdef": "typedef",
         "description": " Extended options structure for `git_repository_init_ext`.",
-        "comments": "<p>This contains extra options for <code>git_repository_init_ext</code> that enable additional initialization features.  The fields are:</p>\n\n<ul>\n<li>flags - Combination of GIT_REPOSITORY_INIT flags above. * mode  - Set to one of the standard GIT_REPOSITORY_INIT_SHARED_...        constants above, or to a custom value that you would like. * workdir_path - The path to the working dir or NULL for default (i.e.        repo_path parent on non-bare repos).  IF THIS IS RELATIVE PATH,        IT WILL BE EVALUATED RELATIVE TO THE REPO_PATH.  If this is not        the &quot;natural&quot; working directory, a .git gitlink file will be        created here linking to the repo_path. * description - If set, this will be used to initialize the &quot;description&quot;        file in the repository, instead of using the template content. * template_path - When GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE is set,        this contains the path to use for the template directory.  If        this is NULL, the config or default directory options will be        used instead. * initial_head - The name of the head to point HEAD at.  If NULL, then        this will be treated as &quot;master&quot; and the HEAD ref will be set        to &quot;refs/heads/master&quot;.  If this begins with &quot;refs/&quot; it will be        used verbatim; otherwise &quot;refs/heads/&quot; will be prefixed. * origin_url - If this is non-NULL, then after the rest of the        repository initialization is completed, an &quot;origin&quot; remote        will be added pointing to this URL.</li>\n</ul>\n",
+        "comments": "<p>This contains extra options for <code>git_repository_init_ext</code> that enable\n additional initialization features.  The fields are:</p>\n\n<ul>\n<li>flags - Combination of GIT_REPOSITORY_INIT flags above.</li>\n<li>mode  - Set to one of the standard GIT_REPOSITORY_INIT_SHARED_...\n    constants above, or to a custom value that you would like.</li>\n<li>workdir_path - The path to the working dir or NULL for default (i.e.\n    repo_path parent on non-bare repos).  IF THIS IS RELATIVE PATH,\n    IT WILL BE EVALUATED RELATIVE TO THE REPO_PATH.  If this is not\n    the &quot;natural&quot; working directory, a .git gitlink file will be\n    created here linking to the repo_path.</li>\n<li>description - If set, this will be used to initialize the &quot;description&quot;\n    file in the repository, instead of using the template content.</li>\n<li>template_path - When GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE is set,\n    this contains the path to use for the template directory.  If\n    this is NULL, the config or default directory options will be\n    used instead.</li>\n<li>initial_head - The name of the head to point HEAD at.  If NULL, then\n    this will be treated as &quot;master&quot; and the HEAD ref will be set\n    to &quot;refs/heads/master&quot;.  If this begins with &quot;refs/&quot; it will be\n    used verbatim; otherwise &quot;refs/heads/&quot; will be prefixed.</li>\n<li>origin_url - If this is non-NULL, then after the rest of the\n    repository initialization is completed, an &quot;origin&quot; remote\n    will be added pointing to this URL.</li>\n</ul>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -35445,9 +38590,9 @@
           "GIT_REPOSITORY_ITEM_WORKTREES"
         ],
         "type": "enum",
-        "file": "repository.h",
-        "line": 412,
-        "lineto": 427,
+        "file": "git2/repository.h",
+        "line": 414,
+        "lineto": 429,
         "block": "GIT_REPOSITORY_ITEM_GITDIR\nGIT_REPOSITORY_ITEM_WORKDIR\nGIT_REPOSITORY_ITEM_COMMONDIR\nGIT_REPOSITORY_ITEM_INDEX\nGIT_REPOSITORY_ITEM_OBJECTS\nGIT_REPOSITORY_ITEM_REFS\nGIT_REPOSITORY_ITEM_PACKED_REFS\nGIT_REPOSITORY_ITEM_REMOTES\nGIT_REPOSITORY_ITEM_CONFIG\nGIT_REPOSITORY_ITEM_INFO\nGIT_REPOSITORY_ITEM_HOOKS\nGIT_REPOSITORY_ITEM_LOGS\nGIT_REPOSITORY_ITEM_MODULES\nGIT_REPOSITORY_ITEM_WORKTREES",
         "tdef": "typedef",
         "description": " List of items which belong to the git repository layout",
@@ -35557,13 +38702,13 @@
           "GIT_REPOSITORY_OPEN_FROM_ENV"
         ],
         "type": "enum",
-        "file": "repository.h",
+        "file": "git2/repository.h",
         "line": 126,
         "lineto": 132,
         "block": "GIT_REPOSITORY_OPEN_NO_SEARCH\nGIT_REPOSITORY_OPEN_CROSS_FS\nGIT_REPOSITORY_OPEN_BARE\nGIT_REPOSITORY_OPEN_NO_DOTGIT\nGIT_REPOSITORY_OPEN_FROM_ENV",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_open_ext`.",
-        "comments": "<ul>\n<li>GIT_REPOSITORY_OPEN_NO_SEARCH - Only open the repository if it can be   immediately found in the start_path.  Do not walk up from the   start_path looking at parent directories. * GIT_REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not   continue searching across filesystem boundaries (i.e. when <code>st_dev</code>   changes from the <code>stat</code> system call).  (E.g. Searching in a user&#39;s home   directory &quot;/home/user/source/&quot; will not return &quot;/.git/&quot; as the found   repo if &quot;/&quot; is a different filesystem than &quot;/home&quot;.) * GIT_REPOSITORY_OPEN_BARE - Open repository as a bare repo regardless   of core.bare config, and defer loading config file for faster setup.   Unlike <code>git_repository_open_bare</code>, this can follow gitlinks. * GIT_REPOSITORY_OPEN_NO_DOTGIT - Do not check for a repository by   appending /.git to the start_path; only open the repository if   start_path itself points to the git directory. * GIT_REPOSITORY_OPEN_FROM_ENV - Find and open a git repository,   respecting the environment variables used by the git command-line   tools. If set, <code>git_repository_open_ext</code> will ignore the other   flags and the <code>ceiling_dirs</code> argument, and will allow a NULL <code>path</code>   to use <code>GIT_DIR</code> or search from the current directory. The search   for a repository will respect $GIT_CEILING_DIRECTORIES and   $GIT_DISCOVERY_ACROSS_FILESYSTEM.  The opened repository will   respect $GIT_INDEX_FILE, $GIT_NAMESPACE, $GIT_OBJECT_DIRECTORY, and   $GIT_ALTERNATE_OBJECT_DIRECTORIES.  In the future, this flag will   also cause <code>git_repository_open_ext</code> to respect $GIT_WORK_TREE and   $GIT_COMMON_DIR; currently, <code>git_repository_open_ext</code> with this   flag will error out if either $GIT_WORK_TREE or $GIT_COMMON_DIR is   set.</li>\n</ul>\n",
+        "comments": "<ul>\n<li>GIT_REPOSITORY_OPEN_NO_SEARCH - Only open the repository if it can be\nimmediately found in the start_path.  Do not walk up from the\nstart_path looking at parent directories.</li>\n<li>GIT_REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not\ncontinue searching across filesystem boundaries (i.e. when <code>st_dev</code>\nchanges from the <code>stat</code> system call).  (E.g. Searching in a user&#39;s home\ndirectory &quot;/home/user/source/&quot; will not return &quot;/.git/&quot; as the found\nrepo if &quot;/&quot; is a different filesystem than &quot;/home&quot;.)</li>\n<li>GIT_REPOSITORY_OPEN_BARE - Open repository as a bare repo regardless\nof core.bare config, and defer loading config file for faster setup.\nUnlike <code>git_repository_open_bare</code>, this can follow gitlinks.</li>\n<li>GIT_REPOSITORY_OPEN_NO_DOTGIT - Do not check for a repository by\nappending /.git to the start_path; only open the repository if\nstart_path itself points to the git directory.</li>\n<li>GIT_REPOSITORY_OPEN_FROM_ENV - Find and open a git repository,\nrespecting the environment variables used by the git command-line\ntools. If set, <code>git_repository_open_ext</code> will ignore the other\nflags and the <code>ceiling_dirs</code> argument, and will allow a NULL <code>path</code>\nto use <code>GIT_DIR</code> or search from the current directory. The search\nfor a repository will respect $GIT_CEILING_DIRECTORIES and\n$GIT_DISCOVERY_ACROSS_FILESYSTEM.  The opened repository will\nrespect $GIT_INDEX_FILE, $GIT_NAMESPACE, $GIT_OBJECT_DIRECTORY, and\n$GIT_ALTERNATE_OBJECT_DIRECTORIES.  In the future, this flag will\nalso cause <code>git_repository_open_ext</code> to respect $GIT_WORK_TREE and\n$GIT_COMMON_DIR; currently, <code>git_repository_open_ext</code> with this\nflag will error out if either $GIT_WORK_TREE or $GIT_COMMON_DIR is\nset.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -35620,13 +38765,13 @@
           "GIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE"
         ],
         "type": "enum",
-        "file": "repository.h",
-        "line": 784,
-        "lineto": 797,
+        "file": "git2/repository.h",
+        "line": 786,
+        "lineto": 799,
         "block": "GIT_REPOSITORY_STATE_NONE\nGIT_REPOSITORY_STATE_MERGE\nGIT_REPOSITORY_STATE_REVERT\nGIT_REPOSITORY_STATE_REVERT_SEQUENCE\nGIT_REPOSITORY_STATE_CHERRYPICK\nGIT_REPOSITORY_STATE_CHERRYPICK_SEQUENCE\nGIT_REPOSITORY_STATE_BISECT\nGIT_REPOSITORY_STATE_REBASE\nGIT_REPOSITORY_STATE_REBASE_INTERACTIVE\nGIT_REPOSITORY_STATE_REBASE_MERGE\nGIT_REPOSITORY_STATE_APPLY_MAILBOX\nGIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE",
         "tdef": "typedef",
         "description": " Repository state",
-        "comments": "<p>These values represent possible states for the repository to be in, based on the current operation which is ongoing.</p>\n",
+        "comments": "<p>These values represent possible states for the repository to be in,\n based on the current operation which is ongoing.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -35716,7 +38861,7 @@
           "GIT_RESET_HARD"
         ],
         "type": "enum",
-        "file": "reset.h",
+        "file": "git2/reset.h",
         "line": 26,
         "lineto": 30,
         "block": "GIT_RESET_SOFT\nGIT_RESET_MIXED\nGIT_RESET_HARD",
@@ -35763,7 +38908,7 @@
         ],
         "type": "struct",
         "value": "git_revert_options",
-        "file": "revert.h",
+        "file": "git2/revert.h",
         "line": 26,
         "lineto": 34,
         "block": "unsigned int version\nunsigned int mainline\ngit_merge_options merge_opts\ngit_checkout_options checkout_opts",
@@ -35810,7 +38955,7 @@
           "GIT_REVPARSE_MERGE_BASE"
         ],
         "type": "enum",
-        "file": "revparse.h",
+        "file": "git2/revparse.h",
         "line": 71,
         "lineto": 78,
         "block": "GIT_REVPARSE_SINGLE\nGIT_REVPARSE_RANGE\nGIT_REVPARSE_MERGE_BASE",
@@ -35853,7 +38998,7 @@
         ],
         "type": "struct",
         "value": "git_revspec",
-        "file": "revparse.h",
+        "file": "git2/revparse.h",
         "line": 83,
         "lineto": 90,
         "block": "git_object * from\ngit_object * to\nunsigned int flags",
@@ -35891,12 +39036,13 @@
         "decl": "git_revwalk",
         "type": "struct",
         "value": "git_revwalk",
-        "file": "types.h",
-        "line": 114,
-        "lineto": 114,
+        "file": "git2/types.h",
+        "line": 117,
+        "lineto": 117,
         "tdef": "typedef",
         "description": " Representation of an in-progress walk through the commits in a repo ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -35932,9 +39078,9 @@
         ],
         "type": "struct",
         "value": "git_signature",
-        "file": "types.h",
-        "line": 166,
-        "lineto": 170,
+        "file": "git2/types.h",
+        "line": 169,
+        "lineto": 173,
         "block": "char * name\nchar * email\ngit_time when",
         "tdef": "typedef",
         "description": " An action signature (e.g. for committers, taggers, etc) ",
@@ -35967,11 +39113,14 @@
           ],
           "needs": [
             "git_commit_amend",
+            "git_commit_author_with_mailmap",
+            "git_commit_committer_with_mailmap",
             "git_commit_create",
             "git_commit_create_buffer",
             "git_commit_create_from_callback",
             "git_commit_create_from_ids",
             "git_commit_create_v",
+            "git_mailmap_resolve_signature",
             "git_note_commit_create",
             "git_note_commit_remove",
             "git_note_create",
@@ -35985,8 +39134,100 @@
             "git_signature_from_buffer",
             "git_signature_new",
             "git_signature_now",
+            "git_stash_save",
             "git_tag_annotation_create",
-            "git_tag_create"
+            "git_tag_create",
+            "git_transaction_set_symbolic_target",
+            "git_transaction_set_target"
+          ]
+        }
+      }
+    ],
+    [
+      "git_smart_service_t",
+      {
+        "decl": [
+          "GIT_SERVICE_UPLOADPACK_LS",
+          "GIT_SERVICE_UPLOADPACK",
+          "GIT_SERVICE_RECEIVEPACK_LS",
+          "GIT_SERVICE_RECEIVEPACK"
+        ],
+        "type": "enum",
+        "file": "git2/sys/transport.h",
+        "line": 273,
+        "lineto": 278,
+        "block": "GIT_SERVICE_UPLOADPACK_LS\nGIT_SERVICE_UPLOADPACK\nGIT_SERVICE_RECEIVEPACK_LS\nGIT_SERVICE_RECEIVEPACK",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_SERVICE_UPLOADPACK_LS",
+            "comments": "",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_SERVICE_UPLOADPACK",
+            "comments": "",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_SERVICE_RECEIVEPACK_LS",
+            "comments": "",
+            "value": 3
+          },
+          {
+            "type": "int",
+            "name": "GIT_SERVICE_RECEIVEPACK",
+            "comments": "",
+            "value": 4
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_smart_subtransport",
+      {
+        "decl": "git_smart_subtransport",
+        "type": "struct",
+        "value": "git_smart_subtransport",
+        "file": "git2/sys/transport.h",
+        "line": 280,
+        "lineto": 280,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int (*)(git_smart_subtransport_stream **, git_smart_subtransport *, const char *, git_smart_service_t)",
+            "name": "action",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_smart_subtransport *)",
+            "name": "close",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(git_smart_subtransport *)",
+            "name": "free",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_smart_subtransport_cb",
+            "git_smart_subtransport_git",
+            "git_smart_subtransport_http",
+            "git_smart_subtransport_ssh"
           ]
         }
       }
@@ -36001,13 +39242,13 @@
         ],
         "type": "struct",
         "value": "git_smart_subtransport_definition",
-        "file": "sys/transport.h",
+        "file": "git2/sys/transport.h",
         "line": 336,
         "lineto": 349,
         "block": "git_smart_subtransport_cb callback\nunsigned int rpc\nvoid * param",
         "tdef": "typedef",
         "description": " Definition for a \"subtransport\"",
-        "comments": "<p>This is used to let the smart protocol code know about the protocol which you are implementing.</p>\n",
+        "comments": "<p>This is used to let the smart protocol code know about the protocol\n which you are implementing.</p>\n",
         "fields": [
           {
             "type": "git_smart_subtransport_cb",
@@ -36032,6 +39273,46 @@
       }
     ],
     [
+      "git_smart_subtransport_stream",
+      {
+        "decl": "git_smart_subtransport_stream",
+        "type": "struct",
+        "value": "git_smart_subtransport_stream",
+        "file": "git2/sys/transport.h",
+        "line": 281,
+        "lineto": 281,
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "git_smart_subtransport *",
+            "name": "subtransport",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_smart_subtransport_stream *, char *, size_t, size_t *)",
+            "name": "read",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_smart_subtransport_stream *, const char *, size_t)",
+            "name": "write",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(git_smart_subtransport_stream *)",
+            "name": "free",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_sort_t",
       {
         "decl": [
@@ -36041,7 +39322,7 @@
           "GIT_SORT_REVERSE"
         ],
         "type": "enum",
-        "file": "revwalk.h",
+        "file": "git2/revwalk.h",
         "line": 26,
         "lineto": 53,
         "block": "GIT_SORT_NONE\nGIT_SORT_TOPOLOGICAL\nGIT_SORT_TIME\nGIT_SORT_REVERSE",
@@ -36052,13 +39333,13 @@
           {
             "type": "int",
             "name": "GIT_SORT_NONE",
-            "comments": "<p>Sort the output with the same default time-order method from git.\n This is the default sorting for new walkers.</p>\n",
+            "comments": "<p>Sort the output with the same default method from <code>git</code>: reverse\n chronological order. This is the default sorting for new walkers.</p>\n",
             "value": 0
           },
           {
             "type": "int",
             "name": "GIT_SORT_TOPOLOGICAL",
-            "comments": "<p>Sort the repository contents in topological order (parents before\n children); this sorting mode can be combined with time sorting to\n produce git&#39;s &quot;time-order&quot;.</p>\n",
+            "comments": "<p>Sort the repository contents in topological order (no parents before\n all of its children are shown); this sorting mode can be combined\n with time sorting to produce <code>git</code>&#39;s <code>--date-order</code>`.</p>\n",
             "value": 1
           },
           {
@@ -36088,9 +39369,9 @@
           "GIT_STASH_APPLY_REINSTATE_INDEX"
         ],
         "type": "enum",
-        "file": "stash.h",
-        "line": 74,
-        "lineto": 81,
+        "file": "git2/stash.h",
+        "line": 75,
+        "lineto": 82,
         "block": "GIT_STASH_APPLY_DEFAULT\nGIT_STASH_APPLY_REINSTATE_INDEX",
         "tdef": "typedef",
         "description": " Stash application flags. ",
@@ -36116,6 +39397,141 @@
       }
     ],
     [
+      "git_stash_apply_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "git_stash_apply_flags flags",
+          "git_checkout_options checkout_options",
+          "git_stash_apply_progress_cb progress_cb",
+          "void * progress_payload"
+        ],
+        "type": "struct",
+        "value": "git_stash_apply_options",
+        "file": "git2/stash.h",
+        "line": 126,
+        "lineto": 138,
+        "block": "unsigned int version\ngit_stash_apply_flags flags\ngit_checkout_options checkout_options\ngit_stash_apply_progress_cb progress_cb\nvoid * progress_payload",
+        "tdef": "typedef",
+        "description": " Stash application options structure",
+        "comments": "<p>Initialize with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_stash_apply_init_options</code>.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "git_stash_apply_flags",
+            "name": "flags",
+            "comments": " See `git_stash_apply_flags_t`, above. "
+          },
+          {
+            "type": "git_checkout_options",
+            "name": "checkout_options",
+            "comments": " Options to use when writing files to the working directory. "
+          },
+          {
+            "type": "git_stash_apply_progress_cb",
+            "name": "progress_cb",
+            "comments": " Optional callback to notify the consumer of application progress. "
+          },
+          {
+            "type": "void *",
+            "name": "progress_payload",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_stash_apply",
+            "git_stash_apply_init_options",
+            "git_stash_pop"
+          ]
+        }
+      }
+    ],
+    [
+      "git_stash_apply_progress_t",
+      {
+        "decl": [
+          "GIT_STASH_APPLY_PROGRESS_NONE",
+          "GIT_STASH_APPLY_PROGRESS_LOADING_STASH",
+          "GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX",
+          "GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED",
+          "GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED",
+          "GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED",
+          "GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED",
+          "GIT_STASH_APPLY_PROGRESS_DONE"
+        ],
+        "type": "enum",
+        "file": "git2/stash.h",
+        "line": 85,
+        "lineto": 108,
+        "block": "GIT_STASH_APPLY_PROGRESS_NONE\nGIT_STASH_APPLY_PROGRESS_LOADING_STASH\nGIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX\nGIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED\nGIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED\nGIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED\nGIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED\nGIT_STASH_APPLY_PROGRESS_DONE",
+        "tdef": "typedef",
+        "description": " Stash apply progression states ",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_NONE",
+            "comments": "",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_LOADING_STASH",
+            "comments": "<p>Loading the stashed data from the object database. </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX",
+            "comments": "<p>The stored index is being analyzed. </p>\n",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED",
+            "comments": "<p>The modified files are being analyzed. </p>\n",
+            "value": 3
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED",
+            "comments": "<p>The untracked and ignored files are being analyzed. </p>\n",
+            "value": 4
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED",
+            "comments": "<p>The untracked files are being written to disk. </p>\n",
+            "value": 5
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED",
+            "comments": "<p>The modified files are being written to disk. </p>\n",
+            "value": 6
+          },
+          {
+            "type": "int",
+            "name": "GIT_STASH_APPLY_PROGRESS_DONE",
+            "comments": "<p>The stash was applied successfully. </p>\n",
+            "value": 7
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_stash_apply_progress_cb"
+          ]
+        }
+      }
+    ],
+    [
       "git_stash_flags",
       {
         "decl": [
@@ -36125,9 +39541,9 @@
           "GIT_STASH_INCLUDE_IGNORED"
         ],
         "type": "enum",
-        "file": "stash.h",
-        "line": 24,
-        "lineto": 47,
+        "file": "git2/stash.h",
+        "line": 25,
+        "lineto": 48,
         "block": "GIT_STASH_DEFAULT\nGIT_STASH_KEEP_INDEX\nGIT_STASH_INCLUDE_UNTRACKED\nGIT_STASH_INCLUDE_IGNORED",
         "tdef": "typedef",
         "description": " Stash flags",
@@ -36165,17 +39581,60 @@
       }
     ],
     [
+      "git_status_entry",
+      {
+        "decl": [
+          "git_status_t status",
+          "git_diff_delta * head_to_index",
+          "git_diff_delta * index_to_workdir"
+        ],
+        "type": "struct",
+        "value": "git_status_entry",
+        "file": "git2/status.h",
+        "line": 221,
+        "lineto": 225,
+        "block": "git_status_t status\ngit_diff_delta * head_to_index\ngit_diff_delta * index_to_workdir",
+        "tdef": "typedef",
+        "description": " A status entry, providing the differences between the file as it exists\n in HEAD and the index, and providing the differences between the index\n and the working directory.",
+        "comments": "<p>The <code>status</code> value provides the status flags for this file.</p>\n\n<p>The <code>head_to_index</code> value provides detailed information about the\n differences between the file in HEAD and the file in the index.</p>\n\n<p>The <code>index_to_workdir</code> value provides detailed information about the\n differences between the file in the index and the file in the\n working directory.</p>\n",
+        "fields": [
+          {
+            "type": "git_status_t",
+            "name": "status",
+            "comments": ""
+          },
+          {
+            "type": "git_diff_delta *",
+            "name": "head_to_index",
+            "comments": ""
+          },
+          {
+            "type": "git_diff_delta *",
+            "name": "index_to_workdir",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [
+            "git_status_byindex"
+          ],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_status_list",
       {
         "decl": "git_status_list",
         "type": "struct",
         "value": "git_status_list",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 188,
         "lineto": 188,
         "tdef": "typedef",
         "description": " Representation of a status collection ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -36210,13 +39669,13 @@
           "GIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED"
         ],
         "type": "enum",
-        "file": "status.h",
-        "line": 137,
-        "lineto": 154,
+        "file": "git2/status.h",
+        "line": 139,
+        "lineto": 156,
         "block": "GIT_STATUS_OPT_INCLUDE_UNTRACKED\nGIT_STATUS_OPT_INCLUDE_IGNORED\nGIT_STATUS_OPT_INCLUDE_UNMODIFIED\nGIT_STATUS_OPT_EXCLUDE_SUBMODULES\nGIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS\nGIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH\nGIT_STATUS_OPT_RECURSE_IGNORED_DIRS\nGIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX\nGIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR\nGIT_STATUS_OPT_SORT_CASE_SENSITIVELY\nGIT_STATUS_OPT_SORT_CASE_INSENSITIVELY\nGIT_STATUS_OPT_RENAMES_FROM_REWRITES\nGIT_STATUS_OPT_NO_REFRESH\nGIT_STATUS_OPT_UPDATE_INDEX\nGIT_STATUS_OPT_INCLUDE_UNREADABLE\nGIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED",
         "tdef": "typedef",
         "description": " Flags to control status callbacks",
-        "comments": "<ul>\n<li>GIT_STATUS_OPT_INCLUDE_UNTRACKED says that callbacks should be made   on untracked files.  These will only be made if the workdir files are   included in the status &quot;show&quot; option. - GIT_STATUS_OPT_INCLUDE_IGNORED says that ignored files get callbacks.   Again, these callbacks will only be made if the workdir files are   included in the status &quot;show&quot; option. - GIT_STATUS_OPT_INCLUDE_UNMODIFIED indicates that callback should be   made even on unmodified files. - GIT_STATUS_OPT_EXCLUDE_SUBMODULES indicates that submodules should be   skipped.  This only applies if there are no pending typechanges to   the submodule (either from or to another type). - GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS indicates that all files in   untracked directories should be included.  Normally if an entire   directory is new, then just the top-level directory is included (with   a trailing slash on the entry name).  This flag says to include all   of the individual files in the directory instead. - GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH indicates that the given path   should be treated as a literal path, and not as a pathspec pattern. - GIT_STATUS_OPT_RECURSE_IGNORED_DIRS indicates that the contents of   ignored directories should be included in the status.  This is like   doing <code>git ls-files -o -i --exclude-standard</code> with core git. - GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX indicates that rename detection   should be processed between the head and the index and enables   the GIT_STATUS_INDEX_RENAMED as a possible status flag. - GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates that rename   detection should be run between the index and the working directory   and enabled GIT_STATUS_WT_RENAMED as a possible status flag. - GIT_STATUS_OPT_SORT_CASE_SENSITIVELY overrides the native case   sensitivity for the file system and forces the output to be in   case-sensitive order - GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY overrides the native case   sensitivity for the file system and forces the output to be in   case-insensitive order - GIT_STATUS_OPT_RENAMES_FROM_REWRITES indicates that rename detection   should include rewritten files - GIT_STATUS_OPT_NO_REFRESH bypasses the default status behavior of   doing a &quot;soft&quot; index reload (i.e. reloading the index data if the   file on disk has been modified outside libgit2). - GIT_STATUS_OPT_UPDATE_INDEX tells libgit2 to refresh the stat cache   in the index for files that are unchanged but have out of date stat   information in the index.  It will result in less work being done on   subsequent calls to get status.  This is mutually exclusive with the   NO_REFRESH option.</li>\n</ul>\n\n<p>Calling <code>git_status_foreach()</code> is like calling the extended version with: GIT_STATUS_OPT_INCLUDE_IGNORED, GIT_STATUS_OPT_INCLUDE_UNTRACKED, and GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS.  Those options are bundled together as <code>GIT_STATUS_OPT_DEFAULTS</code> if you want them as a baseline.</p>\n",
+        "comments": "<ul>\n<li>GIT_STATUS_OPT_INCLUDE_UNTRACKED says that callbacks should be made\non untracked files.  These will only be made if the workdir files are\nincluded in the status &quot;show&quot; option.</li>\n<li>GIT_STATUS_OPT_INCLUDE_IGNORED says that ignored files get callbacks.\nAgain, these callbacks will only be made if the workdir files are\nincluded in the status &quot;show&quot; option.</li>\n<li>GIT_STATUS_OPT_INCLUDE_UNMODIFIED indicates that callback should be\nmade even on unmodified files.</li>\n<li>GIT_STATUS_OPT_EXCLUDE_SUBMODULES indicates that submodules should be\nskipped.  This only applies if there are no pending typechanges to\nthe submodule (either from or to another type).</li>\n<li>GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS indicates that all files in\nuntracked directories should be included.  Normally if an entire\ndirectory is new, then just the top-level directory is included (with\na trailing slash on the entry name).  This flag says to include all\nof the individual files in the directory instead.</li>\n<li>GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH indicates that the given path\nshould be treated as a literal path, and not as a pathspec pattern.</li>\n<li>GIT_STATUS_OPT_RECURSE_IGNORED_DIRS indicates that the contents of\nignored directories should be included in the status.  This is like\ndoing <code>git ls-files -o -i --exclude-standard</code> with core git.</li>\n<li>GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX indicates that rename detection\nshould be processed between the head and the index and enables\nthe GIT_STATUS_INDEX_RENAMED as a possible status flag.</li>\n<li>GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates that rename\ndetection should be run between the index and the working directory\nand enabled GIT_STATUS_WT_RENAMED as a possible status flag.</li>\n<li>GIT_STATUS_OPT_SORT_CASE_SENSITIVELY overrides the native case\nsensitivity for the file system and forces the output to be in\ncase-sensitive order</li>\n<li>GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY overrides the native case\nsensitivity for the file system and forces the output to be in\ncase-insensitive order</li>\n<li>GIT_STATUS_OPT_RENAMES_FROM_REWRITES indicates that rename detection\nshould include rewritten files</li>\n<li>GIT_STATUS_OPT_NO_REFRESH bypasses the default status behavior of\ndoing a &quot;soft&quot; index reload (i.e. reloading the index data if the\nfile on disk has been modified outside libgit2).</li>\n<li>GIT_STATUS_OPT_UPDATE_INDEX tells libgit2 to refresh the stat cache\nin the index for files that are unchanged but have out of date stat\ninformation in the index.  It will result in less work being done on\nsubsequent calls to get status.  This is mutually exclusive with the\nNO_REFRESH option.</li>\n</ul>\n\n<p>Calling <code>git_status_foreach()</code> is like calling the extended version\n with: GIT_STATUS_OPT_INCLUDE_IGNORED, GIT_STATUS_OPT_INCLUDE_UNTRACKED,\n and GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS.  Those options are bundled\n together as <code>GIT_STATUS_OPT_DEFAULTS</code> if you want them as a baseline.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -36322,6 +39781,62 @@
       }
     ],
     [
+      "git_status_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "git_status_show_t show",
+          "unsigned int flags",
+          "git_strarray pathspec",
+          "git_tree * baseline"
+        ],
+        "type": "struct",
+        "value": "git_status_options",
+        "file": "git2/status.h",
+        "line": 182,
+        "lineto": 188,
+        "block": "unsigned int version\ngit_status_show_t show\nunsigned int flags\ngit_strarray pathspec\ngit_tree * baseline",
+        "tdef": "typedef",
+        "description": " Options to control how `git_status_foreach_ext()` will issue callbacks.",
+        "comments": "<p>This structure is set so that zeroing it out will give you relatively\n sane defaults.</p>\n\n<p>The <code>show</code> value is one of the <code>git_status_show_t</code> constants that\n control which files to scan and in what order.</p>\n\n<p>The <code>flags</code> value is an OR&#39;ed combination of the <code>git_status_opt_t</code>\n values above.</p>\n\n<p>The <code>pathspec</code> is an array of path patterns to match (using\n fnmatch-style matching), or just an array of paths to match exactly if\n <code>GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH</code> is specified in the flags.</p>\n\n<p>The <code>baseline</code> is the tree to be used for comparison to the working directory\n and index; defaults to HEAD.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "git_status_show_t",
+            "name": "show",
+            "comments": ""
+          },
+          {
+            "type": "unsigned int",
+            "name": "flags",
+            "comments": ""
+          },
+          {
+            "type": "git_strarray",
+            "name": "pathspec",
+            "comments": ""
+          },
+          {
+            "type": "git_tree *",
+            "name": "baseline",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_status_foreach_ext",
+            "git_status_init_options",
+            "git_status_list_new"
+          ]
+        }
+      }
+    ],
+    [
       "git_status_show_t",
       {
         "decl": [
@@ -36330,13 +39845,13 @@
           "GIT_STATUS_SHOW_WORKDIR_ONLY"
         ],
         "type": "enum",
-        "file": "status.h",
-        "line": 79,
-        "lineto": 83,
+        "file": "git2/status.h",
+        "line": 81,
+        "lineto": 85,
         "block": "GIT_STATUS_SHOW_INDEX_AND_WORKDIR\nGIT_STATUS_SHOW_INDEX_ONLY\nGIT_STATUS_SHOW_WORKDIR_ONLY",
         "tdef": "typedef",
         "description": " Select the files on which to report status.",
-        "comments": "<p>With <code>git_status_foreach_ext</code>, this will control which changes get callbacks.  With <code>git_status_list_new</code>, these will control which changes are included in the list.</p>\n\n<ul>\n<li>GIT_STATUS_SHOW_INDEX_AND_WORKDIR is the default.  This roughly   matches <code>git status --porcelain</code> regarding which files are   included and in what order. - GIT_STATUS_SHOW_INDEX_ONLY only gives status based on HEAD to index   comparison, not looking at working directory changes. - GIT_STATUS_SHOW_WORKDIR_ONLY only gives status based on index to   working directory comparison, not comparing the index to the HEAD.</li>\n</ul>\n",
+        "comments": "<p>With <code>git_status_foreach_ext</code>, this will control which changes get\n callbacks.  With <code>git_status_list_new</code>, these will control which\n changes are included in the list.</p>\n\n<ul>\n<li>GIT_STATUS_SHOW_INDEX_AND_WORKDIR is the default.  This roughly\nmatches <code>git status --porcelain</code> regarding which files are\nincluded and in what order.</li>\n<li>GIT_STATUS_SHOW_INDEX_ONLY only gives status based on HEAD to index\ncomparison, not looking at working directory changes.</li>\n<li>GIT_STATUS_SHOW_WORKDIR_ONLY only gives status based on index to\nworking directory comparison, not comparing the index to the HEAD.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -36383,13 +39898,13 @@
           "GIT_STATUS_CONFLICTED"
         ],
         "type": "enum",
-        "file": "status.h",
-        "line": 32,
-        "lineto": 50,
+        "file": "git2/status.h",
+        "line": 34,
+        "lineto": 52,
         "block": "GIT_STATUS_CURRENT\nGIT_STATUS_INDEX_NEW\nGIT_STATUS_INDEX_MODIFIED\nGIT_STATUS_INDEX_DELETED\nGIT_STATUS_INDEX_RENAMED\nGIT_STATUS_INDEX_TYPECHANGE\nGIT_STATUS_WT_NEW\nGIT_STATUS_WT_MODIFIED\nGIT_STATUS_WT_DELETED\nGIT_STATUS_WT_TYPECHANGE\nGIT_STATUS_WT_RENAMED\nGIT_STATUS_WT_UNREADABLE\nGIT_STATUS_IGNORED\nGIT_STATUS_CONFLICTED",
         "tdef": "typedef",
         "description": " Status flags for a single file.",
-        "comments": "<p>A combination of these values will be returned to indicate the status of a file.  Status compares the working directory, the index, and the current HEAD of the repository.  The <code>GIT_STATUS_INDEX</code> set of flags represents the status of file in the index relative to the HEAD, and the <code>GIT_STATUS_WT</code> set of flags represent the status of the file in the working directory relative to the index.</p>\n",
+        "comments": "<p>A combination of these values will be returned to indicate the status of\n a file.  Status compares the working directory, the index, and the\n current HEAD of the repository.  The <code>GIT_STATUS_INDEX</code> set of flags\n represents the status of file in the index relative to the HEAD, and the\n <code>GIT_STATUS_WT</code> set of flags represent the status of the file in the\n working directory relative to the index.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -36491,7 +40006,7 @@
         ],
         "type": "struct",
         "value": "git_strarray",
-        "file": "strarray.h",
+        "file": "git2/strarray.h",
         "line": 22,
         "lineto": 25,
         "block": "char ** strings\nsize_t count",
@@ -36554,13 +40069,13 @@
         ],
         "type": "struct",
         "value": "git_stream",
-        "file": "sys/stream.h",
+        "file": "git2/sys/stream.h",
         "line": 29,
         "lineto": 41,
         "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const git_proxy_options *) set_proxy\nssize_t (*)(struct git_stream *, void *, size_t) read\nssize_t (*)(struct git_stream *, const char *, size_t, int) write\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
         "tdef": "typedef",
         "description": " Every stream must have this struct as its first element, so the\n API can talk to it. You'd define your stream as",
-        "comments": "<pre><code> struct my_stream {             git_stream parent;             ...     }\n</code></pre>\n\n<p>and fill the functions</p>\n",
+        "comments": "<pre><code> struct my_stream {\n         git_stream parent;\n         ...\n }\n</code></pre>\n\n<p>and fill the functions</p>\n",
         "fields": [
           {
             "type": "int",
@@ -36616,6 +40131,7 @@
         "used": {
           "returns": [],
           "needs": [
+            "git_stream_cb",
             "git_stream_register_tls"
           ]
         }
@@ -36627,12 +40143,13 @@
         "decl": "git_submodule",
         "type": "struct",
         "value": "git_submodule",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 339,
         "lineto": 339,
         "tdef": "typedef",
         "description": " Opaque structure representing a submodule.",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_submodule_fetch_recurse_submodules",
@@ -36685,13 +40202,13 @@
           "GIT_SUBMODULE_IGNORE_ALL"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 403,
         "lineto": 410,
         "block": "GIT_SUBMODULE_IGNORE_UNSPECIFIED\nGIT_SUBMODULE_IGNORE_NONE\nGIT_SUBMODULE_IGNORE_UNTRACKED\nGIT_SUBMODULE_IGNORE_DIRTY\nGIT_SUBMODULE_IGNORE_ALL",
         "tdef": "typedef",
         "description": " Submodule ignore values",
-        "comments": "<p>These values represent settings for the <code>submodule.$name.ignore</code> configuration value which says how deeply to look at the working directory when getting submodule status.</p>\n\n<p>You can override this value in memory on a per-submodule basis with <code>git_submodule_set_ignore()</code> and can write the changed value to disk with <code>git_submodule_save()</code>.  If you have overwritten the value, you can revert to the on disk value by using <code>GIT_SUBMODULE_IGNORE_RESET</code>.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_IGNORE_UNSPECIFIED: use the submodule&#39;s configuration - GIT_SUBMODULE_IGNORE_NONE: don&#39;t ignore any change - i.e. even an   untracked file, will mark the submodule as dirty.  Ignored files are   still ignored, of course. - GIT_SUBMODULE_IGNORE_UNTRACKED: ignore untracked files; only changes   to tracked files, or the index or the HEAD commit will matter. - GIT_SUBMODULE_IGNORE_DIRTY: ignore changes in the working directory,   only considering changes if the HEAD of submodule has moved from the   value in the superproject. - GIT_SUBMODULE_IGNORE_ALL: never check if the submodule is dirty - GIT_SUBMODULE_IGNORE_DEFAULT: not used except as static initializer   when we don&#39;t want any particular ignore rule to be specified.</li>\n</ul>\n",
+        "comments": "<p>These values represent settings for the <code>submodule.$name.ignore</code>\n configuration value which says how deeply to look at the working\n directory when getting submodule status.</p>\n\n<p>You can override this value in memory on a per-submodule basis with\n <code>git_submodule_set_ignore()</code> and can write the changed value to disk\n with <code>git_submodule_save()</code>.  If you have overwritten the value, you\n can revert to the on disk value by using <code>GIT_SUBMODULE_IGNORE_RESET</code>.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_IGNORE_UNSPECIFIED: use the submodule&#39;s configuration</li>\n<li>GIT_SUBMODULE_IGNORE_NONE: don&#39;t ignore any change - i.e. even an\nuntracked file, will mark the submodule as dirty.  Ignored files are\nstill ignored, of course.</li>\n<li>GIT_SUBMODULE_IGNORE_UNTRACKED: ignore untracked files; only changes\nto tracked files, or the index or the HEAD commit will matter.</li>\n<li>GIT_SUBMODULE_IGNORE_DIRTY: ignore changes in the working directory,\nonly considering changes if the HEAD of submodule has moved from the\nvalue in the superproject.</li>\n<li>GIT_SUBMODULE_IGNORE_ALL: never check if the submodule is dirty</li>\n<li>GIT_SUBMODULE_IGNORE_DEFAULT: not used except as static initializer\nwhen we don&#39;t want any particular ignore rule to be specified.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -36744,13 +40261,13 @@
           "GIT_SUBMODULE_RECURSE_ONDEMAND"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 422,
         "lineto": 426,
         "block": "GIT_SUBMODULE_RECURSE_NO\nGIT_SUBMODULE_RECURSE_YES\nGIT_SUBMODULE_RECURSE_ONDEMAND",
         "tdef": "typedef",
         "description": " Options for submodule recurse.",
-        "comments": "<p>Represent the value of <code>submodule.$name.fetchRecurseSubmodules</code></p>\n\n<ul>\n<li>GIT_SUBMODULE_RECURSE_NO    - do no recurse into submodules * GIT_SUBMODULE_RECURSE_YES   - recurse into submodules * GIT_SUBMODULE_RECURSE_ONDEMAND - recurse into submodules only when                                    commit not already in local clone</li>\n</ul>\n",
+        "comments": "<p>Represent the value of <code>submodule.$name.fetchRecurseSubmodules</code></p>\n\n<ul>\n<li>GIT_SUBMODULE_RECURSE_NO    - do no recurse into submodules</li>\n<li>GIT_SUBMODULE_RECURSE_YES   - recurse into submodules</li>\n<li>GIT_SUBMODULE_RECURSE_ONDEMAND - recurse into submodules only when\n                                commit not already in local clone</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -36801,13 +40318,13 @@
           "GIT_SUBMODULE_STATUS_WD_UNTRACKED"
         ],
         "type": "enum",
-        "file": "submodule.h",
+        "file": "git2/submodule.h",
         "line": 74,
         "lineto": 89,
         "block": "GIT_SUBMODULE_STATUS_IN_HEAD\nGIT_SUBMODULE_STATUS_IN_INDEX\nGIT_SUBMODULE_STATUS_IN_CONFIG\nGIT_SUBMODULE_STATUS_IN_WD\nGIT_SUBMODULE_STATUS_INDEX_ADDED\nGIT_SUBMODULE_STATUS_INDEX_DELETED\nGIT_SUBMODULE_STATUS_INDEX_MODIFIED\nGIT_SUBMODULE_STATUS_WD_UNINITIALIZED\nGIT_SUBMODULE_STATUS_WD_ADDED\nGIT_SUBMODULE_STATUS_WD_DELETED\nGIT_SUBMODULE_STATUS_WD_MODIFIED\nGIT_SUBMODULE_STATUS_WD_INDEX_MODIFIED\nGIT_SUBMODULE_STATUS_WD_WD_MODIFIED\nGIT_SUBMODULE_STATUS_WD_UNTRACKED",
         "tdef": "typedef",
         "description": " Return codes for submodule status.",
-        "comments": "<p>A combination of these flags will be returned to describe the status of a submodule.  Depending on the &quot;ignore&quot; property of the submodule, some of the flags may never be returned because they indicate changes that are supposed to be ignored.</p>\n\n<p>Submodule info is contained in 4 places: the HEAD tree, the index, config files (both .git/config and .gitmodules), and the working directory.  Any or all of those places might be missing information about the submodule depending on what state the repo is in.  We consider all four places to build the combination of status flags.</p>\n\n<p>There are four values that are not really status, but give basic info about what sources of submodule data are available.  These will be returned even if ignore is set to &quot;ALL&quot;.</p>\n\n<ul>\n<li>IN_HEAD   - superproject head contains submodule * IN_INDEX  - superproject index contains submodule * IN_CONFIG - superproject gitmodules has submodule * IN_WD     - superproject workdir has submodule</li>\n</ul>\n\n<p>The following values will be returned so long as ignore is not &quot;ALL&quot;.</p>\n\n<ul>\n<li>INDEX_ADDED       - in index, not in head * INDEX_DELETED     - in head, not in index * INDEX_MODIFIED    - index and head don&#39;t match * WD_UNINITIALIZED  - workdir contains empty directory * WD_ADDED          - in workdir, not index * WD_DELETED        - in index, not workdir * WD_MODIFIED       - index and workdir head don&#39;t match</li>\n</ul>\n\n<p>The following can only be returned if ignore is &quot;NONE&quot; or &quot;UNTRACKED&quot;.</p>\n\n<ul>\n<li>WD_INDEX_MODIFIED - submodule workdir index is dirty * WD_WD_MODIFIED    - submodule workdir has modified files</li>\n</ul>\n\n<p>Lastly, the following will only be returned for ignore &quot;NONE&quot;.</p>\n\n<ul>\n<li>WD_UNTRACKED      - wd contains untracked files</li>\n</ul>\n",
+        "comments": "<p>A combination of these flags will be returned to describe the status of a\n submodule.  Depending on the &quot;ignore&quot; property of the submodule, some of\n the flags may never be returned because they indicate changes that are\n supposed to be ignored.</p>\n\n<p>Submodule info is contained in 4 places: the HEAD tree, the index, config\n files (both .git/config and .gitmodules), and the working directory.  Any\n or all of those places might be missing information about the submodule\n depending on what state the repo is in.  We consider all four places to\n build the combination of status flags.</p>\n\n<p>There are four values that are not really status, but give basic info\n about what sources of submodule data are available.  These will be\n returned even if ignore is set to &quot;ALL&quot;.</p>\n\n<ul>\n<li>IN_HEAD   - superproject head contains submodule</li>\n<li>IN_INDEX  - superproject index contains submodule</li>\n<li>IN_CONFIG - superproject gitmodules has submodule</li>\n<li>IN_WD     - superproject workdir has submodule</li>\n</ul>\n\n<p>The following values will be returned so long as ignore is not &quot;ALL&quot;.</p>\n\n<ul>\n<li>INDEX_ADDED       - in index, not in head</li>\n<li>INDEX_DELETED     - in head, not in index</li>\n<li>INDEX_MODIFIED    - index and head don&#39;t match</li>\n<li>WD_UNINITIALIZED  - workdir contains empty directory</li>\n<li>WD_ADDED          - in workdir, not index</li>\n<li>WD_DELETED        - in index, not workdir</li>\n<li>WD_MODIFIED       - index and workdir head don&#39;t match</li>\n</ul>\n\n<p>The following can only be returned if ignore is &quot;NONE&quot; or &quot;UNTRACKED&quot;.</p>\n\n<ul>\n<li>WD_INDEX_MODIFIED - submodule workdir index is dirty</li>\n<li>WD_WD_MODIFIED    - submodule workdir has modified files</li>\n</ul>\n\n<p>Lastly, the following will only be returned for ignore &quot;NONE&quot;.</p>\n\n<ul>\n<li>WD_UNTRACKED      - wd contains untracked files</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -36911,13 +40428,13 @@
         ],
         "type": "struct",
         "value": "git_submodule_update_options",
-        "file": "submodule.h",
-        "line": 129,
-        "lineto": 154,
+        "file": "git2/submodule.h",
+        "line": 128,
+        "lineto": 153,
         "block": "unsigned int version\ngit_checkout_options checkout_opts\ngit_fetch_options fetch_opts\nint allow_fetch",
         "tdef": "typedef",
         "description": " Submodule update options structure",
-        "comments": "<p>Use the GIT_SUBMODULE_UPDATE_OPTIONS_INIT to get the default settings, like this:</p>\n\n<p>git_submodule_update_options opts = GIT_SUBMODULE_UPDATE_OPTIONS_INIT;</p>\n",
+        "comments": "<p>Initialize with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_submodule_update_init_options</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -36960,13 +40477,13 @@
           "GIT_SUBMODULE_UPDATE_DEFAULT"
         ],
         "type": "enum",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 367,
         "lineto": 374,
         "block": "GIT_SUBMODULE_UPDATE_CHECKOUT\nGIT_SUBMODULE_UPDATE_REBASE\nGIT_SUBMODULE_UPDATE_MERGE\nGIT_SUBMODULE_UPDATE_NONE\nGIT_SUBMODULE_UPDATE_DEFAULT",
         "tdef": "typedef",
         "description": " Submodule update values",
-        "comments": "<p>These values represent settings for the <code>submodule.$name.update</code> configuration value which says how to handle <code>git submodule update</code> for this submodule.  The value is usually set in the &quot;.gitmodules&quot; file and copied to &quot;.git/config&quot; when the submodule is initialized.</p>\n\n<p>You can override this setting on a per-submodule basis with <code>git_submodule_set_update()</code> and write the changed value to disk using <code>git_submodule_save()</code>.  If you have overwritten the value, you can revert it by passing <code>GIT_SUBMODULE_UPDATE_RESET</code> to the set function.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_UPDATE_CHECKOUT: the default; when a submodule is   updated, checkout the new detached HEAD to the submodule directory. - GIT_SUBMODULE_UPDATE_REBASE: update by rebasing the current checked   out branch onto the commit from the superproject. - GIT_SUBMODULE_UPDATE_MERGE: update by merging the commit in the   superproject into the current checkout out branch of the submodule. - GIT_SUBMODULE_UPDATE_NONE: do not update this submodule even when   the commit in the superproject is updated. - GIT_SUBMODULE_UPDATE_DEFAULT: not used except as static initializer   when we don&#39;t want any particular update rule to be specified.</li>\n</ul>\n",
+        "comments": "<p>These values represent settings for the <code>submodule.$name.update</code>\n configuration value which says how to handle <code>git submodule update</code> for\n this submodule.  The value is usually set in the &quot;.gitmodules&quot; file and\n copied to &quot;.git/config&quot; when the submodule is initialized.</p>\n\n<p>You can override this setting on a per-submodule basis with\n <code>git_submodule_set_update()</code> and write the changed value to disk using\n <code>git_submodule_save()</code>.  If you have overwritten the value, you can\n revert it by passing <code>GIT_SUBMODULE_UPDATE_RESET</code> to the set function.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_UPDATE_CHECKOUT: the default; when a submodule is\nupdated, checkout the new detached HEAD to the submodule directory.</li>\n<li>GIT_SUBMODULE_UPDATE_REBASE: update by rebasing the current checked\nout branch onto the commit from the superproject.</li>\n<li>GIT_SUBMODULE_UPDATE_MERGE: update by merging the commit in the\nsuperproject into the current checkout out branch of the submodule.</li>\n<li>GIT_SUBMODULE_UPDATE_NONE: do not update this submodule even when\nthe commit in the superproject is updated.</li>\n<li>GIT_SUBMODULE_UPDATE_DEFAULT: not used except as static initializer\nwhen we don&#39;t want any particular update rule to be specified.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -37015,12 +40532,13 @@
         "decl": "git_tag",
         "type": "struct",
         "value": "git_tag",
-        "file": "types.h",
-        "line": 117,
-        "lineto": 117,
+        "file": "git2/types.h",
+        "line": 120,
+        "lineto": 120,
         "tdef": "typedef",
         "description": " Parsed representation of a tag object. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37052,9 +40570,9 @@
         ],
         "type": "struct",
         "value": "git_time",
-        "file": "types.h",
-        "line": 159,
-        "lineto": 163,
+        "file": "git2/types.h",
+        "line": 162,
+        "lineto": 166,
         "block": "git_time_t time\nint offset\nchar sign",
         "tdef": "typedef",
         "description": " Time in a signature ",
@@ -37099,7 +40617,7 @@
           "GIT_TRACE_TRACE"
         ],
         "type": "enum",
-        "file": "trace.h",
+        "file": "git2/trace.h",
         "line": 26,
         "lineto": 47,
         "block": "GIT_TRACE_NONE\nGIT_TRACE_FATAL\nGIT_TRACE_ERROR\nGIT_TRACE_WARN\nGIT_TRACE_INFO\nGIT_TRACE_DEBUG\nGIT_TRACE_TRACE",
@@ -37165,16 +40683,25 @@
         "decl": "git_transaction",
         "type": "struct",
         "value": "git_transaction",
-        "file": "types.h",
-        "line": 179,
-        "lineto": 179,
+        "file": "git2/types.h",
+        "line": 182,
+        "lineto": 182,
         "tdef": "typedef",
         "description": " Transactional interface to references ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
-            "git_config_lock"
+            "git_config_lock",
+            "git_transaction_commit",
+            "git_transaction_free",
+            "git_transaction_lock_ref",
+            "git_transaction_new",
+            "git_transaction_remove",
+            "git_transaction_set_reflog",
+            "git_transaction_set_symbolic_target",
+            "git_transaction_set_target"
           ]
         }
       }
@@ -37193,13 +40720,13 @@
         ],
         "type": "struct",
         "value": "git_transfer_progress",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 257,
         "lineto": 265,
         "block": "unsigned int total_objects\nunsigned int indexed_objects\nunsigned int received_objects\nunsigned int local_objects\nunsigned int total_deltas\nunsigned int indexed_deltas\nsize_t received_bytes",
         "tdef": "typedef",
         "description": " This is passed as the first argument to the callback to allow the\n user to see the progress.",
-        "comments": "<ul>\n<li>total_objects: number of objects in the packfile being downloaded - indexed_objects: received objects that have been hashed - received_objects: objects which have been downloaded - local_objects: locally-available objects that have been injected    in order to fix a thin pack. - received-bytes: size of the packfile received up to now</li>\n</ul>\n",
+        "comments": "<ul>\n<li>total_objects: number of objects in the packfile being downloaded</li>\n<li>indexed_objects: received objects that have been hashed</li>\n<li>received_objects: objects which have been downloaded</li>\n<li>local_objects: locally-available objects that have been injected\nin order to fix a thin pack.</li>\n<li>received-bytes: size of the packfile received up to now</li>\n</ul>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -37244,7 +40771,6 @@
           "needs": [
             "git_indexer_append",
             "git_indexer_commit",
-            "git_indexer_new",
             "git_odb_write_pack",
             "git_packbuilder_write",
             "git_transfer_progress_cb"
@@ -37258,15 +40784,84 @@
         "decl": "git_transport",
         "type": "struct",
         "value": "git_transport",
-        "file": "types.h",
+        "file": "git2/types.h",
         "line": 234,
         "lineto": 234,
+        "block": "unsigned int version\nint (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *) set_callbacks\nint (*)(git_transport *, const git_strarray *) set_custom_headers\nint (*)(git_transport *, const char *, git_cred_acquire_cb, void *, const git_proxy_options *, int, int) connect\nint (*)(const git_remote_head ***, size_t *, git_transport *) ls\nint (*)(git_transport *, git_push *, const git_remote_callbacks *) push\nint (*)(git_transport *, git_repository *, const git_remote_head *const *, size_t) negotiate_fetch\nint (*)(git_transport *, git_repository *, git_transfer_progress *, git_transfer_progress_cb, void *) download_pack\nint (*)(git_transport *) is_connected\nint (*)(git_transport *, int *) read_flags\nvoid (*)(git_transport *) cancel\nint (*)(git_transport *) close\nvoid (*)(git_transport *) free",
         "tdef": "typedef",
         "description": " Interface which represents a transport to communicate with a\n remote.",
         "comments": "",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *)",
+            "name": "set_callbacks",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, const git_strarray *)",
+            "name": "set_custom_headers",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, const char *, git_cred_acquire_cb, void *, const git_proxy_options *, int, int)",
+            "name": "connect",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(const git_remote_head ***, size_t *, git_transport *)",
+            "name": "ls",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, git_push *, const git_remote_callbacks *)",
+            "name": "push",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, git_repository *, const git_remote_head *const *, size_t)",
+            "name": "negotiate_fetch",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, git_repository *, git_transfer_progress *, git_transfer_progress_cb, void *)",
+            "name": "download_pack",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *)",
+            "name": "is_connected",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *, int *)",
+            "name": "read_flags",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(git_transport *)",
+            "name": "cancel",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_transport *)",
+            "name": "close",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(git_transport *)",
+            "name": "free",
+            "comments": ""
+          }
+        ],
         "used": {
           "returns": [],
           "needs": [
+            "git_smart_subtransport_cb",
             "git_smart_subtransport_git",
             "git_smart_subtransport_http",
             "git_smart_subtransport_ssh",
@@ -37292,7 +40887,7 @@
           "GIT_TRANSPORTFLAGS_NONE"
         ],
         "type": "enum",
-        "file": "sys/transport.h",
+        "file": "git2/sys/transport.h",
         "line": 31,
         "lineto": 33,
         "block": "GIT_TRANSPORTFLAGS_NONE",
@@ -37319,12 +40914,13 @@
         "decl": "git_tree",
         "type": "struct",
         "value": "git_tree",
-        "file": "types.h",
-        "line": 129,
-        "lineto": 129,
+        "file": "git2/types.h",
+        "line": 132,
+        "lineto": 132,
         "tdef": "typedef",
         "description": " Representation of a tree object. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_tree_entry_byid",
@@ -37389,12 +40985,13 @@
         "decl": "git_tree_entry",
         "type": "struct",
         "value": "git_tree_entry",
-        "file": "types.h",
-        "line": 126,
-        "lineto": 126,
+        "file": "git2/types.h",
+        "line": 129,
+        "lineto": 129,
         "tdef": "typedef",
         "description": " Representation of each one of the entries in a tree object. ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [
             "git_tree_entry_byid",
@@ -37431,7 +41028,7 @@
         ],
         "type": "struct",
         "value": "git_tree_update",
-        "file": "tree.h",
+        "file": "git2/tree.h",
         "line": 448,
         "lineto": 457,
         "block": "git_tree_update_t action\ngit_oid id\ngit_filemode_t filemode\nconst char * path",
@@ -37476,7 +41073,7 @@
           "GIT_TREE_UPDATE_REMOVE"
         ],
         "type": "enum",
-        "file": "tree.h",
+        "file": "git2/tree.h",
         "line": 438,
         "lineto": 443,
         "block": "GIT_TREE_UPDATE_UPSERT\nGIT_TREE_UPDATE_REMOVE",
@@ -37509,12 +41106,13 @@
         "decl": "git_treebuilder",
         "type": "struct",
         "value": "git_treebuilder",
-        "file": "types.h",
-        "line": 132,
-        "lineto": 132,
+        "file": "git2/types.h",
+        "line": 135,
+        "lineto": 135,
         "tdef": "typedef",
         "description": " Constructor for in-memory trees ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37540,7 +41138,7 @@
           "GIT_TREEWALK_POST"
         ],
         "type": "enum",
-        "file": "tree.h",
+        "file": "git2/tree.h",
         "line": 398,
         "lineto": 401,
         "block": "GIT_TREEWALK_PRE\nGIT_TREEWALK_POST",
@@ -37575,12 +41173,13 @@
         "decl": "git_worktree",
         "type": "struct",
         "value": "git_worktree",
-        "file": "types.h",
-        "line": 108,
-        "lineto": 108,
+        "file": "git2/types.h",
+        "line": 111,
+        "lineto": 111,
         "tdef": "typedef",
         "description": " Representation of a working tree ",
         "comments": "",
+        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37592,11 +41191,94 @@
             "git_worktree_is_prunable",
             "git_worktree_lock",
             "git_worktree_lookup",
+            "git_worktree_name",
             "git_worktree_open_from_repository",
+            "git_worktree_path",
             "git_worktree_prune",
             "git_worktree_prune_init_options",
             "git_worktree_unlock",
             "git_worktree_validate"
+          ]
+        }
+      }
+    ],
+    [
+      "git_worktree_add_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "int lock",
+          "git_reference * ref"
+        ],
+        "type": "struct",
+        "value": "git_worktree_add_options",
+        "file": "git2/worktree.h",
+        "line": 84,
+        "lineto": 89,
+        "block": "unsigned int version\nint lock\ngit_reference * ref",
+        "tdef": "typedef",
+        "description": " Worktree add options structure",
+        "comments": "<p>Initialize with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_worktree_add_init_options</code>.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "int",
+            "name": "lock",
+            "comments": " lock newly created worktree "
+          },
+          {
+            "type": "git_reference *",
+            "name": "ref",
+            "comments": " reference to use for the new worktree HEAD "
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_worktree_add",
+            "git_worktree_add_init_options"
+          ]
+        }
+      }
+    ],
+    [
+      "git_worktree_prune_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "uint32_t flags"
+        ],
+        "type": "struct",
+        "value": "git_worktree_prune_options",
+        "file": "git2/worktree.h",
+        "line": 198,
+        "lineto": 202,
+        "block": "unsigned int version\nuint32_t flags",
+        "tdef": "typedef",
+        "description": " Worktree prune options structure",
+        "comments": "<p>Initialize with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_worktree_prune_init_options</code>.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "uint32_t",
+            "name": "flags",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_worktree_is_prunable",
+            "git_worktree_prune",
+            "git_worktree_prune_init_options"
           ]
         }
       }
@@ -37610,9 +41292,9 @@
           "GIT_WORKTREE_PRUNE_WORKING_TREE"
         ],
         "type": "enum",
-        "file": "worktree.h",
-        "line": 155,
-        "lineto": 162,
+        "file": "git2/worktree.h",
+        "line": 182,
+        "lineto": 189,
         "block": "GIT_WORKTREE_PRUNE_VALID\nGIT_WORKTREE_PRUNE_LOCKED\nGIT_WORKTREE_PRUNE_WORKING_TREE",
         "tdef": "typedef",
         "description": " Flags which can be passed to git_worktree_prune to alter its\n behavior.",
@@ -37649,12 +41331,29 @@
         "decl": "git_writestream",
         "type": "struct",
         "value": "git_writestream",
-        "file": "types.h",
-        "line": 429,
-        "lineto": 429,
+        "file": "git2/types.h",
+        "line": 428,
+        "lineto": 428,
         "tdef": "typedef",
         "description": " A type to write in a streaming fashion, for example, for filters. ",
         "comments": "",
+        "fields": [
+          {
+            "type": "int (*)(git_writestream *, const char *, size_t)",
+            "name": "write",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_writestream *)",
+            "name": "close",
+            "comments": ""
+          },
+          {
+            "type": "void (*)(git_writestream *)",
+            "name": "free",
+            "comments": ""
+          }
+        ],
         "used": {
           "returns": [],
           "needs": [
@@ -37662,13 +41361,48 @@
             "git_blob_create_fromstream_commit",
             "git_filter_list_stream_blob",
             "git_filter_list_stream_data",
-            "git_filter_list_stream_file"
+            "git_filter_list_stream_file",
+            "git_filter_stream_fn"
           ]
+        }
+      }
+    ],
+    [
+      "imaxdiv_t",
+      {
+        "decl": [
+          "intmax_t quot",
+          "intmax_t rem"
+        ],
+        "type": "struct",
+        "value": "imaxdiv_t",
+        "file": "git2/inttypes.h",
+        "line": 51,
+        "lineto": 54,
+        "block": "intmax_t quot\nintmax_t rem",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "intmax_t",
+            "name": "quot",
+            "comments": ""
+          },
+          {
+            "type": "intmax_t",
+            "name": "rem",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
         }
       }
     ]
   ],
-  "prefix": "include/git2",
+  "prefix": "include",
   "groups": [
     [
       "annotated",
@@ -37678,7 +41412,8 @@
         "git_annotated_commit_from_ref",
         "git_annotated_commit_from_revspec",
         "git_annotated_commit_id",
-        "git_annotated_commit_lookup"
+        "git_annotated_commit_lookup",
+        "git_annotated_commit_ref"
       ]
     ],
     [
@@ -37738,14 +41473,18 @@
         "git_branch_move",
         "git_branch_name",
         "git_branch_next",
+        "git_branch_remote_name",
         "git_branch_set_upstream",
-        "git_branch_upstream"
+        "git_branch_upstream",
+        "git_branch_upstream_name",
+        "git_branch_upstream_remote"
       ]
     ],
     [
       "buf",
       [
         "git_buf_contains_nul",
+        "git_buf_dispose",
         "git_buf_free",
         "git_buf_grow",
         "git_buf_is_binary",
@@ -37781,8 +41520,10 @@
       [
         "git_commit_amend",
         "git_commit_author",
+        "git_commit_author_with_mailmap",
         "git_commit_body",
         "git_commit_committer",
+        "git_commit_committer_with_mailmap",
         "git_commit_create",
         "git_commit_create_buffer",
         "git_commit_create_from_callback",
@@ -37883,6 +41624,8 @@
       [
         "git_describe_commit",
         "git_describe_format",
+        "git_describe_init_format_options",
+        "git_describe_init_options",
         "git_describe_result_free",
         "git_describe_workdir"
       ]
@@ -37996,6 +41739,12 @@
       ]
     ],
     [
+      "imaxdiv",
+      [
+        "imaxdiv"
+      ]
+    ],
+    [
       "index",
       [
         "git_index_add",
@@ -38021,6 +41770,10 @@
         "git_index_get_byindex",
         "git_index_get_bypath",
         "git_index_has_conflicts",
+        "git_index_name_add",
+        "git_index_name_clear",
+        "git_index_name_entrycount",
+        "git_index_name_get_byindex",
         "git_index_new",
         "git_index_open",
         "git_index_owner",
@@ -38031,6 +41784,13 @@
         "git_index_remove_all",
         "git_index_remove_bypath",
         "git_index_remove_directory",
+        "git_index_reuc_add",
+        "git_index_reuc_clear",
+        "git_index_reuc_entrycount",
+        "git_index_reuc_find",
+        "git_index_reuc_get_byindex",
+        "git_index_reuc_get_bypath",
+        "git_index_reuc_remove",
         "git_index_set_caps",
         "git_index_set_version",
         "git_index_update_all",
@@ -38047,6 +41807,7 @@
         "git_indexer_commit",
         "git_indexer_free",
         "git_indexer_hash",
+        "git_indexer_init_options",
         "git_indexer_new"
       ]
     ],
@@ -38058,6 +41819,18 @@
         "git_libgit2_opts",
         "git_libgit2_shutdown",
         "git_libgit2_version"
+      ]
+    ],
+    [
+      "mailmap",
+      [
+        "git_mailmap_add_entry",
+        "git_mailmap_free",
+        "git_mailmap_from_buffer",
+        "git_mailmap_from_repository",
+        "git_mailmap_new",
+        "git_mailmap_resolve",
+        "git_mailmap_resolve_signature"
       ]
     ],
     [
@@ -38079,6 +41852,14 @@
         "git_merge_bases",
         "git_merge_bases_many",
         "git_merge_commits",
+        "git_merge_driver_lookup",
+        "git_merge_driver_register",
+        "git_merge_driver_source_ancestor",
+        "git_merge_driver_source_file_options",
+        "git_merge_driver_source_ours",
+        "git_merge_driver_source_repo",
+        "git_merge_driver_source_theirs",
+        "git_merge_driver_unregister",
         "git_merge_file",
         "git_merge_file_from_index",
         "git_merge_file_init_input",
@@ -38106,6 +41887,7 @@
         "git_note_commit_remove",
         "git_note_committer",
         "git_note_create",
+        "git_note_default_ref",
         "git_note_foreach",
         "git_note_free",
         "git_note_id",
@@ -38143,6 +41925,7 @@
         "git_odb_add_backend",
         "git_odb_add_disk_alternate",
         "git_odb_backend_loose",
+        "git_odb_backend_malloc",
         "git_odb_backend_one_pack",
         "git_odb_backend_pack",
         "git_odb_exists",
@@ -38229,6 +42012,7 @@
         "git_packbuilder_set_callbacks",
         "git_packbuilder_set_threads",
         "git_packbuilder_write",
+        "git_packbuilder_write_buf",
         "git_packbuilder_written"
       ]
     ],
@@ -38249,6 +42033,12 @@
         "git_patch_print",
         "git_patch_size",
         "git_patch_to_buf"
+      ]
+    ],
+    [
+      "path",
+      [
+        "git_path_is_gitfile"
       ]
     ],
     [
@@ -38364,6 +42154,8 @@
         "git_reflog_append",
         "git_reflog_delete",
         "git_reflog_drop",
+        "git_reflog_entry__alloc",
+        "git_reflog_entry__free",
         "git_reflog_entry_byindex",
         "git_reflog_entry_committer",
         "git_reflog_entry_id_new",
@@ -38383,6 +42175,8 @@
         "git_refspec_dst",
         "git_refspec_dst_matches",
         "git_refspec_force",
+        "git_refspec_free",
+        "git_refspec_parse",
         "git_refspec_rtransform",
         "git_refspec_src",
         "git_refspec_src_matches",
@@ -38450,6 +42244,7 @@
         "git_repository_hashfile",
         "git_repository_head",
         "git_repository_head_detached",
+        "git_repository_head_detached_for_worktree",
         "git_repository_head_for_worktree",
         "git_repository_head_unborn",
         "git_repository_ident",
@@ -38565,7 +42360,8 @@
         "git_stash_apply_init_options",
         "git_stash_drop",
         "git_stash_foreach",
-        "git_stash_pop"
+        "git_stash_pop",
+        "git_stash_save"
       ]
     ],
     [
@@ -38581,6 +42377,12 @@
         "git_status_list_get_perfdata",
         "git_status_list_new",
         "git_status_should_ignore"
+      ]
+    ],
+    [
+      "stdalloc",
+      [
+        "git_stdalloc_init_allocator"
       ]
     ],
     [
@@ -38672,6 +42474,19 @@
       ]
     ],
     [
+      "transaction",
+      [
+        "git_transaction_commit",
+        "git_transaction_free",
+        "git_transaction_lock_ref",
+        "git_transaction_new",
+        "git_transaction_remove",
+        "git_transaction_set_reflog",
+        "git_transaction_set_symbolic_target",
+        "git_transaction_set_target"
+      ]
+    ],
+    [
       "transport",
       [
         "git_transport_dummy",
@@ -38730,6 +42545,12 @@
       ]
     ],
     [
+      "win32",
+      [
+        "git_win32_crtdbg_init_allocator"
+      ]
+    ],
+    [
       "worktree",
       [
         "git_worktree_add",
@@ -38740,7 +42561,9 @@
         "git_worktree_list",
         "git_worktree_lock",
         "git_worktree_lookup",
+        "git_worktree_name",
         "git_worktree_open_from_repository",
+        "git_worktree_path",
         "git_worktree_prune",
         "git_worktree_prune_init_options",
         "git_worktree_unlock",
@@ -38760,6 +42583,10 @@
     [
       "cat-file.c",
       "ex/HEAD/cat-file.html"
+    ],
+    [
+      "checkout.c",
+      "ex/HEAD/checkout.html"
     ],
     [
       "common.c",
@@ -38788,6 +42615,10 @@
     [
       "log.c",
       "ex/HEAD/log.html"
+    ],
+    [
+      "ls-files.c",
+      "ex/HEAD/ls-files.html"
     ],
     [
       "merge.c",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -777,6 +777,14 @@
             {
               "type": "git_merge_options",
               "name": "merge_options"
+            },
+            {
+              "type": "git_commit_signing_cb",
+              "name": "signing_cb"
+            },
+            {
+              "type": "void *",
+              "name": "payload"
             }
           ],
           "used": {

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -86,30 +86,6 @@
   },
   "new" : {
     "functions": {
-      "git_branch_remote_name": {
-        "type": "function",
-        "file": "branch.h",
-        "args": [
-          {
-            "name": "out",
-            "type": "git_buf *"
-          },
-          {
-            "name": "repo",
-            "type": "git_repository *"
-          },
-          {
-            "name": "canonical_branch_name",
-            "type": "const char *"
-          }
-        ],
-        "isAsync": true,
-        "return": {
-          "type": "int",
-          "isErrorCode": true
-        },
-        "group": "branch"
-      },
       "git_clone": {
         "isManual": true,
         "cFile": "generate/templates/manual/clone/clone.cc",
@@ -374,6 +350,27 @@
           "git_filter_source_id",
           "git_filter_source_mode",
           "git_filter_source_flags"
+        ]
+      ],
+      [
+        "index_name_entry",
+        [
+          "git_index_name_add",
+          "git_index_name_clear",
+          "git_index_name_entrycount",
+          "git_index_name_get_byindex"
+        ]
+      ],
+      [
+        "index_reuc_entry",
+        [
+          "git_index_reuc_add",
+          "git_index_reuc_clear",
+          "git_index_reuc_entrycount",
+          "git_index_reuc_find",
+          "git_index_reuc_get_byindex",
+          "git_index_reuc_get_bypath",
+          "git_index_reuc_remove"
         ]
       ],
       [
@@ -1035,11 +1032,27 @@
         "git_diff_stats_free"
       ]
     },
+    "index": {
+      "functions": [
+        "git_index_name_add",
+        "git_index_name_clear",
+        "git_index_name_entrycount",
+        "git_index_name_get_byindex",
+        "git_index_reuc_add",
+        "git_index_reuc_clear",
+        "git_index_reuc_entrycount",
+        "git_index_reuc_find",
+        "git_index_reuc_get_byindex",
+        "git_index_reuc_get_bypath",
+        "git_index_reuc_remove"
+      ]
+    },
     "merge": {
       "functions": [
         "git_merge_driver_lookup",
         "git_merge_driver_register",
         "git_merge_driver_source_ancestor",
+        "git_merge_driver_source_file_options",
         "git_merge_driver_source_ours",
         "git_merge_driver_source_repo",
         "git_merge_driver_source_theirs",
@@ -1059,6 +1072,10 @@
     },
     "odb": {
       "functions": [
+        "git_odb_backend_loose",
+        "git_odb_backend_malloc",
+        "git_odb_backend_one_pack",
+        "git_odb_backend_pack",
         "git_odb_object_data",
         "git_odb_object_dup",
         "git_odb_object_free",
@@ -1090,6 +1107,8 @@
     },
     "reflog": {
       "functions": [
+        "git_reflog_entry__alloc",
+        "git_reflog_entry__free",
         "git_reflog_entry_committer",
         "git_reflog_entry_id_new",
         "git_reflog_entry_id_old",
@@ -1117,12 +1136,5 @@
       ]
     }
   },
-  "groups": {
-    "branch": [
-      "git_branch_remote_name"
-    ],
-    "stash": [
-      "git_stash_save"
-    ]
-  }
+  "groups": {}
 }

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -51,6 +51,7 @@ module.exports = function generateNativeCode() {
     and: require("../templates/filters/and"),
     argsInfo: require("../templates/filters/args_info"),
     arrayTypeToPlainType: require("../templates/filters/array_type_to_plain_type"),
+    asElementPointer: require("../templates/filters/as_element_pointer"),
     cppToV8: require("../templates/filters/cpp_to_v8"),
     defaultValue: require("../templates/filters/default_value"),
     fieldsInfo: require("../templates/filters/fields_info"),

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -50,11 +50,13 @@ module.exports = function generateNativeCode() {
   var filters = {
     and: require("../templates/filters/and"),
     argsInfo: require("../templates/filters/args_info"),
+    arrayTypeToPlainType: require("../templates/filters/array_type_to_plain_type"),
     cppToV8: require("../templates/filters/cpp_to_v8"),
     defaultValue: require("../templates/filters/default_value"),
     fieldsInfo: require("../templates/filters/fields_info"),
     hasReturnType: require("../templates/filters/has_return_type"),
     hasReturnValue: require("../templates/filters/has_return_value"),
+    isArrayType: require("../templates/filters/is_array_type"),
     isDoublePointer: require("../templates/filters/is_double_pointer"),
     isFixedLengthString: require("../templates/filters/is_fixed_length_string"),
     isOid: require("../templates/filters/is_oid"),
@@ -70,6 +72,7 @@ module.exports = function generateNativeCode() {
     subtract: require("../templates/filters/subtract"),
     titleCase: require("../templates/filters/title_case"),
     toBool: require('../templates/filters/to_bool'),
+    toSizeOfArray: require("../templates/filters/to_size_of_array"),
     unPointer: require("../templates/filters/un_pointer"),
     setUnsigned: require("../templates/filters/unsigned"),
     upper: require("../templates/filters/upper")

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -40,6 +40,7 @@ var Helpers = {
     .replace("struct", "")
     .replace(utils.doublePointerRegex, "")
     .replace(utils.pointerRegex, "")
+    .replace(utils.arrayTypeRegex, "")
     .trim();
   },
 

--- a/generate/scripts/utils.js
+++ b/generate/scripts/utils.js
@@ -9,6 +9,7 @@ const path = require("path");
 var local = path.join.bind(null, __dirname, "../");
 
 var util = {
+  arrayTypeRegex: /\s\[\d+\]\s*/,
   pointerRegex: /\s*\*\s*/,
   doublePointerRegex: /\s*\*\*\s*/,
 

--- a/generate/templates/filters/array_type_to_plain_type.js
+++ b/generate/templates/filters/array_type_to_plain_type.js
@@ -1,0 +1,3 @@
+module.exports = function(cType) {
+  return /(.*)\s\[\d+\]\s*/.exec(cType)[1];
+};

--- a/generate/templates/filters/as_element_pointer.js
+++ b/generate/templates/filters/as_element_pointer.js
@@ -1,0 +1,7 @@
+const isArrayType = require("./is_array_type");
+
+module.exports = function(cType, parsedName) {
+  return isArrayType(cType) ?
+    "&" + parsedName + "[i]" :
+    parsedName;
+};

--- a/generate/templates/filters/is_array_type.js
+++ b/generate/templates/filters/is_array_type.js
@@ -1,0 +1,3 @@
+module.exports = function(cType) {
+  return /\s\[\d+\]\s*/.test(cType);
+};

--- a/generate/templates/filters/to_size_of_array.js
+++ b/generate/templates/filters/to_size_of_array.js
@@ -1,0 +1,3 @@
+module.exports = function(cType) {
+  return /\s\[(\d+)\]\s*/.exec(cType)[1];
+};

--- a/generate/templates/manual/clone/clone.cc
+++ b/generate/templates/manual/clone/clone.cc
@@ -91,7 +91,7 @@ NAN_METHOD(GitClone::Clone) {
 }
 
 void GitClone::CloneWorker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(
@@ -113,8 +113,8 @@ void GitClone::CloneWorker::Execute() {
 
     baton->error_code = result;
 
-    if (result != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
+    if (result != GIT_OK && git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
     }
   }
 }

--- a/generate/templates/manual/commit/extract_signature.cc
+++ b/generate/templates/manual/commit/extract_signature.cc
@@ -37,8 +37,8 @@ NAN_METHOD(GitCommit::ExtractSignature)
     if (git_oid_fromstr(baton->commit_id, (const char *)strdup(*oidString)) != GIT_OK) {
       free(baton->commit_id);
 
-      if (giterr_last()) {
-        return Nan::ThrowError(giterr_last()->message);
+      if (git_error_last()) {
+        return Nan::ThrowError(git_error_last()->message);
       } else {
         return Nan::ThrowError("Unknown Error");
       }
@@ -73,7 +73,7 @@ NAN_METHOD(GitCommit::ExtractSignature)
 
 void GitCommit::ExtractSignatureWorker::Execute()
 {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(
@@ -89,8 +89,8 @@ void GitCommit::ExtractSignatureWorker::Execute()
       (const char *)baton->field
     );
 
-    if (baton->error_code != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
+    if (baton->error_code != GIT_OK && git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
     }
   }
 }
@@ -145,8 +145,8 @@ void GitCommit::ExtractSignatureWorker::HandleOKCallback()
     callback->Call(0, NULL, async_resource);
   }
 
-  git_buf_free(&baton->signature);
-  git_buf_free(&baton->signed_data);
+  git_buf_dispose(&baton->signature);
+  git_buf_dispose(&baton->signed_data);
 
   if (baton->field != NULL) {
     free((void *)baton->field);

--- a/generate/templates/manual/filter_list/load.cc
+++ b/generate/templates/manual/filter_list/load.cc
@@ -108,7 +108,7 @@ NAN_METHOD(GitFilterList::Load) {
 }
 
 void GitFilterList::LoadWorker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(
@@ -119,8 +119,8 @@ void GitFilterList::LoadWorker::Execute() {
 
     baton->error_code = result;
 
-    if (result != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
+    if (result != GIT_OK && git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
     }
   }
 }

--- a/generate/templates/manual/patches/convenient_patches.cc
+++ b/generate/templates/manual/patches/convenient_patches.cc
@@ -26,7 +26,7 @@ NAN_METHOD(GitPatch::ConvenientFromDiff) {
 }
 
 void GitPatch::ConvenientFromDiffWorker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(true, baton->diff);
@@ -50,8 +50,8 @@ void GitPatch::ConvenientFromDiffWorker::Execute() {
 
         baton->error_code = result;
 
-        if (giterr_last() != NULL) {
-          baton->error = git_error_dup(giterr_last());
+        if (git_error_last() != NULL) {
+          baton->error = git_error_dup(git_error_last());
         }
 
         delete baton->out;

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -20,7 +20,7 @@ NAN_METHOD(GitRemote::ReferenceList)
 
 void GitRemote::ReferenceListWorker::Execute()
 {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(
@@ -37,7 +37,7 @@ void GitRemote::ReferenceListWorker::Execute()
     );
 
     if (baton->error_code != GIT_OK) {
-      baton->error = git_error_dup(giterr_last());
+      baton->error = git_error_dup(git_error_last());
       delete baton->out;
       baton->out = NULL;
       return;

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -30,7 +30,7 @@ void GitRevwalk::FastWalkWorker::Execute()
   for (int i = 0; i < baton->max_count; i++)
   {
     git_oid *nextCommit = (git_oid *)malloc(sizeof(git_oid));
-    giterr_clear();
+    git_error_clear();
     baton->error_code = git_revwalk_next(nextCommit, baton->walk);
 
     if (baton->error_code != GIT_OK)
@@ -40,7 +40,7 @@ void GitRevwalk::FastWalkWorker::Execute()
       free(nextCommit);
 
       if (baton->error_code != GIT_ITEROVER) {
-        baton->error = git_error_dup(giterr_last());
+        baton->error = git_error_dup(git_error_last());
 
         while(!baton->out->empty())
         {

--- a/generate/templates/manual/revwalk/file_history_walk.cc
+++ b/generate/templates/manual/revwalk/file_history_walk.cc
@@ -35,7 +35,7 @@ void GitRevwalk::FileHistoryWalkWorker::Execute()
 {
   git_repository *repo = git_revwalk_repository(baton->walk);
   git_oid *nextOid = (git_oid *)malloc(sizeof(git_oid));
-  giterr_clear();
+  git_error_clear();
   for (
     unsigned int i = 0;
     i < baton->max_count && (baton->error_code = git_revwalk_next(nextOid, baton->walk)) == GIT_OK;
@@ -233,7 +233,7 @@ void GitRevwalk::FileHistoryWalkWorker::Execute()
 
   if (baton->error_code != GIT_OK) {
     if (baton->error_code != GIT_ITEROVER) {
-      baton->error = git_error_dup(giterr_last());
+      baton->error = git_error_dup(git_error_last());
 
       while(!baton->out->empty())
       {

--- a/generate/templates/manual/src/filter_registry.cc
+++ b/generate/templates/manual/src/filter_registry.cc
@@ -77,15 +77,15 @@ NAN_METHOD(GitFilterRegistry::GitFilterRegister) {
 }
 
 void GitFilterRegistry::RegisterWorker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(/*asyncAction: */true, baton->filter_name, baton->filter);
     int result = git_filter_register(baton->filter_name, baton->filter, baton->filter_priority);
     baton->error_code = result;
 
-    if (result != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
+    if (result != GIT_OK && git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
     }
   }
 }
@@ -163,15 +163,15 @@ NAN_METHOD(GitFilterRegistry::GitFilterUnregister) {
 }
 
 void GitFilterRegistry::UnregisterWorker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(/*asyncAction: */true, baton->filter_name);
     int result = git_filter_unregister(baton->filter_name);
     baton->error_code = result;
 
-    if (result != GIT_OK && giterr_last() != NULL) {
-      baton->error = git_error_dup(giterr_last());
+    if (result != GIT_OK && git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
     }
   }
 }

--- a/generate/templates/partials/async_function.cc
+++ b/generate/templates/partials/async_function.cc
@@ -79,7 +79,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
 }
 
 void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
-  giterr_clear();
+  git_error_clear();
 
   {
     LockMaster lockMaster(
@@ -107,15 +107,15 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::Execute() {
 
     {%if return.isResultOrError %}
       baton->error_code = result;
-      if (result < GIT_OK && giterr_last() != NULL) {
-        baton->error = git_error_dup(giterr_last());
+      if (result < GIT_OK && git_error_last() != NULL) {
+        baton->error = git_error_dup(git_error_last());
       }
 
     {%elsif return.isErrorCode %}
       baton->error_code = result;
 
-      if (result != GIT_OK && giterr_last() != NULL) {
-        baton->error = git_error_dup(giterr_last());
+      if (result != GIT_OK && git_error_last() != NULL) {
+        baton->error = git_error_dup(git_error_last());
       }
 
     {%elsif not return.cType == 'void' %}
@@ -283,7 +283,7 @@ void {{ cppClassName }}::{{ cppFunctionName }}Worker::HandleOKCallback() {
     {%if arg.cppClassName == "GitBuf" %}
       {%if cppFunctionName == "Set" %}
       {%else%}
-        git_buf_free(baton->{{ arg.name }});
+        git_buf_dispose(baton->{{ arg.name }});
         free((void *)baton->{{ arg.name }});
       {%endif%}
     {%endif%}

--- a/generate/templates/partials/convert_from_v8.cc
+++ b/generate/templates/partials/convert_from_v8.cc
@@ -75,8 +75,8 @@
     if (git_oid_fromstr(oidOut, (const char *) strdup(*oidString)) != GIT_OK) {
       free(oidOut);
 
-      if (giterr_last()) {
-        return Nan::ThrowError(giterr_last()->message);
+      if (git_error_last()) {
+        return Nan::ThrowError(git_error_last()->message);
       } else {
         return Nan::ThrowError("Unknown Error");
       }

--- a/generate/templates/partials/convert_to_v8.cc
+++ b/generate/templates/partials/convert_to_v8.cc
@@ -82,6 +82,7 @@
         {% if ownedBy %}
           {% if isAsync %}
             {% each ownedBy as owner %}
+              {%-- If the owner of this object is "this" in an async method, it will be stored in the persistent handle by name. --%}
               Nan::Set(owners, Nan::New<v8::Number>(owners->Length()), this->GetFromPersistent("{{= owner =}}")->ToObject());
             {% endeach %}
           {% else %}
@@ -92,6 +93,7 @@
         {% endif %}
         {%if isAsync %}
         {% elsif ownedByThis %}
+          {%-- If the owner of this object is "this", it will be retrievable from the info object in a sync method. --%}
           Nan::Set(owners, owners->Length(), info.This());
         {% endif %}
         {% if ownerFn | toBool %}
@@ -137,6 +139,7 @@
       {% if ownedBy %}
         {% if isAsync %}
           {% each ownedBy as owner %}
+            {%-- If the owner of this object is "this" in an async method, it will be stored in the persistent handle by name. --%}
             Nan::Set(owners, Nan::New<v8::Number>(owners->Length()), this->GetFromPersistent("{{= owner =}}")->ToObject());
           {% endeach %}
         {% else %}
@@ -147,6 +150,7 @@
       {% endif %}
       {%if isAsync %}
       {% elsif ownedByThis %}
+        {%-- If the owner of this object is "this", it will be retrievable from the info object in a sync method. --%}
         Nan::Set(owners, owners->Length(), info.This());
       {% endif %}
       {% if ownerFn | toBool %}

--- a/generate/templates/partials/fields.cc
+++ b/generate/templates/partials/fields.cc
@@ -1,21 +1,24 @@
 {% each fields|fieldsInfo as field %}
   {% if not field.ignore %}
+    // start field block
     NAN_METHOD({{ cppClassName }}::{{ field.cppFunctionName }}) {
       v8::Local<v8::Value> to;
 
       {% if field | isFixedLengthString %}
       char* {{ field.name }} = (char *)Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue()->{{ field.name }};
       {% else %}
-      {{ field.cType }}
-        {% if not field.cppClassName|isV8Value %}
-          {% if not field.cType|isPointer %}
-        *
+        {% if field.cType|isArrayType %}
+          {{ field.cType|arrayTypeToPlainType }} *{{ field.name }} =
+        {% else %}
+          {{ field.cType }}
+          {% if not field.cppClassName|isV8Value %}
+            {% if not field.cType|isPointer %}*{% endif %}
           {% endif %}
-        {% endif %}
-        {{ field.name }} =
-        {% if not field.cppClassName|isV8Value %}
-          {% if not field.cType|isPointer %}
-        &
+          {{ field.name }} =
+          {% if not field.cppClassName|isV8Value %}
+            {% if field.cType|isArrayType %}{% elsif not field.cType|isPointer %}
+          &
+            {% endif %}
           {% endif %}
         {% endif %}
         Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue()->{{ field.name }};
@@ -24,5 +27,6 @@
       {% partial convertToV8 field %}
       info.GetReturnValue().Set(to);
     }
+    // end field block
   {% endif %}
 {% endeach %}

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -31,7 +31,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
     if (Nan::ObjectWrap::Unwrap<{{ cppClassName }}>(info.This())->GetValue() != NULL) {
   {%endif%}
 
-  giterr_clear();
+  git_error_clear();
 
   { // lock master scope start
     LockMaster lockMaster(
@@ -79,8 +79,8 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
         {%endif%}
       {%endeach%}
 
-        if (giterr_last()) {
-          return Nan::ThrowError(giterr_last()->message);
+        if (git_error_last()) {
+          return Nan::ThrowError(git_error_last()->message);
         } else {
           return Nan::ThrowError("Unknown Error");
         }

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -161,13 +161,6 @@
           }
         ],
         [
-          "OS=='linux' or OS=='mac' or OS.endswith('bsd')", {
-            "libraries": [
-              "<!(curl-config --libs)"
-            ]
-          }
-        ],
-        [
           "OS=='linux' or OS.endswith('bsd')", {
             "cflags": [
               "-std=c++11"

--- a/guides/cloning/README.md
+++ b/guides/cloning/README.md
@@ -85,7 +85,7 @@ to passthrough the certificate check.
 ``` javascript
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; }
+    certificateCheck: function() { return 0; }
   }
 };
 ```

--- a/guides/cloning/gh-two-factor/README.md
+++ b/guides/cloning/gh-two-factor/README.md
@@ -101,7 +101,7 @@ to passthrough the certificate check.
 ``` javascript
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; }
+    certificateCheck: function() { return 0; }
   }
 };
 ```
@@ -119,7 +119,7 @@ The `fetchOpts` object now looks like this:
 ``` javascript
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; },
+    certificateCheck: function() { return 0; },
     credentials: function() {
       return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
     }

--- a/guides/cloning/gh-two-factor/index.js
+++ b/guides/cloning/gh-two-factor/index.js
@@ -22,7 +22,7 @@ var cloneOptions = {};
 // with libgit2 being able to verify certificates from GitHub.
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; },
+    certificateCheck: function() { return 0; },
     credentials: function() {
       return NodeGit.Cred.userpassPlaintextNew(GITHUB_TOKEN, "x-oauth-basic");
     }

--- a/guides/cloning/index.js
+++ b/guides/cloning/index.js
@@ -18,7 +18,7 @@ var cloneOptions = {};
 // with libgit2 being able to verify certificates from GitHub.
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; }
+    certificateCheck: function() { return 0; }
   }
 };
 

--- a/guides/cloning/ssh-with-agent/README.md
+++ b/guides/cloning/ssh-with-agent/README.md
@@ -83,7 +83,7 @@ to passthrough the certificate check.
 ``` javascript
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; }
+    certificateCheck: function() { return 0; }
   }
 };
 ```
@@ -102,7 +102,7 @@ The `fetchOpts` object now looks like this:
 ``` javascript
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; },
+    certificateCheck: function() { return 0; },
     credentials: function(url, userName) {
       return NodeGit.Cred.sshKeyFromAgent(userName);
     }

--- a/guides/cloning/ssh-with-agent/index.js
+++ b/guides/cloning/ssh-with-agent/index.js
@@ -17,7 +17,7 @@ var cloneOptions = {};
 // with libgit2 being able to verify certificates from GitHub.
 cloneOptions.fetchOpts = {
   callbacks: {
-    certificateCheck: function() { return 1; },
+    certificateCheck: function() { return 0; },
 
     // Credentials are passed two arguments, url and username. We forward the
     // `userName` argument to the `sshKeyFromAgent` function to validate

--- a/lib/buf.js
+++ b/lib/buf.js
@@ -1,0 +1,11 @@
+const { Buf } = require("../");
+
+/**
+ * Sets the content of a GitBuf to a string.
+ * @param {string} The utf8 value to set in the buffer.
+ *                 The string will be null terminated.
+ */
+Buf.prototype.setString = function(content) {
+  const buf = Buffer.from(content + "\0", "utf8");
+  this.set(buf, buf.length);
+};

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -7,21 +7,6 @@ var _init = Rebase.init;
 var _open = Rebase.open;
 var _abort = Rebase.prototype.abort;
 var _commit = Rebase.prototype.commit;
-/**
- * Initializes a rebase
- * @async
- * @param {Repository} repo The repository to perform the rebase
- * @param {AnnotatedCommit} branch The terminal commit to rebase, or NULL to
- *                                 rebase the current branch
- * @param {AnnotatedCommit} upstream The commit to begin rebasing from, or NULL
- *                                   to rebase all reachable commits
- * @param {AnnotatedCommit} onto The branch to rebase onto, or NULL to rebase
- *                               onto the given upstream
- * @param {RebaseOptions} options Options to specify how rebase is performed,
- *                                or NULL
- * @param {Function} callback
- * @return {Remote}
- */
 
 function defaultRebaseOptions(options, checkoutStrategy) {
   var checkoutOptions;
@@ -61,12 +46,38 @@ function defaultRebaseOptions(options, checkoutStrategy) {
   return options;
 }
 
+// Save options on the rebase object. If we don't do this,
+// the options may be cleaned up and cause a segfault
+// when Rebase.prototype.commit is called.
+const lockOptionsOnRebase = (options) => (rebase) => {
+  Object.defineProperty(rebase, "options", {
+    value: options,
+    writable: false
+  });
+  return rebase;
+};
+
+/**
+ * Initializes a rebase
+ * @async
+ * @param {Repository} repo The repository to perform the rebase
+ * @param {AnnotatedCommit} branch The terminal commit to rebase, or NULL to
+ *                                 rebase the current branch
+ * @param {AnnotatedCommit} upstream The commit to begin rebasing from, or NULL
+ *                                   to rebase all reachable commits
+ * @param {AnnotatedCommit} onto The branch to rebase onto, or NULL to rebase
+ *                               onto the given upstream
+ * @param {RebaseOptions} options Options to specify how rebase is performed,
+ *                                or NULL
+ * @return {Remote}
+ */
 Rebase.init = function(repository, branch, upstream, onto, options) {
   options = defaultRebaseOptions(
     options,
     NodeGit.Checkout.STRATEGY.FORCE
   );
-  return _init(repository, branch, upstream, onto, options);
+  return _init(repository, branch, upstream, onto, options)
+    .then(lockOptionsOnRebase(options));
 };
 
 /**
@@ -75,7 +86,6 @@ Rebase.init = function(repository, branch, upstream, onto, options) {
  * @async
  * @param {Repository} repo The repository that has a rebase in-progress
  * @param {RebaseOptions} options Options to specify how rebase is performed
- * @param {Function} callback
  * @return {Remote}
  */
 Rebase.open = function(repository, options) {
@@ -83,7 +93,8 @@ Rebase.open = function(repository, options) {
     options,
     NodeGit.Checkout.STRATEGY.SAFE
   );
-  return _open(repository, options);
+  return _open(repository, options)
+    .then(lockOptionsOnRebase(options));
 };
 
 Rebase.prototype.commit = function(author, committer, encoding, message) {
@@ -93,4 +104,3 @@ Rebase.prototype.commit = function(author, committer, encoding, message) {
 Rebase.prototype.abort = function() {
   return _abort.call(this);
 };
-

--- a/test/tests/clone.js
+++ b/test/tests/clone.js
@@ -43,9 +43,7 @@ describe("Clone", function() {
     var opts = {
         fetchOpts: {
           callbacks: {
-            certificateCheck: function() {
-              return 1;
-          }
+            certificateCheck: () => 0
         }
       }
     };
@@ -202,9 +200,7 @@ describe("Clone", function() {
     var opts = {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          }
+          certificateCheck: () => 0
         }
       }
     };
@@ -221,9 +217,7 @@ describe("Clone", function() {
     var opts = {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          },
+          certificateCheck: () => 0,
           credentials: function(url, userName) {
             return NodeGit.Cred.sshKeyFromAgent(userName);
           }
@@ -243,9 +237,7 @@ describe("Clone", function() {
     var opts = {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          },
+          certificateCheck: () => 0,
           credentials: function(url, userName) {
             return NodeGit.Cred.sshKeyNew(
               userName,
@@ -269,9 +261,7 @@ describe("Clone", function() {
     var opts = {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          },
+          certificateCheck: () => 0,
           credentials: function(url, userName) {
             return NodeGit.Cred.sshKeyNew(
               userName,
@@ -296,9 +286,7 @@ describe("Clone", function() {
     var opts = {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          }
+          certificateCheck: () => 0
         }
       }
     };
@@ -328,9 +316,7 @@ describe("Clone", function() {
     return Clone(url, clonePath, {
       fetchOpts: {
         callbacks: {
-          certificateCheck: function() {
-            return 1;
-          },
+          certificateCheck: () => 0,
           credentials: function() {
             if (firstPass) {
               firstPass = false;

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -476,10 +476,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.PASSTHROUGH;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.PASSTHROUGH;
         },
         check: function() {
           return NodeGit.Error.CODE.OK;
@@ -522,10 +520,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return NodeGit.Error.CODE.OK;
@@ -568,10 +564,8 @@ describe("Filter", function() {
 
         return Registry.register(filterName, {
           apply: function(to, from, source) {
-            return to.set(largeBuffer, largeBufferSize)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+            to.set(largeBuffer, largeBufferSize);
+            return NodeGit.Error.CODE.OK;
           },
           check: function(src, attr) {
             return NodeGit.Error.CODE.OK;
@@ -626,10 +620,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return NodeGit.Error.CODE.OK;
@@ -668,10 +660,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return src.path() === "README.md" ?
@@ -725,10 +715,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return src.path() === "README.md" ?
@@ -956,10 +944,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return NodeGit.Error.CODE.OK;
@@ -999,10 +985,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return NodeGit.Error.CODE.OK;
@@ -1044,10 +1028,8 @@ describe("Filter", function() {
 
       return Registry.register(filterName, {
         apply: function(to, from, source) {
-          return to.set(tempBuffer, length)
-            .then(function() {
-              return NodeGit.Error.CODE.OK;
-            });
+          to.set(tempBuffer, length);
+          return NodeGit.Error.CODE.OK;
         },
         check: function(src, attr) {
           return NodeGit.Error.CODE.OK;

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -3,6 +3,8 @@ var path = require("path");
 var local = path.join.bind(path, __dirname);
 var fse = require("fs-extra");
 
+var garbageCollect = require("../utils/garbage_collect.js");
+
 describe("Rebase", function() {
   var NodeGit = require("../../");
   var Checkout = NodeGit.Checkout;
@@ -1532,6 +1534,195 @@ describe("Rebase", function() {
         // verify that we are on top of "their commit"
         assert.equal(commit.id().toString(),
           "b3c355bb606ec7da87174dfa1a0b0c0e3dc97bc0");
+      });
+  });
+
+  it("can sign commits during the rebase", function() {
+    var baseFileName = "baseNewFile.txt";
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var baseFileContent = "How do you feel about Toll Roads?";
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+          ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+          ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var ourBranch;
+    var theirBranch;
+    var rebase;
+
+    return fse.writeFile(path.join(repository.workdir(), baseFileName),
+      baseFileContent)
+      // Load up the repository index and make our initial commit to HEAD
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, baseFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "b5cdc109d437c4541a13fb7509116b5f03d5039a");
+
+        return repository.createCommit("HEAD", ourSignature,
+          ourSignature, "initial commit", oid, []);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "be03abdf0353d05924c53bebeb0e5bb129cda44a");
+
+        return repository.getCommit(commitOid).then(function(commit) {
+          ourCommit = commit;
+        }).then(function() {
+          return repository.createBranch(ourBranchName, commitOid)
+            .then(function(branch) {
+              ourBranch = branch;
+              return repository.createBranch(theirBranchName, commitOid);
+            });
+        });
+      })
+      .then(function(branch) {
+        theirBranch = branch;
+        return fse.writeFile(path.join(repository.workdir(), theirFileName),
+          theirFileContent);
+      })
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, theirFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "be5f0fd38a39a67135ad68921c93cd5c17fefb3d");
+
+        return repository.createCommit(theirBranch.name(), theirSignature,
+          theirSignature, "they made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+
+        return removeFileFromIndex(repository, theirFileName);
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), theirFileName));
+      })
+      .then(function() {
+        return fse.writeFile(path.join(repository.workdir(), ourFileName),
+          ourFileContent);
+      })
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, ourFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "77867fc0bfeb3f80ab18a78c8d53aa3a06207047");
+
+          return repository.createCommit(ourBranch.name(), ourSignature,
+            ourSignature, "we made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        return removeFileFromIndex(repository, ourFileName);
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), ourFileName));
+      })
+      .then(function() {
+        return repository.checkoutBranch(ourBranchName);
+      })
+      .then(function() {
+        return Promise.all([
+          repository.getReference(ourBranchName),
+          repository.getReference(theirBranchName)
+        ]);
+      })
+      .then(function(refs) {
+        assert.equal(refs.length, 2);
+
+        return Promise.all([
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[0]),
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[1])
+        ]);
+      })
+      .then(function(annotatedCommits) {
+        assert.equal(annotatedCommits.length, 2);
+
+        var ourAnnotatedCommit = annotatedCommits[0];
+        var theirAnnotatedCommit = annotatedCommits[1];
+
+        assert.equal(ourAnnotatedCommit.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+        assert.equal(theirAnnotatedCommit.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+
+        return NodeGit.Rebase.init(repository, ourAnnotatedCommit,
+          theirAnnotatedCommit, null, {
+            signingCb: (signatureBuf, signatureFieldBuf, commitContent) => {
+              signatureBuf.setString("A moose was here.");
+              signatureFieldBuf.setString("moose-sig");
+              return 0;
+            }
+          });
+      })
+      .then(function(newRebase) {
+        rebase = newRebase;
+
+        // there should only be 1 rebase operation to perform
+        assert.equal(rebase.operationEntrycount(), 1);
+
+        return rebase.next();
+      })
+      .then(function(rebaseOperation) {
+        assert.equal(rebaseOperation.type(),
+          NodeGit.RebaseOperation.REBASE_OPERATION.PICK);
+        assert.equal(rebaseOperation.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        // Make sure we don't crash calling the signature CB
+        // after collecting garbage.
+        garbageCollect();
+
+        return rebase.commit(null, ourSignature);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "24250fe6bd8a782ec1aaca8b2c9a2456a90517ed");
+
+        // git_rebase_operation_current returns the index of the rebase
+        // operation that was last applied, so after the first operation, it
+        // should be 0.
+        assert.equal(rebase.operationCurrent(), 0);
+
+        return rebase.finish(ourSignature, {});
+      })
+      .then(function(result) {
+        assert.equal(result, 0);
+
+        return repository.getBranchCommit(ourBranchName);
+      })
+      .then(function(commit) {
+        // verify that the "ours" branch has moved to the correct place
+        assert.equal(commit.id().toString(),
+          "24250fe6bd8a782ec1aaca8b2c9a2456a90517ed");
+
+        return Promise.all([
+          commit.parent(0),
+          NodeGit.Commit.extractSignature(
+            repository,
+            "24250fe6bd8a782ec1aaca8b2c9a2456a90517ed",
+            "moose-sig"
+          )
+        ]);
+      })
+      .then(function([parent, { signature }]) {
+        // verify that we are on top of "their commit"
+        assert.equal(parent.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+        assert.equal(signature, "A moose was here.");
       });
   });
 });

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -120,9 +120,7 @@ describe("Remote", function() {
     return repo.getRemote("origin")
       .then(function(remote) {
         remoteCallbacks = {
-          certificateCheck: function() {
-            return 1;
-          }
+          certificateCheck: () => 0
         };
 
         return remote.connect(NodeGit.Enums.DIRECTION.FETCH, remoteCallbacks)
@@ -201,9 +199,7 @@ describe("Remote", function() {
             credentials: function(url, userName) {
               return NodeGit.Cred.sshKeyFromAgent(userName);
             },
-            certificateCheck: function() {
-              return 1;
-            },
+            certificateCheck: () => 0,
 
             transferProgress: function() {
               wasCalled = true;
@@ -222,9 +218,7 @@ describe("Remote", function() {
 
   it("can get the default branch of a remote", function() {
     var remoteCallbacks = {
-      certificateCheck: function() {
-        return 1;
-      }
+      certificateCheck: () => 0
     };
 
     var remote = this.remote;
@@ -242,9 +236,7 @@ describe("Remote", function() {
         credentials: function(url, userName) {
           return NodeGit.Cred.sshKeyFromAgent(userName);
         },
-        certificateCheck: function() {
-          return 1;
-        }
+        certificateCheck: () => 0
       }
     });
   });
@@ -261,9 +253,7 @@ describe("Remote", function() {
             ""
           );
         },
-        certificateCheck: function() {
-          return 1;
-        }
+        certificateCheck: () => 0
       }
     };
 
@@ -288,9 +278,7 @@ describe("Remote", function() {
               return NodeGit.Cred.sshKeyFromAgent(userName);
             }
           },
-          certificateCheck: function() {
-            return 1;
-          }
+          certificateCheck: () => 0
         }
       };
 
@@ -323,9 +311,7 @@ describe("Remote", function() {
             credentials: function(url, userName) {
               return NodeGit.Cred.sshKeyFromAgent(userName);
             },
-            certificateCheck: function() {
-              return 1;
-            }
+            certificateCheck: () => 0
           }
         });
       });
@@ -350,9 +336,7 @@ describe("Remote", function() {
                 });
               return test;
             },
-            certificateCheck: function() {
-              return 1;
-            }
+            certificateCheck: () => 0
           }
         };
         return remote.push(refs, options);
@@ -384,9 +368,7 @@ describe("Remote", function() {
                 .then(Promise.reject.bind(Promise));
               return test;
             },
-            certificateCheck: function() {
-              return 1;
-            }
+            certificateCheck: () => 0
           }
         };
         return remote.push(refs, options);
@@ -426,9 +408,7 @@ describe("Remote", function() {
                 return Promise.reject();
               }
             },
-            certificateCheck: function() {
-              return 1;
-            }
+            certificateCheck: () => 0
           }
         };
         return remote.push(refs, options);

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -185,9 +185,7 @@ describe("Repository", function() {
       credentials: function(url, userName) {
         return NodeGit.Cred.sshKeyFromAgent(userName);
       },
-      certificateCheck: function() {
-        return 1;
-      }
+      certificateCheck: () => 0
     })
     .then(function() {
       return repo.fetchheadForeach(function(refname, remoteUrl, oid, isMerge) {

--- a/test/tests/stash.js
+++ b/test/tests/stash.js
@@ -57,7 +57,10 @@ describe("Stash", function() {
       .then(function() {
         assert.equal(stashes.length, 1);
         assert.equal(stashes[0].index, 0);
-        assert.equal(stashes[0].message, "On master: " + stashMessage);
+        const expectedMessage = !stashMessage ?
+          "WIP on master: 32789a7 Fixes EJS not being installed via NPM" :
+          "On master: " + stashMessage;
+        assert.equal(stashes[0].message, expectedMessage);
         assert.equal(stashes[0].oid.toString(), stashOid.toString());
 
         return Stash.drop(repo, 0);
@@ -82,11 +85,11 @@ describe("Stash", function() {
   }
 
   it("can save and drop a stash", function() {
-    saveDropStash(this.repository, "stash test");
+    return saveDropStash(this.repository, "stash test");
   });
 
   it("can save a stash with no message and drop it", function() {
-    saveDropStash(this.repository, null);
+    return saveDropStash(this.repository, null);
   });
 
   it("can save and pop a stash", function() {
@@ -198,8 +201,8 @@ describe("Stash", function() {
           return Stash.drop(repo, 0);
         })
         .catch(function(reason) {
-          if (reason.message !== "Reference 'refs/stash' not found") {
-            Promise.reject();
+          if (reason.message !== "reference 'refs/stash' not found") {
+            throw reason;
           }
         });
   });

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -32,6 +32,8 @@
         "libgit2/include/git2/sys/merge.h",
         "libgit2/include/git2/sys/time.h",
         "libgit2/include/git2/worktree.h",
+        "libgit2/src/alloc.c",
+        "libgit2/src/alloc.h",
         "libgit2/src/annotated_commit.c",
         "libgit2/src/annotated_commit.h",
         "libgit2/src/apply.c",
@@ -70,16 +72,17 @@
         "libgit2/src/commit.c",
         "libgit2/src/commit.h",
         "libgit2/src/common.h",
+        "libgit2/src/config_backend.h",
         "libgit2/src/config_cache.c",
+        "libgit2/src/config_entries.c",
+        "libgit2/src/config_entries.h",
         "libgit2/src/config_file.c",
-        "libgit2/src/config_file.h",
+        "libgit2/src/config_mem.c",
         "libgit2/src/config_parse.c",
         "libgit2/src/config_parse.h",
         "libgit2/src/config.c",
         "libgit2/src/config.h",
         "libgit2/src/crlf.c",
-        "libgit2/src/streams/curl.c",
-        "libgit2/src/streams/curl.h",
         "libgit2/src/date.c",
         "libgit2/src/delta.c",
         "libgit2/src/delta.h",
@@ -133,6 +136,8 @@
         "libgit2/src/iterator.c",
         "libgit2/src/iterator.h",
         "libgit2/src/khash.h",
+        "libgit2/src/mailmap.c",
+        "libgit2/src/mailmap.h",
         "libgit2/src/map.h",
         "libgit2/src/merge_driver.c",
         "libgit2/src/merge_file.c",
@@ -163,8 +168,12 @@
         "libgit2/src/oidarray.h",
         "libgit2/src/oidmap.c",
         "libgit2/src/oidmap.h",
+        "libgit2/src/streams/mbedtls.c",
+        "libgit2/src/streams/mbedtls.h",
         "libgit2/src/streams/openssl.c",
         "libgit2/src/streams/openssl.h",
+        "libgit2/src/streams/registry.c",
+        "libgit2/src/streams/registry.h",
         "libgit2/src/pack-objects.c",
         "libgit2/src/pack-objects.h",
         "libgit2/src/pack.c",
@@ -190,6 +199,8 @@
         "libgit2/src/proxy.c",
         "libgit2/src/push.c",
         "libgit2/src/push.h",
+        "libgit2/src/reader.c",
+        "libgit2/src/reader.h",
         "libgit2/src/rebase.c",
         "libgit2/src/refdb_fs.c",
         "libgit2/src/refdb_fs.h",
@@ -223,6 +234,8 @@
         "libgit2/src/stash.c",
         "libgit2/src/status.c",
         "libgit2/src/status.h",
+        "libgit2/src/stdalloc.c",
+        "libgit2/src/stdalloc.h",
         "libgit2/src/strmap.c",
         "libgit2/src/strmap.h",
         "libgit2/src/strnlen.h",
@@ -310,12 +323,7 @@
             }
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd')", {
-          "cflags": [
-            "-DGIT_CURL",
-            "<!(curl-config --cflags)"
-          ],
           "defines": [
-            "GIT_CURL",
             "GIT_SHA1_OPENSSL"
           ],
           "sources": [
@@ -446,7 +454,7 @@
       ],
       "direct_dependent_settings": {
         "include_dirs": [
-          "libgit2/include",
+          "libgit2/include"
         ],
       },
     },


### PR DESCRIPTION
This PR begins to address the many incoming deprecations from Libgit2. It also handles a lot of the additional features Libgit2 has exposed since 0.27.0

- Libcurl dependency has been removed
- IndexNameEntry is new and exposed.
- IndexReucEntry is new and exposed.
- Mailmap is new and exposed.
- Fixed bug that caused segfault due to garbage collection in remote.prototype.getRefspec
- Added pending feature, signing commits during rebase,  into Nodegit's fork of libgit2. See https://github.com/libgit2/libgit2/pull/4913 for more details.

This release also improves some of our capacity to handle code generation for statically allocated arrays as needed for `git_index_reuc_entry`. Check out the field mode and oid on git_index_reuc_entry here https://libgit2.org/libgit2/#HEAD/type/git_index_reuc_entry.

This PR also changes GitBuf.prototype.set and GitBuf.prototype.grow to sync.