### PR TITLE
We should clear the persistent cell in structs when they are destroyed

### DIFF
--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -67,6 +67,8 @@ using namespace std;
               this->raw->{{ fields|payloadFor field.name }} = NULL;
             {% endif %}
           }
+        {% elsif field.hasConstructor |or field.isLibgitType %}
+          this->{{ field.name }}.Reset();
         {% endif %}
       {% endif %}
     {% endif %}


### PR DESCRIPTION
It looks like there might be another way to do this by specifying a trait on the persistent handle that specifies auto reset on destructor, but I couldn't find the trait.