### PR TITLE
Breaking: Repository.prototype.continueRebase enhancements

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -455,13 +455,16 @@ Repository.prototype.checkoutRef = function(reference, opts) {
  *                                    promise, finish() will be called when the
  *                                    promise resolves. This callback will be
  *                                    provided a detailed overview of the rebase
+ * @param {RebaseOptions} rebaseOptions Options to initialize the rebase object
+ *                                      with
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      rebase with conflicts
  */
 Repository.prototype.continueRebase = function(
   signature,
   beforeNextFn,
-  beforeFinishFn
+  beforeFinishFn,
+  rebaseOptions
 ) {
   var repo = this;
 
@@ -474,7 +477,7 @@ Repository.prototype.continueRebase = function(
         throw index;
       }
 
-      return NodeGit.Rebase.open(repo);
+      return NodeGit.Rebase.open(repo, rebaseOptions);
     })
     .then(function(_rebase) {
       rebase = _rebase;
@@ -1505,6 +1508,8 @@ Repository.prototype.isReverting = function() {
  *                                    promise, finish() will be called when the
  *                                    promise resolves. This callback will be
  *                                    provided a detailed overview of the rebase
+ * @param {RebaseOptions} rebaseOptions Options to initialize the rebase object
+ *                                      with
  * @return {Oid|Index}  A commit id for a succesful merge or an index for a
  *                      rebase with conflicts
  */

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -482,11 +482,17 @@ Repository.prototype.continueRebase = function(
     .then(function(_rebase) {
       rebase = _rebase;
       return rebase.commit(null, signature)
-        .catch(function() {
+        .catch(function(e) {
           // Ignore all errors to prevent
           // this routine from choking now
           // that we made rebase.commit
           // asynchronous
+          const errorno = fp.get(["errorno"], e);
+          if (errorno === NodeGit.Error.CODE.EAPPLIED) {
+            return;
+          }
+
+          throw e;
         });
     })
     .then(function() {


### PR DESCRIPTION
1. Enhancement to the `Repository.prototype.continueRebase` method which allows a `RebaseOptions` to be passed in. This achieves parity with `Repository.prototype.rebaseBranches`.

2. Also introduces a breaking change from the error handling pattern introduced to `continueRebase` in #1348. Previously, all errors which occurred in the middle of a `continueRebase` operation would be swallowed. However, the introduction of `signingCb` as a field on `RebaseOptions` shed light on legitimate use cases where `continueRebase` should throw. My solution was to swallow the `EAPPLIED` error (specifically mentioned in the review of #1348) and throw all others.