### PR TITLE
Fix "errorno" typo

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -492,12 +492,12 @@ Repository.prototype.continueRebase = function(
       rebase = _rebase;
       return rebase.commit(null, signature)
         .catch((e) => {
-          // Ignore all errors to prevent
-          // this routine from choking now
-          // that we made rebase.commit
-          // asynchronous
-          const errorno = fp.get(["errorno"], e);
-          if (errorno === NodeGit.Error.CODE.EAPPLIED) {
+          // If the first commit on continueRebase is a
+          // "patch already applied" error,
+          // interpret that as an explicit "skip commit"
+          // and ignore the error.
+          const errno = fp.get(["errno"], e);
+          if (errno === NodeGit.Error.CODE.EAPPLIED) {
             return;
           }
 


### PR DESCRIPTION
This typo prevented the ability to skip commits where the patch was already applied. We will now treat the "patch already applied" error as an explicit "skip commit" action and ignore the error. 