### PR TITLE
Fix non-existent / dangling refs cause Repository.prototype.createCommitWithSignature to fail

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2269,13 +2269,14 @@
           "ignore": true
         },
         "git_oid_fromstr": {
-          "isAsync": false
+          "ignore": true
         },
         "git_oid_fromstrn": {
           "ignore": true
         },
         "git_oid_fromstrp": {
-          "ignore": true
+          "isAsync": false,
+          "jsFunctionName": "fromString"
         },
         "git_oid_nfmt": {
           "ignore": true
@@ -3251,7 +3252,10 @@
       "dupFunction": "git_signature_dup",
 	    "functions": {
         "git_signature_default": {
-          "isAsync": false
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_signature_dup": {
           "ignore": true
@@ -3263,7 +3267,15 @@
 	        "isAsync": false
 	      },
         "git_signature_now": {
-          "isAsync": false
+          "isAsync": false,
+          "args": {
+            "sig_out": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         }
 	    }
 	  },

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -3068,7 +3068,15 @@
           "ignore": true
         },
         "git_repository_ident": {
-          "ignore": true
+          "args": {
+            "name": {
+              "isReturn": true
+            },
+            "email": {
+              "isReturn": true
+            }
+          },
+          "isAsync": false
         },
         "git_repository_init_init_options": {
           "ignore": true

--- a/generate/templates/partials/sync_function.cc
+++ b/generate/templates/partials/sync_function.cc
@@ -50,7 +50,7 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
       {%endeach%}
     );
 
