### PR TITLE
Fix issues with Commit#amendWithSignature

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -146,7 +146,7 @@ Commit.prototype.amendWithSignature = function(
         );
       })
       .then(function(commitContentResult) {
-        commitContent = commitContentResult + "\n";
+        commitContent = commitContentResult;
         return onSignature(commitContent);
       })
       .then(function(signature) {

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -130,8 +130,8 @@ Commit.prototype.amendWithSignature = function(
           message: resolvedMessage,
           tree: resolvedTree
         } = fp.assign(
-          truthyArgs,
-          commitFields
+          commitFields,
+          truthyArgs
         );
 
         return Commit.createBuffer(

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -488,7 +488,7 @@ describe("Commit", function() {
         return repo.getHeadCommit();
       })
       .then(function(headCommit) {
-        message = headCommit.message().trim();
+        message = headCommit.message();
         parents = headCommit.parents();
 
         return headCommit.amendWithSignature(
@@ -512,8 +512,96 @@ describe("Commit", function() {
       })
       .then(function(signatureInfo) {
         assert.equal(signatureInfo.signature, signature);
-        assert.equal(commit.message().trim(), message);
+        assert.equal(commit.message(), message);
         assert.deepEqual(commit.parents(), parents);
+      });
+  });
+
+  it("amending with signature respects overridden arguments", function() {
+    const signature = "-----BEGIN PGP SIGNATURE-----\n" +
+    "\n" +
+    "iQJHBAEBCAAxFiEEKdxGpJ93wnkLaBKfURjJKedOfEMFAlxPKUYTHHN0ZXZla0Bh\n" +
+    "eG9zb2Z0LmNvbQAKCRBRGMkp5058Q3vcD/0Uf6P68g98Kbvsgjg/aidM1ujruXaw\n" +
+    "X5WSsCAw+wWGICOj0n+KBnmQruI4HSFz3zykEshuOpcBv1X/+huwDeB/hBqonCU8\n" +
+    "QdexCdWR70YbT1bufesUwV9v1qwE4WOmFxWXgwh55K0wDRkc0u2aLcwrJkIEEVfs\n" +
+    "HqZyFzU4kwbGekY/m7d1DsBhWyKEGW9/25WMYmjWOWOiaFjeBaHLlxiEM8KGnMLH\n" +
+    "wx37NuFuaABgi23AAcBGdeWy04TEuU4S51+bHM3RotrZ2cryW2lEbkkXodhIJcq0\n" +
+    "RgrStCbvR0ehnOPdYSiRbxK8JNLZuNjHlK2g7wVi+C83vwMQuhU4H6OlYHGVr664\n" +
+    "4YzL83FdIo7wiMOFd2OOMLlCfHgTun60FvjCs4WHjrwH1fQl287FRPLa/4olBSQP\n" +
+    "yUXJaZdxm4cB4L/1pmbb/J/XUiOio3MpaN3GFm2hZloUlag1uPDBtCxTl5odvj4a\n" +
+    "GOmTBWznXxF/zrKnQVSvv+EccNxYFc0VVjAxGgNqPzIxDAKtw1lE5pbBkFpFpNHz\n" +
+    "StmwZkP9QIJY4hJYQfM+pzHLe8xjexL+Kh/TrYXgY1m/4vJe0HJSsnRnaR8Yfqhh\n" +
+    "LReqo94VHRYXR0rZQv4py0D9TrWaI8xHLve6ewhLPNRzyaI9fNrinbcPYZZOWnRi\n" +
+    "ekgUBx+BX6nJOw==\n" +
+    "=4Hy5\n" +
+    "-----END PGP SIGNATURE-----";
+
+    function onSignature(dataToSign) {
+      return new Promise(function (resolve) {
+        return resolve(signature);
+      });
+    }
+
+    var repo;
+    var oid;
+    var commit;
+    var message;
+    var parents;
+    var commitTree;
+
+    var author = NodeGit.Signature.create(
+      "Scooby Doo",
+      "scoob@mystery.com",
+      123456789,
+      60
+    );
+    var committer = NodeGit.Signature.create(
+      "Shaggy Rogers",
+      "shaggy@mystery.com",
+      987654321,
+      90
+    );
+    var tree = Oid.fromString("f4661419a6fbbe865f78644fec722c023ce4b65f");
+
+    return NodeGit.Repository.open(reposPath)
+      .then(function(repoResult) {
+        repo = repoResult;
+        return repo.getHeadCommit();
+      })
+      .then(function(headCommit) {
+        message = headCommit.message();
+        parents = headCommit.parents();
+
+        return headCommit.amendWithSignature(
+          null,
+          author,
+          committer,
+          null,
+          null,
+          tree,
+          "gpgsig",
+          onSignature
+        );
+      })
+      .then(function(oidResult) {
+        oid = oidResult;
+        return NodeGit.Commit.lookup(repo, oid);
+      })
+      .then(function(commitResult) {
+        commit = commitResult;
+        return commit.getTree();
+      })
+      .then(function(commitTreeResult) {
+        commitTree = commitTreeResult;
+        return commit.getSignature("gpgsig");
+      })
+      .then(function(signatureInfo) {
+        assert.equal(signatureInfo.signature, signature);
+        assert.equal(commit.message(), message);
+        assert.deepEqual(commit.parents(), parents);
+        assert.deepEqual(commitTree.id(), tree);
+        assert.deepEqual(commit.author(), author);
+        assert.deepEqual(commit.committer(), committer);
       });
   });
 


### PR DESCRIPTION
Fixes two issues with the `Commit#amendWithSignature` method:
1. Non-null arguments which override the values from the commit object were being ignored.
2. An extra newline was being inserted into the commit message. This caused extraneous newlines to be appended to commit messages, esp. when the amend operation was repeated.