### PR TITLE
Handle new gyp information for electron builds

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -1,21 +1,13 @@
 {
-  "conditions": [
-    ["(OS=='win' and node_root_dir.split('\\\\')[-1].startswith('iojs')) or (OS=='mac' and node_root_dir.split('/')[-1].startswith('iojs'))", {
-      "variables": {
-        "is_electron%": "1",
-      }
-    }, {
-      "variables": {
-        "is_electron%": "0",
-      }
-    }]
-  ],
+  "variables": {
+    "is_electron%": "<!(node ./utils/isBuildingForElectron.js <(node_root_dir))"
+  },
 
   "targets": [
     {
       "target_name": "acquireOpenSSL",
         "conditions": [
-        ["<(is_electron) == 1", {
+        ["<(is_electron) == 1 and OS != 'linux'", {
           "actions": [{
             "action_name": "acquire",
             "action": ["node", "utils/acquireOpenSSL.js"],
@@ -168,7 +160,7 @@
           }
         ],
         [
-          "OS.endswith('bsd') or (node_root_dir.split('/')[-1].startswith('iojs') and OS=='linux')", {
+          "OS.endswith('bsd') or (<(is_electron) == 1 and OS=='linux')", {
             "libraries": [
               "-lcrypto",
               "-lssl"

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,14 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        }
       }
     },
     "babel-generator": {
@@ -3230,10 +3238,19 @@
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "jsonfile": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.0",
+    "json5": "^2.1.0",
     "lodash": "^4.17.11",
     "nan": "^2.11.1",
     "node-gyp": "^3.8.0",

--- a/utils/isBuildingForElectron.js
+++ b/utils/isBuildingForElectron.js
@@ -1,0 +1,32 @@
+const fs = require("fs")
+const JSON5 = require("json5");
+const path = require("path");
+
+if (process.argv.length < 3) {
+  process.exit(1);
+}
+
+const last = arr => arr[arr.length - 1];
+const sep = process.platform === "win32" ? "\\\\" : "/";
+const [, , nodeRootDir] = process.argv;
+
+let isElectron = last(nodeRootDir.split(sep)).startsWith("iojs");
+
+if (!isElectron) {
+  try {
+    // Not ideal, would love it if there were a full featured gyp package to do this operation instead.
+    const { variables: { built_with_electron } } = JSON5.parse(
+      fs.readFileSync(
+        path.resolve(nodeRootDir, "include", "node", "config.gypi"),
+        "utf8"
+      )
+    );
+
+    if (built_with_electron) {
+      isElectron = true;
+    }
+  } catch (e) {}
+}
+
+fs.writeFileSync("was_electron", isElectron ? "1" : "0");
+process.stdout.write(isElectron ? "1" : "0");


### PR DESCRIPTION
Since Electron is now at version >4, the iojs qualifier on the version number in the folder name for node headers stored in `~/.node-gyp` is no longer appended. This is because iojs and node merged at node v4. So that's the reason the <4 electron headers had iojs appended onto their header folder name. Now we need to support >4.

I tried messing about a bit with the exported config.gypi that is provided in the electron headers, but it doesn't seem to be included from the start :(. In lieu of going back to some sort of pangyp again, I've just parsed the config.gypi with json5 and am hoping for the best. We'll probably be back here in a year or 2 going, why? Why?!