-    {%if .|hasReturnValue %} {{ return.cType }} result = {%endif%}
+    {%if .|hasReturnType %} {{ return.cType }} result = {%endif%}
     {{ cFunctionName }}(
       {%each args|argsInfo as arg %}
         {%if arg.isReturn %}
@@ -67,15 +67,15 @@ NAN_METHOD({{ cppClassName }}::{{ cppFunctionName }}) {
       {%endeach%}
     );
 
-    {%if .|hasReturnValue |and return.isErrorCode %}
+    {%if .|hasReturnType |and return.isErrorCode %}
       if (result != GIT_OK) {
       {%each args|argsInfo as arg %}
-        {%if arg.shouldAlloc %}
-          free({{ arg.name }});
-        {%elsif arg | isOid %}
+        {%if arg | isOid %}
           if (info[{{ arg.jsArg }}]->IsString()) {
-            free({{ arg.name }});
+            free((void *)from_{{ arg.name }});
           }
+        {%elsif arg.shouldAlloc %}
+          free({{ arg.name }});
         {%endif%}
       {%endeach%}
 

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -163,9 +163,12 @@ Reference.updateTerminal = function (
     })
     .then(() => NodeGit.Reflog.read(repo, refName))
     .then((reflog) => {
-      // We may want some kind of transactional logic for this
-      // There is a theoretical timing issue that could result in updating
-      // the wrong reflog
+      // Janky, but works. Ideally, we would want to generate the correct reflog
+      // entry in the first place, rather than drop the most recent entry and
+      // write the correct one.
+      // NOTE: There is a theoretical race condition that could happen here.
+      // We may want to consider some kind of transactional logic to make sure
+      // that the reflog on disk isn't modified before we can write back.
       reflog.drop(0, 1);
       reflog.append(oid, signatureToUse, logMessage);
       return reflog.write();

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -63,3 +63,111 @@ Reference.prototype.isValid = function() {
 Reference.prototype.toString = function() {
  return this.name();
 };
+
+const MAX_NESTING_LEVEL = 10;
+
+const getTerminal = (repo, refName, nesting, prevRef = null) => {
+  if (nesting > MAX_NESTING_LEVEL) {
+    return Promise.resolve({
+      error: NodeGit.Error.CODE.ENOTFOUND,
+      out: prevRef
+    });
+  }
+
+  return NodeGit.Reference.lookup(repo, refName)
+    .then((ref) => {
+      if (ref.type() === NodeGit.Reference.TYPE.OID) {
+        return {
+          error: NodeGit.Error.CODE.OK,
+          out: ref
+        };
+      } else {
+        return getTerminal(repo, ref.symbolicTarget(), nesting + 1, ref)
+          .then(({ error, out }) => {
+            if (error === NodeGit.Error.CODE.ENOTFOUND && !out) {
+              return { error, out: ref };
+            } else {
+              return { error, out };
+            }
+          });
+      }
+    })
+    .catch((error) => {
+      return {
+        error: error.errno,
+        out: null
+      };
+    });
+};
+
+const getSignatureForReflog = (repo) => {
+  const { email, name } = repo.ident();
+  if (email && name) {
+    return Promise.resolve(NodeGit.Signature.now(name, email));
+  }
+
+  return NodeGit.Signature.default(repo)
+    .catch(() => NodeGit.Signature.now("unknown", "unknown"));
+};
+
+Reference.updateTerminal = function (
+  repo,
+  refName,
+  oid,
+  signature,
+  logMessage
+) {
+  let signatureToUse;
+  let promiseChain = Promise.resolve();
+
+  if (!signature) {
+    promiseChain = promiseChain
+      .then(() => getSignatureForReflog(repo))
+      .then((sig) => {
+        signatureToUse = sig;
+        return Promise.resolve();
+      });
+  } else {
+    signatureToUse = signature;
+  }
+
+  return promiseChain
+    .then(() => getTerminal(repo, refName, 0))
+    .then(({ error, out }) => {
+      if (error === NodeGit.Error.CODE.ENOTFOUND && out) {
+        return NodeGit.Reference.create(
+          repo,
+          out.symbolicTarget(),
+          oid,
+          0,
+          logMessage
+        );
+      } else if (error === NodeGit.Error.CODE.ENOTFOUND) {
+        return NodeGit.Reference.create(
+          repo,
+          refName,
+          oid,
+          0,
+          logMessage
+        );
+      } else {
+        return NodeGit.Reference.createMatching(
+          repo,
+          out.name(),
+          oid,
+          1,
+          out.target(),
+          logMessage
+        );
+      }
+    })
+    .then(() => NodeGit.Reflog.read(repo, refName))
+    .then((reflog) => {
+      // We may want some kind of transactional logic for this
+      // There is a theoretical timing issue that could result in updating
+      // the wrong reflog
+      reflog.drop(0, 1);
+      reflog.append(oid, signatureToUse, logMessage);
+      return reflog.write();
+    });
+};

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -64,10 +64,8 @@ Reference.prototype.toString = function() {
  return this.name();
 };
 
-const MAX_NESTING_LEVEL = 10;
-
-const getTerminal = (repo, refName, nesting, prevRef = null) => {
-  if (nesting > MAX_NESTING_LEVEL) {
+const getTerminal = (repo, refName, depth = 10, prevRef = null) => {
+  if (depth <= 0) {
     return Promise.resolve({
       error: NodeGit.Error.CODE.ENOTFOUND,
       out: prevRef
@@ -82,7 +80,7 @@ const getTerminal = (repo, refName, nesting, prevRef = null) => {
           out: ref
         };
       } else {
-        return getTerminal(repo, ref.symbolicTarget(), nesting + 1, ref)
+        return getTerminal(repo, ref.symbolicTarget(), depth - 1, ref)
           .then(({ error, out }) => {
             if (error === NodeGit.Error.CODE.ENOTFOUND && !out) {
               return { error, out: ref };
@@ -110,12 +108,23 @@ const getSignatureForReflog = (repo) => {
     .catch(() => NodeGit.Signature.now("unknown", "unknown"));
 };
 
+/**
+ * Given a reference name, follows symbolic links and updates the direct
+ * reference to point to a given OID. Updates the reflog with a given message.
+ *
+ * @async
+ * @param {Repository} repo The repo where the reference and objects live
+ * @param {String} refName The reference name to update
+ * @param {Oid} oid The target OID that the reference will point to
+ * @param {String} logMessage The reflog message to be writted
+ * @param {Signature} signature Optional signature to use for the reflog entry
+ */
 Reference.updateTerminal = function (
   repo,
   refName,
   oid,
-  signature,
-  logMessage
+  logMessage,
+  signature
 ) {
   let signatureToUse;
   let promiseChain = Promise.resolve();
@@ -132,7 +141,7 @@ Reference.updateTerminal = function (
   }
 
   return promiseChain
-    .then(() => getTerminal(repo, refName, 0))
+    .then(() => getTerminal(repo, refName))
     .then(({ error, out }) => {
       if (error === NodeGit.Error.CODE.ENOTFOUND && out) {
         return NodeGit.Reference.create(

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -466,23 +466,32 @@ Repository.prototype.continueRebase = function(
   beforeFinishFn,
   rebaseOptions
 ) {
-  var repo = this;
+  const repo = this;
 
-  signature = signature || repo.defaultSignature();
+  let rebase;
+  let promiseChain = Promise.resolve();
 
-  var rebase;
-  return repo.refreshIndex()
-    .then(function(index) {
+  if (!signature) {
+    promiseChain = promiseChain
+      .then(() => repo.defaultSignature())
+      .then((signatureResult) => {
+        signature = signatureResult;
+      });
+  }
+
+  return promiseChain
+    .then(() => repo.refreshIndex())
+    .then((index) => {
       if (index.hasConflicts()) {
         throw index;
       }
 
       return NodeGit.Rebase.open(repo, rebaseOptions);
     })
-    .then(function(_rebase) {
+    .then((_rebase) => {
       rebase = _rebase;
       return rebase.commit(null, signature)
-        .catch(function(e) {
+        .catch((e) => {
           // Ignore all errors to prevent
           // this routine from choking now
           // that we made rebase.commit
@@ -495,7 +504,7 @@ Repository.prototype.continueRebase = function(
           throw e;
         });
     })
-    .then(function() {
+    .then(() => {
       return performRebase(
         repo,
         rebase,
@@ -504,7 +513,7 @@ Repository.prototype.continueRebase = function(
         beforeFinishFn
       );
     })
-    .then(function(error) {
+    .then((error) => {
       if (error) {
         throw error;
       }
@@ -866,15 +875,19 @@ Repository.prototype.createRevWalk = function() {
  * @return {Tag}
  */
 Repository.prototype.createTag = function(oid, name, message, callback) {
-  var repository = this;
-  var signature = repository.defaultSignature();
+  const repository = this;
+  let signature = null;
 
-  return Commit.lookup(repository, oid)
-    .then(function(commit) {
+  return repository.defaultSignature()
+    .then((signatureResult) => {
+      signature = signatureResult;
+      return Commit.lookup(repository, oid);
+    })
+    .then((commit) => {
       // Final argument is `force` which overwrites any previous tag
       return Tag.create(repository, name, commit, signature, message, 0);
     })
-    .then(function(tagOid) {
+    .then((tagOid) => {
       return repository.getTag(tagOid, callback);
     });
 };
@@ -884,13 +897,16 @@ Repository.prototype.createTag = function(oid, name, message, callback) {
  * @return {Signature}
  */
 Repository.prototype.defaultSignature = function() {
-  var result = NodeGit.Signature.default(this);
-
-  if (!result || !result.name()) {
-    result = NodeGit.Signature.now("unknown", "unknown@example.com");
-  }
-
-  return result;
+  return NodeGit.Signature.default(this)
+    .then((result) => {
+      if (!result || !result.name()) {
+        result = NodeGit.Signature.now("unknown", "unknown@example.com");
+      }
+      return result;
+    })
+    .catch(() => {
+      return NodeGit.Signature.now("unknown", "unknown@example.com");
+    });
 };
 
 /**
@@ -1558,12 +1574,21 @@ Repository.prototype.rebaseBranches = function(
   rebaseOptions
 )
 {
-  var repo = this;
-  var branchCommit;
-  var upstreamCommit;
-  var ontoCommit;
-  var mergeOptions = (rebaseOptions || {}).mergeOptions;
-  signature = signature || repo.defaultSignature();
+  const repo = this;
+  let branchCommit;
+  let upstreamCommit;
+  let ontoCommit;
+  let mergeOptions = (rebaseOptions || {}).mergeOptions;
+
+  let promiseChain = Promise.resolve();
+
+  if (!signature) {
+    promiseChain = promiseChain
+      .then(() => repo.defaultSignature())
+      .then((signatureResult) => {
+        signature = signatureResult;
+      });
+  }
 
   return Promise.all([
     repo.getReference(branch),
@@ -1667,21 +1692,30 @@ Repository.prototype.mergeBranches = function(
   mergeOptions,
   processMergeMessageCallback
 ) {
-  var repo = this;
-  var fromBranch;
-  var toBranch;
+  const repo = this;
+  let fromBranch;
+  let toBranch;
   processMergeMessageCallback = processMergeMessageCallback ||
     function (message) { return message; };
 
   mergePreference = mergePreference || NodeGit.Merge.PREFERENCE.NONE;
   mergeOptions = normalizeOptions(mergeOptions, NodeGit.MergeOptions);
 
-  signature = signature || repo.defaultSignature();
+  let promiseChain = Promise.resolve();
 
-  return Promise.all([
-      repo.getBranch(to),
-      repo.getBranch(from)
-  ]).then(function(objects) {
+  if (!signature) {
+    promiseChain = promiseChain
+      .then(() => repo.defaultSignature())
+      .then((signatureResult) => {
+        signature = signatureResult;
+      });
+  }
+
+  return promiseChain.then(() => Promise.all([
+    repo.getBranch(to),
+    repo.getBranch(from)
+  ]))
+  .then((objects) => {
     toBranch = objects[0];
     fromBranch = objects[1];
 
@@ -1690,12 +1724,12 @@ Repository.prototype.mergeBranches = function(
       repo.getBranchCommit(fromBranch)
     ]);
   })
-  .then(function(branchCommits) {
+  .then((branchCommits) => {
     var toCommitOid = branchCommits[0].toString();
     var fromCommitOid = branchCommits[1].toString();
 
     return NodeGit.Merge.base(repo, toCommitOid, fromCommitOid)
-    .then(function(baseCommit) {
+    .then((baseCommit) => {
       if (baseCommit.toString() == fromCommitOid) {
         // The commit we're merging to is already in our history.
         // nothing to do so just return the commit the branch is on
@@ -1711,7 +1745,7 @@ Repository.prototype.mergeBranches = function(
           fromBranch.shorthand();
 
         return branchCommits[1].getTree()
-        .then(function(tree) {
+        .then((tree) => {
           if (toBranch.isHead()) {
             // Checkout the tree if we're on the branch
             var opts = {
@@ -1721,11 +1755,11 @@ Repository.prototype.mergeBranches = function(
             return NodeGit.Checkout.tree(repo, tree, opts);
           }
         })
-        .then(function() {
+        .then(() => {
           return toBranch.setTarget(
             fromCommitOid,
             message)
-          .then(function() {
+          .then(() => {
             return fromCommitOid;
           });
         });
@@ -1734,10 +1768,10 @@ Repository.prototype.mergeBranches = function(
         var updateHead;
         // We have to merge. Lets do it!
         return NodeGit.Reference.lookup(repo, "HEAD")
-        .then(function(headRef) {
+        .then((headRef) => {
           return headRef.resolve();
         })
-        .then(function(headRef) {
+        .then((headRef) => {
           updateHead = !!headRef && (headRef.name() === toBranch.name());
           return NodeGit.Merge.commits(
             repo,
@@ -1746,7 +1780,7 @@ Repository.prototype.mergeBranches = function(
             mergeOptions
           );
         })
-        .then(function(index) {
+        .then((index) => {
           // if we have conflicts then throw the index
           if (index.hasConflicts()) {
             throw index;
@@ -1755,7 +1789,7 @@ Repository.prototype.mergeBranches = function(
           // No conflicts so just go ahead with the merge
           return index.writeTreeTo(repo);
         })
-        .then(function(oid) {
+        .then((oid) => {
           var mergeDecorator;
           if (fromBranch.isTag()) {
             mergeDecorator = "tag";
@@ -1779,7 +1813,7 @@ Repository.prototype.mergeBranches = function(
 
           return Promise.all([oid, processMergeMessageCallback(message)]);
         })
-        .then(function([oid, message]) {
+        .then(([oid, message]) => {
           return repo.createCommit(
             toBranch.name(),
             signature,
@@ -1789,25 +1823,25 @@ Repository.prototype.mergeBranches = function(
             [toCommitOid, fromCommitOid]
           );
         })
-        .then(function(commit) {
+        .then((commit) => {
           // we've updated the checked out branch, so make sure we update
           // head so that our index isn't messed up
           if (updateHead) {
             return repo.getBranch(to)
-            .then(function(branch) {
+            .then((branch) => {
               return repo.getBranchCommit(branch);
             })
-            .then(function(branchCommit) {
+            .then((branchCommit) => {
               return branchCommit.getTree();
             })
-            .then(function(tree) {
+            .then((tree) => {
               var opts = {
                 checkoutStrategy: NodeGit.Checkout.STRATEGY.SAFE |
                   NodeGit.Checkout.STRATEGY.RECREATE_MISSING
               };
               return NodeGit.Checkout.tree(repo, tree, opts);
             })
-            .then(function() {
+            .then(() => {
               return commit;
             });
           }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -683,7 +683,6 @@ Repository.prototype.createCommitWithSignature = function(
   var repo = this;
   var promises = [];
   var commitContent;
-  var commit;
   var skippedSigning;
 
   parents = parents || [];
@@ -766,14 +765,18 @@ Repository.prototype.createCommitWithSignature = function(
 
       return repo.getCommit(commitOid)
         .then(function(commitResult) {
-          commit = commitResult;
-          return repo.getReference(updateRef);
-        }).then(function(ref) {
-          return ref.setTarget(commitOid, getReflogMessageForCommit(commit));
-        }).then(function() {
+          return Reference.updateTerminal(
+            repo,
+            updateRef,
+            commitOid,
+            committer,
+            getReflogMessageForCommit(commitResult)
+          );
+        })
+        .then(function() {
           return commitOid;
         });
-    });
+      });
 };
 
 /**

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -769,8 +769,8 @@ Repository.prototype.createCommitWithSignature = function(
             repo,
             updateRef,
             commitOid,
-            committer,
-            getReflogMessageForCommit(commitResult)
+            getReflogMessageForCommit(commitResult),
+            committer
           );
         })
         .then(function() {
@@ -897,6 +897,8 @@ Repository.prototype.createTag = function(oid, name, message, callback) {
 
 /**
  * Gets the default signature for the default user and now timestamp
+ *
+ * @async
  * @return {Signature}
  */
 Repository.prototype.defaultSignature = function() {

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -120,9 +120,10 @@ describe("Repository", function() {
   });
 
   it("can get the default signature", function() {
-    var sig = this.repository.defaultSignature();
-
-    assert(sig instanceof Signature);
+    this.repository.defaultSignature()
+      .then((sig) => {
+        assert(sig instanceof Signature);
+      });
   });
 
   it("gets statuses with StatusFile", function() {
@@ -263,16 +264,21 @@ describe("Repository", function() {
   });
 
   it("can commit on head on a empty repo with createCommitOnHead", function() {
-    var fileName = "my-new-file-that-shouldnt-exist.file";
-    var fileContent = "new file from repository test";
-    var repo = this.emptyRepo;
-    var filePath = path.join(repo.workdir(), fileName);
-    var authSig = repo.defaultSignature();
-    var commitSig = repo.defaultSignature();
-    var commitMsg = "Doug this has been commited";
+    const fileName = "my-new-file-that-shouldnt-exist.file";
+    const fileContent = "new file from repository test";
+    const repo = this.emptyRepo;
+    const filePath = path.join(repo.workdir(), fileName);
+    const commitMsg = "Doug this has been commited";
+    let authSig;
+    let commitSig;
 
-    return fse.writeFile(filePath, fileContent)
-      .then(function() {
+    return repo.defaultSignature()
+      .then((sig) => {
+        authSig = sig;
+        commitSig = sig;
+        return fse.writeFile(filePath, fileContent);
+      })
+      .then(() => {
         return repo.createCommitOnHead(
           [fileName],
           authSig,
@@ -280,7 +286,7 @@ describe("Repository", function() {
           commitMsg
         );
       })
-      .then(function(oidResult) {
+      .then((oidResult) => {
         return repo.getHeadCommit()
           .then(function(commit) {
             assert.equal(

--- a/test/tests/signature.js
+++ b/test/tests/signature.js
@@ -45,37 +45,39 @@ describe("Signature", function() {
     var savedUserName;
     var savedUserEmail;
 
-    var cleanUp = function() {
+    var cleanUp = () => {
       return exec("git config --global user.name \"" + savedUserName + "\"")
-      .then(function() {
+      .then(() => {
         exec("git config --global user.email \"" + savedUserEmail + "\"");
       });
     };
 
     return exec("git config --global user.name")
-    .then(function(userName) {
+    .then((userName) => {
       savedUserName = userName.trim();
 
       return exec("git config --global user.email");
     })
-    .then(function(userEmail) {
+    .then((userEmail) => {
       savedUserEmail = userEmail.trim();
 
       return exec("git config --global --unset user.name");
     })
-    .then(function() {
+    .then(() => {
       return exec("git config --global --unset user.email");
     })
-    .then(function() {
+    .then(() => {
       return Repository.open(reposPath);
     })
-    .then(function(repo) {
-      var sig = repo.defaultSignature();
+    .then((repo) => {
+      return repo.defaultSignature();
+    })
+    .then((sig) => {
       assert.equal(sig.name(), "unknown");
       assert.equal(sig.email(), "unknown@example.com");
     })
     .then(cleanUp)
-    .catch(function(e) {
+    .catch((e) => {
       return cleanUp()
       .then(function() {
         return Promise.reject(e);

--- a/test/tests/stash.js
+++ b/test/tests/stash.js
@@ -31,22 +31,23 @@ describe("Stash", function() {
   });
 
   function saveDropStash(repo, stashMessage) {
-    var fileName = "README.md";
-    var fileContent = "Cha-cha-cha-chaaaaaangessssss";
-    var filePath = path.join(repo.workdir(), fileName);
-    var oldContent;
-    var stashes = [];
-    var stashOid;
+    const fileName = "README.md";
+    const fileContent = "Cha-cha-cha-chaaaaaangessssss";
+    const filePath = path.join(repo.workdir(), fileName);
+    let oldContent;
+    let stashes = [];
+    let stashOid;
 
     return fse.readFile(filePath)
-      .then(function(content) {
+      .then((content) => {
         oldContent = content;
         return fse.writeFile(filePath, fileContent);
       })
-      .then(function() {
-        return Stash.save(repo, repo.defaultSignature(), stashMessage, 0);
+      .then(() => repo.defaultSignature())
+      .then((signature) => {
+        return Stash.save(repo, signature, stashMessage, 0);
       })
-      .then(function(oid) {
+      .then((oid) => {
         stashOid = oid;
         var stashCb = function(index, message, oid) {
           stashes.push({index: index, message: message, oid: oid});
@@ -54,7 +55,7 @@ describe("Stash", function() {
 
         return Stash.foreach(repo, stashCb);
       })
-      .then(function() {
+      .then(() => {
         assert.equal(stashes.length, 1);
         assert.equal(stashes[0].index, 0);
         const expectedMessage = !stashMessage ?
@@ -65,20 +66,20 @@ describe("Stash", function() {
 
         return Stash.drop(repo, 0);
       })
-      .then(function () {
+      .then(() => {
         stashes = [];
-        var stashCb = function(index, message, oid) {
+        var stashCb = (index, message, oid) => {
           stashes.push({index: index, message: message, oid: oid});
         };
 
         return Stash.foreach(repo, stashCb);
       })
-      .then(function() {
+      .then(() => {
         assert.equal(stashes.length, 0);
       })
-      .catch(function(e) {
+      .catch((e) => {
         return fse.writeFile(filePath, oldContent)
-          .then(function() {
+          .then(() => {
             return Promise.reject(e);
           });
       });
@@ -93,78 +94,80 @@ describe("Stash", function() {
   });
 
   it("can save and pop a stash", function() {
-    var fileNameA = "README.md";
-    var fileNameB = "install.js";
-    var oldContentA;
-    var oldContentB;
-    var fileContent = "Cha-cha-cha-chaaaaaangessssss";
-    var repo = this.repository;
-    var filePathA = path.join(repo.workdir(), fileNameA);
-    var filePathB = path.join(repo.workdir(), fileNameB);
-    var stashMessage = "stash test";
+    const fileNameA = "README.md";
+    const fileNameB = "install.js";
+    let oldContentA;
+    let oldContentB;
+    const fileContent = "Cha-cha-cha-chaaaaaangessssss";
+    const repo = this.repository;
+    const filePathA = path.join(repo.workdir(), fileNameA);
+    const filePathB = path.join(repo.workdir(), fileNameB);
+    const stashMessage = "stash test";
 
     return fse.readFile(filePathA, "utf-8")
-      .then(function(content) {
+      .then((content) => {
         oldContentA = content;
         return fse.writeFile(filePathA, fileContent);
       })
-      .then(function() {
+      .then(() => {
         return fse.readFile(filePathB, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         oldContentB = content;
         return fse.writeFile(filePathB, fileContent);
       })
-      .then(function() {
-        return Stash.save(repo, repo.defaultSignature(), stashMessage, 0);
+      .then(() => repo.defaultSignature())
+      .then((signature) => {
+        return Stash.save(repo, signature, stashMessage, 0);
       })
-      .then(function() {
+      .then(() => {
         return fse.readFile(filePathA, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(oldContentA, content);
         return fse.readFile(filePathB, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(oldContentB, content);
         return Stash.pop(repo, 0);
       })
-      .then(function() {
+      .then(() => {
         return fse.readFile(filePathA, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(fileContent, content);
         return fse.readFile(filePathB, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(fileContent, content);
       });
   });
 
   it("can save a stash, change files, and fail to pop stash", function() {
-      var fileName = "README.md";
-      var fileContent = "Cha-cha-cha-chaaaaaangessssss";
-      var fileContent2 = "Somewhere over the repo, changes were made.";
-      var repo = this.repository;
-      var filePath = path.join(repo.workdir(), fileName);
-      var oldContent;
-      var stashMessage = "stash test";
+      const fileName = "README.md";
+      const fileContent = "Cha-cha-cha-chaaaaaangessssss";
+      const fileContent2 = "Somewhere over the repo, changes were made.";
+      const repo = this.repository;
+      const filePath = path.join(repo.workdir(), fileName);
+      let oldContent;
+      const stashMessage = "stash test";
 
       return fse.readFile(filePath)
-        .then(function(content) {
+        .then((content) => {
           oldContent = content;
           return fse.writeFile(filePath, fileContent);
         })
-        .then(function() {
-          return Stash.save(repo, repo.defaultSignature(), stashMessage, 0);
+        .then(() => repo.defaultSignature())
+        .then((signature) => {
+          return Stash.save(repo, signature, stashMessage, 0);
         })
-        .then(function() {
+        .then(() => {
           return fse.writeFile(filePath, fileContent2);
         })
-        .then(function() {
+        .then(() => {
           return Stash.pop(repo, 0);
         })
-        .catch(function(reason) {
+        .catch((reason) => {
           if (reason.message !== "1 conflict prevents checkout") {
             throw reason;
           } else {
@@ -174,33 +177,34 @@ describe("Stash", function() {
   });
 
   it("can save, apply, then drop the stash", function() {
-      var fileName = "README.md";
-      var fileContent = "Cha-cha-cha-chaaaaaangessssss";
-      var repo = this.repository;
-      var filePath = path.join(repo.workdir(), fileName);
-      var oldContent;
-      var stashMessage = "stash test";
+      const fileName = "README.md";
+      const fileContent = "Cha-cha-cha-chaaaaaangessssss";
+      const repo = this.repository;
+      const filePath = path.join(repo.workdir(), fileName);
+      let oldContent;
+      const stashMessage = "stash test";
 
       return fse.readFile(filePath)
-        .then(function(content) {
+        .then((content) => {
           oldContent = content;
           return fse.writeFile(filePath, fileContent);
         })
-        .then(function() {
-          return Stash.save(repo, repo.defaultSignature(), stashMessage, 0);
+        .then(() => repo.defaultSignature())
+        .then((signature) => {
+          return Stash.save(repo, signature, stashMessage, 0);
         })
-        .then(function() {
+        .then(() => {
           return Stash.apply(repo, 0);
         })
-        .then(function() {
+        .then(() => {
           return Stash.drop(repo, 0);
-        }, function() {
+        }, () => {
           throw new Error("Unable to drop stash after apply.");
         })
-        .then(function() {
+        .then(() => {
           return Stash.drop(repo, 0);
         })
-        .catch(function(reason) {
+        .catch((reason) => {
           if (reason.message !== "reference 'refs/stash' not found") {
             throw reason;
           }
@@ -208,46 +212,48 @@ describe("Stash", function() {
   });
 
   it("can save multiple stashes and pop an arbitrary stash", function() {
-    var fileName = "README.md";
-    var fileContentA = "Hi. It's me. I'm the dog. My name is the dog.";
-    var fileContentB = "Everyone likes me. I'm cute.";
-    var fileContentC = "I think I will bark at nothing now. Ba. Ba. Baba Baba.";
-    var repo = this.repository;
-    var filePath = path.join(repo.workdir(), fileName);
-    var oldContent;
-    var stashMessageA = "stash test A";
-    var stashMessageB = "stash test B";
-    var stashMessageC = "stash test C";
+    const fileName = "README.md";
+    const fileContentA = "Hi. It's me. I'm the dog. My name is the dog.";
+    const fileContentB = "Everyone likes me. I'm cute.";
+    const fileContentC =
+      "I think I will bark at nothing now. Ba. Ba. Baba Baba.";
+    const repo = this.repository;
+    const filePath = path.join(repo.workdir(), fileName);
+    let oldContent;
+    const stashMessageA = "stash test A";
+    const stashMessageB = "stash test B";
+    const stashMessageC = "stash test C";
 
-    function writeAndStash(path, content, message) {
+    const writeAndStash = (path, content, message) => {
       return fse.writeFile(path, content)
-        .then(function() {
-          return Stash.save(repo, repo.defaultSignature(), message, 0);
+        .then(() => repo.defaultSignature())
+        .then((signature) => {
+          return Stash.save(repo, signature, message, 0);
         });
-    }
+    };
 
     return fse.readFile(filePath, "utf-8")
-      .then(function (content) {
+      .then((content) => {
         oldContent = content;
         return writeAndStash(filePath, fileContentA, stashMessageA);
       })
-      .then(function() {
+      .then(() => {
         return writeAndStash(filePath, fileContentB, stashMessageB);
       })
-      .then(function() {
+      .then(() => {
         return writeAndStash(filePath, fileContentC, stashMessageC);
       })
-      .then(function() {
+      .then(() => {
         return fse.readFile(filePath, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(oldContent, content);
         return Stash.pop(repo, 1);
       })
-      .then(function() {
+      .then(() => {
         return fse.readFile(filePath, "utf-8");
       })
-      .then(function(content) {
+      .then((content) => {
         assert.equal(fileContentB, content);
       });
   });

--- a/test/tests/tag.js
+++ b/test/tests/tag.js
@@ -159,11 +159,15 @@ describe("Tag", function() {
   it("can create a new signed tag with Tag.create and delete it", function() {
     var name = "created-signed-tag-create";
     var repository = this.repository;
-    var signature = Signature.default(repository);
+    var signature = null;
     var commit = null;
     var commit2 = null;
 
-    return repository.getCommit(commitPointedTo)
+    return Signature.default(repository)
+      .then(function(signatureResult) {
+        signature = signatureResult;
+        return repository.getCommit(commitPointedTo);
+      })
       .then(function(theCommit) {
         commit = theCommit;
         return repository.getCommit(commitPointedTo2);
@@ -580,10 +584,14 @@ describe("Tag", function() {
     var oid = Oid.fromString(commitPointedTo);
     var name = "created-signed-tag-annotationCreate";
     var repository = this.repository;
-    var signature = Signature.default(repository);
+    var signature = null;
     var odb = null;
 
-    return repository.odb()
+    return Signature.default(repository)
+      .then(function(signatureResult) {
+        signature = signatureResult;
+        return repository.odb();
+      })
       .then(function(theOdb) {
         odb = theOdb;
       })


### PR DESCRIPTION
`Repository.prototype.createCommit` is able to handle updates to refs which do not exist because of the internal implementation of `git_commit_create` in libgit2. This PR exposes a reimplementation of this functionality so that `Repository.prototype.createCommitWithSignature` exhibits the same functionality.