### PR TITLE
Update LibGit2 docs to v0.28.0

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -1,4 +1,40 @@
 {
+  "git_apply_delta_cb": {
+    "args": [
+      {
+        "name": "delta",
+        "cType": "const git_diff_delta *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 1,
+      "success": 0,
+      "error": -1
+    }
+  },
+  "git_apply_hunk_cb": {
+    "args": [
+      {
+        "name": "hunk",
+        "cType": "const git_diff_hunk *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 1,
+      "success": 0,
+      "error": -1
+    }
+  },
   "git_attr_foreach_cb": {
     "args": [
       {

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -48,7 +48,7 @@
     "repository_init_flag": {
       "removeString": "INIT_"
     },
-    "otype": {
+    "object": {
       "JsName": "TYPE",
       "owner": "Object",
       "removeString": "OBJ_"
@@ -57,7 +57,7 @@
       "JsName": "PROXY",
       "isMask": false
     },
-    "ref": {
+    "reference": {
       "owner": "Reference",
       "JsName": "TYPE"
     },
@@ -71,6 +71,9 @@
     "status": {
       "JsName": "STATUS",
       "isMask": false
+    },
+    "stream": {
+      "ignore": true
     }
   },
   "types":
@@ -110,6 +113,9 @@
           }
         }
       }
+    },
+    "apply_options": {
+      "hasConstructor": true
     },
     "attr": {
       "functions": {
@@ -1734,9 +1740,68 @@
         "../include/str_array_converter.h"
       ]
     },
+    "index_conflict_iterator": {
+      "selfFreeing": true,
+      "freeFunctionName": "git_index_conflict_iterator_free",
+      "functions": {
+        "git_index_conflict_iterator_free": {
+          "ignore": true
+        },
+        "git_index_conflict_iterator_new": {
+          "args": {
+            "iterator_out": {
+              "ownedBy": ["index"]
+            }
+          }
+        },
+        "git_index_conflict_next": {
+          "isAsync": false,
+          "jsFunctionName": "next",
+          "cppFunctionName": "Next",
+          "args": {
+            "ancestor_out": {
+              "isReturn": true,
+              "ownedByThis": true
+            },
+            "our_out": {
+              "isReturn": true,
+              "ownedByThis": true
+            },
+            "their_out": {
+              "isReturn": true,
+              "ownedByThis": true
+            }
+          }
+        }
+      }
+    },
     "index_entry": {
       "hasConstructor": true,
       "ignoreInit": true
+    },
+    "index_iterator": {
+      "selfFreeing": true,
+      "freeFunctionName": "git_index_iterator_free",
+      "functions": {
+        "git_index_iterator_free": {
+          "ignore": true
+        },
+        "git_index_iterator_new": {
+          "args": {
+            "iterator_out": {
+              "ownedBy": ["index"]
+            }
+          }
+        },
+        "git_index_iterator_next": {
+          "isAsync": false,
+          "args": {
+            "out": {
+              "ownedByThis": true
+            }
+          }
+        }
+      }
     },
     "index_name_entry": {
       "functions": {
@@ -1768,6 +1833,11 @@
       ]
     },
     "index_reuc_entry": {
+      "fields": {
+        "mode": {
+          "cType": "uint32_t [3]"
+        }
+      },
       "functions": {
         "git_index_reuc_add": {
           "cppFunctionName": "Add",
@@ -1934,7 +2004,51 @@
           }
         },
         "git_merge_analysis": {
-          "ignore": true
+          "isAsync": true,
+          "args": {
+            "analysis_out": {
+              "isReturn": true
+            },
+            "preference_out": {
+              "isReturn": true
+            },
+            "their_heads": {
+              "cType": "const git_annotated_commit **",
+              "cppClassName": "Array",
+              "jsClassName": "Array",
+              "arrayElementCppClassName": "GitAnnotatedCommit"
+            },
+            "their_heads_len": {
+              "cType": "size_t",
+              "cppClassName": "Number",
+              "jsClassName": "Number"
+            }
+          }
+        },
+        "git_merge_analysis_for_ref": {
+          "isAsync": true,
+          "args": {
+            "analysis_out": {
+              "isReturn": true
+            },
+            "preference_out": {
+              "isReturn": true
+            },
+            "their_heads": {
+              "cType": "const git_annotated_commit **",
+              "cppClassName": "Array",
+              "jsClassName": "Array",
+              "arrayElementCppClassName": "GitAnnotatedCommit"
+            },
+            "their_heads_len": {
+              "cType": "size_t",
+              "cppClassName": "Number",
+              "jsClassName": "Number"
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_merge_base_many": {
           "ignore": true
@@ -2854,6 +2968,13 @@
             }
           }
         },
+        "git_remote_create_with_opts": {
+          "args": {
+            "opts": {
+              "isOptional": true
+            }
+          }
+        },
         "git_remote_connect": {
           "isAsync": true,
           "return": {
@@ -3432,6 +3553,9 @@
       "cDependencies": [
         "git2/sys/stream.h"
       ]
+    },
+    "stream_registration": {
+      "ignore": true
     },
     "submodule": {
       "selfFreeing": true,

--- a/generate/input/libgit2-docs.json
+++ b/generate/input/libgit2-docs.json
@@ -15,6 +15,17 @@
       "lines": 121
     },
     {
+      "file": "git2/apply.h",
+      "functions": [
+        "git_apply_delta_cb",
+        "git_apply_hunk_cb",
+        "git_apply_to_tree",
+        "git_apply"
+      ],
+      "meta": {},
+      "lines": 125
+    },
+    {
       "file": "git2/attr.h",
       "functions": [
         "git_attr_value",
@@ -91,14 +102,13 @@
       "file": "git2/buffer.h",
       "functions": [
         "git_buf_dispose",
-        "git_buf_free",
         "git_buf_grow",
         "git_buf_set",
         "git_buf_is_binary",
         "git_buf_contains_nul"
       ],
       "meta": {},
-      "lines": 134
+      "lines": 122
     },
     {
       "file": "git2/checkout.h",
@@ -181,7 +191,7 @@
         "git_libgit2_opts"
       ],
       "meta": {},
-      "lines": 393
+      "lines": 402
     },
     {
       "file": "git2/config.h",
@@ -241,6 +251,18 @@
       ],
       "meta": {},
       "lines": 48
+    },
+    {
+      "file": "git2/deprecated.h",
+      "functions": [
+        "git_buf_free",
+        "giterr_last",
+        "giterr_clear",
+        "giterr_set_str",
+        "giterr_set_oom"
+      ],
+      "meta": {},
+      "lines": 148
     },
     {
       "file": "git2/describe.h",
@@ -305,13 +327,13 @@
     {
       "file": "git2/errors.h",
       "functions": [
-        "giterr_last",
-        "giterr_clear",
-        "giterr_set_str",
-        "giterr_set_oom"
+        "git_error_last",
+        "git_error_clear",
+        "git_error_set_str",
+        "git_error_set_oom"
       ],
       "meta": {},
-      "lines": 156
+      "lines": 157
     },
     {
       "file": "git2/filter.h",
@@ -385,6 +407,9 @@
         "git_index_add",
         "git_index_entry_stage",
         "git_index_entry_is_conflict",
+        "git_index_iterator_new",
+        "git_index_iterator_next",
+        "git_index_iterator_free",
         "git_index_add_bypath",
         "git_index_add_frombuffer",
         "git_index_remove_bypath",
@@ -403,7 +428,7 @@
         "git_index_conflict_iterator_free"
       ],
       "meta": {},
-      "lines": 806
+      "lines": 829
     },
     {
       "file": "git2/indexer.h",
@@ -447,6 +472,7 @@
         "git_merge_file_init_options",
         "git_merge_init_options",
         "git_merge_analysis",
+        "git_merge_analysis_for_ref",
         "git_merge_base",
         "git_merge_bases",
         "git_merge_base_many",
@@ -460,7 +486,7 @@
         "git_merge"
       ],
       "meta": {},
-      "lines": 587
+      "lines": 606
     },
     {
       "file": "git2/message.h",
@@ -805,6 +831,8 @@
       "file": "git2/remote.h",
       "functions": [
         "git_remote_create",
+        "git_remote_create_init_options",
+        "git_remote_create_with_opts",
         "git_remote_create_with_fetchspec",
         "git_remote_create_anonymous",
         "git_remote_create_detached",
@@ -851,7 +879,7 @@
         "git_remote_default_branch"
       ],
       "meta": {},
-      "lines": 852
+      "lines": 926
     },
     {
       "file": "git2/repository.h",
@@ -904,7 +932,7 @@
         "git_repository_set_ident"
       ],
       "meta": {},
-      "lines": 864
+      "lines": 877
     },
     {
       "file": "git2/reset.h",
@@ -1255,11 +1283,12 @@
     {
       "file": "git2/sys/stream.h",
       "functions": [
+        "git_stream_register",
         "git_stream_cb",
         "git_stream_register_tls"
       ],
       "meta": {},
-      "lines": 54
+      "lines": 130
     },
     {
       "file": "git2/sys/time.h",
@@ -1289,7 +1318,7 @@
         "git_smart_subtransport_ssh"
       ],
       "meta": {},
-      "lines": 389
+      "lines": 435
     },
     {
       "file": "git2/tag.h",
@@ -1414,7 +1443,7 @@
         "git_transport_certificate_check_cb"
       ],
       "meta": {},
-      "lines": 438
+      "lines": 442
     },
     {
       "file": "git2/worktree.h",
@@ -1601,12 +1630,12 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_annotated_commit_id-1"
+          "ex/v0.28.0/checkout.html#git_annotated_commit_id-1"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_annotated_commit_id-1",
-          "ex/HEAD/merge.html#git_annotated_commit_id-2",
-          "ex/HEAD/merge.html#git_annotated_commit_id-3"
+          "ex/v0.28.0/merge.html#git_annotated_commit_id-1",
+          "ex/v0.28.0/merge.html#git_annotated_commit_id-2",
+          "ex/v0.28.0/merge.html#git_annotated_commit_id-3"
         ]
       }
     },
@@ -1633,8 +1662,8 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_annotated_commit_ref-2",
-          "ex/HEAD/checkout.html#git_annotated_commit_ref-3"
+          "ex/v0.28.0/checkout.html#git_annotated_commit_ref-2",
+          "ex/v0.28.0/checkout.html#git_annotated_commit_ref-3"
         ]
       }
     },
@@ -1661,9 +1690,88 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_annotated_commit_free-4"
+          "ex/v0.28.0/checkout.html#git_annotated_commit_free-4"
         ]
       }
+    },
+    "git_apply_to_tree": {
+      "type": "function",
+      "file": "git2/apply.h",
+      "line": 85,
+      "lineto": 90,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_index **",
+          "comment": "the postimage of the application"
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository to apply"
+        },
+        {
+          "name": "preimage",
+          "type": "git_tree *",
+          "comment": "the tree to apply the diff to"
+        },
+        {
+          "name": "diff",
+          "type": "git_diff *",
+          "comment": "the diff to apply"
+        },
+        {
+          "name": "options",
+          "type": "const git_apply_options *",
+          "comment": "the options for the apply (or null for defaults)"
+        }
+      ],
+      "argline": "git_index **out, git_repository *repo, git_tree *preimage, git_diff *diff, const git_apply_options *options",
+      "sig": "git_index **::git_repository *::git_tree *::git_diff *::const git_apply_options *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Apply a <code>git_diff</code> to a <code>git_tree</code>, and return the resulting image\n as an index.</p>\n",
+      "comments": "",
+      "group": "apply"
+    },
+    "git_apply": {
+      "type": "function",
+      "file": "git2/apply.h",
+      "line": 121,
+      "lineto": 125,
+      "args": [
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository to apply to"
+        },
+        {
+          "name": "diff",
+          "type": "git_diff *",
+          "comment": "the diff to apply"
+        },
+        {
+          "name": "location",
+          "type": "git_apply_location_t",
+          "comment": "the location to apply (workdir, index or both)"
+        },
+        {
+          "name": "options",
+          "type": "const git_apply_options *",
+          "comment": "the options for the apply (or null for defaults)"
+        }
+      ],
+      "argline": "git_repository *repo, git_diff *diff, git_apply_location_t location, const git_apply_options *options",
+      "sig": "git_repository *::git_diff *::git_apply_location_t::const git_apply_options *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Apply a <code>git_diff</code> to the given repository, making changes directly\n in the working directory, the index, or both.</p>\n",
+      "comments": "",
+      "group": "apply"
     },
     "git_attr_value": {
       "type": "function",
@@ -1696,36 +1804,36 @@
         {
           "name": "value_out",
           "type": "const char **",
-          "comment": "Output of the value of the attribute.  Use the GIT_ATTR_...\n             macros to test for TRUE, FALSE, UNSPECIFIED, etc. or just\n             use the string value for attributes set to a value.  You\n             should NOT modify or free this value."
+          "comment": null
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "The repository containing the path."
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "A combination of GIT_ATTR_CHECK... flags."
+          "type": "int",
+          "comment": null
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": "The path to check for attributes.  Relative paths are\n             interpreted relative to the repo root.  The file does\n             not have to exist, but if it does not, then it will be\n             treated as a plain file (not a directory)."
+          "comment": null
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": "The name of the attribute to look up."
+          "comment": null
         }
       ],
-      "argline": "const char **value_out, git_repository *repo, uint32_t flags, const char *path, const char *name",
-      "sig": "const char **::git_repository *::uint32_t::const char *::const char *",
+      "argline": "const char **value_out, git_repository *repo, int flags, const char *path, const char *name",
+      "sig": "const char **::git_repository *::int::const char *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Look up the value of one git attribute for path.</p>\n",
+      "description": "",
       "comments": "",
       "group": "attr"
     },
@@ -1738,42 +1846,42 @@
         {
           "name": "values_out",
           "type": "const char **",
-          "comment": "An array of num_attr entries that will have string\n             pointers written into it for the values of the attributes.\n             You should not modify or free the values that are written\n             into this array (although of course, you should free the\n             array itself if you allocated it)."
+          "comment": null
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "The repository containing the path."
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "A combination of GIT_ATTR_CHECK... flags."
+          "type": "int",
+          "comment": null
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": "The path inside the repo to check attributes.  This\n             does not have to exist, but if it does not, then\n             it will be treated as a plain file (i.e. not a directory)."
+          "comment": null
         },
         {
           "name": "num_attr",
           "type": "size_t",
-          "comment": "The number of attributes being looked up"
+          "comment": null
         },
         {
           "name": "names",
           "type": "const char **",
-          "comment": "An array of num_attr strings containing attribute names."
+          "comment": null
         }
       ],
-      "argline": "const char **values_out, git_repository *repo, uint32_t flags, const char *path, size_t num_attr, const char **names",
-      "sig": "const char **::git_repository *::uint32_t::const char *::size_t::const char **",
+      "argline": "const char **values_out, git_repository *repo, int flags, const char *path, size_t num_attr, const char **names",
+      "sig": "const char **::git_repository *::int::const char *::size_t::const char **",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Look up a list of git attributes for path.</p>\n",
-      "comments": "<p>Use this if you have a known list of attributes that you want to\n look up in a single call.  This is somewhat more efficient than\n calling <code>git_attr_get()</code> multiple times.</p>\n\n<p>For example, you might write:</p>\n\n<pre><code> const char *attrs[] = { &quot;crlf&quot;, &quot;diff&quot;, &quot;foo&quot; };\n const char **values[3];\n git_attr_get_many(values, repo, 0, &quot;my/fun/file.c&quot;, 3, attrs);\n</code></pre>\n\n<p>Then you could loop through the 3 values to get the settings for\n the three attributes you asked about.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "attr"
     },
     "git_attr_foreach": {
@@ -1785,36 +1893,36 @@
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "The repository containing the path."
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "A combination of GIT_ATTR_CHECK... flags."
+          "type": "int",
+          "comment": null
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": "Path inside the repo to check attributes.  This does not have\n             to exist, but if it does not, then it will be treated as a\n             plain file (i.e. not a directory)."
+          "comment": null
         },
         {
           "name": "callback",
           "type": "git_attr_foreach_cb",
-          "comment": "Function to invoke on each attribute name and value.\n                 See git_attr_foreach_cb."
+          "comment": null
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": "Passed on as extra parameter to callback function."
+          "comment": null
         }
       ],
-      "argline": "git_repository *repo, uint32_t flags, const char *path, git_attr_foreach_cb callback, void *payload",
-      "sig": "git_repository *::uint32_t::const char *::git_attr_foreach_cb::void *",
+      "argline": "git_repository *repo, int flags, const char *path, git_attr_foreach_cb callback, void *payload",
+      "sig": "git_repository *::int::const char *::git_attr_foreach_cb::void *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, non-zero callback return value, or error code"
+        "comment": null
       },
-      "description": "<p>Loop over all the git attributes for a path.</p>\n",
+      "description": "",
       "comments": "",
       "group": "attr"
     },
@@ -1904,20 +2012,14 @@
       "file": "git2/blame.h",
       "line": 154,
       "lineto": 154,
-      "args": [
-        {
-          "name": "blame",
-          "type": "git_blame *",
-          "comment": null
-        }
-      ],
-      "argline": "git_blame *blame",
-      "sig": "git_blame *",
+      "args": [],
+      "argline": "",
+      "sig": "",
       "return": {
-        "type": "uint32_t",
+        "type": "int",
         "comment": null
       },
-      "description": "<p>Gets the number of hunks that exist in the blame structure.</p>\n",
+      "description": "",
       "comments": "",
       "group": "blame"
     },
@@ -1930,21 +2032,21 @@
         {
           "name": "blame",
           "type": "git_blame *",
-          "comment": "the blame structure to query"
+          "comment": null
         },
         {
           "name": "index",
-          "type": "uint32_t",
-          "comment": "index of the hunk to retrieve"
+          "type": "int",
+          "comment": null
         }
       ],
-      "argline": "git_blame *blame, uint32_t index",
-      "sig": "git_blame *::uint32_t",
+      "argline": "git_blame *blame, int index",
+      "sig": "git_blame *::int",
       "return": {
         "type": "const git_blame_hunk *",
-        "comment": " the hunk at the given index, or NULL on error"
+        "comment": null
       },
-      "description": "<p>Gets the blame hunk at the given index.</p>\n",
+      "description": "",
       "comments": "",
       "group": "blame"
     },
@@ -1976,7 +2078,7 @@
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blame_get_hunk_byline-1"
+          "ex/v0.28.0/blame.html#git_blame_get_hunk_byline-1"
         ]
       }
     },
@@ -2011,14 +2113,14 @@
       "sig": "git_blame **::git_repository *::const char *::git_blame_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, or an error code. (use giterr_last for information\n         about the error.)"
+        "comment": " 0 on success, or an error code. (use git_error_last for information\n         about the error.)"
       },
       "description": "<p>Get the blame for a single file.</p>\n",
       "comments": "",
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blame_file-2"
+          "ex/v0.28.0/blame.html#git_blame_file-2"
         ]
       }
     },
@@ -2053,7 +2155,7 @@
       "sig": "git_blame **::git_blame *::const char *::size_t",
       "return": {
         "type": "int",
-        "comment": " 0 on success, or an error code. (use giterr_last for information\n         about the error)"
+        "comment": " 0 on success, or an error code. (use git_error_last for information\n         about the error)"
       },
       "description": "<p>Get blame data for a file that has been modified in memory. The <code>reference</code>\n parameter is a pre-calculated blame for the in-odb history of the file. This\n means that once a file blame is completed (which can be expensive), updating\n the buffer blame is very fast.</p>\n",
       "comments": "<p>Lines that differ between the buffer and the committed version are marked as\n having a zero OID for their final_commit_id.</p>\n",
@@ -2082,7 +2184,7 @@
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blame_free-3"
+          "ex/v0.28.0/blame.html#git_blame_free-3"
         ]
       }
     },
@@ -2119,10 +2221,10 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blob_lookup-4"
+          "ex/v0.28.0/blame.html#git_blob_lookup-4"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_blob_lookup-1"
+          "ex/v0.28.0/general.html#git_blob_lookup-1"
         ]
       }
     },
@@ -2186,10 +2288,10 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blob_free-5"
+          "ex/v0.28.0/blame.html#git_blob_free-5"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_blob_free-2"
+          "ex/v0.28.0/general.html#git_blob_free-2"
         ]
       }
     },
@@ -2260,13 +2362,13 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blob_rawcontent-6"
+          "ex/v0.28.0/blame.html#git_blob_rawcontent-6"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_blob_rawcontent-1"
+          "ex/v0.28.0/cat-file.html#git_blob_rawcontent-1"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_blob_rawcontent-3"
+          "ex/v0.28.0/general.html#git_blob_rawcontent-3"
         ]
       }
     },
@@ -2293,14 +2395,14 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_blob_rawsize-7"
+          "ex/v0.28.0/blame.html#git_blob_rawsize-7"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_blob_rawsize-2"
+          "ex/v0.28.0/cat-file.html#git_blob_rawsize-2"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_blob_rawsize-4",
-          "ex/HEAD/general.html#git_blob_rawsize-5"
+          "ex/v0.28.0/general.html#git_blob_rawsize-4",
+          "ex/v0.28.0/general.html#git_blob_rawsize-5"
         ]
       }
     },
@@ -2844,7 +2946,7 @@
       "group": "branch",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_branch_name-4"
+          "ex/v0.28.0/merge.html#git_branch_name-4"
         ]
       }
     },
@@ -3065,43 +3167,21 @@
       "group": "buf",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_buf_dispose-1"
+          "ex/v0.28.0/diff.html#git_buf_dispose-1"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_buf_dispose-1"
+          "ex/v0.28.0/remote.html#git_buf_dispose-1"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_buf_dispose-1"
+          "ex/v0.28.0/tag.html#git_buf_dispose-1"
         ]
       }
-    },
-    "git_buf_free": {
-      "type": "function",
-      "file": "git2/buffer.h",
-      "line": 84,
-      "lineto": 84,
-      "args": [
-        {
-          "name": "buffer",
-          "type": "git_buf *",
-          "comment": null
-        }
-      ],
-      "argline": "git_buf *buffer",
-      "sig": "git_buf *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "buf"
     },
     "git_buf_grow": {
       "type": "function",
       "file": "git2/buffer.h",
-      "line": 107,
-      "lineto": 107,
+      "line": 95,
+      "lineto": 95,
       "args": [
         {
           "name": "buffer",
@@ -3127,8 +3207,8 @@
     "git_buf_set": {
       "type": "function",
       "file": "git2/buffer.h",
-      "line": 117,
-      "lineto": 118,
+      "line": 105,
+      "lineto": 106,
       "args": [
         {
           "name": "buffer",
@@ -3159,8 +3239,8 @@
     "git_buf_is_binary": {
       "type": "function",
       "file": "git2/buffer.h",
-      "line": 126,
-      "lineto": 126,
+      "line": 114,
+      "lineto": 114,
       "args": [
         {
           "name": "buf",
@@ -3181,8 +3261,8 @@
     "git_buf_contains_nul": {
       "type": "function",
       "file": "git2/buffer.h",
-      "line": 134,
-      "lineto": 134,
+      "line": 122,
+      "lineto": 122,
       "args": [
         {
           "name": "buf",
@@ -3248,7 +3328,7 @@
       "sig": "git_repository *::const git_checkout_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, GIT_EUNBORNBRANCH if HEAD points to a non\n         existing branch, non-zero value returned by `notify_cb`, or\n         other error code \n<\n 0 (use giterr_last for error details)"
+        "comment": " 0 on success, GIT_EUNBORNBRANCH if HEAD points to a non\n         existing branch, non-zero value returned by `notify_cb`, or\n         other error code \n<\n 0 (use git_error_last for error details)"
       },
       "description": "<p>Updates files in the index and the working tree to match the content of\n the commit pointed at by HEAD.</p>\n",
       "comments": "<p>Note that this is <em>not</em> the correct mechanism used to switch branches;\n do not change your <code>HEAD</code> and then call this method, that would leave\n you with checkout conflicts since your working directory would then\n appear to be dirty.  Instead, checkout the target of the branch and\n then update <code>HEAD</code> using <code>git_repository_set_head</code> to point to the\n branch you checked out.</p>\n",
@@ -3280,7 +3360,7 @@
       "sig": "git_repository *::git_index *::const git_checkout_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, non-zero return value from `notify_cb`, or error\n         code \n<\n 0 (use giterr_last for error details)"
+        "comment": " 0 on success, non-zero return value from `notify_cb`, or error\n         code \n<\n 0 (use git_error_last for error details)"
       },
       "description": "<p>Updates files in the working tree to match the content of the index.</p>\n",
       "comments": "",
@@ -3312,17 +3392,17 @@
       "sig": "git_repository *::const git_object *::const git_checkout_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, non-zero return value from `notify_cb`, or error\n         code \n<\n 0 (use giterr_last for error details)"
+        "comment": " 0 on success, non-zero return value from `notify_cb`, or error\n         code \n<\n 0 (use git_error_last for error details)"
       },
       "description": "<p>Updates files in the index and working tree to match the content of the\n tree pointed at by the treeish.</p>\n",
       "comments": "",
       "group": "checkout",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_checkout_tree-5"
+          "ex/v0.28.0/checkout.html#git_checkout_tree-5"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_checkout_tree-5"
+          "ex/v0.28.0/merge.html#git_checkout_tree-5"
         ]
       }
     },
@@ -3490,7 +3570,7 @@
       "sig": "git_repository **::const char *::const char *::const git_clone_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `giterr_last` for a detailed error message)"
+        "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `git_error_last` for a detailed error message)"
       },
       "description": "<p>Clone a remote repository.</p>\n",
       "comments": "<p>By default this creates its repository and initial remote to match\n git&#39;s defaults. You can use the options in the callback to\n customize how these are created.</p>\n",
@@ -3529,18 +3609,18 @@
       "group": "commit",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_commit_lookup-6"
+          "ex/v0.28.0/checkout.html#git_commit_lookup-6"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_lookup-6",
-          "ex/HEAD/general.html#git_commit_lookup-7",
-          "ex/HEAD/general.html#git_commit_lookup-8"
+          "ex/v0.28.0/general.html#git_commit_lookup-6",
+          "ex/v0.28.0/general.html#git_commit_lookup-7",
+          "ex/v0.28.0/general.html#git_commit_lookup-8"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_lookup-1"
+          "ex/v0.28.0/log.html#git_commit_lookup-1"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_commit_lookup-6"
+          "ex/v0.28.0/merge.html#git_commit_lookup-6"
         ]
       }
     },
@@ -3604,20 +3684,20 @@
       "group": "commit",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_commit_free-7"
+          "ex/v0.28.0/checkout.html#git_commit_free-7"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_free-9",
-          "ex/HEAD/general.html#git_commit_free-10",
-          "ex/HEAD/general.html#git_commit_free-11",
-          "ex/HEAD/general.html#git_commit_free-12",
-          "ex/HEAD/general.html#git_commit_free-13"
+          "ex/v0.28.0/general.html#git_commit_free-9",
+          "ex/v0.28.0/general.html#git_commit_free-10",
+          "ex/v0.28.0/general.html#git_commit_free-11",
+          "ex/v0.28.0/general.html#git_commit_free-12",
+          "ex/v0.28.0/general.html#git_commit_free-13"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_free-2",
-          "ex/HEAD/log.html#git_commit_free-3",
-          "ex/HEAD/log.html#git_commit_free-4",
-          "ex/HEAD/log.html#git_commit_free-5"
+          "ex/v0.28.0/log.html#git_commit_free-2",
+          "ex/v0.28.0/log.html#git_commit_free-3",
+          "ex/v0.28.0/log.html#git_commit_free-4",
+          "ex/v0.28.0/log.html#git_commit_free-5"
         ]
       }
     },
@@ -3644,10 +3724,10 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_commit_id-14"
+          "ex/v0.28.0/general.html#git_commit_id-14"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_id-6"
+          "ex/v0.28.0/log.html#git_commit_id-6"
         ]
       }
     },
@@ -3674,8 +3754,8 @@
       "group": "commit",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_commit_owner-7",
-          "ex/HEAD/log.html#git_commit_owner-8"
+          "ex/v0.28.0/log.html#git_commit_owner-7",
+          "ex/v0.28.0/log.html#git_commit_owner-8"
         ]
       }
     },
@@ -3724,21 +3804,21 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_message-3",
-          "ex/HEAD/cat-file.html#git_commit_message-4"
+          "ex/v0.28.0/cat-file.html#git_commit_message-3",
+          "ex/v0.28.0/cat-file.html#git_commit_message-4"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_message-15",
-          "ex/HEAD/general.html#git_commit_message-16",
-          "ex/HEAD/general.html#git_commit_message-17"
+          "ex/v0.28.0/general.html#git_commit_message-15",
+          "ex/v0.28.0/general.html#git_commit_message-16",
+          "ex/v0.28.0/general.html#git_commit_message-17"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_message-9",
-          "ex/HEAD/log.html#git_commit_message-10",
-          "ex/HEAD/log.html#git_commit_message-11"
+          "ex/v0.28.0/log.html#git_commit_message-9",
+          "ex/v0.28.0/log.html#git_commit_message-10",
+          "ex/v0.28.0/log.html#git_commit_message-11"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_commit_message-2"
+          "ex/v0.28.0/tag.html#git_commit_message-2"
         ]
       }
     },
@@ -3831,8 +3911,8 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_commit_time-18",
-          "ex/HEAD/general.html#git_commit_time-19"
+          "ex/v0.28.0/general.html#git_commit_time-18",
+          "ex/v0.28.0/general.html#git_commit_time-19"
         ]
       }
     },
@@ -3881,13 +3961,13 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_committer-5"
+          "ex/v0.28.0/cat-file.html#git_commit_committer-5"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_committer-20"
+          "ex/v0.28.0/general.html#git_commit_committer-20"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_committer-12"
+          "ex/v0.28.0/log.html#git_commit_committer-12"
         ]
       }
     },
@@ -3914,15 +3994,15 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_author-6"
+          "ex/v0.28.0/cat-file.html#git_commit_author-6"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_author-21",
-          "ex/HEAD/general.html#git_commit_author-22"
+          "ex/v0.28.0/general.html#git_commit_author-21",
+          "ex/v0.28.0/general.html#git_commit_author-22"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_author-13",
-          "ex/HEAD/log.html#git_commit_author-14"
+          "ex/v0.28.0/log.html#git_commit_author-13",
+          "ex/v0.28.0/log.html#git_commit_author-14"
         ]
       }
     },
@@ -4040,11 +4120,11 @@
       "group": "commit",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_commit_tree-15",
-          "ex/HEAD/log.html#git_commit_tree-16",
-          "ex/HEAD/log.html#git_commit_tree-17",
-          "ex/HEAD/log.html#git_commit_tree-18",
-          "ex/HEAD/log.html#git_commit_tree-19"
+          "ex/v0.28.0/log.html#git_commit_tree-15",
+          "ex/v0.28.0/log.html#git_commit_tree-16",
+          "ex/v0.28.0/log.html#git_commit_tree-17",
+          "ex/v0.28.0/log.html#git_commit_tree-18",
+          "ex/v0.28.0/log.html#git_commit_tree-19"
         ]
       }
     },
@@ -4071,7 +4151,7 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_tree_id-7"
+          "ex/v0.28.0/cat-file.html#git_commit_tree_id-7"
         ]
       }
     },
@@ -4098,14 +4178,14 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_parentcount-8"
+          "ex/v0.28.0/cat-file.html#git_commit_parentcount-8"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_commit_parentcount-23"
+          "ex/v0.28.0/general.html#git_commit_parentcount-23"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parentcount-20",
-          "ex/HEAD/log.html#git_commit_parentcount-21"
+          "ex/v0.28.0/log.html#git_commit_parentcount-20",
+          "ex/v0.28.0/log.html#git_commit_parentcount-21"
         ]
       }
     },
@@ -4142,11 +4222,11 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_commit_parent-24"
+          "ex/v0.28.0/general.html#git_commit_parent-24"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parent-22",
-          "ex/HEAD/log.html#git_commit_parent-23"
+          "ex/v0.28.0/log.html#git_commit_parent-22",
+          "ex/v0.28.0/log.html#git_commit_parent-23"
         ]
       }
     },
@@ -4178,10 +4258,10 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_commit_parent_id-9"
+          "ex/v0.28.0/cat-file.html#git_commit_parent_id-9"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_commit_parent_id-24"
+          "ex/v0.28.0/log.html#git_commit_parent_id-24"
         ]
       }
     },
@@ -4288,7 +4368,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the id is not for a commit\n or the commit does not have a signature."
       },
       "description": "<p>Extract the signature from a commit</p>\n",
-      "comments": "<p>If the id is not for a commit, the error class will be\n <code>GITERR_INVALID</code>. If the commit does not have a signature, the\n error class will be <code>GITERR_OBJECT</code>.</p>\n",
+      "comments": "<p>If the id is not for a commit, the error class will be\n <code>GIT_ERROR_INVALID</code>. If the commit does not have a signature, the\n error class will be <code>GIT_ERROR_OBJECT</code>.</p>\n",
       "group": "commit"
     },
     "git_commit_create": {
@@ -4359,7 +4439,7 @@
       "group": "commit",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_commit_create-7"
+          "ex/v0.28.0/merge.html#git_commit_create-7"
         ]
       }
     },
@@ -4426,10 +4506,10 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_commit_create_v-25"
+          "ex/v0.28.0/general.html#git_commit_create_v-25"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_commit_create_v-1"
+          "ex/v0.28.0/init.html#git_commit_create_v-1"
         ]
       }
     },
@@ -4624,8 +4704,8 @@
     "git_libgit2_version": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 116,
-      "lineto": 116,
+      "line": 124,
+      "lineto": 124,
       "args": [
         {
           "name": "major",
@@ -4656,8 +4736,8 @@
     "git_libgit2_features": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 165,
-      "lineto": 165,
+      "line": 173,
+      "lineto": 173,
       "args": [],
       "argline": "",
       "sig": "",
@@ -4672,8 +4752,8 @@
     "git_libgit2_opts": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 393,
-      "lineto": 393,
+      "line": 402,
+      "lineto": 402,
       "args": [
         {
           "name": "option",
@@ -4688,7 +4768,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set or query a library global option</p>\n",
-      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time\n    by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must\n    &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,\n    &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n    &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path\n    &gt; applied to shared attributes and ignore files, too.\n    &gt;\n    &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.\n    &gt;   Pass NULL to reset to the default (generally based on environment\n    &gt;   variables).  Use magic path `$PATH` to include the old value\n    &gt;   of the path (if you want to prepend or append, for instance).\n    &gt;\n    &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,\n    &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or\n    &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_otype type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be\n    &gt; considered eligible for caching in memory.  Setting to value to\n    &gt; zero means that that type of object will not be cached.\n    &gt; Defaults to 0 for GIT_OBJ_BLOB (i.e. won&#39;t cache blobs) and 4k\n    &gt; for GIT_OBJ_COMMIT, GIT_OBJ_TREE, and GIT_OBJ_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory\n    &gt; across all repositories before libgit2 starts evicting objects\n    &gt; from the cache.  This is a soft limit, in that the library might\n    &gt; briefly exceed it, but will start aggressively evicting objects\n    &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.\n    &gt;\n    &gt; Because caches are repository-specific, disabling the cache\n    &gt; cannot immediately clear all cached objects, but each cache will\n    &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be\n    &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.\n    &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.\n    &gt;\n    &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.\n    &gt;\n    &gt; - `file` is the location of a file containing several\n    &gt;   certificates concatenated together.\n    &gt; - `path` is the location of a directory holding several\n    &gt;   certificates, one per file.\n    &gt;\n    &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be\n    &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.\n    &gt;\n    &gt; - `user_agent` is the value that will be delivered as the\n    &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.\n    &gt; For more information, see the documentation for CreateFile.\n    &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is\n    &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects\n    &gt; to ensure that all inputs to the new objects are valid.  For\n    &gt; example, when this is enabled, the parent(s) and tree inputs\n    &gt; will be validated when creating a new commit.  This defaults\n    &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For\n    &gt; example, `foobar` is not a valid ref, therefore `foobar` is\n    &gt; not a valid target for a symbolic ref by default, whereas\n    &gt; `refs/heads/foobar` is.  Disabling this bypasses validation\n    &gt; so that an arbitrary strings such as `foobar` can be used\n    &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.\n    &gt;\n    &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,\n    &gt; and the negotiation of them when talking to a remote server.\n    &gt; Offset deltas store a delta base location as an offset into the\n    &gt; packfile from the current location, which provides a shorter encoding\n    &gt; and thus smaller resultant packfiles.\n    &gt; Packfiles containing offset deltas can still be read.\n    &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`\n    &gt; (or the platform equivalent) to ensure that new object data\n    &gt; is written to permanent storage, not simply cached.  This\n    &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading\n    &gt; objects from disk. This may impact performance due to an\n    &gt; additional checksum calculation on each object. This defaults\n    &gt; to enabled.\n\n opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)\n\n    &gt; Set the memory allocator to a different memory allocator. This\n    &gt; allocator will then be used to make all memory allocations for\n    &gt; libgit2 operations.\n\n opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, int enabled)\n\n    &gt; Ensure that there are no unsaved changes in the index before\n    &gt; beginning any operation that reloads the index from disk (eg,\n    &gt; checkout).  If there are unsaved changes, the instruction will\n    &gt; fail.  (Using the FORCE flag to checkout will still overwrite\n    &gt; these changes.)\n\n opts(GIT_OPT_GET_PACK_MAX_OBJECTS, size_t *out)\n\n    &gt; Get the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote. This can be\n    &gt; used to limit maximum memory usage when fetching from an untrusted\n    &gt; remote.\n\n opts(GIT_OPT_SET_PACK_MAX_OBJECTS, size_t objects)\n\n    &gt; Set the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote.\n</code></pre>\n",
+      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time\n    by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must\n    &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,\n    &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n    &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path\n    &gt; applied to shared attributes and ignore files, too.\n    &gt;\n    &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.\n    &gt;   Pass NULL to reset to the default (generally based on environment\n    &gt;   variables).  Use magic path `$PATH` to include the old value\n    &gt;   of the path (if you want to prepend or append, for instance).\n    &gt;\n    &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,\n    &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or\n    &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_object_t type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be\n    &gt; considered eligible for caching in memory.  Setting to value to\n    &gt; zero means that that type of object will not be cached.\n    &gt; Defaults to 0 for GIT_OBJECT_BLOB (i.e. won&#39;t cache blobs) and 4k\n    &gt; for GIT_OBJECT_COMMIT, GIT_OBJECT_TREE, and GIT_OBJECT_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory\n    &gt; across all repositories before libgit2 starts evicting objects\n    &gt; from the cache.  This is a soft limit, in that the library might\n    &gt; briefly exceed it, but will start aggressively evicting objects\n    &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.\n    &gt;\n    &gt; Because caches are repository-specific, disabling the cache\n    &gt; cannot immediately clear all cached objects, but each cache will\n    &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be\n    &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.\n    &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.\n    &gt;\n    &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.\n    &gt;\n    &gt; - `file` is the location of a file containing several\n    &gt;   certificates concatenated together.\n    &gt; - `path` is the location of a directory holding several\n    &gt;   certificates, one per file.\n    &gt;\n    &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be\n    &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.\n    &gt;\n    &gt; - `user_agent` is the value that will be delivered as the\n    &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.\n    &gt; For more information, see the documentation for CreateFile.\n    &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is\n    &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects\n    &gt; to ensure that all inputs to the new objects are valid.  For\n    &gt; example, when this is enabled, the parent(s) and tree inputs\n    &gt; will be validated when creating a new commit.  This defaults\n    &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For\n    &gt; example, `foobar` is not a valid ref, therefore `foobar` is\n    &gt; not a valid target for a symbolic ref by default, whereas\n    &gt; `refs/heads/foobar` is.  Disabling this bypasses validation\n    &gt; so that an arbitrary strings such as `foobar` can be used\n    &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.\n    &gt;\n    &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,\n    &gt; and the negotiation of them when talking to a remote server.\n    &gt; Offset deltas store a delta base location as an offset into the\n    &gt; packfile from the current location, which provides a shorter encoding\n    &gt; and thus smaller resultant packfiles.\n    &gt; Packfiles containing offset deltas can still be read.\n    &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`\n    &gt; (or the platform equivalent) to ensure that new object data\n    &gt; is written to permanent storage, not simply cached.  This\n    &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading\n    &gt; objects from disk. This may impact performance due to an\n    &gt; additional checksum calculation on each object. This defaults\n    &gt; to enabled.\n\n opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)\n\n    &gt; Set the memory allocator to a different memory allocator. This\n    &gt; allocator will then be used to make all memory allocations for\n    &gt; libgit2 operations.  If the given `allocator` is NULL, then the\n    &gt; system default will be restored.\n\n opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, int enabled)\n\n    &gt; Ensure that there are no unsaved changes in the index before\n    &gt; beginning any operation that reloads the index from disk (eg,\n    &gt; checkout).  If there are unsaved changes, the instruction will\n    &gt; fail.  (Using the FORCE flag to checkout will still overwrite\n    &gt; these changes.)\n\n opts(GIT_OPT_GET_PACK_MAX_OBJECTS, size_t *out)\n\n    &gt; Get the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote. This can be\n    &gt; used to limit maximum memory usage when fetching from an untrusted\n    &gt; remote.\n\n opts(GIT_OPT_SET_PACK_MAX_OBJECTS, size_t objects)\n\n    &gt; Set the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote.\n</code></pre>\n",
       "group": "libgit2"
     },
     "git_config_entry_free": {
@@ -4915,7 +4995,7 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_open_ondisk-26"
+          "ex/v0.28.0/general.html#git_config_open_ondisk-26"
         ]
       }
     },
@@ -5028,8 +5108,8 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_free-27",
-          "ex/HEAD/general.html#git_config_free-28"
+          "ex/v0.28.0/general.html#git_config_free-27",
+          "ex/v0.28.0/general.html#git_config_free-28"
         ]
       }
     },
@@ -5073,33 +5153,33 @@
       "args": [
         {
           "name": "out",
-          "type": "int32_t *",
-          "comment": "pointer to the variable where the value should be stored"
+          "type": "int *",
+          "comment": null
         },
         {
           "name": "cfg",
           "type": "const git_config *",
-          "comment": "where to look for the variable"
+          "comment": null
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": "the variable's name"
+          "comment": null
         }
       ],
-      "argline": "int32_t *out, const git_config *cfg, const char *name",
-      "sig": "int32_t *::const git_config *::const char *",
+      "argline": "int *out, const git_config *cfg, const char *name",
+      "sig": "int *::const git_config *::const char *",
       "return": {
         "type": "int",
-        "comment": " 0 or an error code"
+        "comment": null
       },
-      "description": "<p>Get the value of an integer config variable.</p>\n",
-      "comments": "<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_get_int32-29",
-          "ex/HEAD/general.html#git_config_get_int32-30"
+          "ex/v0.28.0/general.html#git_config_get_int32-29",
+          "ex/v0.28.0/general.html#git_config_get_int32-30"
         ]
       }
     },
@@ -5111,28 +5191,28 @@
       "args": [
         {
           "name": "out",
-          "type": "int64_t *",
-          "comment": "pointer to the variable where the value should be stored"
+          "type": "int *",
+          "comment": null
         },
         {
           "name": "cfg",
           "type": "const git_config *",
-          "comment": "where to look for the variable"
+          "comment": null
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": "the variable's name"
+          "comment": null
         }
       ],
-      "argline": "int64_t *out, const git_config *cfg, const char *name",
-      "sig": "int64_t *::const git_config *::const char *",
+      "argline": "int *out, const git_config *cfg, const char *name",
+      "sig": "int *::const git_config *::const char *",
       "return": {
         "type": "int",
-        "comment": " 0 or an error code"
+        "comment": null
       },
-      "description": "<p>Get the value of a long integer config variable.</p>\n",
-      "comments": "<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "config"
     },
     "git_config_get_bool": {
@@ -5232,8 +5312,8 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_config_get_string-31",
-          "ex/HEAD/general.html#git_config_get_string-32"
+          "ex/v0.28.0/general.html#git_config_get_string-31",
+          "ex/v0.28.0/general.html#git_config_get_string-32"
         ]
       }
     },
@@ -5406,26 +5486,26 @@
         {
           "name": "cfg",
           "type": "git_config *",
-          "comment": "where to look for the variable"
+          "comment": null
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": "the variable's name"
+          "comment": null
         },
         {
           "name": "value",
-          "type": "int32_t",
-          "comment": "Integer value for the variable"
+          "type": "int",
+          "comment": null
         }
       ],
-      "argline": "git_config *cfg, const char *name, int32_t value",
-      "sig": "git_config *::const char *::int32_t",
+      "argline": "git_config *cfg, const char *name, int value",
+      "sig": "git_config *::const char *::int",
       "return": {
         "type": "int",
-        "comment": " 0 or an error code"
+        "comment": null
       },
-      "description": "<p>Set the value of an integer config variable in the config file\n with the highest level (usually the local one).</p>\n",
+      "description": "",
       "comments": "",
       "group": "config"
     },
@@ -5438,26 +5518,26 @@
         {
           "name": "cfg",
           "type": "git_config *",
-          "comment": "where to look for the variable"
+          "comment": null
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": "the variable's name"
+          "comment": null
         },
         {
           "name": "value",
-          "type": "int64_t",
-          "comment": "Long integer value for the variable"
+          "type": "int",
+          "comment": null
         }
       ],
-      "argline": "git_config *cfg, const char *name, int64_t value",
-      "sig": "git_config *::const char *::int64_t",
+      "argline": "git_config *cfg, const char *name, int value",
+      "sig": "git_config *::const char *::int",
       "return": {
         "type": "int",
-        "comment": " 0 or an error code"
+        "comment": null
       },
-      "description": "<p>Set the value of a long integer config variable in the config file\n with the highest level (usually the local one).</p>\n",
+      "description": "",
       "comments": "",
       "group": "config"
     },
@@ -5863,23 +5943,23 @@
       "args": [
         {
           "name": "out",
-          "type": "int32_t *",
-          "comment": "place to store the result of the parsing"
+          "type": "int *",
+          "comment": null
         },
         {
           "name": "value",
           "type": "const char *",
-          "comment": "value to parse"
+          "comment": null
         }
       ],
-      "argline": "int32_t *out, const char *value",
-      "sig": "int32_t *::const char *",
+      "argline": "int *out, const char *value",
+      "sig": "int *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Parse a string value as an int32.</p>\n",
-      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will\n cause the value to be multiplied by 1024, 1048576,\n or 1073741824 prior to output.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "config"
     },
     "git_config_parse_int64": {
@@ -5890,23 +5970,23 @@
       "args": [
         {
           "name": "out",
-          "type": "int64_t *",
-          "comment": "place to store the result of the parsing"
+          "type": "int *",
+          "comment": null
         },
         {
           "name": "value",
           "type": "const char *",
-          "comment": "value to parse"
+          "comment": null
         }
       ],
-      "argline": "int64_t *out, const char *value",
-      "sig": "int64_t *::const char *",
+      "argline": "int *out, const char *value",
+      "sig": "int *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Parse a string value as an int64.</p>\n",
-      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will\n cause the value to be multiplied by 1024, 1048576,\n or 1073741824 prior to output.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "config"
     },
     "git_config_parse_path": {
@@ -6042,6 +6122,103 @@
       "comments": "",
       "group": "cred"
     },
+    "git_buf_free": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 51,
+      "lineto": 51,
+      "args": [
+        {
+          "name": "buffer",
+          "type": "git_buf *",
+          "comment": null
+        }
+      ],
+      "argline": "git_buf *buffer",
+      "sig": "git_buf *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free the memory referred to by the git_buf.  This is an alias of\n <code>git_buf_dispose</code> and is preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "group": "buf"
+    },
+    "giterr_last": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 112,
+      "lineto": 112,
+      "args": [],
+      "argline": "",
+      "sig": "",
+      "return": {
+        "type": "const git_error *",
+        "comment": null
+      },
+      "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread.  This is an alias of <code>git_error_last</code> and is\n preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "group": "giterr"
+    },
+    "giterr_clear": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 124,
+      "lineto": 124,
+      "args": [],
+      "argline": "",
+      "sig": "",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Clear the last error.  This is an alias of <code>git_error_last</code> and is\n preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "group": "giterr"
+    },
+    "giterr_set_str": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 136,
+      "lineto": 136,
+      "args": [
+        {
+          "name": "error_class",
+          "type": "int",
+          "comment": null
+        },
+        {
+          "name": "string",
+          "type": "const char *",
+          "comment": null
+        }
+      ],
+      "argline": "int error_class, const char *string",
+      "sig": "int::const char *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Sets the error message to the given string.  This is an alias of\n <code>git_error_set_str</code> and is preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "group": "giterr"
+    },
+    "giterr_set_oom": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 148,
+      "lineto": 148,
+      "args": [],
+      "argline": "",
+      "sig": "",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Indicates that an out-of-memory situation occured.  This is an alias\n of <code>git_error_set_oom</code> and is preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "group": "giterr"
+    },
     "git_describe_init_options": {
       "type": "function",
       "file": "git2/describe.h",
@@ -6070,7 +6247,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_init_options-1"
+          "ex/v0.28.0/describe.html#git_describe_init_options-1"
         ]
       }
     },
@@ -6102,7 +6279,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_init_format_options-2"
+          "ex/v0.28.0/describe.html#git_describe_init_format_options-2"
         ]
       }
     },
@@ -6139,7 +6316,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_commit-3"
+          "ex/v0.28.0/describe.html#git_describe_commit-3"
         ]
       }
     },
@@ -6176,7 +6353,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_workdir-4"
+          "ex/v0.28.0/describe.html#git_describe_workdir-4"
         ]
       }
     },
@@ -6213,7 +6390,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/HEAD/describe.html#git_describe_format-5"
+          "ex/v0.28.0/describe.html#git_describe_format-5"
         ]
       }
     },
@@ -6316,11 +6493,11 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_free-2"
+          "ex/v0.28.0/diff.html#git_diff_free-2"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_free-25",
-          "ex/HEAD/log.html#git_diff_free-26"
+          "ex/v0.28.0/log.html#git_diff_free-25",
+          "ex/v0.28.0/log.html#git_diff_free-26"
         ]
       }
     },
@@ -6367,11 +6544,11 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_tree_to_tree-3"
+          "ex/v0.28.0/diff.html#git_diff_tree_to_tree-3"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_tree_to_tree-27",
-          "ex/HEAD/log.html#git_diff_tree_to_tree-28"
+          "ex/v0.28.0/log.html#git_diff_tree_to_tree-27",
+          "ex/v0.28.0/log.html#git_diff_tree_to_tree-28"
         ]
       }
     },
@@ -6418,7 +6595,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_tree_to_index-4"
+          "ex/v0.28.0/diff.html#git_diff_tree_to_index-4"
         ]
       }
     },
@@ -6460,7 +6637,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_index_to_workdir-5"
+          "ex/v0.28.0/diff.html#git_diff_index_to_workdir-5"
         ]
       }
     },
@@ -6502,7 +6679,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_tree_to_workdir-6"
+          "ex/v0.28.0/diff.html#git_diff_tree_to_workdir-6"
         ]
       }
     },
@@ -6544,7 +6721,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_tree_to_workdir_with_index-7"
+          "ex/v0.28.0/diff.html#git_diff_tree_to_workdir_with_index-7"
         ]
       }
     },
@@ -6645,7 +6822,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_find_similar-8"
+          "ex/v0.28.0/diff.html#git_diff_find_similar-8"
         ]
       }
     },
@@ -6672,7 +6849,7 @@
       "group": "diff",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_diff_num_deltas-29"
+          "ex/v0.28.0/log.html#git_diff_num_deltas-29"
         ]
       }
     },
@@ -6859,10 +7036,10 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_print-9"
+          "ex/v0.28.0/diff.html#git_diff_print-9"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_diff_print-30"
+          "ex/v0.28.0/log.html#git_diff_print-30"
         ]
       }
     },
@@ -7174,7 +7351,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_get_stats-10"
+          "ex/v0.28.0/diff.html#git_diff_get_stats-10"
         ]
       }
     },
@@ -7282,7 +7459,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_stats_to_buf-11"
+          "ex/v0.28.0/diff.html#git_diff_stats_to_buf-11"
         ]
       }
     },
@@ -7309,7 +7486,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_diff_stats_free-12"
+          "ex/v0.28.0/diff.html#git_diff_stats_free-12"
         ]
       }
     },
@@ -7483,11 +7660,11 @@
       "comments": "<p>Calculate a stable patch ID for the given patch by summing the\n hash of the file diffs, ignoring whitespace and line numbers.\n This can be used to derive whether two diffs are the same with\n a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as\n defined in git-patch-id(1), and should in fact generate the\n same IDs as the upstream git project does.</p>\n",
       "group": "diff"
     },
-    "giterr_last": {
+    "git_error_last": {
       "type": "function",
       "file": "git2/errors.h",
-      "line": 122,
-      "lineto": 122,
+      "line": 123,
+      "lineto": 123,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7497,28 +7674,28 @@
       },
       "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread.</p>\n",
       "comments": "<p>The default behaviour of this function is to return NULL if no previous error has occurred.\n However, libgit2&#39;s error strings are not cleared aggressively, so a prior\n (unrelated) error may be returned. This can be avoided by only calling\n this function if the prior call to a libgit2 API returned an error.</p>\n",
-      "group": "giterr",
+      "group": "error",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#giterr_last-8",
-          "ex/HEAD/checkout.html#giterr_last-9",
-          "ex/HEAD/checkout.html#giterr_last-10",
-          "ex/HEAD/checkout.html#giterr_last-11"
+          "ex/v0.28.0/checkout.html#git_error_last-8",
+          "ex/v0.28.0/checkout.html#git_error_last-9",
+          "ex/v0.28.0/checkout.html#git_error_last-10",
+          "ex/v0.28.0/checkout.html#git_error_last-11"
         ],
         "general.c": [
-          "ex/HEAD/general.html#giterr_last-33"
+          "ex/v0.28.0/general.html#git_error_last-33"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#giterr_last-8",
-          "ex/HEAD/merge.html#giterr_last-9"
+          "ex/v0.28.0/merge.html#git_error_last-8",
+          "ex/v0.28.0/merge.html#git_error_last-9"
         ]
       }
     },
-    "giterr_clear": {
+    "git_error_clear": {
       "type": "function",
       "file": "git2/errors.h",
-      "line": 127,
-      "lineto": 127,
+      "line": 128,
+      "lineto": 128,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7528,13 +7705,13 @@
       },
       "description": "<p>Clear the last library error that occurred for this thread.</p>\n",
       "comments": "",
-      "group": "giterr"
+      "group": "error"
     },
-    "giterr_set_str": {
+    "git_error_set_str": {
       "type": "function",
       "file": "git2/errors.h",
-      "line": 145,
-      "lineto": 145,
+      "line": 146,
+      "lineto": 146,
       "args": [
         {
           "name": "error_class",
@@ -7555,13 +7732,13 @@
       },
       "description": "<p>Set the error message string for this thread.</p>\n",
       "comments": "<p>This function is public so that custom ODB backends and the like can\n relay an error message through libgit2.  Most regular users of libgit2\n will never need to call this function -- actually, calling it in most\n circumstances (for example, calling from within a callback function)\n will just end up having the value overwritten by libgit2 internals.</p>\n\n<p>This error message is stored in thread-local storage and only applies\n to the particular thread that this libgit2 call is made from.</p>\n",
-      "group": "giterr"
+      "group": "error"
     },
-    "giterr_set_oom": {
+    "git_error_set_oom": {
       "type": "function",
       "file": "git2/errors.h",
-      "line": 156,
-      "lineto": 156,
+      "line": 157,
+      "lineto": 157,
       "args": [],
       "argline": "",
       "sig": "",
@@ -7570,8 +7747,8 @@
         "comment": null
       },
       "description": "<p>Set the error message to a special value for memory allocation failure.</p>\n",
-      "comments": "<p>The normal <code>giterr_set_str()</code> function attempts to <code>strdup()</code> the string\n that is passed in.  This is not a good idea when the error in question\n is a memory allocation failure.  That circumstance has a special setter\n function that sets the error string to a known and statically allocated\n internal value.</p>\n",
-      "group": "giterr"
+      "comments": "<p>The normal <code>git_error_set_str()</code> function attempts to <code>strdup()</code> the\n string that is passed in.  This is not a good idea when the error in\n question is a memory allocation failure.  That circumstance has a\n special setter function that sets the error string to a known and\n statically allocated internal value.</p>\n",
+      "group": "error"
     },
     "git_filter_list_load": {
       "type": "function",
@@ -7582,42 +7759,42 @@
         {
           "name": "filters",
           "type": "git_filter_list **",
-          "comment": "Output newly created git_filter_list (or NULL)"
+          "comment": null
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "Repository object that contains `path`"
+          "comment": null
         },
         {
           "name": "blob",
           "type": "git_blob *",
-          "comment": "The blob to which the filter will be applied (if known)"
+          "comment": null
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": "Relative path of the file to be filtered"
+          "comment": null
         },
         {
           "name": "mode",
           "type": "git_filter_mode_t",
-          "comment": "Filtering direction (WT->ODB or ODB->WT)"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of `git_filter_flag_t` flags"
+          "type": "int",
+          "comment": null
         }
       ],
-      "argline": "git_filter_list **filters, git_repository *repo, git_blob *blob, const char *path, git_filter_mode_t mode, uint32_t flags",
-      "sig": "git_filter_list **::git_repository *::git_blob *::const char *::git_filter_mode_t::uint32_t",
+      "argline": "git_filter_list **filters, git_repository *repo, git_blob *blob, const char *path, git_filter_mode_t mode, int flags",
+      "sig": "git_filter_list **::git_repository *::git_blob *::const char *::git_filter_mode_t::int",
       "return": {
         "type": "int",
-        "comment": " 0 on success (which could still return NULL if no filters are\n         needed for the requested file), \n<\n0 on error"
+        "comment": null
       },
-      "description": "<p>Load the filter list for a given path.</p>\n",
-      "comments": "<p>This will return 0 (success) but set the output git_filter_list to NULL\n if no filters are requested for the given file.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "filter"
     },
     "git_filter_list_contains": {
@@ -7888,46 +8065,46 @@
       "group": "libgit2",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_libgit2_init-8"
+          "ex/v0.28.0/blame.html#git_libgit2_init-8"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_libgit2_init-10"
+          "ex/v0.28.0/cat-file.html#git_libgit2_init-10"
         ],
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_libgit2_init-12"
+          "ex/v0.28.0/checkout.html#git_libgit2_init-12"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_libgit2_init-6"
+          "ex/v0.28.0/describe.html#git_libgit2_init-6"
         ],
         "diff.c": [
-          "ex/HEAD/diff.html#git_libgit2_init-13"
+          "ex/v0.28.0/diff.html#git_libgit2_init-13"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_libgit2_init-34"
+          "ex/v0.28.0/general.html#git_libgit2_init-34"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_libgit2_init-2"
+          "ex/v0.28.0/init.html#git_libgit2_init-2"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_libgit2_init-31"
+          "ex/v0.28.0/log.html#git_libgit2_init-31"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_libgit2_init-1"
+          "ex/v0.28.0/ls-files.html#git_libgit2_init-1"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_libgit2_init-10"
+          "ex/v0.28.0/merge.html#git_libgit2_init-10"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_libgit2_init-2"
+          "ex/v0.28.0/remote.html#git_libgit2_init-2"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_libgit2_init-1"
+          "ex/v0.28.0/rev-parse.html#git_libgit2_init-1"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_libgit2_init-1"
+          "ex/v0.28.0/status.html#git_libgit2_init-1"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_libgit2_init-3"
+          "ex/v0.28.0/tag.html#git_libgit2_init-3"
         ]
       }
     },
@@ -7948,43 +8125,43 @@
       "group": "libgit2",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_libgit2_shutdown-9"
+          "ex/v0.28.0/blame.html#git_libgit2_shutdown-9"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_libgit2_shutdown-11"
+          "ex/v0.28.0/cat-file.html#git_libgit2_shutdown-11"
         ],
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_libgit2_shutdown-13"
+          "ex/v0.28.0/checkout.html#git_libgit2_shutdown-13"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_libgit2_shutdown-7"
+          "ex/v0.28.0/describe.html#git_libgit2_shutdown-7"
         ],
         "diff.c": [
-          "ex/HEAD/diff.html#git_libgit2_shutdown-14"
+          "ex/v0.28.0/diff.html#git_libgit2_shutdown-14"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_libgit2_shutdown-3"
+          "ex/v0.28.0/init.html#git_libgit2_shutdown-3"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_libgit2_shutdown-32"
+          "ex/v0.28.0/log.html#git_libgit2_shutdown-32"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_libgit2_shutdown-2"
+          "ex/v0.28.0/ls-files.html#git_libgit2_shutdown-2"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_libgit2_shutdown-11"
+          "ex/v0.28.0/merge.html#git_libgit2_shutdown-11"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_libgit2_shutdown-3"
+          "ex/v0.28.0/remote.html#git_libgit2_shutdown-3"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_libgit2_shutdown-2"
+          "ex/v0.28.0/rev-parse.html#git_libgit2_shutdown-2"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_libgit2_shutdown-2"
+          "ex/v0.28.0/status.html#git_libgit2_shutdown-2"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_libgit2_shutdown-4"
+          "ex/v0.28.0/tag.html#git_libgit2_shutdown-4"
         ]
       }
     },
@@ -8146,8 +8323,8 @@
     "git_index_open": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 203,
-      "lineto": 203,
+      "line": 186,
+      "lineto": 186,
       "args": [
         {
           "name": "out",
@@ -8173,8 +8350,8 @@
     "git_index_new": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 216,
-      "lineto": 216,
+      "line": 199,
+      "lineto": 199,
       "args": [
         {
           "name": "out",
@@ -8195,8 +8372,8 @@
     "git_index_free": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 223,
-      "lineto": 223,
+      "line": 206,
+      "lineto": 206,
       "args": [
         {
           "name": "index",
@@ -8215,21 +8392,21 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_free-35"
+          "ex/v0.28.0/general.html#git_index_free-35"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_index_free-4"
+          "ex/v0.28.0/init.html#git_index_free-4"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_index_free-3"
+          "ex/v0.28.0/ls-files.html#git_index_free-3"
         ]
       }
     },
     "git_index_owner": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 231,
-      "lineto": 231,
+      "line": 214,
+      "lineto": 214,
       "args": [
         {
           "name": "index",
@@ -8250,8 +8427,8 @@
     "git_index_caps": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 239,
-      "lineto": 239,
+      "line": 222,
+      "lineto": 222,
       "args": [
         {
           "name": "index",
@@ -8263,7 +8440,7 @@
       "sig": "const git_index *",
       "return": {
         "type": "int",
-        "comment": " A combination of GIT_INDEXCAP values"
+        "comment": " A combination of GIT_INDEX_CAPABILITY values"
       },
       "description": "<p>Read index capabilities flags.</p>\n",
       "comments": "",
@@ -8272,8 +8449,8 @@
     "git_index_set_caps": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 252,
-      "lineto": 252,
+      "line": 235,
+      "lineto": 235,
       "args": [
         {
           "name": "index",
@@ -8283,7 +8460,7 @@
         {
           "name": "caps",
           "type": "int",
-          "comment": "A combination of GIT_INDEXCAP values"
+          "comment": "A combination of GIT_INDEX_CAPABILITY values"
         }
       ],
       "argline": "git_index *index, int caps",
@@ -8293,14 +8470,14 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Set index capabilities flags.</p>\n",
-      "comments": "<p>If you pass <code>GIT_INDEXCAP_FROM_OWNER</code> for the caps, then the\n capabilities will be read from the config of the owner object,\n looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
+      "comments": "<p>If you pass <code>GIT_INDEX_CAPABILITY_FROM_OWNER</code> for the caps, then\n capabilities will be read from the config of the owner object,\n looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
       "group": "index"
     },
     "git_index_version": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 264,
-      "lineto": 264,
+      "line": 247,
+      "lineto": 247,
       "args": [
         {
           "name": "index",
@@ -8321,8 +8498,8 @@
     "git_index_set_version": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 277,
-      "lineto": 277,
+      "line": 260,
+      "lineto": 260,
       "args": [
         {
           "name": "index",
@@ -8348,8 +8525,8 @@
     "git_index_read": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 296,
-      "lineto": 296,
+      "line": 279,
+      "lineto": 279,
       "args": [
         {
           "name": "index",
@@ -8375,8 +8552,8 @@
     "git_index_write": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 305,
-      "lineto": 305,
+      "line": 288,
+      "lineto": 288,
       "args": [
         {
           "name": "index",
@@ -8397,8 +8574,8 @@
     "git_index_path": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 313,
-      "lineto": 313,
+      "line": 296,
+      "lineto": 296,
       "args": [
         {
           "name": "index",
@@ -8419,8 +8596,8 @@
     "git_index_checksum": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 325,
-      "lineto": 325,
+      "line": 308,
+      "lineto": 308,
       "args": [
         {
           "name": "index",
@@ -8441,8 +8618,8 @@
     "git_index_read_tree": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 336,
-      "lineto": 336,
+      "line": 319,
+      "lineto": 319,
       "args": [
         {
           "name": "index",
@@ -8468,8 +8645,8 @@
     "git_index_write_tree": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 357,
-      "lineto": 357,
+      "line": 340,
+      "lineto": 340,
       "args": [
         {
           "name": "out",
@@ -8493,18 +8670,18 @@
       "group": "index",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_index_write_tree-5"
+          "ex/v0.28.0/init.html#git_index_write_tree-5"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_write_tree-12"
+          "ex/v0.28.0/merge.html#git_index_write_tree-12"
         ]
       }
     },
     "git_index_write_tree_to": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 374,
-      "lineto": 374,
+      "line": 357,
+      "lineto": 357,
       "args": [
         {
           "name": "out",
@@ -8535,8 +8712,8 @@
     "git_index_entrycount": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 393,
-      "lineto": 393,
+      "line": 376,
+      "lineto": 376,
       "args": [
         {
           "name": "index",
@@ -8555,18 +8732,18 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_entrycount-36"
+          "ex/v0.28.0/general.html#git_index_entrycount-36"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_index_entrycount-4"
+          "ex/v0.28.0/ls-files.html#git_index_entrycount-4"
         ]
       }
     },
     "git_index_clear": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 404,
-      "lineto": 404,
+      "line": 387,
+      "lineto": 387,
       "args": [
         {
           "name": "index",
@@ -8587,8 +8764,8 @@
     "git_index_get_byindex": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 417,
-      "lineto": 418,
+      "line": 400,
+      "lineto": 401,
       "args": [
         {
           "name": "index",
@@ -8612,18 +8789,18 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_index_get_byindex-37"
+          "ex/v0.28.0/general.html#git_index_get_byindex-37"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_index_get_byindex-5"
+          "ex/v0.28.0/ls-files.html#git_index_get_byindex-5"
         ]
       }
     },
     "git_index_get_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 432,
-      "lineto": 433,
+      "line": 415,
+      "lineto": 416,
       "args": [
         {
           "name": "index",
@@ -8652,15 +8829,15 @@
       "group": "index",
       "examples": {
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_index_get_bypath-6"
+          "ex/v0.28.0/ls-files.html#git_index_get_bypath-6"
         ]
       }
     },
     "git_index_remove": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 443,
-      "lineto": 443,
+      "line": 426,
+      "lineto": 426,
       "args": [
         {
           "name": "index",
@@ -8691,8 +8868,8 @@
     "git_index_remove_directory": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 453,
-      "lineto": 454,
+      "line": 436,
+      "lineto": 437,
       "args": [
         {
           "name": "index",
@@ -8723,8 +8900,8 @@
     "git_index_add": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 470,
-      "lineto": 470,
+      "line": 453,
+      "lineto": 453,
       "args": [
         {
           "name": "index",
@@ -8750,8 +8927,8 @@
     "git_index_entry_stage": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 482,
-      "lineto": 482,
+      "line": 465,
+      "lineto": 465,
       "args": [
         {
           "name": "entry",
@@ -8766,14 +8943,14 @@
         "comment": " the stage number"
       },
       "description": "<p>Return the stage number from a git index entry</p>\n",
-      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags \n</code></pre>\n\n<p>&amp;\n GIT_IDXENTRY_STAGEMASK) &gt;&gt; GIT_IDXENTRY_STAGESHIFT</p>\n",
+      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags \n</code></pre>\n\n<p>&amp;\n GIT_INDEX_ENTRY_STAGEMASK) &gt;&gt; GIT_INDEX_ENTRY_STAGESHIFT</p>\n",
       "group": "index"
     },
     "git_index_entry_is_conflict": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 491,
-      "lineto": 491,
+      "line": 474,
+      "lineto": 474,
       "args": [
         {
           "name": "entry",
@@ -8791,11 +8968,87 @@
       "comments": "",
       "group": "index"
     },
+    "git_index_iterator_new": {
+      "type": "function",
+      "file": "git2/index.h",
+      "line": 494,
+      "lineto": 496,
+      "args": [
+        {
+          "name": "iterator_out",
+          "type": "git_index_iterator **",
+          "comment": "The newly created iterator"
+        },
+        {
+          "name": "index",
+          "type": "git_index *",
+          "comment": "The index to iterate"
+        }
+      ],
+      "argline": "git_index_iterator **iterator_out, git_index *index",
+      "sig": "git_index_iterator **::git_index *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Create an iterator that will return every entry contained in the\n index at the time of creation.  Entries are returned in order,\n sorted by path.  This iterator is backed by a snapshot that allows\n callers to modify the index while iterating without affecting the\n iterator.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_iterator_next": {
+      "type": "function",
+      "file": "git2/index.h",
+      "line": 505,
+      "lineto": 507,
+      "args": [
+        {
+          "name": "out",
+          "type": "const git_index_entry **",
+          "comment": "Pointer to store the index entry in"
+        },
+        {
+          "name": "iterator",
+          "type": "git_index_iterator *",
+          "comment": "The iterator"
+        }
+      ],
+      "argline": "const git_index_entry **out, git_index_iterator *iterator",
+      "sig": "const git_index_entry **::git_index_iterator *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_ITEROVER on iteration completion or an error code"
+      },
+      "description": "<p>Return the next index entry in-order from the iterator.</p>\n",
+      "comments": "",
+      "group": "index"
+    },
+    "git_index_iterator_free": {
+      "type": "function",
+      "file": "git2/index.h",
+      "line": 514,
+      "lineto": 514,
+      "args": [
+        {
+          "name": "iterator",
+          "type": "git_index_iterator *",
+          "comment": "The iterator to free"
+        }
+      ],
+      "argline": "git_index_iterator *iterator",
+      "sig": "git_index_iterator *",
+      "return": {
+        "type": "void",
+        "comment": null
+      },
+      "description": "<p>Free the index iterator</p>\n",
+      "comments": "",
+      "group": "index"
+    },
     "git_index_add_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 522,
-      "lineto": 522,
+      "line": 545,
+      "lineto": 545,
       "args": [
         {
           "name": "index",
@@ -8821,8 +9074,8 @@
     "git_index_add_frombuffer": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 551,
-      "lineto": 554,
+      "line": 574,
+      "lineto": 577,
       "args": [
         {
           "name": "index",
@@ -8858,8 +9111,8 @@
     "git_index_remove_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 570,
-      "lineto": 570,
+      "line": 593,
+      "lineto": 593,
       "args": [
         {
           "name": "index",
@@ -8885,8 +9138,8 @@
     "git_index_add_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 618,
-      "lineto": 623,
+      "line": 641,
+      "lineto": 646,
       "args": [
         {
           "name": "index",
@@ -8927,8 +9180,8 @@
     "git_index_remove_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 640,
-      "lineto": 644,
+      "line": 663,
+      "lineto": 667,
       "args": [
         {
           "name": "index",
@@ -8964,8 +9217,8 @@
     "git_index_update_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 669,
-      "lineto": 673,
+      "line": 692,
+      "lineto": 696,
       "args": [
         {
           "name": "index",
@@ -9001,8 +9254,8 @@
     "git_index_find": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 684,
-      "lineto": 684,
+      "line": 707,
+      "lineto": 707,
       "args": [
         {
           "name": "at_pos",
@@ -9033,8 +9286,8 @@
     "git_index_find_prefix": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 695,
-      "lineto": 695,
+      "line": 718,
+      "lineto": 718,
       "args": [
         {
           "name": "at_pos",
@@ -9065,8 +9318,8 @@
     "git_index_conflict_add": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 720,
-      "lineto": 724,
+      "line": 743,
+      "lineto": 747,
       "args": [
         {
           "name": "index",
@@ -9102,8 +9355,8 @@
     "git_index_conflict_get": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 740,
-      "lineto": 745,
+      "line": 763,
+      "lineto": 768,
       "args": [
         {
           "name": "ancestor_out",
@@ -9144,8 +9397,8 @@
     "git_index_conflict_remove": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 754,
-      "lineto": 754,
+      "line": 777,
+      "lineto": 777,
       "args": [
         {
           "name": "index",
@@ -9171,8 +9424,8 @@
     "git_index_conflict_cleanup": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 762,
-      "lineto": 762,
+      "line": 785,
+      "lineto": 785,
       "args": [
         {
           "name": "index",
@@ -9193,8 +9446,8 @@
     "git_index_has_conflicts": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 769,
-      "lineto": 769,
+      "line": 792,
+      "lineto": 792,
       "args": [
         {
           "name": "index",
@@ -9213,15 +9466,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_has_conflicts-13"
+          "ex/v0.28.0/merge.html#git_index_has_conflicts-13"
         ]
       }
     },
     "git_index_conflict_iterator_new": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 780,
-      "lineto": 782,
+      "line": 803,
+      "lineto": 805,
       "args": [
         {
           "name": "iterator_out",
@@ -9245,15 +9498,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_iterator_new-14"
+          "ex/v0.28.0/merge.html#git_index_conflict_iterator_new-14"
         ]
       }
     },
     "git_index_conflict_next": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 794,
-      "lineto": 798,
+      "line": 817,
+      "lineto": 821,
       "args": [
         {
           "name": "ancestor_out",
@@ -9287,15 +9540,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_next-15"
+          "ex/v0.28.0/merge.html#git_index_conflict_next-15"
         ]
       }
     },
     "git_index_conflict_iterator_free": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 805,
-      "lineto": 806,
+      "line": 828,
+      "lineto": 829,
       "args": [
         {
           "name": "iterator",
@@ -9314,7 +9567,7 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_index_conflict_iterator_free-16"
+          "ex/v0.28.0/merge.html#git_index_conflict_iterator_free-16"
         ]
       }
     },
@@ -9865,15 +10118,62 @@
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_merge_analysis-17"
+          "ex/v0.28.0/merge.html#git_merge_analysis-17"
         ]
       }
+    },
+    "git_merge_analysis_for_ref": {
+      "type": "function",
+      "file": "git2/merge.h",
+      "line": 402,
+      "lineto": 408,
+      "args": [
+        {
+          "name": "analysis_out",
+          "type": "git_merge_analysis_t *",
+          "comment": "analysis enumeration that the result is written into"
+        },
+        {
+          "name": "preference_out",
+          "type": "git_merge_preference_t *",
+          "comment": null
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": "the repository to merge"
+        },
+        {
+          "name": "our_ref",
+          "type": "git_reference *",
+          "comment": "the reference to perform the analysis from"
+        },
+        {
+          "name": "their_heads",
+          "type": "const git_annotated_commit **",
+          "comment": "the heads to merge into"
+        },
+        {
+          "name": "their_heads_len",
+          "type": "size_t",
+          "comment": "the number of heads to merge"
+        }
+      ],
+      "argline": "git_merge_analysis_t *analysis_out, git_merge_preference_t *preference_out, git_repository *repo, git_reference *our_ref, const git_annotated_commit **their_heads, size_t their_heads_len",
+      "sig": "git_merge_analysis_t *::git_merge_preference_t *::git_repository *::git_reference *::const git_annotated_commit **::size_t",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success or error code"
+      },
+      "description": "<p>Analyzes the given branch(es) and determines the opportunities for\n merging them into a reference.</p>\n",
+      "comments": "",
+      "group": "merge"
     },
     "git_merge_base": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 400,
-      "lineto": 404,
+      "line": 419,
+      "lineto": 423,
       "args": [
         {
           "name": "out",
@@ -9907,18 +10207,18 @@
       "group": "merge",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_merge_base-33"
+          "ex/v0.28.0/log.html#git_merge_base-33"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_merge_base-3"
+          "ex/v0.28.0/rev-parse.html#git_merge_base-3"
         ]
       }
     },
     "git_merge_bases": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 415,
-      "lineto": 419,
+      "line": 434,
+      "lineto": 438,
       "args": [
         {
           "name": "out",
@@ -9954,8 +10254,8 @@
     "git_merge_base_many": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 430,
-      "lineto": 434,
+      "line": 449,
+      "lineto": 453,
       "args": [
         {
           "name": "out",
@@ -9991,8 +10291,8 @@
     "git_merge_bases_many": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 445,
-      "lineto": 449,
+      "line": 464,
+      "lineto": 468,
       "args": [
         {
           "name": "out",
@@ -10028,8 +10328,8 @@
     "git_merge_base_octopus": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 460,
-      "lineto": 464,
+      "line": 479,
+      "lineto": 483,
       "args": [
         {
           "name": "out",
@@ -10065,8 +10365,8 @@
     "git_merge_file": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 482,
-      "lineto": 487,
+      "line": 501,
+      "lineto": 506,
       "args": [
         {
           "name": "out",
@@ -10107,8 +10407,8 @@
     "git_merge_file_from_index": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 503,
-      "lineto": 509,
+      "line": 522,
+      "lineto": 528,
       "args": [
         {
           "name": "out",
@@ -10154,8 +10454,8 @@
     "git_merge_file_result_free": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 516,
-      "lineto": 516,
+      "line": 535,
+      "lineto": 535,
       "args": [
         {
           "name": "result",
@@ -10176,8 +10476,8 @@
     "git_merge_trees": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 534,
-      "lineto": 540,
+      "line": 553,
+      "lineto": 559,
       "args": [
         {
           "name": "out",
@@ -10223,8 +10523,8 @@
     "git_merge_commits": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 557,
-      "lineto": 562,
+      "line": 576,
+      "lineto": 581,
       "args": [
         {
           "name": "out",
@@ -10265,8 +10565,8 @@
     "git_merge": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 582,
-      "lineto": 587,
+      "line": 601,
+      "lineto": 606,
       "args": [
         {
           "name": "repo",
@@ -10305,7 +10605,7 @@
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_merge-18"
+          "ex/v0.28.0/merge.html#git_merge-18"
         ]
       }
     },
@@ -10987,25 +11287,25 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "the type of the object"
         }
       ],
-      "argline": "git_object **object, git_repository *repo, const git_oid *id, git_otype type",
-      "sig": "git_object **::git_repository *::const git_oid *::git_otype",
+      "argline": "git_object **object, git_repository *repo, const git_oid *id, git_object_t type",
+      "sig": "git_object **::git_repository *::const git_oid *::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository.</p>\n",
-      "comments": "<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJ_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
       "group": "object",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_object_lookup-34"
+          "ex/v0.28.0/log.html#git_object_lookup-34"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_object_lookup-19"
+          "ex/v0.28.0/merge.html#git_object_lookup-19"
         ]
       }
     },
@@ -11037,18 +11337,18 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "the type of the object"
         }
       ],
-      "argline": "git_object **object_out, git_repository *repo, const git_oid *id, size_t len, git_otype type",
-      "sig": "git_object **::git_repository *::const git_oid *::size_t::git_otype",
+      "argline": "git_object **object_out, git_repository *repo, const git_oid *id, size_t len, git_object_t type",
+      "sig": "git_object **::git_repository *::const git_oid *::size_t::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository,\n given a prefix of its identifier (short id).</p>\n",
-      "comments": "<p>The object obtained will be so that its identifier\n matches the first &#39;len&#39; hexadecimal characters\n (packets of 4 bits) of the given &#39;id&#39;.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and\n long enough to identify a unique object matching\n the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJ_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The object obtained will be so that its identifier\n matches the first &#39;len&#39; hexadecimal characters\n (packets of 4 bits) of the given &#39;id&#39;.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and\n long enough to identify a unique object matching\n the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
       "group": "object"
     },
     "git_object_lookup_bypath": {
@@ -11074,12 +11374,12 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "type of object desired"
         }
       ],
-      "argline": "git_object **out, const git_object *treeish, const char *path, git_otype type",
-      "sig": "git_object **::const git_object *::const char *::git_otype",
+      "argline": "git_object **out, const git_object *treeish, const char *path, git_object_t type",
+      "sig": "git_object **::const git_object *::const char *::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 on success, or an error code"
@@ -11111,27 +11411,27 @@
       "group": "object",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_object_id-10",
-          "ex/HEAD/blame.html#git_object_id-11",
-          "ex/HEAD/blame.html#git_object_id-12",
-          "ex/HEAD/blame.html#git_object_id-13"
+          "ex/v0.28.0/blame.html#git_object_id-10",
+          "ex/v0.28.0/blame.html#git_object_id-11",
+          "ex/v0.28.0/blame.html#git_object_id-12",
+          "ex/v0.28.0/blame.html#git_object_id-13"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_object_id-12",
-          "ex/HEAD/cat-file.html#git_object_id-13"
+          "ex/v0.28.0/cat-file.html#git_object_id-12",
+          "ex/v0.28.0/cat-file.html#git_object_id-13"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_object_id-35",
-          "ex/HEAD/log.html#git_object_id-36",
-          "ex/HEAD/log.html#git_object_id-37",
-          "ex/HEAD/log.html#git_object_id-38"
+          "ex/v0.28.0/log.html#git_object_id-35",
+          "ex/v0.28.0/log.html#git_object_id-36",
+          "ex/v0.28.0/log.html#git_object_id-37",
+          "ex/v0.28.0/log.html#git_object_id-38"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_object_id-4",
-          "ex/HEAD/rev-parse.html#git_object_id-5",
-          "ex/HEAD/rev-parse.html#git_object_id-6",
-          "ex/HEAD/rev-parse.html#git_object_id-7",
-          "ex/HEAD/rev-parse.html#git_object_id-8"
+          "ex/v0.28.0/rev-parse.html#git_object_id-4",
+          "ex/v0.28.0/rev-parse.html#git_object_id-5",
+          "ex/v0.28.0/rev-parse.html#git_object_id-6",
+          "ex/v0.28.0/rev-parse.html#git_object_id-7",
+          "ex/v0.28.0/rev-parse.html#git_object_id-8"
         ]
       }
     },
@@ -11163,7 +11463,7 @@
       "group": "object",
       "examples": {
         "tag.c": [
-          "ex/HEAD/tag.html#git_object_short_id-5"
+          "ex/v0.28.0/tag.html#git_object_short_id-5"
         ]
       }
     },
@@ -11182,7 +11482,7 @@
       "argline": "const git_object *obj",
       "sig": "const git_object *",
       "return": {
-        "type": "git_otype",
+        "type": "git_object_t",
         "comment": " the object's type"
       },
       "description": "<p>Get the object type of an object</p>\n",
@@ -11190,12 +11490,12 @@
       "group": "object",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_object_type-14",
-          "ex/HEAD/cat-file.html#git_object_type-15",
-          "ex/HEAD/cat-file.html#git_object_type-16"
+          "ex/v0.28.0/cat-file.html#git_object_type-14",
+          "ex/v0.28.0/cat-file.html#git_object_type-15",
+          "ex/v0.28.0/cat-file.html#git_object_type-16"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_object_type-6"
+          "ex/v0.28.0/tag.html#git_object_type-6"
         ]
       }
     },
@@ -11244,33 +11544,33 @@
       "group": "object",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_object_free-14",
-          "ex/HEAD/blame.html#git_object_free-15",
-          "ex/HEAD/blame.html#git_object_free-16",
-          "ex/HEAD/blame.html#git_object_free-17"
+          "ex/v0.28.0/blame.html#git_object_free-14",
+          "ex/v0.28.0/blame.html#git_object_free-15",
+          "ex/v0.28.0/blame.html#git_object_free-16",
+          "ex/v0.28.0/blame.html#git_object_free-17"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_object_free-17"
+          "ex/v0.28.0/cat-file.html#git_object_free-17"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_object_free-38"
+          "ex/v0.28.0/general.html#git_object_free-38"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_object_free-39"
+          "ex/v0.28.0/log.html#git_object_free-39"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_object_free-20"
+          "ex/v0.28.0/merge.html#git_object_free-20"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_object_free-9",
-          "ex/HEAD/rev-parse.html#git_object_free-10",
-          "ex/HEAD/rev-parse.html#git_object_free-11"
+          "ex/v0.28.0/rev-parse.html#git_object_free-9",
+          "ex/v0.28.0/rev-parse.html#git_object_free-10",
+          "ex/v0.28.0/rev-parse.html#git_object_free-11"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_object_free-7",
-          "ex/HEAD/tag.html#git_object_free-8",
-          "ex/HEAD/tag.html#git_object_free-9",
-          "ex/HEAD/tag.html#git_object_free-10"
+          "ex/v0.28.0/tag.html#git_object_free-7",
+          "ex/v0.28.0/tag.html#git_object_free-8",
+          "ex/v0.28.0/tag.html#git_object_free-9",
+          "ex/v0.28.0/tag.html#git_object_free-10"
         ]
       }
     },
@@ -11282,12 +11582,12 @@
       "args": [
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "object type to convert."
         }
       ],
-      "argline": "git_otype type",
-      "sig": "git_otype",
+      "argline": "git_object_t type",
+      "sig": "git_object_t",
       "return": {
         "type": "const char *",
         "comment": " the corresponding string representation."
@@ -11297,14 +11597,14 @@
       "group": "object",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_object_type2string-18",
-          "ex/HEAD/cat-file.html#git_object_type2string-19",
-          "ex/HEAD/cat-file.html#git_object_type2string-20",
-          "ex/HEAD/cat-file.html#git_object_type2string-21"
+          "ex/v0.28.0/cat-file.html#git_object_type2string-18",
+          "ex/v0.28.0/cat-file.html#git_object_type2string-19",
+          "ex/v0.28.0/cat-file.html#git_object_type2string-20",
+          "ex/v0.28.0/cat-file.html#git_object_type2string-21"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_object_type2string-39",
-          "ex/HEAD/general.html#git_object_type2string-40"
+          "ex/v0.28.0/general.html#git_object_type2string-39",
+          "ex/v0.28.0/general.html#git_object_type2string-40"
         ]
       }
     },
@@ -11323,10 +11623,10 @@
       "argline": "const char *str",
       "sig": "const char *",
       "return": {
-        "type": "git_otype",
-        "comment": " the corresponding git_otype."
+        "type": "git_object_t",
+        "comment": " the corresponding git_object_t."
       },
-      "description": "<p>Convert a string object type representation to it&#39;s git_otype.</p>\n",
+      "description": "<p>Convert a string object type representation to it&#39;s git_object_t.</p>\n",
       "comments": "",
       "group": "object"
     },
@@ -11338,17 +11638,17 @@
       "args": [
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "object type to test."
         }
       ],
-      "argline": "git_otype type",
-      "sig": "git_otype",
+      "argline": "git_object_t type",
+      "sig": "git_object_t",
       "return": {
         "type": "int",
         "comment": " true if the type represents a valid loose object type,\n false otherwise."
       },
-      "description": "<p>Determine if the given git_otype is a valid loose object type.</p>\n",
+      "description": "<p>Determine if the given git_object_t is a valid loose object type.</p>\n",
       "comments": "",
       "group": "object"
     },
@@ -11360,12 +11660,12 @@
       "args": [
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "object type to get its size"
         }
       ],
-      "argline": "git_otype type",
-      "sig": "git_otype",
+      "argline": "git_object_t type",
+      "sig": "git_object_t",
       "return": {
         "type": "size_t",
         "comment": " size in bytes of the object"
@@ -11392,18 +11692,18 @@
         },
         {
           "name": "target_type",
-          "type": "git_otype",
-          "comment": "The type of the requested object (a GIT_OBJ_ value)"
+          "type": "git_object_t",
+          "comment": "The type of the requested object (a GIT_OBJECT_ value)"
         }
       ],
-      "argline": "git_object **peeled, const git_object *object, git_otype target_type",
-      "sig": "git_object **::const git_object *::git_otype",
+      "argline": "git_object **peeled, const git_object *object, git_object_t target_type",
+      "sig": "git_object **::const git_object *::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 on success, GIT_EINVALIDSPEC, GIT_EPEEL, or an error code"
       },
       "description": "<p>Recursively peel an object until an object of the specified type is met.</p>\n",
-      "comments": "<p>If the query cannot be satisfied due to the object model,\n GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a\n tree).</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object will\n be peeled until the type changes. A tag will be peeled until the\n referenced object is no longer a tag, and a commit will be peeled\n to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to\n the target type due to the object model, GIT_EPEEL will be\n returned.</p>\n\n<p>You must free the returned object.</p>\n",
+      "comments": "<p>If the query cannot be satisfied due to the object model,\n GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a\n tree).</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object will\n be peeled until the type changes. A tag will be peeled until the\n referenced object is no longer a tag, and a commit will be peeled\n to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to\n the target type due to the object model, GIT_EPEEL will be\n returned.</p>\n\n<p>You must free the returned object.</p>\n",
       "group": "object"
     },
     "git_object_dup": {
@@ -11532,10 +11832,10 @@
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_odb_free-22"
+          "ex/v0.28.0/cat-file.html#git_odb_free-22"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_free-41"
+          "ex/v0.28.0/general.html#git_odb_free-41"
         ]
       }
     },
@@ -11572,10 +11872,10 @@
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_odb_read-23"
+          "ex/v0.28.0/cat-file.html#git_odb_read-23"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_read-42"
+          "ex/v0.28.0/general.html#git_odb_read-42"
         ]
       }
     },
@@ -11629,7 +11929,7 @@
         },
         {
           "name": "type_out",
-          "type": "git_otype *",
+          "type": "git_object_t *",
           "comment": "pointer where to store the type"
         },
         {
@@ -11643,8 +11943,8 @@
           "comment": "identity of the object to read."
         }
       ],
-      "argline": "size_t *len_out, git_otype *type_out, git_odb *db, const git_oid *id",
-      "sig": "size_t *::git_otype *::git_odb *::const git_oid *",
+      "argline": "size_t *len_out, git_object_t *type_out, git_odb *db, const git_oid *id",
+      "sig": "size_t *::git_object_t *::git_odb *::const git_oid *",
       "return": {
         "type": "int",
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database."
@@ -11831,12 +12131,12 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "type of the data to store"
         }
       ],
-      "argline": "git_oid *out, git_odb *odb, const void *data, size_t len, git_otype type",
-      "sig": "git_oid *::git_odb *::const void *::size_t::git_otype",
+      "argline": "git_oid *out, git_odb *odb, const void *data, size_t len, git_object_t type",
+      "sig": "git_oid *::git_odb *::const void *::size_t::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
@@ -11846,7 +12146,7 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_write-43"
+          "ex/v0.28.0/general.html#git_odb_write-43"
         ]
       }
     },
@@ -11873,12 +12173,12 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "type of the object that will be written"
         }
       ],
-      "argline": "git_odb_stream **out, git_odb *db, git_off_t size, git_otype type",
-      "sig": "git_odb_stream **::git_odb *::git_off_t::git_otype",
+      "argline": "git_odb_stream **out, git_odb *db, git_off_t size, git_object_t type",
+      "sig": "git_odb_stream **::git_odb *::git_off_t::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 if the stream was created; error code otherwise"
@@ -12018,7 +12318,7 @@
         },
         {
           "name": "type",
-          "type": "git_otype *",
+          "type": "git_object_t *",
           "comment": "pointer where to store the type of the object"
         },
         {
@@ -12032,8 +12332,8 @@
           "comment": "oid of the object the stream will read from"
         }
       ],
-      "argline": "git_odb_stream **out, size_t *len, git_otype *type, git_odb *db, const git_oid *oid",
-      "sig": "git_odb_stream **::size_t *::git_otype *::git_odb *::const git_oid *",
+      "argline": "git_odb_stream **out, size_t *len, git_object_t *type, git_odb *db, const git_oid *oid",
+      "sig": "git_odb_stream **::size_t *::git_object_t *::git_odb *::const git_oid *",
       "return": {
         "type": "int",
         "comment": " 0 if the stream was created; error code otherwise"
@@ -12102,12 +12402,12 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "of the data to hash"
         }
       ],
-      "argline": "git_oid *out, const void *data, size_t len, git_otype type",
-      "sig": "git_oid *::const void *::size_t::git_otype",
+      "argline": "git_oid *out, const void *data, size_t len, git_object_t type",
+      "sig": "git_oid *::const void *::size_t::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
@@ -12134,12 +12434,12 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
+          "type": "git_object_t",
           "comment": "the type of the object that will be hashed"
         }
       ],
-      "argline": "git_oid *out, const char *path, git_otype type",
-      "sig": "git_oid *::const char *::git_otype",
+      "argline": "git_oid *out, const char *path, git_object_t type",
+      "sig": "git_oid *::const char *::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
@@ -12198,10 +12498,10 @@
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_odb_object_free-24"
+          "ex/v0.28.0/cat-file.html#git_odb_object_free-24"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_free-44"
+          "ex/v0.28.0/general.html#git_odb_object_free-44"
         ]
       }
     },
@@ -12250,7 +12550,7 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_data-45"
+          "ex/v0.28.0/general.html#git_odb_object_data-45"
         ]
       }
     },
@@ -12277,10 +12577,10 @@
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_odb_object_size-25"
+          "ex/v0.28.0/cat-file.html#git_odb_object_size-25"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_size-46"
+          "ex/v0.28.0/general.html#git_odb_object_size-46"
         ]
       }
     },
@@ -12299,7 +12599,7 @@
       "argline": "git_odb_object *object",
       "sig": "git_odb_object *",
       "return": {
-        "type": "git_otype",
+        "type": "git_object_t",
         "comment": " the type"
       },
       "description": "<p>Return the type of an ODB object</p>\n",
@@ -12307,7 +12607,7 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_odb_object_type-47"
+          "ex/v0.28.0/general.html#git_odb_object_type-47"
         ]
       }
     },
@@ -12558,14 +12858,14 @@
       "group": "oid",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_oid_fromstr-48",
-          "ex/HEAD/general.html#git_oid_fromstr-49",
-          "ex/HEAD/general.html#git_oid_fromstr-50",
-          "ex/HEAD/general.html#git_oid_fromstr-51",
-          "ex/HEAD/general.html#git_oid_fromstr-52",
-          "ex/HEAD/general.html#git_oid_fromstr-53",
-          "ex/HEAD/general.html#git_oid_fromstr-54",
-          "ex/HEAD/general.html#git_oid_fromstr-55"
+          "ex/v0.28.0/general.html#git_oid_fromstr-48",
+          "ex/v0.28.0/general.html#git_oid_fromstr-49",
+          "ex/v0.28.0/general.html#git_oid_fromstr-50",
+          "ex/v0.28.0/general.html#git_oid_fromstr-51",
+          "ex/v0.28.0/general.html#git_oid_fromstr-52",
+          "ex/v0.28.0/general.html#git_oid_fromstr-53",
+          "ex/v0.28.0/general.html#git_oid_fromstr-54",
+          "ex/v0.28.0/general.html#git_oid_fromstr-55"
         ]
       }
     },
@@ -12683,19 +12983,19 @@
       "group": "oid",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_oid_fmt-56",
-          "ex/HEAD/general.html#git_oid_fmt-57",
-          "ex/HEAD/general.html#git_oid_fmt-58",
-          "ex/HEAD/general.html#git_oid_fmt-59",
-          "ex/HEAD/general.html#git_oid_fmt-60",
-          "ex/HEAD/general.html#git_oid_fmt-61"
+          "ex/v0.28.0/general.html#git_oid_fmt-56",
+          "ex/v0.28.0/general.html#git_oid_fmt-57",
+          "ex/v0.28.0/general.html#git_oid_fmt-58",
+          "ex/v0.28.0/general.html#git_oid_fmt-59",
+          "ex/v0.28.0/general.html#git_oid_fmt-60",
+          "ex/v0.28.0/general.html#git_oid_fmt-61"
         ],
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_oid_fmt-1",
-          "ex/HEAD/network/fetch.html#git_oid_fmt-2"
+          "ex/v0.28.0/network/fetch.html#git_oid_fmt-1",
+          "ex/v0.28.0/network/fetch.html#git_oid_fmt-2"
         ],
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_oid_fmt-1"
+          "ex/v0.28.0/network/ls-remote.html#git_oid_fmt-1"
         ]
       }
     },
@@ -12781,8 +13081,8 @@
       "group": "oid",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_oid_tostr_s-21",
-          "ex/HEAD/merge.html#git_oid_tostr_s-22"
+          "ex/v0.28.0/merge.html#git_oid_tostr_s-21",
+          "ex/v0.28.0/merge.html#git_oid_tostr_s-22"
         ]
       }
     },
@@ -12819,25 +13119,25 @@
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_oid_tostr-18",
-          "ex/HEAD/blame.html#git_oid_tostr-19"
+          "ex/v0.28.0/blame.html#git_oid_tostr-18",
+          "ex/v0.28.0/blame.html#git_oid_tostr-19"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_oid_tostr-26",
-          "ex/HEAD/cat-file.html#git_oid_tostr-27",
-          "ex/HEAD/cat-file.html#git_oid_tostr-28",
-          "ex/HEAD/cat-file.html#git_oid_tostr-29",
-          "ex/HEAD/cat-file.html#git_oid_tostr-30"
+          "ex/v0.28.0/cat-file.html#git_oid_tostr-26",
+          "ex/v0.28.0/cat-file.html#git_oid_tostr-27",
+          "ex/v0.28.0/cat-file.html#git_oid_tostr-28",
+          "ex/v0.28.0/cat-file.html#git_oid_tostr-29",
+          "ex/v0.28.0/cat-file.html#git_oid_tostr-30"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_oid_tostr-40",
-          "ex/HEAD/log.html#git_oid_tostr-41"
+          "ex/v0.28.0/log.html#git_oid_tostr-40",
+          "ex/v0.28.0/log.html#git_oid_tostr-41"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_oid_tostr-12",
-          "ex/HEAD/rev-parse.html#git_oid_tostr-13",
-          "ex/HEAD/rev-parse.html#git_oid_tostr-14",
-          "ex/HEAD/rev-parse.html#git_oid_tostr-15"
+          "ex/v0.28.0/rev-parse.html#git_oid_tostr-12",
+          "ex/v0.28.0/rev-parse.html#git_oid_tostr-13",
+          "ex/v0.28.0/rev-parse.html#git_oid_tostr-14",
+          "ex/v0.28.0/rev-parse.html#git_oid_tostr-15"
         ]
       }
     },
@@ -12869,9 +13169,9 @@
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_oid_cpy-20",
-          "ex/HEAD/blame.html#git_oid_cpy-21",
-          "ex/HEAD/blame.html#git_oid_cpy-22"
+          "ex/v0.28.0/blame.html#git_oid_cpy-20",
+          "ex/v0.28.0/blame.html#git_oid_cpy-21",
+          "ex/v0.28.0/blame.html#git_oid_cpy-22"
         ]
       }
     },
@@ -13038,10 +13338,10 @@
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_oid_iszero-23"
+          "ex/v0.28.0/blame.html#git_oid_iszero-23"
         ],
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_oid_iszero-3"
+          "ex/v0.28.0/network/fetch.html#git_oid_iszero-3"
         ]
       }
     },
@@ -13091,7 +13391,7 @@
         "comment": " the minimal length to uniquely identify all OIDs\n\t\tadded so far to the set; or an error code (\n<\n0) if an\n\t\terror occurs."
       },
       "description": "<p>Add a new OID to set of shortened OIDs and calculate\n the minimal length to uniquely identify all the OIDs in\n the set.</p>\n",
-      "comments": "<p>The OID is expected to be a 40-char hexadecimal string.\n The OID is owned by the user and will not be modified\n or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many\n OIDs can be added to a single set (around ~32000, assuming\n a mostly randomized distribution), which should be enough\n for any kind of program, and keeps the algorithm fast and\n memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a\n GITERR_INVALID error</p>\n",
+      "comments": "<p>The OID is expected to be a 40-char hexadecimal string.\n The OID is owned by the user and will not be modified\n or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many\n OIDs can be added to a single set (around ~32000, assuming\n a mostly randomized distribution), which should be enough\n for any kind of program, and keeps the algorithm fast and\n memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a\n GIT_ERROR_INVALID error</p>\n",
       "group": "oid"
     },
     "git_oid_shorten_free": {
@@ -14074,7 +14374,7 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_new-42"
+          "ex/v0.28.0/log.html#git_pathspec_new-42"
         ]
       }
     },
@@ -14101,7 +14401,7 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_free-43"
+          "ex/v0.28.0/log.html#git_pathspec_free-43"
         ]
       }
     },
@@ -14114,27 +14414,27 @@
         {
           "name": "ps",
           "type": "const git_pathspec *",
-          "comment": "The compiled pathspec"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of git_pathspec_flag_t options to control match"
+          "type": "int",
+          "comment": null
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": "The pathname to attempt to match"
+          "comment": null
         }
       ],
-      "argline": "const git_pathspec *ps, uint32_t flags, const char *path",
-      "sig": "const git_pathspec *::uint32_t::const char *",
+      "argline": "const git_pathspec *ps, int flags, const char *path",
+      "sig": "const git_pathspec *::int::const char *",
       "return": {
         "type": "int",
-        "comment": " 1 is path matches spec, 0 if it does not"
+        "comment": null
       },
-      "description": "<p>Try to match a path against a pathspec</p>\n",
-      "comments": "<p>Unlike most of the other pathspec matching functions, this will not\n fall back on the native case-sensitivity for your platform.  You must\n explicitly pass flags to control case sensitivity or else this will\n fall back on being case sensitive.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "pathspec"
     },
     "git_pathspec_match_workdir": {
@@ -14146,32 +14446,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": "Output list of matches; pass NULL to just get return value"
+          "comment": null
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "The repository in which to match; bare repo is an error"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of git_pathspec_flag_t options to control match"
+          "type": "int",
+          "comment": null
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": "Pathspec to be matched"
+          "comment": null
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_repository *repo, uint32_t flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_repository *::uint32_t::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_repository *repo, int flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_repository *::int::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag was given"
+        "comment": null
       },
-      "description": "<p>Match a pathspec against the working directory of a repository.</p>\n",
-      "comments": "<p>This matches the pathspec against the current files in the working\n directory of the repository.  It is an error to invoke this on a bare\n repo.  This handles git ignores (i.e. ignored files will not be\n considered to match the <code>pathspec</code> unless the file is tracked in the\n index).</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "pathspec"
     },
     "git_pathspec_match_index": {
@@ -14183,32 +14483,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": "Output list of matches; pass NULL to just get return value"
+          "comment": null
         },
         {
           "name": "index",
           "type": "git_index *",
-          "comment": "The index to match against"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of git_pathspec_flag_t options to control match"
+          "type": "int",
+          "comment": null
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": "Pathspec to be matched"
+          "comment": null
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_index *index, uint32_t flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_index *::uint32_t::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_index *index, int flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_index *::int::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
+        "comment": null
       },
-      "description": "<p>Match a pathspec against entries in an index.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the repository index.</p>\n\n<p>NOTE: At the moment, the case sensitivity of this match is controlled\n by the current case-sensitivity of the index object itself and the\n USE_CASE and IGNORE_CASE flags will have no effect.  This behavior will\n be corrected in a future release.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "pathspec"
     },
     "git_pathspec_match_tree": {
@@ -14220,36 +14520,36 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": "Output list of matches; pass NULL to just get return value"
+          "comment": null
         },
         {
           "name": "tree",
           "type": "git_tree *",
-          "comment": "The root-level tree to match against"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of git_pathspec_flag_t options to control match"
+          "type": "int",
+          "comment": null
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": "Pathspec to be matched"
+          "comment": null
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_tree *tree, uint32_t flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_tree *::uint32_t::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_tree *tree, int flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_tree *::int::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
+        "comment": null
       },
-      "description": "<p>Match a pathspec against files in a tree.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the given tree.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_pathspec_match_tree-44"
+          "ex/v0.28.0/log.html#git_pathspec_match_tree-44"
         ]
       }
     },
@@ -14262,32 +14562,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": "Output list of matches; pass NULL to just get return value"
+          "comment": null
         },
         {
           "name": "diff",
           "type": "git_diff *",
-          "comment": "A generated diff list"
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Combination of git_pathspec_flag_t options to control match"
+          "type": "int",
+          "comment": null
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": "Pathspec to be matched"
+          "comment": null
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_diff *diff, uint32_t flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_diff *::uint32_t::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_diff *diff, int flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_diff *::int::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
+        "comment": null
       },
-      "description": "<p>Match a pathspec against files in a diff list.</p>\n",
-      "comments": "<p>This matches the pathspec against the files in the given diff list.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That\n contains the list of all matched filenames (unless you pass the\n <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of\n pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code>\n flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "pathspec"
     },
     "git_pathspec_match_list_free": {
@@ -15285,10 +15585,10 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_lookup-62"
+          "ex/v0.28.0/general.html#git_reference_lookup-62"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_lookup-23"
+          "ex/v0.28.0/merge.html#git_reference_lookup-23"
         ]
       }
     },
@@ -15357,7 +15657,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_dwim-24"
+          "ex/v0.28.0/merge.html#git_reference_dwim-24"
         ]
       }
     },
@@ -15508,7 +15808,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_create-25"
+          "ex/v0.28.0/merge.html#git_reference_create-25"
         ]
       }
     },
@@ -15587,7 +15887,7 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_target-63"
+          "ex/v0.28.0/general.html#git_reference_target-63"
         ]
       }
     },
@@ -15636,10 +15936,10 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_symbolic_target-64"
+          "ex/v0.28.0/general.html#git_reference_symbolic_target-64"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_symbolic_target-26"
+          "ex/v0.28.0/merge.html#git_reference_symbolic_target-26"
         ]
       }
     },
@@ -15658,15 +15958,15 @@
       "argline": "const git_reference *ref",
       "sig": "const git_reference *",
       "return": {
-        "type": "git_ref_t",
+        "type": "git_reference_t",
         "comment": " the type"
       },
       "description": "<p>Get the type of a reference.</p>\n",
-      "comments": "<p>Either direct (GIT_REF_OID) or symbolic (GIT_REF_SYMBOLIC)</p>\n",
+      "comments": "<p>Either direct (GIT_REFERENCE_DIRECT) or symbolic (GIT_REFERENCE_SYMBOLIC)</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_type-65"
+          "ex/v0.28.0/general.html#git_reference_type-65"
         ]
       }
     },
@@ -15693,7 +15993,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_name-27"
+          "ex/v0.28.0/merge.html#git_reference_name-27"
         ]
       }
     },
@@ -15821,7 +16121,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_set_target-28"
+          "ex/v0.28.0/merge.html#git_reference_set_target-28"
         ]
       }
     },
@@ -15944,7 +16244,7 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_list-66"
+          "ex/v0.28.0/general.html#git_reference_list-66"
         ]
       }
     },
@@ -16062,15 +16362,15 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_reference_free-67"
+          "ex/v0.28.0/general.html#git_reference_free-67"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_free-29",
-          "ex/HEAD/merge.html#git_reference_free-30",
-          "ex/HEAD/merge.html#git_reference_free-31"
+          "ex/v0.28.0/merge.html#git_reference_free-29",
+          "ex/v0.28.0/merge.html#git_reference_free-30",
+          "ex/v0.28.0/merge.html#git_reference_free-31"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_reference_free-3"
+          "ex/v0.28.0/status.html#git_reference_free-3"
         ]
       }
     },
@@ -16439,7 +16739,7 @@
         {
           "name": "flags",
           "type": "unsigned int",
-          "comment": "Flags to constrain name validation rules - see the\n              GIT_REF_FORMAT constants above."
+          "comment": "Flags to constrain name validation rules - see the\n              GIT_REFERENCE_FORMAT constants above."
         }
       ],
       "argline": "char *buffer_out, size_t buffer_size, const char *name, unsigned int flags",
@@ -16465,27 +16765,27 @@
         },
         {
           "name": "ref",
-          "type": "git_reference *",
+          "type": "const git_reference *",
           "comment": "The reference to be processed"
         },
         {
           "name": "type",
-          "type": "git_otype",
-          "comment": "The type of the requested object (GIT_OBJ_COMMIT,\n GIT_OBJ_TAG, GIT_OBJ_TREE, GIT_OBJ_BLOB or GIT_OBJ_ANY)."
+          "type": "git_object_t",
+          "comment": "The type of the requested object (GIT_OBJECT_COMMIT,\n GIT_OBJECT_TAG, GIT_OBJECT_TREE, GIT_OBJECT_BLOB or GIT_OBJECT_ANY)."
         }
       ],
-      "argline": "git_object **out, git_reference *ref, git_otype type",
-      "sig": "git_object **::git_reference *::git_otype",
+      "argline": "git_object **out, const git_reference *ref, git_object_t type",
+      "sig": "git_object **::const git_reference *::git_object_t",
       "return": {
         "type": "int",
         "comment": " 0 on success, GIT_EAMBIGUOUS, GIT_ENOTFOUND or an error code"
       },
       "description": "<p>Recursively peel reference until object of the specified type is found.</p>\n",
-      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJ_ANY</code> as the target type, then the object\n will be peeled until a non-tag object is met.</p>\n",
+      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object\n will be peeled until a non-tag object is met.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_reference_peel-32"
+          "ex/v0.28.0/merge.html#git_reference_peel-32"
         ]
       }
     },
@@ -16534,7 +16834,7 @@
       "group": "reference",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_reference_shorthand-4"
+          "ex/v0.28.0/status.html#git_reference_shorthand-4"
         ]
       }
     },
@@ -16858,15 +17158,74 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_create-4"
+          "ex/v0.28.0/remote.html#git_remote_create-4"
         ]
       }
+    },
+    "git_remote_create_init_options": {
+      "type": "function",
+      "file": "git2/remote.h",
+      "line": 97,
+      "lineto": 99,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_remote_create_options *",
+          "comment": "The `git_remote_create_options` struct to initialize."
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": "The struct version; pass `GIT_REMOTE_CREATE_OPTIONS_VERSION`."
+        }
+      ],
+      "argline": "git_remote_create_options *opts, unsigned int version",
+      "sig": "git_remote_create_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": " Zero on success; -1 on failure."
+      },
+      "description": "<p>Initialize git_remote_create_options structure</p>\n",
+      "comments": "<p>Initializes a <code>git_remote_create_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>.</p>\n",
+      "group": "remote"
+    },
+    "git_remote_create_with_opts": {
+      "type": "function",
+      "file": "git2/remote.h",
+      "line": 113,
+      "lineto": 116,
+      "args": [
+        {
+          "name": "out",
+          "type": "git_remote **",
+          "comment": "the resulting remote"
+        },
+        {
+          "name": "url",
+          "type": "const char *",
+          "comment": "the remote's url"
+        },
+        {
+          "name": "opts",
+          "type": "const git_remote_create_options *",
+          "comment": "the remote creation options"
+        }
+      ],
+      "argline": "git_remote **out, const char *url, const git_remote_create_options *opts",
+      "sig": "git_remote **::const char *::const git_remote_create_options *",
+      "return": {
+        "type": "int",
+        "comment": " 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
+      },
+      "description": "<p>Create a remote, with options.</p>\n",
+      "comments": "<p>This function allows more fine-grained control over the remote creation.</p>\n\n<p>Passing NULL as the opts argument will result in a detached remote.</p>\n",
+      "group": "remote"
     },
     "git_remote_create_with_fetchspec": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 55,
-      "lineto": 60,
+      "line": 129,
+      "lineto": 134,
       "args": [
         {
           "name": "out",
@@ -16907,8 +17266,8 @@
     "git_remote_create_anonymous": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 73,
-      "lineto": 76,
+      "line": 147,
+      "lineto": 150,
       "args": [
         {
           "name": "out",
@@ -16937,18 +17296,18 @@
       "group": "remote",
       "examples": {
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_remote_create_anonymous-4"
+          "ex/v0.28.0/network/fetch.html#git_remote_create_anonymous-4"
         ],
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_remote_create_anonymous-2"
+          "ex/v0.28.0/network/ls-remote.html#git_remote_create_anonymous-2"
         ]
       }
     },
     "git_remote_create_detached": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 92,
-      "lineto": 94,
+      "line": 166,
+      "lineto": 168,
       "args": [
         {
           "name": "out",
@@ -16974,8 +17333,8 @@
     "git_remote_lookup": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 107,
-      "lineto": 107,
+      "line": 181,
+      "lineto": 181,
       "args": [
         {
           "name": "out",
@@ -17004,21 +17363,21 @@
       "group": "remote",
       "examples": {
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_remote_lookup-5"
+          "ex/v0.28.0/network/fetch.html#git_remote_lookup-5"
         ],
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_remote_lookup-3"
+          "ex/v0.28.0/network/ls-remote.html#git_remote_lookup-3"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_lookup-5"
+          "ex/v0.28.0/remote.html#git_remote_lookup-5"
         ]
       }
     },
     "git_remote_dup": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 119,
-      "lineto": 119,
+      "line": 193,
+      "lineto": 193,
       "args": [
         {
           "name": "dest",
@@ -17044,8 +17403,8 @@
     "git_remote_owner": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 127,
-      "lineto": 127,
+      "line": 201,
+      "lineto": 201,
       "args": [
         {
           "name": "remote",
@@ -17066,8 +17425,8 @@
     "git_remote_name": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 135,
-      "lineto": 135,
+      "line": 209,
+      "lineto": 209,
       "args": [
         {
           "name": "remote",
@@ -17088,8 +17447,8 @@
     "git_remote_url": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 146,
-      "lineto": 146,
+      "line": 220,
+      "lineto": 220,
       "args": [
         {
           "name": "remote",
@@ -17108,15 +17467,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_url-6"
+          "ex/v0.28.0/remote.html#git_remote_url-6"
         ]
       }
     },
     "git_remote_pushurl": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 157,
-      "lineto": 157,
+      "line": 231,
+      "lineto": 231,
       "args": [
         {
           "name": "remote",
@@ -17135,15 +17494,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_pushurl-7"
+          "ex/v0.28.0/remote.html#git_remote_pushurl-7"
         ]
       }
     },
     "git_remote_set_url": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 170,
-      "lineto": 170,
+      "line": 244,
+      "lineto": 244,
       "args": [
         {
           "name": "repo",
@@ -17172,15 +17531,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_set_url-8"
+          "ex/v0.28.0/remote.html#git_remote_set_url-8"
         ]
       }
     },
     "git_remote_set_pushurl": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 183,
-      "lineto": 183,
+      "line": 257,
+      "lineto": 257,
       "args": [
         {
           "name": "repo",
@@ -17209,15 +17568,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_set_pushurl-9"
+          "ex/v0.28.0/remote.html#git_remote_set_pushurl-9"
         ]
       }
     },
     "git_remote_add_fetch": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 196,
-      "lineto": 196,
+      "line": 270,
+      "lineto": 270,
       "args": [
         {
           "name": "repo",
@@ -17248,8 +17607,8 @@
     "git_remote_get_fetch_refspecs": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 207,
-      "lineto": 207,
+      "line": 281,
+      "lineto": 281,
       "args": [
         {
           "name": "array",
@@ -17275,8 +17634,8 @@
     "git_remote_add_push": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 220,
-      "lineto": 220,
+      "line": 294,
+      "lineto": 294,
       "args": [
         {
           "name": "repo",
@@ -17307,8 +17666,8 @@
     "git_remote_get_push_refspecs": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 231,
-      "lineto": 231,
+      "line": 305,
+      "lineto": 305,
       "args": [
         {
           "name": "array",
@@ -17334,8 +17693,8 @@
     "git_remote_refspec_count": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 239,
-      "lineto": 239,
+      "line": 313,
+      "lineto": 313,
       "args": [
         {
           "name": "remote",
@@ -17356,8 +17715,8 @@
     "git_remote_get_refspec": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 248,
-      "lineto": 248,
+      "line": 322,
+      "lineto": 322,
       "args": [
         {
           "name": "remote",
@@ -17383,8 +17742,8 @@
     "git_remote_connect": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 265,
-      "lineto": 265,
+      "line": 339,
+      "lineto": 339,
       "args": [
         {
           "name": "remote",
@@ -17423,15 +17782,15 @@
       "group": "remote",
       "examples": {
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_remote_connect-4"
+          "ex/v0.28.0/network/ls-remote.html#git_remote_connect-4"
         ]
       }
     },
     "git_remote_ls": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 287,
-      "lineto": 287,
+      "line": 361,
+      "lineto": 361,
       "args": [
         {
           "name": "out",
@@ -17460,15 +17819,15 @@
       "group": "remote",
       "examples": {
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_remote_ls-5"
+          "ex/v0.28.0/network/ls-remote.html#git_remote_ls-5"
         ]
       }
     },
     "git_remote_connected": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 298,
-      "lineto": 298,
+      "line": 372,
+      "lineto": 372,
       "args": [
         {
           "name": "remote",
@@ -17489,8 +17848,8 @@
     "git_remote_stop": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 308,
-      "lineto": 308,
+      "line": 382,
+      "lineto": 382,
       "args": [
         {
           "name": "remote",
@@ -17511,8 +17870,8 @@
     "git_remote_disconnect": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 317,
-      "lineto": 317,
+      "line": 391,
+      "lineto": 391,
       "args": [
         {
           "name": "remote",
@@ -17533,8 +17892,8 @@
     "git_remote_free": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 327,
-      "lineto": 327,
+      "line": 401,
+      "lineto": 401,
       "args": [
         {
           "name": "remote",
@@ -17553,22 +17912,22 @@
       "group": "remote",
       "examples": {
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_remote_free-6",
-          "ex/HEAD/network/fetch.html#git_remote_free-7"
+          "ex/v0.28.0/network/fetch.html#git_remote_free-6",
+          "ex/v0.28.0/network/fetch.html#git_remote_free-7"
         ],
         "network/ls-remote.c": [
-          "ex/HEAD/network/ls-remote.html#git_remote_free-6"
+          "ex/v0.28.0/network/ls-remote.html#git_remote_free-6"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_free-10"
+          "ex/v0.28.0/remote.html#git_remote_free-10"
         ]
       }
     },
     "git_remote_list": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 338,
-      "lineto": 338,
+      "line": 412,
+      "lineto": 412,
       "args": [
         {
           "name": "out",
@@ -17592,15 +17951,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_list-11"
+          "ex/v0.28.0/remote.html#git_remote_list-11"
         ]
       }
     },
     "git_remote_init_callbacks": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 503,
-      "lineto": 505,
+      "line": 577,
+      "lineto": 579,
       "args": [
         {
           "name": "opts",
@@ -17626,8 +17985,8 @@
     "git_fetch_init_options": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 608,
-      "lineto": 610,
+      "line": 682,
+      "lineto": 684,
       "args": [
         {
           "name": "opts",
@@ -17653,8 +18012,8 @@
     "git_push_init_options": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 658,
-      "lineto": 660,
+      "line": 732,
+      "lineto": 734,
       "args": [
         {
           "name": "opts",
@@ -17680,8 +18039,8 @@
     "git_remote_download": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 678,
-      "lineto": 678,
+      "line": 752,
+      "lineto": 752,
       "args": [
         {
           "name": "remote",
@@ -17712,8 +18071,8 @@
     "git_remote_upload": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 692,
-      "lineto": 692,
+      "line": 766,
+      "lineto": 766,
       "args": [
         {
           "name": "remote",
@@ -17744,8 +18103,8 @@
     "git_remote_update_tips": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 708,
-      "lineto": 713,
+      "line": 782,
+      "lineto": 787,
       "args": [
         {
           "name": "remote",
@@ -17786,8 +18145,8 @@
     "git_remote_fetch": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 729,
-      "lineto": 733,
+      "line": 803,
+      "lineto": 807,
       "args": [
         {
           "name": "remote",
@@ -17821,15 +18180,15 @@
       "group": "remote",
       "examples": {
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_remote_fetch-8"
+          "ex/v0.28.0/network/fetch.html#git_remote_fetch-8"
         ]
       }
     },
     "git_remote_prune": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 742,
-      "lineto": 742,
+      "line": 816,
+      "lineto": 816,
       "args": [
         {
           "name": "remote",
@@ -17855,8 +18214,8 @@
     "git_remote_push": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 754,
-      "lineto": 756,
+      "line": 828,
+      "lineto": 830,
       "args": [
         {
           "name": "remote",
@@ -17887,8 +18246,8 @@
     "git_remote_stats": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 761,
-      "lineto": 761,
+      "line": 835,
+      "lineto": 835,
       "args": [
         {
           "name": "remote",
@@ -17907,15 +18266,15 @@
       "group": "remote",
       "examples": {
         "network/fetch.c": [
-          "ex/HEAD/network/fetch.html#git_remote_stats-9"
+          "ex/v0.28.0/network/fetch.html#git_remote_stats-9"
         ]
       }
     },
     "git_remote_autotag": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 769,
-      "lineto": 769,
+      "line": 843,
+      "lineto": 843,
       "args": [
         {
           "name": "remote",
@@ -17936,8 +18295,8 @@
     "git_remote_set_autotag": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 781,
-      "lineto": 781,
+      "line": 855,
+      "lineto": 855,
       "args": [
         {
           "name": "repo",
@@ -17968,8 +18327,8 @@
     "git_remote_prune_refs": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 788,
-      "lineto": 788,
+      "line": 862,
+      "lineto": 862,
       "args": [
         {
           "name": "remote",
@@ -17990,8 +18349,8 @@
     "git_remote_rename": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 810,
-      "lineto": 814,
+      "line": 884,
+      "lineto": 888,
       "args": [
         {
           "name": "problems",
@@ -18025,15 +18384,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_rename-12"
+          "ex/v0.28.0/remote.html#git_remote_rename-12"
         ]
       }
     },
     "git_remote_is_valid_name": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 822,
-      "lineto": 822,
+      "line": 896,
+      "lineto": 896,
       "args": [
         {
           "name": "remote_name",
@@ -18054,8 +18413,8 @@
     "git_remote_delete": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 834,
-      "lineto": 834,
+      "line": 908,
+      "lineto": 908,
       "args": [
         {
           "name": "repo",
@@ -18079,15 +18438,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_remote_delete-13"
+          "ex/v0.28.0/remote.html#git_remote_delete-13"
         ]
       }
     },
     "git_remote_default_branch": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 852,
-      "lineto": 852,
+      "line": 926,
+      "lineto": 926,
       "args": [
         {
           "name": "out",
@@ -18138,10 +18497,10 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_open-68"
+          "ex/v0.28.0/general.html#git_repository_open-68"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_repository_open-14"
+          "ex/v0.28.0/remote.html#git_repository_open-14"
         ]
       }
     },
@@ -18237,15 +18596,15 @@
       "group": "repository",
       "examples": {
         "remote.c": [
-          "ex/HEAD/remote.html#git_repository_discover-15"
+          "ex/v0.28.0/remote.html#git_repository_discover-15"
         ]
       }
     },
     "git_repository_open_ext": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 152,
-      "lineto": 156,
+      "line": 165,
+      "lineto": 169,
       "args": [
         {
           "name": "out",
@@ -18279,46 +18638,46 @@
       "group": "repository",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_repository_open_ext-24"
+          "ex/v0.28.0/blame.html#git_repository_open_ext-24"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_repository_open_ext-31"
+          "ex/v0.28.0/cat-file.html#git_repository_open_ext-31"
         ],
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_repository_open_ext-14"
+          "ex/v0.28.0/checkout.html#git_repository_open_ext-14"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_repository_open_ext-8"
+          "ex/v0.28.0/describe.html#git_repository_open_ext-8"
         ],
         "diff.c": [
-          "ex/HEAD/diff.html#git_repository_open_ext-15"
+          "ex/v0.28.0/diff.html#git_repository_open_ext-15"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_repository_open_ext-45",
-          "ex/HEAD/log.html#git_repository_open_ext-46"
+          "ex/v0.28.0/log.html#git_repository_open_ext-45",
+          "ex/v0.28.0/log.html#git_repository_open_ext-46"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_repository_open_ext-7"
+          "ex/v0.28.0/ls-files.html#git_repository_open_ext-7"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_open_ext-33"
+          "ex/v0.28.0/merge.html#git_repository_open_ext-33"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_repository_open_ext-16"
+          "ex/v0.28.0/rev-parse.html#git_repository_open_ext-16"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_repository_open_ext-5"
+          "ex/v0.28.0/status.html#git_repository_open_ext-5"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_repository_open_ext-11"
+          "ex/v0.28.0/tag.html#git_repository_open_ext-11"
         ]
       }
     },
     "git_repository_open_bare": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 169,
-      "lineto": 169,
+      "line": 182,
+      "lineto": 182,
       "args": [
         {
           "name": "out",
@@ -18344,8 +18703,8 @@
     "git_repository_free": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 182,
-      "lineto": 182,
+      "line": 195,
+      "lineto": 195,
       "args": [
         {
           "name": "repo",
@@ -18364,51 +18723,51 @@
       "group": "repository",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_repository_free-25"
+          "ex/v0.28.0/blame.html#git_repository_free-25"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_repository_free-32"
+          "ex/v0.28.0/cat-file.html#git_repository_free-32"
         ],
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_repository_free-15"
+          "ex/v0.28.0/checkout.html#git_repository_free-15"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_repository_free-9"
+          "ex/v0.28.0/describe.html#git_repository_free-9"
         ],
         "diff.c": [
-          "ex/HEAD/diff.html#git_repository_free-16"
+          "ex/v0.28.0/diff.html#git_repository_free-16"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_repository_free-69"
+          "ex/v0.28.0/general.html#git_repository_free-69"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_repository_free-6"
+          "ex/v0.28.0/init.html#git_repository_free-6"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_repository_free-47"
+          "ex/v0.28.0/log.html#git_repository_free-47"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_repository_free-8"
+          "ex/v0.28.0/ls-files.html#git_repository_free-8"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_free-34"
+          "ex/v0.28.0/merge.html#git_repository_free-34"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_repository_free-17"
+          "ex/v0.28.0/rev-parse.html#git_repository_free-17"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_repository_free-6"
+          "ex/v0.28.0/status.html#git_repository_free-6"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_repository_free-12"
+          "ex/v0.28.0/tag.html#git_repository_free-12"
         ]
       }
     },
     "git_repository_init": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 199,
-      "lineto": 202,
+      "line": 212,
+      "lineto": 215,
       "args": [
         {
           "name": "out",
@@ -18437,15 +18796,15 @@
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_repository_init-7"
+          "ex/v0.28.0/init.html#git_repository_init-7"
         ]
       }
     },
     "git_repository_init_init_options": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 313,
-      "lineto": 315,
+      "line": 326,
+      "lineto": 328,
       "args": [
         {
           "name": "opts",
@@ -18471,8 +18830,8 @@
     "git_repository_init_ext": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 330,
-      "lineto": 333,
+      "line": 343,
+      "lineto": 346,
       "args": [
         {
           "name": "out",
@@ -18501,15 +18860,15 @@
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_repository_init_ext-8"
+          "ex/v0.28.0/init.html#git_repository_init_ext-8"
         ]
       }
     },
     "git_repository_head": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 348,
-      "lineto": 348,
+      "line": 361,
+      "lineto": 361,
       "args": [
         {
           "name": "out",
@@ -18533,19 +18892,19 @@
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_head-35",
-          "ex/HEAD/merge.html#git_repository_head-36"
+          "ex/v0.28.0/merge.html#git_repository_head-35",
+          "ex/v0.28.0/merge.html#git_repository_head-36"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_repository_head-7"
+          "ex/v0.28.0/status.html#git_repository_head-7"
         ]
       }
     },
     "git_repository_head_for_worktree": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 358,
-      "lineto": 359,
+      "line": 371,
+      "lineto": 372,
       "args": [
         {
           "name": "out",
@@ -18576,8 +18935,8 @@
     "git_repository_head_detached": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 371,
-      "lineto": 371,
+      "line": 384,
+      "lineto": 384,
       "args": [
         {
           "name": "repo",
@@ -18598,8 +18957,8 @@
     "git_repository_head_detached_for_worktree": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 384,
-      "lineto": 385,
+      "line": 397,
+      "lineto": 398,
       "args": [
         {
           "name": "repo",
@@ -18625,8 +18984,8 @@
     "git_repository_head_unborn": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 397,
-      "lineto": 397,
+      "line": 410,
+      "lineto": 410,
       "args": [
         {
           "name": "repo",
@@ -18647,8 +19006,8 @@
     "git_repository_is_empty": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 409,
-      "lineto": 409,
+      "line": 422,
+      "lineto": 422,
       "args": [
         {
           "name": "repo",
@@ -18669,8 +19028,8 @@
     "git_repository_item_path": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 445,
-      "lineto": 445,
+      "line": 458,
+      "lineto": 458,
       "args": [
         {
           "name": "out",
@@ -18701,8 +19060,8 @@
     "git_repository_path": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 456,
-      "lineto": 456,
+      "line": 469,
+      "lineto": 469,
       "args": [
         {
           "name": "repo",
@@ -18721,18 +19080,18 @@
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_repository_path-9"
+          "ex/v0.28.0/init.html#git_repository_path-9"
         ],
         "status.c": [
-          "ex/HEAD/status.html#git_repository_path-8"
+          "ex/v0.28.0/status.html#git_repository_path-8"
         ]
       }
     },
     "git_repository_workdir": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 467,
-      "lineto": 467,
+      "line": 480,
+      "lineto": 480,
       "args": [
         {
           "name": "repo",
@@ -18751,15 +19110,15 @@
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_repository_workdir-10"
+          "ex/v0.28.0/init.html#git_repository_workdir-10"
         ]
       }
     },
     "git_repository_commondir": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 478,
-      "lineto": 478,
+      "line": 491,
+      "lineto": 491,
       "args": [
         {
           "name": "repo",
@@ -18780,8 +19139,8 @@
     "git_repository_set_workdir": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 497,
-      "lineto": 498,
+      "line": 510,
+      "lineto": 511,
       "args": [
         {
           "name": "repo",
@@ -18812,8 +19171,8 @@
     "git_repository_is_bare": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 506,
-      "lineto": 506,
+      "line": 519,
+      "lineto": 519,
       "args": [
         {
           "name": "repo",
@@ -18832,15 +19191,15 @@
       "group": "repository",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_repository_is_bare-9"
+          "ex/v0.28.0/status.html#git_repository_is_bare-9"
         ]
       }
     },
     "git_repository_is_worktree": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 514,
-      "lineto": 514,
+      "line": 527,
+      "lineto": 527,
       "args": [
         {
           "name": "repo",
@@ -18861,8 +19220,8 @@
     "git_repository_config": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 530,
-      "lineto": 530,
+      "line": 543,
+      "lineto": 543,
       "args": [
         {
           "name": "out",
@@ -18888,8 +19247,8 @@
     "git_repository_config_snapshot": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 546,
-      "lineto": 546,
+      "line": 559,
+      "lineto": 559,
       "args": [
         {
           "name": "out",
@@ -18913,16 +19272,16 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_config_snapshot-70",
-          "ex/HEAD/general.html#git_repository_config_snapshot-71"
+          "ex/v0.28.0/general.html#git_repository_config_snapshot-70",
+          "ex/v0.28.0/general.html#git_repository_config_snapshot-71"
         ]
       }
     },
     "git_repository_odb": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 562,
-      "lineto": 562,
+      "line": 575,
+      "lineto": 575,
       "args": [
         {
           "name": "out",
@@ -18946,18 +19305,18 @@
       "group": "repository",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_repository_odb-33"
+          "ex/v0.28.0/cat-file.html#git_repository_odb-33"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_repository_odb-72"
+          "ex/v0.28.0/general.html#git_repository_odb-72"
         ]
       }
     },
     "git_repository_refdb": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 578,
-      "lineto": 578,
+      "line": 591,
+      "lineto": 591,
       "args": [
         {
           "name": "out",
@@ -18983,8 +19342,8 @@
     "git_repository_index": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 594,
-      "lineto": 594,
+      "line": 607,
+      "lineto": 607,
       "args": [
         {
           "name": "out",
@@ -19008,24 +19367,24 @@
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_repository_index-73"
+          "ex/v0.28.0/general.html#git_repository_index-73"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_repository_index-11"
+          "ex/v0.28.0/init.html#git_repository_index-11"
         ],
         "ls-files.c": [
-          "ex/HEAD/ls-files.html#git_repository_index-9"
+          "ex/v0.28.0/ls-files.html#git_repository_index-9"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_index-37"
+          "ex/v0.28.0/merge.html#git_repository_index-37"
         ]
       }
     },
     "git_repository_message": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 612,
-      "lineto": 612,
+      "line": 625,
+      "lineto": 625,
       "args": [
         {
           "name": "out",
@@ -19051,8 +19410,8 @@
     "git_repository_message_remove": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 619,
-      "lineto": 619,
+      "line": 632,
+      "lineto": 632,
       "args": [
         {
           "name": "repo",
@@ -19073,8 +19432,8 @@
     "git_repository_state_cleanup": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 628,
-      "lineto": 628,
+      "line": 641,
+      "lineto": 641,
       "args": [
         {
           "name": "repo",
@@ -19093,15 +19452,15 @@
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_state_cleanup-38"
+          "ex/v0.28.0/merge.html#git_repository_state_cleanup-38"
         ]
       }
     },
     "git_repository_fetchhead_foreach": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 647,
-      "lineto": 650,
+      "line": 660,
+      "lineto": 663,
       "args": [
         {
           "name": "repo",
@@ -19132,8 +19491,8 @@
     "git_repository_mergehead_foreach": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 667,
-      "lineto": 670,
+      "line": 680,
+      "lineto": 683,
       "args": [
         {
           "name": "repo",
@@ -19164,8 +19523,8 @@
     "git_repository_hashfile": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 695,
-      "lineto": 700,
+      "line": 708,
+      "lineto": 713,
       "args": [
         {
           "name": "out",
@@ -19184,8 +19543,8 @@
         },
         {
           "name": "type",
-          "type": "git_otype",
-          "comment": "The object type to hash as (e.g. GIT_OBJ_BLOB)"
+          "type": "git_object_t",
+          "comment": "The object type to hash as (e.g. GIT_OBJECT_BLOB)"
         },
         {
           "name": "as_path",
@@ -19193,8 +19552,8 @@
           "comment": "The path to use to look up filtering rules. If this is\n             NULL, then the `path` parameter will be used instead. If\n             this is passed as the empty string, then no filters will be\n             applied when calculating the hash."
         }
       ],
-      "argline": "git_oid *out, git_repository *repo, const char *path, git_otype type, const char *as_path",
-      "sig": "git_oid *::git_repository *::const char *::git_otype::const char *",
+      "argline": "git_oid *out, git_repository *repo, const char *path, git_object_t type, const char *as_path",
+      "sig": "git_oid *::git_repository *::const char *::git_object_t::const char *",
       "return": {
         "type": "int",
         "comment": " 0 on success, or an error code"
@@ -19206,8 +19565,8 @@
     "git_repository_set_head": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 720,
-      "lineto": 722,
+      "line": 733,
+      "lineto": 735,
       "args": [
         {
           "name": "repo",
@@ -19231,15 +19590,15 @@
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_repository_set_head-16"
+          "ex/v0.28.0/checkout.html#git_repository_set_head-16"
         ]
       }
     },
     "git_repository_set_head_detached": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 740,
-      "lineto": 742,
+      "line": 753,
+      "lineto": 755,
       "args": [
         {
           "name": "repo",
@@ -19265,8 +19624,8 @@
     "git_repository_set_head_detached_from_annotated": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 756,
-      "lineto": 758,
+      "line": 769,
+      "lineto": 771,
       "args": [
         {
           "name": "repo",
@@ -19290,15 +19649,15 @@
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_repository_set_head_detached_from_annotated-17"
+          "ex/v0.28.0/checkout.html#git_repository_set_head_detached_from_annotated-17"
         ]
       }
     },
     "git_repository_detach_head": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 777,
-      "lineto": 778,
+      "line": 790,
+      "lineto": 791,
       "args": [
         {
           "name": "repo",
@@ -19319,8 +19678,8 @@
     "git_repository_state": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 808,
-      "lineto": 808,
+      "line": 821,
+      "lineto": 821,
       "args": [
         {
           "name": "repo",
@@ -19339,18 +19698,18 @@
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/HEAD/checkout.html#git_repository_state-18"
+          "ex/v0.28.0/checkout.html#git_repository_state-18"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_repository_state-39"
+          "ex/v0.28.0/merge.html#git_repository_state-39"
         ]
       }
     },
     "git_repository_set_namespace": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 822,
-      "lineto": 822,
+      "line": 835,
+      "lineto": 835,
       "args": [
         {
           "name": "repo",
@@ -19376,8 +19735,8 @@
     "git_repository_get_namespace": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 830,
-      "lineto": 830,
+      "line": 843,
+      "lineto": 843,
       "args": [
         {
           "name": "repo",
@@ -19398,8 +19757,8 @@
     "git_repository_is_shallow": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 839,
-      "lineto": 839,
+      "line": 852,
+      "lineto": 852,
       "args": [
         {
           "name": "repo",
@@ -19420,8 +19779,8 @@
     "git_repository_ident": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 851,
-      "lineto": 851,
+      "line": 864,
+      "lineto": 864,
       "args": [
         {
           "name": "name",
@@ -19452,8 +19811,8 @@
     "git_repository_set_ident": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 864,
-      "lineto": 864,
+      "line": 877,
+      "lineto": 877,
       "args": [
         {
           "name": "repo",
@@ -19726,22 +20085,22 @@
       "group": "revparse",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_revparse_single-26"
+          "ex/v0.28.0/blame.html#git_revparse_single-26"
         ],
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_revparse_single-34"
+          "ex/v0.28.0/cat-file.html#git_revparse_single-34"
         ],
         "describe.c": [
-          "ex/HEAD/describe.html#git_revparse_single-10"
+          "ex/v0.28.0/describe.html#git_revparse_single-10"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revparse_single-48"
+          "ex/v0.28.0/log.html#git_revparse_single-48"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_revparse_single-13",
-          "ex/HEAD/tag.html#git_revparse_single-14",
-          "ex/HEAD/tag.html#git_revparse_single-15",
-          "ex/HEAD/tag.html#git_revparse_single-16"
+          "ex/v0.28.0/tag.html#git_revparse_single-13",
+          "ex/v0.28.0/tag.html#git_revparse_single-14",
+          "ex/v0.28.0/tag.html#git_revparse_single-15",
+          "ex/v0.28.0/tag.html#git_revparse_single-16"
         ]
       }
     },
@@ -19815,14 +20174,14 @@
       "group": "revparse",
       "examples": {
         "blame.c": [
-          "ex/HEAD/blame.html#git_revparse-27"
+          "ex/v0.28.0/blame.html#git_revparse-27"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revparse-49"
+          "ex/v0.28.0/log.html#git_revparse-49"
         ],
         "rev-parse.c": [
-          "ex/HEAD/rev-parse.html#git_revparse-18",
-          "ex/HEAD/rev-parse.html#git_revparse-19"
+          "ex/v0.28.0/rev-parse.html#git_revparse-18",
+          "ex/v0.28.0/rev-parse.html#git_revparse-19"
         ]
       }
     },
@@ -19854,11 +20213,11 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_new-74"
+          "ex/v0.28.0/general.html#git_revwalk_new-74"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_new-50",
-          "ex/HEAD/log.html#git_revwalk_new-51"
+          "ex/v0.28.0/log.html#git_revwalk_new-50",
+          "ex/v0.28.0/log.html#git_revwalk_new-51"
         ]
       }
     },
@@ -19912,10 +20271,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_push-75"
+          "ex/v0.28.0/general.html#git_revwalk_push-75"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_push-52"
+          "ex/v0.28.0/log.html#git_revwalk_push-52"
         ]
       }
     },
@@ -19969,7 +20328,7 @@
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_push_head-53"
+          "ex/v0.28.0/log.html#git_revwalk_push_head-53"
         ]
       }
     },
@@ -20001,7 +20360,7 @@
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_hide-54"
+          "ex/v0.28.0/log.html#git_revwalk_hide-54"
         ]
       }
     },
@@ -20136,10 +20495,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_next-76"
+          "ex/v0.28.0/general.html#git_revwalk_next-76"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_next-55"
+          "ex/v0.28.0/log.html#git_revwalk_next-55"
         ]
       }
     },
@@ -20171,11 +20530,11 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_sorting-77"
+          "ex/v0.28.0/general.html#git_revwalk_sorting-77"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_sorting-56",
-          "ex/HEAD/log.html#git_revwalk_sorting-57"
+          "ex/v0.28.0/log.html#git_revwalk_sorting-56",
+          "ex/v0.28.0/log.html#git_revwalk_sorting-57"
         ]
       }
     },
@@ -20251,10 +20610,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_revwalk_free-78"
+          "ex/v0.28.0/general.html#git_revwalk_free-78"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_revwalk_free-58"
+          "ex/v0.28.0/log.html#git_revwalk_free-58"
         ]
       }
     },
@@ -20308,7 +20667,7 @@
         "type": "int",
         "comment": null
       },
-      "description": "<p>Adds a callback function to hide a commit and its parents</p>\n",
+      "description": "<p>Adds, changes or removes a callback function to hide a commit and its parents</p>\n",
       "comments": "",
       "group": "revwalk"
     },
@@ -20336,12 +20695,12 @@
         {
           "name": "time",
           "type": "git_time_t",
-          "comment": "time when the action happened"
+          "comment": "time (in seconds from epoch) when the action happened"
         },
         {
           "name": "offset",
           "type": "int",
-          "comment": "timezone offset in minutes for the time"
+          "comment": "timezone offset (in minutes) for the time"
         }
       ],
       "argline": "git_signature **out, const char *name, const char *email, git_time_t time, int offset",
@@ -20355,8 +20714,8 @@
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_signature_new-79",
-          "ex/HEAD/general.html#git_signature_new-80"
+          "ex/v0.28.0/general.html#git_signature_new-79",
+          "ex/v0.28.0/general.html#git_signature_new-80"
         ]
       }
     },
@@ -20393,7 +20752,7 @@
       "group": "signature",
       "examples": {
         "merge.c": [
-          "ex/HEAD/merge.html#git_signature_now-40"
+          "ex/v0.28.0/merge.html#git_signature_now-40"
         ]
       }
     },
@@ -20425,10 +20784,10 @@
       "group": "signature",
       "examples": {
         "init.c": [
-          "ex/HEAD/init.html#git_signature_default-12"
+          "ex/v0.28.0/init.html#git_signature_default-12"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_signature_default-17"
+          "ex/v0.28.0/tag.html#git_signature_default-17"
         ]
       }
     },
@@ -20509,14 +20868,14 @@
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_signature_free-81",
-          "ex/HEAD/general.html#git_signature_free-82"
+          "ex/v0.28.0/general.html#git_signature_free-81",
+          "ex/v0.28.0/general.html#git_signature_free-82"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_signature_free-13"
+          "ex/v0.28.0/init.html#git_signature_free-13"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_signature_free-18"
+          "ex/v0.28.0/tag.html#git_signature_free-18"
         ]
       }
     },
@@ -20529,36 +20888,36 @@
         {
           "name": "out",
           "type": "git_oid *",
-          "comment": "Object id of the commit containing the stashed state.\n This commit is also the target of the direct reference refs/stash."
+          "comment": null
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": "The owning repository."
+          "comment": null
         },
         {
           "name": "stasher",
           "type": "const git_signature *",
-          "comment": "The identity of the person performing the stashing."
+          "comment": null
         },
         {
           "name": "message",
           "type": "const char *",
-          "comment": "Optional description along with the stashed state."
+          "comment": null
         },
         {
           "name": "flags",
-          "type": "uint32_t",
-          "comment": "Flags to control the stashing process. (see GIT_STASH_* above)"
+          "type": "int",
+          "comment": null
         }
       ],
-      "argline": "git_oid *out, git_repository *repo, const git_signature *stasher, const char *message, uint32_t flags",
-      "sig": "git_oid *::git_repository *::const git_signature *::const char *::uint32_t",
+      "argline": "git_oid *out, git_repository *repo, const git_signature *stasher, const char *message, int flags",
+      "sig": "git_oid *::git_repository *::const git_signature *::const char *::int",
       "return": {
         "type": "int",
-        "comment": " 0 on success, GIT_ENOTFOUND where there's nothing to stash,\n or error code."
+        "comment": null
       },
-      "description": "<p>Save the local modifications to a new stash.</p>\n",
+      "description": "",
       "comments": "",
       "group": "stash"
     },
@@ -20772,7 +21131,7 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_foreach-10"
+          "ex/v0.28.0/status.html#git_status_foreach-10"
         ]
       }
     },
@@ -20814,7 +21173,7 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_foreach_ext-11"
+          "ex/v0.28.0/status.html#git_status_foreach_ext-11"
         ]
       }
     },
@@ -20883,8 +21242,8 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_list_new-12",
-          "ex/HEAD/status.html#git_status_list_new-13"
+          "ex/v0.28.0/status.html#git_status_list_new-12",
+          "ex/v0.28.0/status.html#git_status_list_new-13"
         ]
       }
     },
@@ -20911,8 +21270,8 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_list_entrycount-14",
-          "ex/HEAD/status.html#git_status_list_entrycount-15"
+          "ex/v0.28.0/status.html#git_status_list_entrycount-14",
+          "ex/v0.28.0/status.html#git_status_list_entrycount-15"
         ]
       }
     },
@@ -20944,12 +21303,12 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_byindex-16",
-          "ex/HEAD/status.html#git_status_byindex-17",
-          "ex/HEAD/status.html#git_status_byindex-18",
-          "ex/HEAD/status.html#git_status_byindex-19",
-          "ex/HEAD/status.html#git_status_byindex-20",
-          "ex/HEAD/status.html#git_status_byindex-21"
+          "ex/v0.28.0/status.html#git_status_byindex-16",
+          "ex/v0.28.0/status.html#git_status_byindex-17",
+          "ex/v0.28.0/status.html#git_status_byindex-18",
+          "ex/v0.28.0/status.html#git_status_byindex-19",
+          "ex/v0.28.0/status.html#git_status_byindex-20",
+          "ex/v0.28.0/status.html#git_status_byindex-21"
         ]
       }
     },
@@ -20976,7 +21335,7 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_status_list_free-22"
+          "ex/v0.28.0/status.html#git_status_list_free-22"
         ]
       }
     },
@@ -21035,14 +21394,14 @@
       "group": "strarray",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_strarray_free-83"
+          "ex/v0.28.0/general.html#git_strarray_free-83"
         ],
         "remote.c": [
-          "ex/HEAD/remote.html#git_strarray_free-16",
-          "ex/HEAD/remote.html#git_strarray_free-17"
+          "ex/v0.28.0/remote.html#git_strarray_free-16",
+          "ex/v0.28.0/remote.html#git_strarray_free-17"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_strarray_free-19"
+          "ex/v0.28.0/tag.html#git_strarray_free-19"
         ]
       }
     },
@@ -21126,7 +21485,7 @@
       "sig": "git_submodule *::int::git_submodule_update_options *",
       "return": {
         "type": "int",
-        "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `giterr_last` for a detailed error message)."
+        "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `git_error_last` for a detailed error message)."
       },
       "description": "<p>Update a submodule. This will clone a missing submodule and\n checkout the subrepository to the commit specified in the index of\n the containing repository. If the submodule repository doesn&#39;t contain\n the target commit (e.g. because fetchRecurseSubmodules isn&#39;t set), then\n the submodule is fetched using the fetch options supplied in options.</p>\n",
       "comments": "",
@@ -21219,7 +21578,7 @@
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_submodule_foreach-23"
+          "ex/v0.28.0/status.html#git_submodule_foreach-23"
         ]
       }
     },
@@ -21359,7 +21718,7 @@
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_submodule_name-24"
+          "ex/v0.28.0/status.html#git_submodule_name-24"
         ]
       }
     },
@@ -21386,7 +21745,7 @@
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_submodule_path-25"
+          "ex/v0.28.0/status.html#git_submodule_path-25"
         ]
       }
     },
@@ -21931,7 +22290,7 @@
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/HEAD/status.html#git_submodule_status-26"
+          "ex/v0.28.0/status.html#git_submodule_status-26"
         ]
       }
     },
@@ -22382,18 +22741,18 @@
         },
         {
           "name": "options",
-          "type": "uint32_t",
+          "type": "int",
           "comment": null
         }
       ],
-      "argline": "git_filter_list **out, git_repository *repo, git_filter_mode_t mode, uint32_t options",
-      "sig": "git_filter_list **::git_repository *::git_filter_mode_t::uint32_t",
+      "argline": "git_filter_list **out, git_repository *repo, git_filter_mode_t mode, int options",
+      "sig": "git_filter_list **::git_repository *::git_filter_mode_t::int",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Create a new empty filter list</p>\n",
-      "comments": "<p>Normally you won&#39;t use this because <code>git_filter_list_load</code> will create\n the filter list for you, but you can use this in combination with the\n <code>git_filter_lookup</code> and <code>git_filter_list_push</code> functions to assemble\n your own chains of filters.</p>\n",
+      "description": "",
+      "comments": "",
       "group": "filter"
     },
     "git_filter_list_push": {
@@ -22499,20 +22858,14 @@
       "file": "git2/sys/filter.h",
       "line": 111,
       "lineto": 111,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
+      "args": [],
+      "argline": "",
+      "sig": "",
       "return": {
-        "type": "uint16_t",
+        "type": "int",
         "comment": null
       },
-      "description": "<p>Get the file mode of the source file\n If the mode is unknown, this will return 0</p>\n",
+      "description": "",
       "comments": "",
       "group": "filter"
     },
@@ -22565,20 +22918,14 @@
       "file": "git2/sys/filter.h",
       "line": 128,
       "lineto": 128,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
+      "args": [],
+      "argline": "",
+      "sig": "",
       "return": {
-        "type": "uint32_t",
+        "type": "int",
         "comment": null
       },
-      "description": "<p>Get the combination git_filter_flag_t options to be applied</p>\n",
+      "description": "",
       "comments": "",
       "group": "filter"
     },
@@ -23890,26 +24237,53 @@
       "comments": "<p>Clear the submodule cache populated by <code>git_repository_submodule_cache_all</code>.\n If there is no cache, do nothing.</p>\n\n<p>The cache incorporates data from the repository&#39;s configuration, as well\n as the state of the working tree, the index, and HEAD.  So any time any\n of these has changed, the cache might become invalid.</p>\n",
       "group": "repository"
     },
+    "git_stream_register": {
+      "type": "function",
+      "file": "git2/sys/stream.h",
+      "line": 98,
+      "lineto": 99,
+      "args": [
+        {
+          "name": "type",
+          "type": "git_stream_t",
+          "comment": "the type or types of stream to register"
+        },
+        {
+          "name": "registration",
+          "type": "git_stream_registration *",
+          "comment": "the registration data"
+        }
+      ],
+      "argline": "git_stream_t type, git_stream_registration *registration",
+      "sig": "git_stream_t::git_stream_registration *",
+      "return": {
+        "type": "int",
+        "comment": " 0 or an error code"
+      },
+      "description": "<p>Register stream constructors for the library to use</p>\n",
+      "comments": "<p>If a registration structure is already set, it will be overwritten.\n Pass <code>NULL</code> in order to deregister the current constructor and return\n to the system defaults.</p>\n\n<p>The type parameter may be a bitwise AND of types.</p>\n",
+      "group": "stream"
+    },
     "git_stream_register_tls": {
       "type": "function",
       "file": "git2/sys/stream.h",
-      "line": 54,
-      "lineto": 54,
+      "line": 130,
+      "lineto": 130,
       "args": [
         {
           "name": "ctor",
           "type": "git_stream_cb",
-          "comment": "the constructor to use"
+          "comment": null
         }
       ],
       "argline": "git_stream_cb ctor",
       "sig": "git_stream_cb",
       "return": {
         "type": "int",
-        "comment": " 0 or an error code"
+        "comment": null
       },
-      "description": "<p>Register a TLS stream constructor for the library to use</p>\n",
-      "comments": "<p>If a constructor is already set, it will be overwritten. Pass\n <code>NULL</code> in order to deregister the current constructor.</p>\n",
+      "description": "<p>Register a TLS stream constructor for the library to use.  This stream\n will not support HTTP CONNECT proxies.  This internally calls\n <code>git_stream_register</code> and is preserved for backward compatibility.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
       "group": "stream"
     },
     "git_time_monotonic": {
@@ -23931,8 +24305,8 @@
     "git_transport_init": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 119,
-      "lineto": 121,
+      "line": 137,
+      "lineto": 139,
       "args": [
         {
           "name": "opts",
@@ -23958,8 +24332,8 @@
     "git_transport_new": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 133,
-      "lineto": 133,
+      "line": 151,
+      "lineto": 151,
       "args": [
         {
           "name": "out",
@@ -23990,8 +24364,8 @@
     "git_transport_ssh_with_paths": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 149,
-      "lineto": 149,
+      "line": 167,
+      "lineto": 167,
       "args": [
         {
           "name": "out",
@@ -24022,8 +24396,8 @@
     "git_transport_register": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 164,
-      "lineto": 167,
+      "line": 182,
+      "lineto": 185,
       "args": [
         {
           "name": "prefix",
@@ -24054,8 +24428,8 @@
     "git_transport_unregister": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 177,
-      "lineto": 178,
+      "line": 198,
+      "lineto": 199,
       "args": [
         {
           "name": "prefix",
@@ -24070,14 +24444,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Unregister a custom transport definition which was previously registered\n with git_transport_register.</p>\n",
-      "comments": "",
+      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register\n and git_transport_unregister with other calls to the library that\n instantiate transports.</p>\n",
       "group": "transport"
     },
     "git_transport_dummy": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 191,
-      "lineto": 194,
+      "line": 212,
+      "lineto": 215,
       "args": [
         {
           "name": "out",
@@ -24108,8 +24482,8 @@
     "git_transport_local": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 204,
-      "lineto": 207,
+      "line": 225,
+      "lineto": 228,
       "args": [
         {
           "name": "out",
@@ -24140,8 +24514,8 @@
     "git_transport_smart": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 217,
-      "lineto": 220,
+      "line": 238,
+      "lineto": 241,
       "args": [
         {
           "name": "out",
@@ -24172,8 +24546,8 @@
     "git_transport_smart_certificate_check": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 231,
-      "lineto": 231,
+      "line": 255,
+      "lineto": 255,
       "args": [
         {
           "name": "transport",
@@ -24200,7 +24574,7 @@
       "sig": "git_transport *::git_cert *::int::const char *",
       "return": {
         "type": "int",
-        "comment": " the return value of the callback"
+        "comment": " the return value of the callback: 0 for no error, GIT_PASSTHROUGH\n         to indicate that there is no callback registered (or the callback\n         refused to validate the certificate and callers should behave as\n         if no callback was set), or \n<\n 0 for an error"
       },
       "description": "<p>Call the certificate check for this transport.</p>\n",
       "comments": "",
@@ -24209,8 +24583,8 @@
     "git_transport_smart_credentials": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 242,
-      "lineto": 242,
+      "line": 269,
+      "lineto": 269,
       "args": [
         {
           "name": "out",
@@ -24237,7 +24611,7 @@
       "sig": "git_cred **::git_transport *::const char *::int",
       "return": {
         "type": "int",
-        "comment": " the return value of the callback"
+        "comment": " the return value of the callback: 0 for no error, GIT_PASSTHROUGH\n         to indicate that there is no callback registered (or the callback\n         refused to provide credentials and callers should behave as if no\n         callback was set), or \n<\n 0 for an error"
       },
       "description": "<p>Call the credentials callback for this transport</p>\n",
       "comments": "",
@@ -24246,8 +24620,8 @@
     "git_transport_smart_proxy_options": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 252,
-      "lineto": 252,
+      "line": 279,
+      "lineto": 279,
       "args": [
         {
           "name": "out",
@@ -24273,8 +24647,8 @@
     "git_smart_subtransport_http": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 362,
-      "lineto": 365,
+      "line": 408,
+      "lineto": 411,
       "args": [
         {
           "name": "out",
@@ -24298,15 +24672,15 @@
         "type": "int",
         "comment": " 0 or an error code"
       },
-      "description": "<p>Create an instance of the http subtransport. This subtransport\n also supports https. On Win32, this subtransport may be implemented\n using the WinHTTP library.</p>\n",
-      "comments": "",
+      "description": "<p>Create an instance of the http subtransport.</p>\n",
+      "comments": "<p>This subtransport also supports https.</p>\n",
       "group": "smart"
     },
     "git_smart_subtransport_git": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 374,
-      "lineto": 377,
+      "line": 420,
+      "lineto": 423,
       "args": [
         {
           "name": "out",
@@ -24337,8 +24711,8 @@
     "git_smart_subtransport_ssh": {
       "type": "function",
       "file": "git2/sys/transport.h",
-      "line": 386,
-      "lineto": 389,
+      "line": 432,
+      "lineto": 435,
       "args": [
         {
           "name": "out",
@@ -24399,7 +24773,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_lookup-84"
+          "ex/v0.28.0/general.html#git_tag_lookup-84"
         ]
       }
     },
@@ -24463,7 +24837,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_free-85"
+          "ex/v0.28.0/general.html#git_tag_free-85"
         ]
       }
     },
@@ -24539,7 +24913,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tag_target-86"
+          "ex/v0.28.0/general.html#git_tag_target-86"
         ]
       }
     },
@@ -24566,7 +24940,7 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tag_target_id-35"
+          "ex/v0.28.0/cat-file.html#git_tag_target_id-35"
         ]
       }
     },
@@ -24585,7 +24959,7 @@
       "argline": "const git_tag *tag",
       "sig": "const git_tag *",
       "return": {
-        "type": "git_otype",
+        "type": "git_object_t",
         "comment": " type of the tagged object"
       },
       "description": "<p>Get the type of a tag&#39;s tagged object</p>\n",
@@ -24593,10 +24967,10 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tag_target_type-36"
+          "ex/v0.28.0/cat-file.html#git_tag_target_type-36"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_target_type-87"
+          "ex/v0.28.0/general.html#git_tag_target_type-87"
         ]
       }
     },
@@ -24623,13 +24997,13 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tag_name-37"
+          "ex/v0.28.0/cat-file.html#git_tag_name-37"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_name-88"
+          "ex/v0.28.0/general.html#git_tag_name-88"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_name-20"
+          "ex/v0.28.0/tag.html#git_tag_name-20"
         ]
       }
     },
@@ -24656,7 +25030,7 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tag_tagger-38"
+          "ex/v0.28.0/cat-file.html#git_tag_tagger-38"
         ]
       }
     },
@@ -24683,14 +25057,14 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tag_message-39",
-          "ex/HEAD/cat-file.html#git_tag_message-40"
+          "ex/v0.28.0/cat-file.html#git_tag_message-39",
+          "ex/v0.28.0/cat-file.html#git_tag_message-40"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tag_message-89"
+          "ex/v0.28.0/general.html#git_tag_message-89"
         ],
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_message-21"
+          "ex/v0.28.0/tag.html#git_tag_message-21"
         ]
       }
     },
@@ -24747,7 +25121,7 @@
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_create-22"
+          "ex/v0.28.0/tag.html#git_tag_create-22"
         ]
       }
     },
@@ -24878,7 +25252,7 @@
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_create_lightweight-23"
+          "ex/v0.28.0/tag.html#git_tag_create_lightweight-23"
         ]
       }
     },
@@ -24910,7 +25284,7 @@
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_delete-24"
+          "ex/v0.28.0/tag.html#git_tag_delete-24"
         ]
       }
     },
@@ -24974,7 +25348,7 @@
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/HEAD/tag.html#git_tag_list_match-25"
+          "ex/v0.28.0/tag.html#git_tag_list_match-25"
         ]
       }
     },
@@ -25685,14 +26059,14 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_lookup-90",
-          "ex/HEAD/general.html#git_tree_lookup-91"
+          "ex/v0.28.0/general.html#git_tree_lookup-90",
+          "ex/v0.28.0/general.html#git_tree_lookup-91"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_tree_lookup-14"
+          "ex/v0.28.0/init.html#git_tree_lookup-14"
         ],
         "merge.c": [
-          "ex/HEAD/merge.html#git_tree_lookup-41"
+          "ex/v0.28.0/merge.html#git_tree_lookup-41"
         ]
       }
     },
@@ -25756,22 +26130,22 @@
       "group": "tree",
       "examples": {
         "diff.c": [
-          "ex/HEAD/diff.html#git_tree_free-17",
-          "ex/HEAD/diff.html#git_tree_free-18"
+          "ex/v0.28.0/diff.html#git_tree_free-17",
+          "ex/v0.28.0/diff.html#git_tree_free-18"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_free-92",
-          "ex/HEAD/general.html#git_tree_free-93"
+          "ex/v0.28.0/general.html#git_tree_free-92",
+          "ex/v0.28.0/general.html#git_tree_free-93"
         ],
         "init.c": [
-          "ex/HEAD/init.html#git_tree_free-15"
+          "ex/v0.28.0/init.html#git_tree_free-15"
         ],
         "log.c": [
-          "ex/HEAD/log.html#git_tree_free-59",
-          "ex/HEAD/log.html#git_tree_free-60",
-          "ex/HEAD/log.html#git_tree_free-61",
-          "ex/HEAD/log.html#git_tree_free-62",
-          "ex/HEAD/log.html#git_tree_free-63"
+          "ex/v0.28.0/log.html#git_tree_free-59",
+          "ex/v0.28.0/log.html#git_tree_free-60",
+          "ex/v0.28.0/log.html#git_tree_free-61",
+          "ex/v0.28.0/log.html#git_tree_free-62",
+          "ex/v0.28.0/log.html#git_tree_free-63"
         ]
       }
     },
@@ -25842,10 +26216,10 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entrycount-41"
+          "ex/v0.28.0/cat-file.html#git_tree_entrycount-41"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entrycount-94"
+          "ex/v0.28.0/general.html#git_tree_entrycount-94"
         ]
       }
     },
@@ -25877,7 +26251,7 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_byname-95"
+          "ex/v0.28.0/general.html#git_tree_entry_byname-95"
         ]
       }
     },
@@ -25909,10 +26283,10 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entry_byindex-42"
+          "ex/v0.28.0/cat-file.html#git_tree_entry_byindex-42"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_byindex-96"
+          "ex/v0.28.0/general.html#git_tree_entry_byindex-96"
         ]
       }
     },
@@ -26047,11 +26421,11 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entry_name-43"
+          "ex/v0.28.0/cat-file.html#git_tree_entry_name-43"
         ],
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_name-97",
-          "ex/HEAD/general.html#git_tree_entry_name-98"
+          "ex/v0.28.0/general.html#git_tree_entry_name-97",
+          "ex/v0.28.0/general.html#git_tree_entry_name-98"
         ]
       }
     },
@@ -26078,7 +26452,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entry_id-44"
+          "ex/v0.28.0/cat-file.html#git_tree_entry_id-44"
         ]
       }
     },
@@ -26097,7 +26471,7 @@
       "argline": "const git_tree_entry *entry",
       "sig": "const git_tree_entry *",
       "return": {
-        "type": "git_otype",
+        "type": "git_object_t",
         "comment": " the type of the pointed object"
       },
       "description": "<p>Get the type of the object pointed by the entry</p>\n",
@@ -26105,7 +26479,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entry_type-45"
+          "ex/v0.28.0/cat-file.html#git_tree_entry_type-45"
         ]
       }
     },
@@ -26132,7 +26506,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/HEAD/cat-file.html#git_tree_entry_filemode-46"
+          "ex/v0.28.0/cat-file.html#git_tree_entry_filemode-46"
         ]
       }
     },
@@ -26218,7 +26592,7 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/HEAD/general.html#git_tree_entry_to_object-99"
+          "ex/v0.28.0/general.html#git_tree_entry_to_object-99"
         ]
       }
     },
@@ -27015,6 +27389,58 @@
     }
   },
   "callbacks": {
+    "git_apply_delta_cb": {
+      "type": "callback",
+      "file": "git2/apply.h",
+      "line": 36,
+      "lineto": 38,
+      "args": [
+        {
+          "name": "delta",
+          "type": "const git_diff_delta *",
+          "comment": "The delta to be applied"
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": "User-specified payload"
+        }
+      ],
+      "argline": "const git_diff_delta *delta, void *payload",
+      "sig": "const git_diff_delta *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>When applying a patch, callback that will be made per delta (file).</p>\n",
+      "comments": "<p>When the callback:\n - returns \n&lt;\n 0, the apply process will be aborted.\n - returns &gt; 0, the delta will not be applied, but the apply process\n      continues\n - returns 0, the delta is applied, and the apply process continues.</p>\n"
+    },
+    "git_apply_hunk_cb": {
+      "type": "callback",
+      "file": "git2/apply.h",
+      "line": 52,
+      "lineto": 54,
+      "args": [
+        {
+          "name": "hunk",
+          "type": "const git_diff_hunk *",
+          "comment": "The hunk to be applied"
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": "User-specified payload"
+        }
+      ],
+      "argline": "const git_diff_hunk *hunk, void *payload",
+      "sig": "const git_diff_hunk *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>When applying a patch, callback that will be made per hunk.</p>\n",
+      "comments": "<p>When the callback:\n - returns \n&lt;\n 0, the apply process will be aborted.\n - returns &gt; 0, the hunk will not be applied, but the apply process\n      continues\n - returns 0, the hunk is applied, and the apply process continues.</p>\n"
+    },
     "git_attr_foreach_cb": {
       "type": "callback",
       "file": "git2/attr.h",
@@ -27461,8 +27887,8 @@
     "git_index_matched_path_cb": {
       "type": "callback",
       "file": "git2/index.h",
-      "line": 146,
-      "lineto": 147,
+      "line": 135,
+      "lineto": 136,
       "args": [
         {
           "name": "path",
@@ -27616,12 +28042,12 @@
         },
         {
           "name": "current",
-          "type": "uint32_t",
+          "type": "int",
           "comment": null
         },
         {
           "name": "total",
-          "type": "uint32_t",
+          "type": "int",
           "comment": null
         },
         {
@@ -27630,8 +28056,8 @@
           "comment": null
         }
       ],
-      "argline": "int stage, uint32_t current, uint32_t total, void *payload",
-      "sig": "int::uint32_t::uint32_t::void *",
+      "argline": "int stage, int current, int total, void *payload",
+      "sig": "int::int::int::void *",
       "return": {
         "type": "int",
         "comment": null
@@ -27694,8 +28120,8 @@
     "git_push_transfer_progress": {
       "type": "callback",
       "file": "git2/remote.h",
-      "line": 351,
-      "lineto": 355,
+      "line": 425,
+      "lineto": 429,
       "args": [
         {
           "name": "current",
@@ -27730,8 +28156,8 @@
     "git_push_negotiation": {
       "type": "callback",
       "file": "git2/remote.h",
-      "line": 386,
-      "lineto": 386,
+      "line": 460,
+      "lineto": 460,
       "args": [
         {
           "name": "updates",
@@ -27761,8 +28187,8 @@
     "git_push_update_reference_cb": {
       "type": "callback",
       "file": "git2/remote.h",
-      "line": 400,
-      "lineto": 400,
+      "line": 474,
+      "lineto": 474,
       "args": [
         {
           "name": "refname",
@@ -27792,8 +28218,8 @@
     "git_repository_fetchhead_foreach_cb": {
       "type": "callback",
       "file": "git2/repository.h",
-      "line": 630,
-      "lineto": 634,
+      "line": 643,
+      "lineto": 647,
       "args": [
         {
           "name": "ref_name",
@@ -27833,8 +28259,8 @@
     "git_repository_mergehead_foreach_cb": {
       "type": "callback",
       "file": "git2/repository.h",
-      "line": 652,
-      "lineto": 653,
+      "line": 665,
+      "lineto": 666,
       "args": [
         {
           "name": "oid",
@@ -28252,7 +28678,7 @@
         },
         {
           "name": "mode_out",
-          "type": "uint32_t *",
+          "type": "int *",
           "comment": null
         },
         {
@@ -28271,8 +28697,8 @@
           "comment": null
         }
       ],
-      "argline": "git_merge_driver *self, const char **path_out, uint32_t *mode_out, git_buf *merged_out, const char *filter_name, const git_merge_driver_source *src",
-      "sig": "git_merge_driver *::const char **::uint32_t *::git_buf *::const char *::const git_merge_driver_source *",
+      "argline": "git_merge_driver *self, const char **path_out, int *mode_out, git_buf *merged_out, const char *filter_name, const git_merge_driver_source *src",
+      "sig": "git_merge_driver *::const char **::int *::git_buf *::const char *::const git_merge_driver_source *",
       "return": {
         "type": "int",
         "comment": null
@@ -28283,8 +28709,8 @@
     "git_stream_cb": {
       "type": "callback",
       "file": "git2/sys/stream.h",
-      "line": 43,
-      "lineto": 43,
+      "line": 117,
+      "lineto": 117,
       "args": [
         {
           "name": "out",
@@ -28314,8 +28740,8 @@
     "git_smart_subtransport_cb": {
       "type": "callback",
       "file": "git2/sys/transport.h",
-      "line": 325,
-      "lineto": 328,
+      "line": 364,
+      "lineto": 367,
       "args": [
         {
           "name": "out",
@@ -28339,7 +28765,7 @@
         "type": "int",
         "comment": null
       },
-      "description": "",
+      "description": "<p>A function which creates a new subtransport for the smart transport </p>\n",
       "comments": ""
     },
     "git_tag_foreach_cb": {
@@ -28633,8 +29059,8 @@
     "git_transfer_progress_cb": {
       "type": "callback",
       "file": "git2/types.h",
-      "line": 274,
-      "lineto": 274,
+      "line": 275,
+      "lineto": 275,
       "args": [
         {
           "name": "stats",
@@ -28659,8 +29085,8 @@
     "git_transport_message_cb": {
       "type": "callback",
       "file": "git2/types.h",
-      "line": 284,
-      "lineto": 284,
+      "line": 285,
+      "lineto": 285,
       "args": [
         {
           "name": "str",
@@ -28690,8 +29116,8 @@
     "git_transport_certificate_check_cb": {
       "type": "callback",
       "file": "git2/types.h",
-      "line": 334,
-      "lineto": 334,
+      "line": 338,
+      "lineto": 338,
       "args": [
         {
           "name": "cert",
@@ -28718,7 +29144,7 @@
       "sig": "git_cert *::int::const char *::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 to proceed with the connection, \n<\n 0 to fail the connection\n         or > 0 to indicate that the callback refused to act and that\n         the existing validity determination should be honored"
       },
       "description": "<p>Callback for the user&#39;s custom certificate checks.</p>\n",
       "comments": ""
@@ -28929,8 +29355,8 @@
         "type": "struct",
         "value": "git_annotated_commit",
         "file": "git2/types.h",
-        "line": 185,
-        "lineto": 185,
+        "line": 186,
+        "lineto": 186,
         "tdef": "typedef",
         "description": " Annotated commits, the input to merge and rebase. ",
         "comments": "",
@@ -28948,9 +29374,103 @@
             "git_branch_create_from_annotated",
             "git_merge",
             "git_merge_analysis",
+            "git_merge_analysis_for_ref",
             "git_rebase_init",
             "git_repository_set_head_detached_from_annotated",
             "git_reset_from_annotated"
+          ]
+        }
+      }
+    ],
+    [
+      "git_apply_location_t",
+      {
+        "decl": [
+          "GIT_APPLY_LOCATION_WORKDIR",
+          "GIT_APPLY_LOCATION_INDEX",
+          "GIT_APPLY_LOCATION_BOTH"
+        ],
+        "type": "enum",
+        "file": "git2/apply.h",
+        "line": 92,
+        "lineto": 110,
+        "block": "GIT_APPLY_LOCATION_WORKDIR\nGIT_APPLY_LOCATION_INDEX\nGIT_APPLY_LOCATION_BOTH",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_APPLY_LOCATION_WORKDIR",
+            "comments": "<p>Apply the patch to the workdir, leaving the index untouched.\n This is the equivalent of <code>git apply</code> with no location argument.</p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_APPLY_LOCATION_INDEX",
+            "comments": "<p>Apply the patch to the index, leaving the working directory\n untouched.  This is the equivalent of <code>git apply --cached</code>.</p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_APPLY_LOCATION_BOTH",
+            "comments": "<p>Apply the patch to both the working directory and the index.\n This is the equivalent of <code>git apply --index</code>.</p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_apply"
+          ]
+        }
+      }
+    ],
+    [
+      "git_apply_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "git_apply_delta_cb delta_cb",
+          "git_apply_hunk_cb hunk_cb",
+          "void * payload"
+        ],
+        "type": "struct",
+        "value": "git_apply_options",
+        "file": "git2/apply.h",
+        "line": 64,
+        "lineto": 70,
+        "block": "unsigned int version\ngit_apply_delta_cb delta_cb\ngit_apply_hunk_cb hunk_cb\nvoid * payload",
+        "tdef": "typedef",
+        "description": " Apply options structure",
+        "comments": "<p>Initialize with <code>GIT_APPLY_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_apply_init_options</code>.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "git_apply_delta_cb",
+            "name": "delta_cb",
+            "comments": ""
+          },
+          {
+            "type": "git_apply_hunk_cb",
+            "name": "hunk_cb",
+            "comments": ""
+          },
+          {
+            "type": "void *",
+            "name": "payload",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_apply",
+            "git_apply_to_tree"
           ]
         }
       }
@@ -29030,7 +29550,6 @@
             "git_blame_free",
             "git_blame_get_hunk_byindex",
             "git_blame_get_hunk_byline",
-            "git_blame_get_hunk_count",
             "git_blame_init_options"
           ]
         }
@@ -29190,8 +29709,8 @@
       {
         "decl": [
           "unsigned int version",
-          "uint32_t flags",
-          "uint16_t min_match_characters",
+          "int flags",
+          "int min_match_characters",
           "git_oid newest_commit",
           "git_oid oldest_commit",
           "size_t min_line",
@@ -29202,10 +29721,10 @@
         "file": "git2/blame.h",
         "line": 59,
         "lineto": 88,
-        "block": "unsigned int version\nuint32_t flags\nuint16_t min_match_characters\ngit_oid newest_commit\ngit_oid oldest_commit\nsize_t min_line\nsize_t max_line",
+        "block": "unsigned int version\nint flags\nint min_match_characters\ngit_oid newest_commit\ngit_oid oldest_commit\nsize_t min_line\nsize_t max_line",
         "tdef": "typedef",
-        "description": " Blame options structure",
-        "comments": "<p>Initialize with <code>GIT_BLAME_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_blame_init_options</code>.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -29213,14 +29732,14 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
-            "comments": " A combination of `git_blame_flag_t` "
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "min_match_characters",
-            "comments": " The lower bound on the number of alphanumeric\n   characters that must be detected as moving/copying within a file for it to\n   associate those lines with the parent commit. The default value is 20.\n   This value only takes effect if any of the `GIT_BLAME_TRACK_COPIES_*`\n   flags are specified."
+            "comments": ""
           },
           {
             "type": "git_oid",
@@ -29259,8 +29778,8 @@
         "type": "struct",
         "value": "git_blob",
         "file": "git2/types.h",
-        "line": 123,
-        "lineto": 123,
+        "line": 121,
+        "lineto": 121,
         "tdef": "typedef",
         "description": " In-memory representation of a blob object. ",
         "comments": "",
@@ -29322,8 +29841,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 202,
-        "lineto": 206,
+        "line": 203,
+        "lineto": 207,
         "block": "GIT_BRANCH_LOCAL\nGIT_BRANCH_REMOTE\nGIT_BRANCH_ALL",
         "tdef": "typedef",
         "description": " Basic type of any Git branch. ",
@@ -29454,8 +29973,8 @@
         "type": "struct",
         "value": "git_cert",
         "file": "git2/types.h",
-        "line": 318,
-        "lineto": 323,
+        "line": 319,
+        "lineto": 324,
         "block": "git_cert_t cert_type",
         "tdef": "typedef",
         "description": " Parent type for `git_cert_hostkey` and `git_cert_x509`.",
@@ -29568,8 +30087,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 290,
-        "lineto": 313,
+        "line": 291,
+        "lineto": 314,
         "block": "GIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY\nGIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY",
         "tdef": "typedef",
         "description": " Type of host certificate structure that is passed to the check callback",
@@ -30275,8 +30794,8 @@
         "type": "struct",
         "value": "git_commit",
         "file": "git2/types.h",
-        "line": 126,
-        "lineto": 126,
+        "line": 124,
+        "lineto": 124,
         "tdef": "typedef",
         "description": " Parsed representation of a commit object. ",
         "comments": "",
@@ -30335,8 +30854,8 @@
         "type": "struct",
         "value": "git_config",
         "file": "git2/types.h",
-        "line": 144,
-        "lineto": 144,
+        "line": 145,
+        "lineto": 145,
         "tdef": "typedef",
         "description": " Memory representation of a set of config files ",
         "comments": "",
@@ -30395,8 +30914,8 @@
         "type": "struct",
         "value": "git_config_backend",
         "file": "git2/types.h",
-        "line": 147,
-        "lineto": 147,
+        "line": 148,
+        "lineto": 148,
         "block": "unsigned int version\nint readonly\nstruct git_config * cfg\nint (*)(struct git_config_backend *, git_config_level_t, const git_repository *) open\nint (*)(struct git_config_backend *, const char *, git_config_entry **) get\nint (*)(struct git_config_backend *, const char *, const char *) set\nint (*)(git_config_backend *, const char *, const char *, const char *) set_multivar\nint (*)(struct git_config_backend *, const char *) del\nint (*)(struct git_config_backend *, const char *, const char *) del_multivar\nint (*)(git_config_iterator **, struct git_config_backend *) iterator\nint (*)(struct git_config_backend **, struct git_config_backend *) snapshot\nint (*)(struct git_config_backend *) lock\nint (*)(struct git_config_backend *, int) unlock\nvoid (*)(struct git_config_backend *) free",
         "tdef": "typedef",
         "description": " Interface to access a configuration file ",
@@ -30455,17 +30974,17 @@
           {
             "type": "int (*)(struct git_config_backend **, struct git_config_backend *)",
             "name": "snapshot",
-            "comments": " Produce a read-only version of this backend "
+            "comments": ""
           },
           {
             "type": "int (*)(struct git_config_backend *)",
             "name": "lock",
-            "comments": " Lock this backend.\n\n Prevent any writes to the data store backing this\n backend. Any updates must not be visible to any other\n readers."
+            "comments": ""
           },
           {
             "type": "int (*)(struct git_config_backend *, int)",
             "name": "unlock",
-            "comments": " Unlock the data store backing this backend. If success is\n true, the changes should be committed, otherwise rolled\n back."
+            "comments": ""
           },
           {
             "type": "void (*)(struct git_config_backend *)",
@@ -30527,7 +31046,7 @@
           {
             "type": "void (*)(struct git_config_entry *)",
             "name": "free",
-            "comments": " Free function for this entry "
+            "comments": ""
           },
           {
             "type": "void *",
@@ -30572,12 +31091,12 @@
           {
             "type": "int (*)(git_config_entry **, git_config_iterator *)",
             "name": "next",
-            "comments": " Return the current entry and advance the iterator. The\n memory belongs to the library."
+            "comments": ""
           },
           {
             "type": "void (*)(git_config_iterator *)",
             "name": "free",
-            "comments": " Free the iterator"
+            "comments": ""
           }
         ],
         "used": {
@@ -31454,6 +31973,10 @@
             "git_pathspec_match_list_diff_entry"
           ],
           "needs": [
+            "git_apply",
+            "git_apply_delta_cb",
+            "git_apply_hunk_cb",
+            "git_apply_to_tree",
             "git_checkout_notify_cb",
             "git_diff_binary_cb",
             "git_diff_blob_to_buffer",
@@ -31649,9 +32172,9 @@
       {
         "decl": [
           "git_delta_t status",
-          "uint32_t flags",
-          "uint16_t similarity",
-          "uint16_t nfiles",
+          "int flags",
+          "int similarity",
+          "int nfiles",
           "git_diff_file old_file",
           "git_diff_file new_file"
         ],
@@ -31660,10 +32183,10 @@
         "file": "git2/diff.h",
         "line": 309,
         "lineto": 316,
-        "block": "git_delta_t status\nuint32_t flags\nuint16_t similarity\nuint16_t nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
+        "block": "git_delta_t status\nint flags\nint similarity\nint nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
         "tdef": "typedef",
-        "description": " Description of changes to one entry.",
-        "comments": "<p>A <code>delta</code> is a file pair with an old and new revision.  The old version\n may be absent if the file was just created and the new version may be\n absent if the file was deleted.  A diff is mostly just a list of deltas.</p>\n\n<p>When iterating over a diff, this will be passed to most callbacks and\n you can use the contents to understand exactly what has changed.</p>\n\n<p>The <code>old_file</code> represents the &quot;from&quot; side of the diff and the <code>new_file</code>\n represents to &quot;to&quot; side of the diff.  What those means depend on the\n function that was used to generate the diff and will be documented below.\n You can also use the <code>GIT_DIFF_REVERSE</code> flag to flip it around.</p>\n\n<p>Although the two sides of the delta are named &quot;old_file&quot; and &quot;new_file&quot;,\n they actually may correspond to entries that represent a file, a symbolic\n link, a submodule commit id, or even a tree (if you are tracking type\n changes or ignored/untracked directories).</p>\n\n<p>Under some circumstances, in the name of efficiency, not all fields will\n be filled in, but we generally try to fill in as much as possible.  One\n example is that the &quot;flags&quot; field may not have either the <code>BINARY</code> or the\n <code>NOT_BINARY</code> flag set to avoid examining file contents if you do not pass\n in hunk and/or line callbacks to the diff foreach iteration function.  It\n will just use the git attributes for those files.</p>\n\n<p>The similarity score is zero unless you call <code>git_diff_find_similar()</code>\n which does a similarity analysis of files in the diff.  Use that\n function to do rename and copy detection, and to split heavily modified\n files in add/delete pairs.  After that call, deltas with a status of\n GIT_DELTA_RENAMED or GIT_DELTA_COPIED will have a similarity score\n between 0 and 100 indicating how similar the old and new sides are.</p>\n\n<p>If you ask <code>git_diff_find_similar</code> to find heavily modified files to\n break, but to not <em>actually</em> break the records, then GIT_DELTA_MODIFIED\n records may have a non-zero similarity score if the self-similarity is\n below the split threshold.  To display this value like core Git, invert\n the score (a la <code>printf(&quot;M%03d&quot;, 100 - delta-&gt;similarity)</code>).</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "git_delta_t",
@@ -31671,19 +32194,19 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
-            "comments": " git_diff_flag_t values "
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "similarity",
-            "comments": " for RENAMED and COPIED, value 0-100 "
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "nfiles",
-            "comments": " number of files in this delta "
+            "comments": ""
           },
           {
             "type": "git_diff_file",
@@ -31703,6 +32226,7 @@
             "git_pathspec_match_list_diff_entry"
           ],
           "needs": [
+            "git_apply_delta_cb",
             "git_diff_binary_cb",
             "git_diff_file_cb",
             "git_diff_hunk_cb",
@@ -31721,19 +32245,19 @@
           "git_oid id",
           "const char * path",
           "git_off_t size",
-          "uint32_t flags",
-          "uint16_t mode",
-          "uint16_t id_abbrev"
+          "int flags",
+          "int mode",
+          "int id_abbrev"
         ],
         "type": "struct",
         "value": "git_diff_file",
         "file": "git2/diff.h",
         "line": 260,
         "lineto": 267,
-        "block": "git_oid id\nconst char * path\ngit_off_t size\nuint32_t flags\nuint16_t mode\nuint16_t id_abbrev",
+        "block": "git_oid id\nconst char * path\ngit_off_t size\nint flags\nint mode\nint id_abbrev",
         "tdef": "typedef",
-        "description": " Description of one side of a delta.",
-        "comments": "<p>Although this is called a &quot;file&quot;, it could represent a file, a symbolic\n link, a submodule commit id, or even a tree (although that only if you\n are tracking type changes or ignored/untracked directories).</p>\n\n<p>The <code>id</code> is the <code>git_oid</code> of the item.  If the entry represents an\n absent side of a diff (e.g. the <code>old_file</code> of a <code>GIT_DELTA_ADDED</code> delta),\n then the oid will be zeroes.</p>\n\n<p><code>path</code> is the NUL-terminated path to the entry relative to the working\n directory of the repository.</p>\n\n<p><code>size</code> is the size of the entry in bytes.</p>\n\n<p><code>flags</code> is a combination of the <code>git_diff_flag_t</code> types</p>\n\n<p><code>mode</code> is, roughly, the stat() <code>st_mode</code> value for the item.  This will\n be restricted to one of the <code>git_filemode_t</code> values.</p>\n\n<p>The <code>id_abbrev</code> represents the known length of the <code>id</code> field, when\n converted to a hex string.  It is generally <code>GIT_OID_HEXSZ</code>, unless this\n delta was created from reading a patch file, in which case it may be\n abbreviated to something reasonable, like 7 characters.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "git_oid",
@@ -31751,17 +32275,17 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "mode",
             "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "id_abbrev",
             "comments": ""
           }
@@ -31783,11 +32307,11 @@
       {
         "decl": [
           "unsigned int version",
-          "uint32_t flags",
-          "uint16_t rename_threshold",
-          "uint16_t rename_from_rewrite_threshold",
-          "uint16_t copy_threshold",
-          "uint16_t break_rewrite_threshold",
+          "int flags",
+          "int rename_threshold",
+          "int rename_from_rewrite_threshold",
+          "int copy_threshold",
+          "int break_rewrite_threshold",
           "size_t rename_limit",
           "git_diff_similarity_metric * metric"
         ],
@@ -31796,10 +32320,10 @@
         "file": "git2/diff.h",
         "line": 718,
         "lineto": 772,
-        "block": "unsigned int version\nuint32_t flags\nuint16_t rename_threshold\nuint16_t rename_from_rewrite_threshold\nuint16_t copy_threshold\nuint16_t break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
+        "block": "unsigned int version\nint flags\nint rename_threshold\nint rename_from_rewrite_threshold\nint copy_threshold\nint break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
         "tdef": "typedef",
-        "description": " Control behavior of rename and copy detection",
-        "comments": "<p>These options mostly mimic parameters that can be passed to git-diff.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -31807,29 +32331,29 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
-            "comments": " Combination of git_diff_find_t values (default GIT_DIFF_FIND_BY_CONFIG).\n NOTE: if you don't explicitly set this, `diff.renames` could be set\n to false, resulting in `git_diff_find_similar` doing nothing."
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "rename_threshold",
-            "comments": " Threshold above which similar files will be considered renames.\n This is equivalent to the -M option. Defaults to 50."
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "rename_from_rewrite_threshold",
-            "comments": " Threshold below which similar files will be eligible to be a rename source.\n This is equivalent to the first part of the -B option. Defaults to 50."
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "copy_threshold",
-            "comments": " Threshold above which similar files will be considered copies.\n This is equivalent to the -C option. Defaults to 50."
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "break_rewrite_threshold",
-            "comments": " Treshold below which similar files will be split into a delete/add pair.\n This is equivalent to the last part of the -B option. Defaults to 60."
+            "comments": ""
           },
           {
             "type": "size_t",
@@ -32257,6 +32781,7 @@
         "used": {
           "returns": [],
           "needs": [
+            "git_apply_hunk_cb",
             "git_diff_blob_to_buffer",
             "git_diff_blobs",
             "git_diff_buffers",
@@ -32665,15 +33190,15 @@
       {
         "decl": [
           "unsigned int version",
-          "uint32_t flags",
+          "int flags",
           "git_submodule_ignore_t ignore_submodules",
           "git_strarray pathspec",
           "git_diff_notify_cb notify_cb",
           "git_diff_progress_cb progress_cb",
           "void * payload",
-          "uint32_t context_lines",
-          "uint32_t interhunk_lines",
-          "uint16_t id_abbrev",
+          "int context_lines",
+          "int interhunk_lines",
+          "int id_abbrev",
           "git_off_t max_size",
           "const char * old_prefix",
           "const char * new_prefix"
@@ -32683,10 +33208,10 @@
         "file": "git2/diff.h",
         "line": 361,
         "lineto": 433,
-        "block": "unsigned int version\nuint32_t flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nuint32_t context_lines\nuint32_t interhunk_lines\nuint16_t id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
+        "block": "unsigned int version\nint flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nint context_lines\nint interhunk_lines\nint id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
         "tdef": "typedef",
-        "description": " Structure describing options about how the diff should be executed.",
-        "comments": "<p>Setting all values of the structure to zero will yield the default\n values.  Similarly, passing NULL for the options structure will\n give the defaults.  The default values are marked below.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -32694,9 +33219,9 @@
             "comments": " version for the struct "
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
-            "comments": " A combination of `git_diff_option_t` values above.\n Defaults to GIT_DIFF_NORMAL"
+            "comments": ""
           },
           {
             "type": "git_submodule_ignore_t",
@@ -32724,19 +33249,19 @@
             "comments": " The payload to pass to the callback functions. "
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "context_lines",
-            "comments": " The number of unchanged lines that define the boundary of a hunk\n (and to display before and after). Defaults to 3."
+            "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "interhunk_lines",
-            "comments": " The maximum number of unchanged lines between hunk boundaries before\n the hunks will be merged into one. Defaults to 0."
+            "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "id_abbrev",
-            "comments": " The abbreviation length to use when formatting object ids.\n Defaults to the value of 'core.abbrev' from the config, or 7 if unset."
+            "comments": ""
           },
           {
             "type": "git_off_t",
@@ -33034,8 +33559,8 @@
         "type": "struct",
         "value": "git_error",
         "file": "git2/errors.h",
-        "line": 68,
-        "lineto": 71,
+        "line": 69,
+        "lineto": 72,
         "block": "char * message\nint klass",
         "tdef": "typedef",
         "description": " Structure to store extra details of the last error that occurred.",
@@ -33054,6 +33579,7 @@
         ],
         "used": {
           "returns": [
+            "git_error_last",
             "giterr_last"
           ],
           "needs": []
@@ -33092,13 +33618,14 @@
           "GIT_ITEROVER",
           "GIT_RETRY",
           "GIT_EMISMATCH",
-          "GIT_EINDEXDIRTY"
+          "GIT_EINDEXDIRTY",
+          "GIT_EAPPLYFAIL"
         ],
         "type": "enum",
         "file": "git2/errors.h",
         "line": 21,
-        "lineto": 60,
-        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER\nGIT_RETRY\nGIT_EMISMATCH\nGIT_EINDEXDIRTY",
+        "lineto": 61,
+        "block": "GIT_OK\nGIT_ERROR\nGIT_ENOTFOUND\nGIT_EEXISTS\nGIT_EAMBIGUOUS\nGIT_EBUFS\nGIT_EUSER\nGIT_EBAREREPO\nGIT_EUNBORNBRANCH\nGIT_EUNMERGED\nGIT_ENONFASTFORWARD\nGIT_EINVALIDSPEC\nGIT_ECONFLICT\nGIT_ELOCKED\nGIT_EMODIFIED\nGIT_EAUTH\nGIT_ECERTIFICATE\nGIT_EAPPLIED\nGIT_EPEEL\nGIT_EEOF\nGIT_EINVALID\nGIT_EUNCOMMITTED\nGIT_EDIRECTORY\nGIT_EMERGECONFLICT\nGIT_PASSTHROUGH\nGIT_ITEROVER\nGIT_RETRY\nGIT_EMISMATCH\nGIT_EINDEXDIRTY\nGIT_EAPPLYFAIL",
         "tdef": "typedef",
         "description": " Generic return codes ",
         "comments": "",
@@ -33250,7 +33777,7 @@
           {
             "type": "int",
             "name": "GIT_PASSTHROUGH",
-            "comments": "<p>Internal only </p>\n",
+            "comments": "<p>A user-configured callback refused to act </p>\n",
             "value": -30
           },
           {
@@ -33276,6 +33803,12 @@
             "name": "GIT_EINDEXDIRTY",
             "comments": "<p>Unsaved changes in the index would be overwritten </p>\n",
             "value": -34
+          },
+          {
+            "type": "int",
+            "name": "GIT_EAPPLYFAIL",
+            "comments": "<p>Patch application failed </p>\n",
+            "value": -35
           }
         ],
         "used": {
@@ -33288,251 +33821,251 @@
       "git_error_t",
       {
         "decl": [
-          "GITERR_NONE",
-          "GITERR_NOMEMORY",
-          "GITERR_OS",
-          "GITERR_INVALID",
-          "GITERR_REFERENCE",
-          "GITERR_ZLIB",
-          "GITERR_REPOSITORY",
-          "GITERR_CONFIG",
-          "GITERR_REGEX",
-          "GITERR_ODB",
-          "GITERR_INDEX",
-          "GITERR_OBJECT",
-          "GITERR_NET",
-          "GITERR_TAG",
-          "GITERR_TREE",
-          "GITERR_INDEXER",
-          "GITERR_SSL",
-          "GITERR_SUBMODULE",
-          "GITERR_THREAD",
-          "GITERR_STASH",
-          "GITERR_CHECKOUT",
-          "GITERR_FETCHHEAD",
-          "GITERR_MERGE",
-          "GITERR_SSH",
-          "GITERR_FILTER",
-          "GITERR_REVERT",
-          "GITERR_CALLBACK",
-          "GITERR_CHERRYPICK",
-          "GITERR_DESCRIBE",
-          "GITERR_REBASE",
-          "GITERR_FILESYSTEM",
-          "GITERR_PATCH",
-          "GITERR_WORKTREE",
-          "GITERR_SHA1"
+          "GIT_ERROR_NONE",
+          "GIT_ERROR_NOMEMORY",
+          "GIT_ERROR_OS",
+          "GIT_ERROR_INVALID",
+          "GIT_ERROR_REFERENCE",
+          "GIT_ERROR_ZLIB",
+          "GIT_ERROR_REPOSITORY",
+          "GIT_ERROR_CONFIG",
+          "GIT_ERROR_REGEX",
+          "GIT_ERROR_ODB",
+          "GIT_ERROR_INDEX",
+          "GIT_ERROR_OBJECT",
+          "GIT_ERROR_NET",
+          "GIT_ERROR_TAG",
+          "GIT_ERROR_TREE",
+          "GIT_ERROR_INDEXER",
+          "GIT_ERROR_SSL",
+          "GIT_ERROR_SUBMODULE",
+          "GIT_ERROR_THREAD",
+          "GIT_ERROR_STASH",
+          "GIT_ERROR_CHECKOUT",
+          "GIT_ERROR_FETCHHEAD",
+          "GIT_ERROR_MERGE",
+          "GIT_ERROR_SSH",
+          "GIT_ERROR_FILTER",
+          "GIT_ERROR_REVERT",
+          "GIT_ERROR_CALLBACK",
+          "GIT_ERROR_CHERRYPICK",
+          "GIT_ERROR_DESCRIBE",
+          "GIT_ERROR_REBASE",
+          "GIT_ERROR_FILESYSTEM",
+          "GIT_ERROR_PATCH",
+          "GIT_ERROR_WORKTREE",
+          "GIT_ERROR_SHA1"
         ],
         "type": "enum",
         "file": "git2/errors.h",
-        "line": 74,
-        "lineto": 109,
-        "block": "GITERR_NONE\nGITERR_NOMEMORY\nGITERR_OS\nGITERR_INVALID\nGITERR_REFERENCE\nGITERR_ZLIB\nGITERR_REPOSITORY\nGITERR_CONFIG\nGITERR_REGEX\nGITERR_ODB\nGITERR_INDEX\nGITERR_OBJECT\nGITERR_NET\nGITERR_TAG\nGITERR_TREE\nGITERR_INDEXER\nGITERR_SSL\nGITERR_SUBMODULE\nGITERR_THREAD\nGITERR_STASH\nGITERR_CHECKOUT\nGITERR_FETCHHEAD\nGITERR_MERGE\nGITERR_SSH\nGITERR_FILTER\nGITERR_REVERT\nGITERR_CALLBACK\nGITERR_CHERRYPICK\nGITERR_DESCRIBE\nGITERR_REBASE\nGITERR_FILESYSTEM\nGITERR_PATCH\nGITERR_WORKTREE\nGITERR_SHA1",
+        "line": 75,
+        "lineto": 110,
+        "block": "GIT_ERROR_NONE\nGIT_ERROR_NOMEMORY\nGIT_ERROR_OS\nGIT_ERROR_INVALID\nGIT_ERROR_REFERENCE\nGIT_ERROR_ZLIB\nGIT_ERROR_REPOSITORY\nGIT_ERROR_CONFIG\nGIT_ERROR_REGEX\nGIT_ERROR_ODB\nGIT_ERROR_INDEX\nGIT_ERROR_OBJECT\nGIT_ERROR_NET\nGIT_ERROR_TAG\nGIT_ERROR_TREE\nGIT_ERROR_INDEXER\nGIT_ERROR_SSL\nGIT_ERROR_SUBMODULE\nGIT_ERROR_THREAD\nGIT_ERROR_STASH\nGIT_ERROR_CHECKOUT\nGIT_ERROR_FETCHHEAD\nGIT_ERROR_MERGE\nGIT_ERROR_SSH\nGIT_ERROR_FILTER\nGIT_ERROR_REVERT\nGIT_ERROR_CALLBACK\nGIT_ERROR_CHERRYPICK\nGIT_ERROR_DESCRIBE\nGIT_ERROR_REBASE\nGIT_ERROR_FILESYSTEM\nGIT_ERROR_PATCH\nGIT_ERROR_WORKTREE\nGIT_ERROR_SHA1",
         "tdef": "typedef",
         "description": " Error classes ",
         "comments": "",
         "fields": [
           {
             "type": "int",
-            "name": "GITERR_NONE",
+            "name": "GIT_ERROR_NONE",
             "comments": "",
             "value": 0
           },
           {
             "type": "int",
-            "name": "GITERR_NOMEMORY",
+            "name": "GIT_ERROR_NOMEMORY",
             "comments": "",
             "value": 1
           },
           {
             "type": "int",
-            "name": "GITERR_OS",
+            "name": "GIT_ERROR_OS",
             "comments": "",
             "value": 2
           },
           {
             "type": "int",
-            "name": "GITERR_INVALID",
+            "name": "GIT_ERROR_INVALID",
             "comments": "",
             "value": 3
           },
           {
             "type": "int",
-            "name": "GITERR_REFERENCE",
+            "name": "GIT_ERROR_REFERENCE",
             "comments": "",
             "value": 4
           },
           {
             "type": "int",
-            "name": "GITERR_ZLIB",
+            "name": "GIT_ERROR_ZLIB",
             "comments": "",
             "value": 5
           },
           {
             "type": "int",
-            "name": "GITERR_REPOSITORY",
+            "name": "GIT_ERROR_REPOSITORY",
             "comments": "",
             "value": 6
           },
           {
             "type": "int",
-            "name": "GITERR_CONFIG",
+            "name": "GIT_ERROR_CONFIG",
             "comments": "",
             "value": 7
           },
           {
             "type": "int",
-            "name": "GITERR_REGEX",
+            "name": "GIT_ERROR_REGEX",
             "comments": "",
             "value": 8
           },
           {
             "type": "int",
-            "name": "GITERR_ODB",
+            "name": "GIT_ERROR_ODB",
             "comments": "",
             "value": 9
           },
           {
             "type": "int",
-            "name": "GITERR_INDEX",
+            "name": "GIT_ERROR_INDEX",
             "comments": "",
             "value": 10
           },
           {
             "type": "int",
-            "name": "GITERR_OBJECT",
+            "name": "GIT_ERROR_OBJECT",
             "comments": "",
             "value": 11
           },
           {
             "type": "int",
-            "name": "GITERR_NET",
+            "name": "GIT_ERROR_NET",
             "comments": "",
             "value": 12
           },
           {
             "type": "int",
-            "name": "GITERR_TAG",
+            "name": "GIT_ERROR_TAG",
             "comments": "",
             "value": 13
           },
           {
             "type": "int",
-            "name": "GITERR_TREE",
+            "name": "GIT_ERROR_TREE",
             "comments": "",
             "value": 14
           },
           {
             "type": "int",
-            "name": "GITERR_INDEXER",
+            "name": "GIT_ERROR_INDEXER",
             "comments": "",
             "value": 15
           },
           {
             "type": "int",
-            "name": "GITERR_SSL",
+            "name": "GIT_ERROR_SSL",
             "comments": "",
             "value": 16
           },
           {
             "type": "int",
-            "name": "GITERR_SUBMODULE",
+            "name": "GIT_ERROR_SUBMODULE",
             "comments": "",
             "value": 17
           },
           {
             "type": "int",
-            "name": "GITERR_THREAD",
+            "name": "GIT_ERROR_THREAD",
             "comments": "",
             "value": 18
           },
           {
             "type": "int",
-            "name": "GITERR_STASH",
+            "name": "GIT_ERROR_STASH",
             "comments": "",
             "value": 19
           },
           {
             "type": "int",
-            "name": "GITERR_CHECKOUT",
+            "name": "GIT_ERROR_CHECKOUT",
             "comments": "",
             "value": 20
           },
           {
             "type": "int",
-            "name": "GITERR_FETCHHEAD",
+            "name": "GIT_ERROR_FETCHHEAD",
             "comments": "",
             "value": 21
           },
           {
             "type": "int",
-            "name": "GITERR_MERGE",
+            "name": "GIT_ERROR_MERGE",
             "comments": "",
             "value": 22
           },
           {
             "type": "int",
-            "name": "GITERR_SSH",
+            "name": "GIT_ERROR_SSH",
             "comments": "",
             "value": 23
           },
           {
             "type": "int",
-            "name": "GITERR_FILTER",
+            "name": "GIT_ERROR_FILTER",
             "comments": "",
             "value": 24
           },
           {
             "type": "int",
-            "name": "GITERR_REVERT",
+            "name": "GIT_ERROR_REVERT",
             "comments": "",
             "value": 25
           },
           {
             "type": "int",
-            "name": "GITERR_CALLBACK",
+            "name": "GIT_ERROR_CALLBACK",
             "comments": "",
             "value": 26
           },
           {
             "type": "int",
-            "name": "GITERR_CHERRYPICK",
+            "name": "GIT_ERROR_CHERRYPICK",
             "comments": "",
             "value": 27
           },
           {
             "type": "int",
-            "name": "GITERR_DESCRIBE",
+            "name": "GIT_ERROR_DESCRIBE",
             "comments": "",
             "value": 28
           },
           {
             "type": "int",
-            "name": "GITERR_REBASE",
+            "name": "GIT_ERROR_REBASE",
             "comments": "",
             "value": 29
           },
           {
             "type": "int",
-            "name": "GITERR_FILESYSTEM",
+            "name": "GIT_ERROR_FILESYSTEM",
             "comments": "",
             "value": 30
           },
           {
             "type": "int",
-            "name": "GITERR_PATCH",
+            "name": "GIT_ERROR_PATCH",
             "comments": "",
             "value": 31
           },
           {
             "type": "int",
-            "name": "GITERR_WORKTREE",
+            "name": "GIT_ERROR_WORKTREE",
             "comments": "",
             "value": 32
           },
           {
             "type": "int",
-            "name": "GITERR_SHA1",
+            "name": "GIT_ERROR_SHA1",
             "comments": "",
             "value": 33
           }
@@ -33554,8 +34087,8 @@
         ],
         "type": "enum",
         "file": "git2/common.h",
-        "line": 122,
-        "lineto": 145,
+        "line": 130,
+        "lineto": 153,
         "block": "GIT_FEATURE_THREADS\nGIT_FEATURE_HTTPS\nGIT_FEATURE_SSH\nGIT_FEATURE_NSEC",
         "tdef": "typedef",
         "description": " Combinations of these values describe the features with which libgit2\n was compiled",
@@ -33607,8 +34140,8 @@
         "type": "struct",
         "value": "git_fetch_options",
         "file": "git2/remote.h",
-        "line": 555,
-        "lineto": 592,
+        "line": 629,
+        "lineto": 666,
         "block": "int version\ngit_remote_callbacks callbacks\ngit_fetch_prune_t prune\nint update_fetchhead\ngit_remote_autotag_option_t download_tags\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Fetch options structure.",
@@ -33670,8 +34203,8 @@
         ],
         "type": "enum",
         "file": "git2/remote.h",
-        "line": 507,
-        "lineto": 520,
+        "line": 581,
+        "lineto": 594,
         "block": "GIT_FETCH_PRUNE_UNSPECIFIED\nGIT_FETCH_PRUNE\nGIT_FETCH_NO_PRUNE",
         "tdef": "typedef",
         "description": "",
@@ -33715,8 +34248,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 209,
-        "lineto": 216,
+        "line": 210,
+        "lineto": 217,
         "block": "GIT_FILEMODE_UNREADABLE\nGIT_FILEMODE_TREE\nGIT_FILEMODE_BLOB\nGIT_FILEMODE_BLOB_EXECUTABLE\nGIT_FILEMODE_LINK\nGIT_FILEMODE_COMMIT",
         "tdef": "typedef",
         "description": " Valid modes for index and tree entries. ",
@@ -33849,8 +34382,6 @@
             "git_filter_list_stream_file",
             "git_filter_register",
             "git_filter_shutdown_fn",
-            "git_filter_source_filemode",
-            "git_filter_source_flags",
             "git_filter_source_id",
             "git_filter_source_mode",
             "git_filter_source_path",
@@ -33999,8 +34530,6 @@
           "needs": [
             "git_filter_apply_fn",
             "git_filter_check_fn",
-            "git_filter_source_filemode",
-            "git_filter_source_flags",
             "git_filter_source_id",
             "git_filter_source_mode",
             "git_filter_source_path",
@@ -34087,133 +34616,14 @@
       }
     ],
     [
-      "git_idxentry_extended_flag_t",
-      {
-        "decl": [
-          "GIT_IDXENTRY_INTENT_TO_ADD",
-          "GIT_IDXENTRY_SKIP_WORKTREE",
-          "GIT_IDXENTRY_EXTENDED2",
-          "GIT_IDXENTRY_EXTENDED_FLAGS",
-          "GIT_IDXENTRY_UPDATE",
-          "GIT_IDXENTRY_REMOVE",
-          "GIT_IDXENTRY_UPTODATE",
-          "GIT_IDXENTRY_ADDED",
-          "GIT_IDXENTRY_HASHED",
-          "GIT_IDXENTRY_UNHASHED",
-          "GIT_IDXENTRY_WT_REMOVE",
-          "GIT_IDXENTRY_CONFLICTED",
-          "GIT_IDXENTRY_UNPACKED",
-          "GIT_IDXENTRY_NEW_SKIP_WORKTREE"
-        ],
-        "type": "enum",
-        "file": "git2/index.h",
-        "line": 115,
-        "lineto": 135,
-        "block": "GIT_IDXENTRY_INTENT_TO_ADD\nGIT_IDXENTRY_SKIP_WORKTREE\nGIT_IDXENTRY_EXTENDED2\nGIT_IDXENTRY_EXTENDED_FLAGS\nGIT_IDXENTRY_UPDATE\nGIT_IDXENTRY_REMOVE\nGIT_IDXENTRY_UPTODATE\nGIT_IDXENTRY_ADDED\nGIT_IDXENTRY_HASHED\nGIT_IDXENTRY_UNHASHED\nGIT_IDXENTRY_WT_REMOVE\nGIT_IDXENTRY_CONFLICTED\nGIT_IDXENTRY_UNPACKED\nGIT_IDXENTRY_NEW_SKIP_WORKTREE",
-        "tdef": "typedef",
-        "description": " Bitmasks for on-disk fields of `git_index_entry`'s `flags_extended`",
-        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the\n fields that are read from and written to disk, and other fields that\n in-memory only and used by libgit2.  Only the flags in\n <code>GIT_IDXENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the\n <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You\n can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code>\n <code>flags_extended</code> value that are only used in-memory by libgit2.\n You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_INTENT_TO_ADD",
-            "comments": "",
-            "value": 8192
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_SKIP_WORKTREE",
-            "comments": "",
-            "value": 16384
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_EXTENDED2",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 32768
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_EXTENDED_FLAGS",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 24576
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_UPDATE",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 1
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_REMOVE",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 2
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_UPTODATE",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 4
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_ADDED",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 8
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_HASHED",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 16
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_UNHASHED",
-            "comments": "<p>Reserved for future extension </p>\n",
-            "value": 32
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_WT_REMOVE",
-            "comments": "<p>remove in work directory </p>\n",
-            "value": 64
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_CONFLICTED",
-            "comments": "",
-            "value": 128
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_UNPACKED",
-            "comments": "",
-            "value": 256
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_NEW_SKIP_WORKTREE",
-            "comments": "",
-            "value": 512
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
       "git_index",
       {
         "decl": "git_index",
         "type": "struct",
         "value": "git_index",
         "file": "git2/types.h",
-        "line": 138,
-        "lineto": 138,
+        "line": 136,
+        "lineto": 136,
         "tdef": "typedef",
         "description": " Memory representation of an index file. ",
         "comments": "",
@@ -34230,6 +34640,7 @@
             "git_merge_driver_source_theirs"
           ],
           "needs": [
+            "git_apply_to_tree",
             "git_checkout_index",
             "git_cherrypick_commit",
             "git_diff_index_to_index",
@@ -34258,6 +34669,9 @@
             "git_index_get_byindex",
             "git_index_get_bypath",
             "git_index_has_conflicts",
+            "git_index_iterator_free",
+            "git_index_iterator_new",
+            "git_index_iterator_next",
             "git_index_name_add",
             "git_index_name_clear",
             "git_index_name_entrycount",
@@ -34315,8 +34729,8 @@
         ],
         "type": "enum",
         "file": "git2/index.h",
-        "line": 150,
-        "lineto": 155,
+        "line": 139,
+        "lineto": 144,
         "block": "GIT_INDEX_ADD_DEFAULT\nGIT_INDEX_ADD_FORCE\nGIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH\nGIT_INDEX_ADD_CHECK_PATHSPEC",
         "tdef": "typedef",
         "description": " Flags for APIs that add files matching pathspec ",
@@ -34354,14 +34768,63 @@
       }
     ],
     [
+      "git_index_capability_t",
+      {
+        "decl": [
+          "GIT_INDEX_CAPABILITY_IGNORE_CASE",
+          "GIT_INDEX_CAPABILITY_NO_FILEMODE",
+          "GIT_INDEX_CAPABILITY_NO_SYMLINKS",
+          "GIT_INDEX_CAPABILITY_FROM_OWNER"
+        ],
+        "type": "enum",
+        "file": "git2/index.h",
+        "line": 126,
+        "lineto": 131,
+        "block": "GIT_INDEX_CAPABILITY_IGNORE_CASE\nGIT_INDEX_CAPABILITY_NO_FILEMODE\nGIT_INDEX_CAPABILITY_NO_SYMLINKS\nGIT_INDEX_CAPABILITY_FROM_OWNER",
+        "tdef": "typedef",
+        "description": " Capabilities of system that affect index actions. ",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_INDEX_CAPABILITY_IGNORE_CASE",
+            "comments": "",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_CAPABILITY_NO_FILEMODE",
+            "comments": "",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_CAPABILITY_NO_SYMLINKS",
+            "comments": "",
+            "value": 4
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_CAPABILITY_FROM_OWNER",
+            "comments": "",
+            "value": -1
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_index_conflict_iterator",
       {
         "decl": "git_index_conflict_iterator",
         "type": "struct",
         "value": "git_index_conflict_iterator",
         "file": "git2/types.h",
-        "line": 141,
-        "lineto": 141,
+        "line": 142,
+        "lineto": 142,
         "tdef": "typedef",
         "description": " An iterator for conflicts in the index. ",
         "comments": "",
@@ -34382,15 +34845,15 @@
         "decl": [
           "git_index_time ctime",
           "git_index_time mtime",
-          "uint32_t dev",
-          "uint32_t ino",
-          "uint32_t mode",
-          "uint32_t uid",
-          "uint32_t gid",
-          "uint32_t file_size",
+          "int dev",
+          "int ino",
+          "int mode",
+          "int uid",
+          "int gid",
+          "int file_size",
           "git_oid id",
-          "uint16_t flags",
-          "uint16_t flags_extended",
+          "int flags",
+          "int flags_extended",
           "const char * path"
         ],
         "type": "struct",
@@ -34398,10 +34861,10 @@
         "file": "git2/index.h",
         "line": 53,
         "lineto": 70,
-        "block": "git_index_time ctime\ngit_index_time mtime\nuint32_t dev\nuint32_t ino\nuint32_t mode\nuint32_t uid\nuint32_t gid\nuint32_t file_size\ngit_oid id\nuint16_t flags\nuint16_t flags_extended\nconst char * path",
+        "block": "git_index_time ctime\ngit_index_time mtime\nint dev\nint ino\nint mode\nint uid\nint gid\nint file_size\ngit_oid id\nint flags\nint flags_extended\nconst char * path",
         "tdef": "typedef",
-        "description": " In-memory representation of a file entry in the index.",
-        "comments": "<p>This is a public structure that represents a file entry in the index.\n The meaning of the fields corresponds to core Git&#39;s documentation (in\n &quot;Documentation/technical/index-format.txt&quot;).</p>\n\n<p>The <code>flags</code> field consists of a number of bit fields which can be\n accessed via the first set of <code>GIT_IDXENTRY_...</code> bitmasks below.  These\n flags are all read from and persisted to disk.</p>\n\n<p>The <code>flags_extended</code> field also has a number of bit fields which can be\n accessed via the later <code>GIT_IDXENTRY_...</code> bitmasks below.  Some of\n these flags are read from and written to disk, but some are set aside\n for in-memory only reference.</p>\n\n<p>Note that the time and size fields are truncated to 32 bits. This\n is enough to detect changes, which is enough for the index to\n function as a cache, but it should not be taken as an authoritative\n source for that data.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "git_index_time",
@@ -34414,32 +34877,32 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "dev",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "ino",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "mode",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "uid",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "gid",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "file_size",
             "comments": ""
           },
@@ -34449,12 +34912,12 @@
             "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "uint16_t",
+            "type": "int",
             "name": "flags_extended",
             "comments": ""
           },
@@ -34480,7 +34943,115 @@
             "git_index_conflict_next",
             "git_index_entry_is_conflict",
             "git_index_entry_stage",
+            "git_index_iterator_next",
             "git_merge_file_from_index"
+          ]
+        }
+      }
+    ],
+    [
+      "git_index_entry_extended_flag_t",
+      {
+        "decl": [
+          "GIT_INDEX_ENTRY_INTENT_TO_ADD",
+          "GIT_INDEX_ENTRY_SKIP_WORKTREE",
+          "GIT_INDEX_ENTRY_EXTENDED_FLAGS",
+          "GIT_INDEX_ENTRY_UPTODATE"
+        ],
+        "type": "enum",
+        "file": "git2/index.h",
+        "line": 116,
+        "lineto": 123,
+        "block": "GIT_INDEX_ENTRY_INTENT_TO_ADD\nGIT_INDEX_ENTRY_SKIP_WORKTREE\nGIT_INDEX_ENTRY_EXTENDED_FLAGS\nGIT_INDEX_ENTRY_UPTODATE",
+        "tdef": "typedef",
+        "description": " Bitmasks for on-disk fields of `git_index_entry`'s `flags_extended`",
+        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the\n fields that are read from and written to disk, and other fields that\n in-memory only and used by libgit2.  Only the flags in\n <code>GIT_INDEX_ENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the\n <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You\n can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code>\n <code>flags_extended</code> value that are only used in-memory by libgit2.\n You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_INTENT_TO_ADD",
+            "comments": "",
+            "value": 8192
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_SKIP_WORKTREE",
+            "comments": "",
+            "value": 16384
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_EXTENDED_FLAGS",
+            "comments": "",
+            "value": 24576
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_UPTODATE",
+            "comments": "",
+            "value": 4
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_index_entry_flag_t",
+      {
+        "decl": [
+          "GIT_INDEX_ENTRY_EXTENDED",
+          "GIT_INDEX_ENTRY_VALID"
+        ],
+        "type": "enum",
+        "file": "git2/index.h",
+        "line": 87,
+        "lineto": 90,
+        "block": "GIT_INDEX_ENTRY_EXTENDED\nGIT_INDEX_ENTRY_VALID",
+        "tdef": "typedef",
+        "description": " Flags for index entries",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_EXTENDED",
+            "comments": "",
+            "value": 16384
+          },
+          {
+            "type": "int",
+            "name": "GIT_INDEX_ENTRY_VALID",
+            "comments": "",
+            "value": 32768
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_index_iterator",
+      {
+        "decl": "git_index_iterator",
+        "type": "struct",
+        "value": "git_index_iterator",
+        "file": "git2/types.h",
+        "line": 139,
+        "lineto": 139,
+        "tdef": "typedef",
+        "description": " An iterator for entries in the index. ",
+        "comments": "",
+        "fields": [],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_index_iterator_free",
+            "git_index_iterator_new",
+            "git_index_iterator_next"
           ]
         }
       }
@@ -34531,7 +35102,7 @@
       "git_index_reuc_entry",
       {
         "decl": [
-          "uint32_t [3] mode",
+          "int [3] mode",
           "git_oid [3] oid",
           "char * path"
         ],
@@ -34540,13 +35111,13 @@
         "file": "git2/sys/index.h",
         "line": 30,
         "lineto": 34,
-        "block": "uint32_t [3] mode\ngit_oid [3] oid\nchar * path",
+        "block": "int [3] mode\ngit_oid [3] oid\nchar * path",
         "tdef": "typedef",
-        "description": " Representation of a resolve undo entry in the index. ",
+        "description": "",
         "comments": "",
         "fields": [
           {
-            "type": "uint32_t [3]",
+            "type": "int [3]",
             "name": "mode",
             "comments": ""
           },
@@ -34582,8 +35153,8 @@
         ],
         "type": "enum",
         "file": "git2/index.h",
-        "line": 157,
-        "lineto": 177,
+        "line": 146,
+        "lineto": 166,
         "block": "GIT_INDEX_STAGE_ANY\nGIT_INDEX_STAGE_NORMAL\nGIT_INDEX_STAGE_ANCESTOR\nGIT_INDEX_STAGE_OURS\nGIT_INDEX_STAGE_THEIRS",
         "tdef": "typedef",
         "description": "",
@@ -34630,77 +35201,28 @@
       "git_index_time",
       {
         "decl": [
-          "int32_t seconds",
-          "uint32_t nanoseconds"
+          "int seconds",
+          "int nanoseconds"
         ],
         "type": "struct",
         "value": "git_index_time",
         "file": "git2/index.h",
         "line": 26,
         "lineto": 30,
-        "block": "int32_t seconds\nuint32_t nanoseconds",
+        "block": "int seconds\nint nanoseconds",
         "tdef": "typedef",
-        "description": " Time structure used in a git index entry ",
+        "description": "",
         "comments": "",
         "fields": [
           {
-            "type": "int32_t",
+            "type": "int",
             "name": "seconds",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "nanoseconds",
             "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "git_indexcap_t",
-      {
-        "decl": [
-          "GIT_INDEXCAP_IGNORE_CASE",
-          "GIT_INDEXCAP_NO_FILEMODE",
-          "GIT_INDEXCAP_NO_SYMLINKS",
-          "GIT_INDEXCAP_FROM_OWNER"
-        ],
-        "type": "enum",
-        "file": "git2/index.h",
-        "line": 138,
-        "lineto": 143,
-        "block": "GIT_INDEXCAP_IGNORE_CASE\nGIT_INDEXCAP_NO_FILEMODE\nGIT_INDEXCAP_NO_SYMLINKS\nGIT_INDEXCAP_FROM_OWNER",
-        "tdef": "typedef",
-        "description": " Capabilities of system that affect index actions. ",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_INDEXCAP_IGNORE_CASE",
-            "comments": "",
-            "value": 1
-          },
-          {
-            "type": "int",
-            "name": "GIT_INDEXCAP_NO_FILEMODE",
-            "comments": "",
-            "value": 2
-          },
-          {
-            "type": "int",
-            "name": "GIT_INDEXCAP_NO_SYMLINKS",
-            "comments": "",
-            "value": 4
-          },
-          {
-            "type": "int",
-            "name": "GIT_INDEXCAP_FROM_OWNER",
-            "comments": "",
-            "value": -1
           }
         ],
         "used": {
@@ -34785,41 +35307,6 @@
       }
     ],
     [
-      "git_indxentry_flag_t",
-      {
-        "decl": [
-          "GIT_IDXENTRY_EXTENDED",
-          "GIT_IDXENTRY_VALID"
-        ],
-        "type": "enum",
-        "file": "git2/index.h",
-        "line": 86,
-        "lineto": 89,
-        "block": "GIT_IDXENTRY_EXTENDED\nGIT_IDXENTRY_VALID",
-        "tdef": "typedef",
-        "description": " Flags for index entries",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_EXTENDED",
-            "comments": "",
-            "value": 16384
-          },
-          {
-            "type": "int",
-            "name": "GIT_IDXENTRY_VALID",
-            "comments": "",
-            "value": 32768
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
       "git_iterator",
       {
         "decl": [],
@@ -34872,8 +35359,8 @@
         ],
         "type": "enum",
         "file": "git2/common.h",
-        "line": 173,
-        "lineto": 201,
+        "line": 181,
+        "lineto": 209,
         "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION\nGIT_OPT_SET_ALLOCATOR\nGIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY\nGIT_OPT_GET_PACK_MAX_OBJECTS\nGIT_OPT_SET_PACK_MAX_OBJECTS",
         "tdef": "typedef",
         "description": " Global library options",
@@ -35055,8 +35542,8 @@
         "type": "struct",
         "value": "git_mailmap",
         "file": "git2/types.h",
-        "line": 438,
-        "lineto": 438,
+        "line": 442,
+        "lineto": 442,
         "tdef": "typedef",
         "description": " Representation of .mailmap file state. ",
         "comments": "",
@@ -35130,7 +35617,8 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_merge_analysis"
+            "git_merge_analysis",
+            "git_merge_analysis_for_ref"
           ]
         }
       }
@@ -35698,7 +36186,8 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_merge_analysis"
+            "git_merge_analysis",
+            "git_merge_analysis_for_ref"
           ]
         }
       }
@@ -35790,8 +36279,8 @@
         "type": "struct",
         "value": "git_note",
         "file": "git2/types.h",
-        "line": 156,
-        "lineto": 156,
+        "line": 157,
+        "lineto": 157,
         "tdef": "typedef",
         "description": " Representation of a git note ",
         "comments": "",
@@ -35845,17 +36334,24 @@
         "type": "struct",
         "value": "git_object",
         "file": "git2/types.h",
-        "line": 114,
-        "lineto": 114,
+        "line": 112,
+        "lineto": 112,
         "tdef": "typedef",
         "description": " Representation of a generic object in a repository ",
         "comments": "",
         "fields": [],
         "used": {
-          "returns": [],
+          "returns": [
+            "git_object_string2type",
+            "git_object_type",
+            "git_odb_object_type",
+            "git_tag_target_type",
+            "git_tree_entry_type"
+          ],
           "needs": [
             "git_checkout_tree",
             "git_describe_commit",
+            "git_object__size",
             "git_object_dup",
             "git_object_free",
             "git_object_id",
@@ -35866,7 +36362,16 @@
             "git_object_peel",
             "git_object_short_id",
             "git_object_type",
+            "git_object_type2string",
+            "git_object_typeisloose",
+            "git_odb_hash",
+            "git_odb_hashfile",
+            "git_odb_open_rstream",
+            "git_odb_open_wstream",
+            "git_odb_read_header",
+            "git_odb_write",
             "git_reference_peel",
+            "git_repository_hashfile",
             "git_reset",
             "git_reset_default",
             "git_revparse_ext",
@@ -35882,14 +36387,113 @@
       }
     ],
     [
+      "git_object_t",
+      {
+        "decl": [
+          "GIT_OBJECT_ANY",
+          "GIT_OBJECT_INVALID",
+          "GIT_OBJECT_COMMIT",
+          "GIT_OBJECT_TREE",
+          "GIT_OBJECT_BLOB",
+          "GIT_OBJECT_TAG",
+          "GIT_OBJECT_OFS_DELTA",
+          "GIT_OBJECT_REF_DELTA"
+        ],
+        "type": "enum",
+        "file": "git2/types.h",
+        "line": 70,
+        "lineto": 79,
+        "block": "GIT_OBJECT_ANY\nGIT_OBJECT_INVALID\nGIT_OBJECT_COMMIT\nGIT_OBJECT_TREE\nGIT_OBJECT_BLOB\nGIT_OBJECT_TAG\nGIT_OBJECT_OFS_DELTA\nGIT_OBJECT_REF_DELTA",
+        "tdef": "typedef",
+        "description": " Basic type (loose or packed) of any Git object. ",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_ANY",
+            "comments": "<p>Object can be any of the following </p>\n",
+            "value": -2
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_INVALID",
+            "comments": "<p>Object is invalid. </p>\n",
+            "value": -1
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_COMMIT",
+            "comments": "<p>A commit object. </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_TREE",
+            "comments": "<p>A tree (directory listing) object. </p>\n",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_BLOB",
+            "comments": "<p>A file revision object. </p>\n",
+            "value": 3
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_TAG",
+            "comments": "<p>An annotated tag object. </p>\n",
+            "value": 4
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_OFS_DELTA",
+            "comments": "<p>A delta, base is given by an offset. </p>\n",
+            "value": 6
+          },
+          {
+            "type": "int",
+            "name": "GIT_OBJECT_REF_DELTA",
+            "comments": "<p>A delta, base is given by object id. </p>\n",
+            "value": 7
+          }
+        ],
+        "used": {
+          "returns": [
+            "git_object_string2type",
+            "git_object_type",
+            "git_odb_object_type",
+            "git_tag_target_type",
+            "git_tree_entry_type"
+          ],
+          "needs": [
+            "git_object__size",
+            "git_object_lookup",
+            "git_object_lookup_bypath",
+            "git_object_lookup_prefix",
+            "git_object_peel",
+            "git_object_type2string",
+            "git_object_typeisloose",
+            "git_odb_hash",
+            "git_odb_hashfile",
+            "git_odb_open_rstream",
+            "git_odb_open_wstream",
+            "git_odb_read_header",
+            "git_odb_write",
+            "git_reference_peel",
+            "git_repository_hashfile"
+          ]
+        }
+      }
+    ],
+    [
       "git_odb",
       {
         "decl": "git_odb",
         "type": "struct",
         "value": "git_odb",
         "file": "git2/types.h",
-        "line": 84,
-        "lineto": 84,
+        "line": 82,
+        "lineto": 82,
         "tdef": "typedef",
         "description": " An open object database handle. ",
         "comments": "",
@@ -35950,9 +36554,9 @@
         "type": "struct",
         "value": "git_odb_backend",
         "file": "git2/types.h",
-        "line": 87,
-        "lineto": 87,
-        "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_otype *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_otype *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_otype *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_otype) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_otype) writestream\nint (*)(git_odb_stream **, size_t *, git_otype *, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
+        "line": 85,
+        "lineto": 85,
+        "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_object_t *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_object_t) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_object_t) writestream\nint (*)(git_odb_stream **, size_t *, git_object_t *, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
         "tdef": "typedef",
         "description": " A custom backend in an ODB ",
         "comments": "",
@@ -35968,32 +36572,32 @@
             "comments": ""
           },
           {
-            "type": "int (*)(void **, size_t *, git_otype *, git_odb_backend *, const git_oid *)",
+            "type": "int (*)(void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
             "name": "read",
             "comments": ""
           },
           {
-            "type": "int (*)(git_oid *, void **, size_t *, git_otype *, git_odb_backend *, const git_oid *, size_t)",
+            "type": "int (*)(git_oid *, void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *, size_t)",
             "name": "read_prefix",
             "comments": ""
           },
           {
-            "type": "int (*)(size_t *, git_otype *, git_odb_backend *, const git_oid *)",
+            "type": "int (*)(size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
             "name": "read_header",
             "comments": ""
           },
           {
-            "type": "int (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_otype)",
+            "type": "int (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_object_t)",
             "name": "write",
-            "comments": " Write an object into the backend. The id of the object has\n already been calculated and is passed in."
+            "comments": ""
           },
           {
-            "type": "int (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_otype)",
+            "type": "int (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_object_t)",
             "name": "writestream",
             "comments": ""
           },
           {
-            "type": "int (*)(git_odb_stream **, size_t *, git_otype *, git_odb_backend *, const git_oid *)",
+            "type": "int (*)(git_odb_stream **, size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
             "name": "readstream",
             "comments": ""
           },
@@ -36010,7 +36614,7 @@
           {
             "type": "int (*)(git_odb_backend *)",
             "name": "refresh",
-            "comments": " If the backend implements a refreshing mechanism, it should be exposed\n through this endpoint. Each call to `git_odb_refresh()` will invoke it.\n\n However, the backend implementation should try to stay up-to-date as much\n as possible by itself as libgit2 will not automatically invoke\n `git_odb_refresh()`. For instance, a potential strategy for the backend\n implementation to achieve this could be to internally invoke this\n endpoint on failed lookups (ie. `exists()`, `read()`, `read_header()`)."
+            "comments": ""
           },
           {
             "type": "int (*)(git_odb_backend *, git_odb_foreach_cb, void *)",
@@ -36025,12 +36629,12 @@
           {
             "type": "int (*)(git_odb_backend *, const git_oid *)",
             "name": "freshen",
-            "comments": " \"Freshens\" an already existing object, updating its last-used\n time.  This occurs when `git_odb_write` was called, but the\n object already existed (and will not be re-written).  The\n underlying implementation may want to update last-used timestamps.\n\n If callers implement this, they should return `0` if the object\n exists and was freshened, and non-zero otherwise."
+            "comments": ""
           },
           {
             "type": "void (*)(git_odb_backend *)",
             "name": "free",
-            "comments": " Frees any resources held by the odb (including the `git_odb_backend`\n itself). An odb backend implementation must provide this function."
+            "comments": ""
           }
         ],
         "used": {
@@ -36057,14 +36661,14 @@
         "decl": [
           "git_oid id",
           "unsigned short length",
-          "git_otype type"
+          "git_object_t type"
         ],
         "type": "struct",
         "value": "git_odb_expand_id",
         "file": "git2/odb.h",
         "line": 180,
         "lineto": 195,
-        "block": "git_oid id\nunsigned short length\ngit_otype type",
+        "block": "git_oid id\nunsigned short length\ngit_object_t type",
         "tdef": "typedef",
         "description": " The information about object IDs to query in `git_odb_expand_ids`,\n which will be populated upon return.",
         "comments": "",
@@ -36080,9 +36684,9 @@
             "comments": " The length of the object ID (in nibbles, or packets of 4 bits; the\n number of hex characters)"
           },
           {
-            "type": "git_otype",
+            "type": "git_object_t",
             "name": "type",
-            "comments": " The (optional) type of the object to search for; leave as `0` or set\n to `GIT_OBJ_ANY` to query for any object matching the ID."
+            "comments": " The (optional) type of the object to search for; leave as `0` or set\n to `GIT_OBJECT_ANY` to query for any object matching the ID."
           }
         ],
         "used": {
@@ -36100,8 +36704,8 @@
         "type": "struct",
         "value": "git_odb_object",
         "file": "git2/types.h",
-        "line": 90,
-        "lineto": 90,
+        "line": 88,
+        "lineto": 88,
         "tdef": "typedef",
         "description": " An object read from the ODB ",
         "comments": "",
@@ -36128,8 +36732,8 @@
         "type": "struct",
         "value": "git_odb_stream",
         "file": "git2/types.h",
-        "line": 93,
-        "lineto": 93,
+        "line": 91,
+        "lineto": 91,
         "block": "git_odb_backend * backend\nunsigned int mode\nvoid * hash_ctx\ngit_off_t declared_size\ngit_off_t received_bytes\nint (*)(git_odb_stream *, char *, size_t) read\nint (*)(git_odb_stream *, const char *, size_t) write\nint (*)(git_odb_stream *, const git_oid *) finalize_write\nvoid (*)(git_odb_stream *) free",
         "tdef": "typedef",
         "description": " A stream to read/write from the ODB ",
@@ -36163,22 +36767,22 @@
           {
             "type": "int (*)(git_odb_stream *, char *, size_t)",
             "name": "read",
-            "comments": " Write at most `len` bytes into `buffer` and advance the stream."
+            "comments": ""
           },
           {
             "type": "int (*)(git_odb_stream *, const char *, size_t)",
             "name": "write",
-            "comments": " Write `len` bytes from `buffer` into the stream."
+            "comments": ""
           },
           {
             "type": "int (*)(git_odb_stream *, const git_oid *)",
             "name": "finalize_write",
-            "comments": " Store the contents of the stream as an object with the id\n specified in `oid`.\n\n This method might not be invoked if:\n - an error occurs earlier with the `write` callback,\n - the object referred to by `oid` already exists in any backend, or\n - the final number of received bytes differs from the size declared\n   with `git_odb_open_wstream()`"
+            "comments": ""
           },
           {
             "type": "void (*)(git_odb_stream *)",
             "name": "free",
-            "comments": " Free the stream's memory.\n\n This method might be called without a call to `finalize_write` if\n an error occurs or if the object is already present in the ODB."
+            "comments": ""
           }
         ],
         "used": {
@@ -36243,8 +36847,8 @@
         "type": "struct",
         "value": "git_odb_writepack",
         "file": "git2/types.h",
-        "line": 96,
-        "lineto": 96,
+        "line": 94,
+        "lineto": 94,
         "block": "git_odb_backend * backend\nint (*)(git_odb_writepack *, const void *, size_t, git_transfer_progress *) append\nint (*)(git_odb_writepack *, git_transfer_progress *) commit\nvoid (*)(git_odb_writepack *) free",
         "tdef": "typedef",
         "description": " A stream to write a packfile to the ODB ",
@@ -36500,127 +37104,14 @@
       }
     ],
     [
-      "git_otype",
-      {
-        "decl": [
-          "GIT_OBJ_ANY",
-          "GIT_OBJ_BAD",
-          "GIT_OBJ__EXT1",
-          "GIT_OBJ_COMMIT",
-          "GIT_OBJ_TREE",
-          "GIT_OBJ_BLOB",
-          "GIT_OBJ_TAG",
-          "GIT_OBJ__EXT2",
-          "GIT_OBJ_OFS_DELTA",
-          "GIT_OBJ_REF_DELTA"
-        ],
-        "type": "enum",
-        "file": "git2/types.h",
-        "line": 70,
-        "lineto": 81,
-        "block": "GIT_OBJ_ANY\nGIT_OBJ_BAD\nGIT_OBJ__EXT1\nGIT_OBJ_COMMIT\nGIT_OBJ_TREE\nGIT_OBJ_BLOB\nGIT_OBJ_TAG\nGIT_OBJ__EXT2\nGIT_OBJ_OFS_DELTA\nGIT_OBJ_REF_DELTA",
-        "tdef": "typedef",
-        "description": " Basic type (loose or packed) of any Git object. ",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_OBJ_ANY",
-            "comments": "<p>Object can be any of the following </p>\n",
-            "value": -2
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_BAD",
-            "comments": "<p>Object is invalid. </p>\n",
-            "value": -1
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ__EXT1",
-            "comments": "<p>Reserved for future use. </p>\n",
-            "value": 0
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_COMMIT",
-            "comments": "<p>A commit object. </p>\n",
-            "value": 1
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_TREE",
-            "comments": "<p>A tree (directory listing) object. </p>\n",
-            "value": 2
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_BLOB",
-            "comments": "<p>A file revision object. </p>\n",
-            "value": 3
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_TAG",
-            "comments": "<p>An annotated tag object. </p>\n",
-            "value": 4
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ__EXT2",
-            "comments": "<p>Reserved for future use. </p>\n",
-            "value": 5
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_OFS_DELTA",
-            "comments": "<p>A delta, base is given by an offset. </p>\n",
-            "value": 6
-          },
-          {
-            "type": "int",
-            "name": "GIT_OBJ_REF_DELTA",
-            "comments": "<p>A delta, base is given by object id. </p>\n",
-            "value": 7
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_object_string2type",
-            "git_object_type",
-            "git_odb_object_type",
-            "git_tag_target_type",
-            "git_tree_entry_type"
-          ],
-          "needs": [
-            "git_object__size",
-            "git_object_lookup",
-            "git_object_lookup_bypath",
-            "git_object_lookup_prefix",
-            "git_object_peel",
-            "git_object_type2string",
-            "git_object_typeisloose",
-            "git_odb_hash",
-            "git_odb_hashfile",
-            "git_odb_open_rstream",
-            "git_odb_open_wstream",
-            "git_odb_read_header",
-            "git_odb_write",
-            "git_reference_peel",
-            "git_repository_hashfile"
-          ]
-        }
-      }
-    ],
-    [
       "git_packbuilder",
       {
         "decl": "git_packbuilder",
         "type": "struct",
         "value": "git_packbuilder",
         "file": "git2/types.h",
-        "line": 159,
-        "lineto": 159,
+        "line": 160,
+        "lineto": 160,
         "tdef": "typedef",
         "description": " Representation of a git packbuilder ",
         "comments": "",
@@ -37048,8 +37539,8 @@
         "type": "struct",
         "value": "git_push",
         "file": "git2/types.h",
-        "line": 240,
-        "lineto": 240,
+        "line": 241,
+        "lineto": 241,
         "tdef": "typedef",
         "description": " Preparation for a push operation. Can be used to configure what to\n push and the level of parallelism of the packfile builder.",
         "comments": "",
@@ -37078,8 +37569,8 @@
         "type": "struct",
         "value": "git_push_options",
         "file": "git2/remote.h",
-        "line": 616,
-        "lineto": 643,
+        "line": 690,
+        "lineto": 717,
         "block": "unsigned int version\nunsigned int pb_parallelism\ngit_remote_callbacks callbacks\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Controls the behavior of a git_push object.",
@@ -37133,8 +37624,8 @@
         "type": "struct",
         "value": "git_push_update",
         "file": "git2/remote.h",
-        "line": 359,
-        "lineto": 376,
+        "line": 433,
+        "lineto": 450,
         "block": "char * src_refname\nchar * dst_refname\ngit_oid src\ngit_oid dst",
         "tdef": "typedef",
         "description": " Represents an update which will be performed on the remote during push",
@@ -37176,8 +37667,8 @@
         "type": "struct",
         "value": "git_rebase",
         "file": "git2/types.h",
-        "line": 191,
-        "lineto": 191,
+        "line": 192,
+        "lineto": 192,
         "tdef": "typedef",
         "description": " Representation of a rebase ",
         "comments": "",
@@ -37373,65 +37864,14 @@
       }
     ],
     [
-      "git_ref_t",
-      {
-        "decl": [
-          "GIT_REF_INVALID",
-          "GIT_REF_OID",
-          "GIT_REF_SYMBOLIC",
-          "GIT_REF_LISTALL"
-        ],
-        "type": "enum",
-        "file": "git2/types.h",
-        "line": 194,
-        "lineto": 199,
-        "block": "GIT_REF_INVALID\nGIT_REF_OID\nGIT_REF_SYMBOLIC\nGIT_REF_LISTALL",
-        "tdef": "typedef",
-        "description": " Basic type of any Git reference. ",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_REF_INVALID",
-            "comments": "<p>Invalid reference </p>\n",
-            "value": 0
-          },
-          {
-            "type": "int",
-            "name": "GIT_REF_OID",
-            "comments": "<p>A reference which points at an object id </p>\n",
-            "value": 1
-          },
-          {
-            "type": "int",
-            "name": "GIT_REF_SYMBOLIC",
-            "comments": "<p>A reference which points at another reference </p>\n",
-            "value": 2
-          },
-          {
-            "type": "int",
-            "name": "GIT_REF_LISTALL",
-            "comments": "",
-            "value": 3
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_reference_type"
-          ],
-          "needs": []
-        }
-      }
-    ],
-    [
       "git_refdb",
       {
         "decl": "git_refdb",
         "type": "struct",
         "value": "git_refdb",
         "file": "git2/types.h",
-        "line": 99,
-        "lineto": 99,
+        "line": 97,
+        "lineto": 97,
         "tdef": "typedef",
         "description": " An open refs database handle. ",
         "comments": "",
@@ -37459,8 +37899,8 @@
         "type": "struct",
         "value": "git_refdb_backend",
         "file": "git2/types.h",
-        "line": 102,
-        "lineto": 102,
+        "line": 100,
+        "lineto": 100,
         "block": "unsigned int version\nint (*)(int *, git_refdb_backend *, const char *) exists\nint (*)(git_reference **, git_refdb_backend *, const char *) lookup\nint (*)(git_reference_iterator **, struct git_refdb_backend *, const char *) iterator\nint (*)(git_refdb_backend *, const git_reference *, int, const git_signature *, const char *, const git_oid *, const char *) write\nint (*)(git_reference **, git_refdb_backend *, const char *, const char *, int, const git_signature *, const char *) rename\nint (*)(git_refdb_backend *, const char *, const git_oid *, const char *) del\nint (*)(git_refdb_backend *) compress\nint (*)(git_refdb_backend *, const char *) has_log\nint (*)(git_refdb_backend *, const char *) ensure_log\nvoid (*)(git_refdb_backend *) free\nint (*)(git_reflog **, git_refdb_backend *, const char *) reflog_read\nint (*)(git_refdb_backend *, git_reflog *) reflog_write\nint (*)(git_refdb_backend *, const char *, const char *) reflog_rename\nint (*)(git_refdb_backend *, const char *) reflog_delete\nint (*)(void **, git_refdb_backend *, const char *) lock\nint (*)(git_refdb_backend *, void *, int, int, const git_reference *, const git_signature *, const char *) unlock",
         "tdef": "typedef",
         "description": " A custom backend for refs ",
@@ -37474,17 +37914,17 @@
           {
             "type": "int (*)(int *, git_refdb_backend *, const char *)",
             "name": "exists",
-            "comments": " Queries the refdb backend to determine if the given ref_name\n exists.  A refdb implementation must provide this function."
+            "comments": ""
           },
           {
             "type": "int (*)(git_reference **, git_refdb_backend *, const char *)",
             "name": "lookup",
-            "comments": " Queries the refdb backend for a given reference.  A refdb\n implementation must provide this function."
+            "comments": ""
           },
           {
             "type": "int (*)(git_reference_iterator **, struct git_refdb_backend *, const char *)",
             "name": "iterator",
-            "comments": " Allocate an iterator object for the backend.\n\n A refdb implementation must provide this function."
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, const git_reference *, int, const git_signature *, const char *, const git_oid *, const char *)",
@@ -37499,57 +37939,57 @@
           {
             "type": "int (*)(git_refdb_backend *, const char *, const git_oid *, const char *)",
             "name": "del",
-            "comments": " Deletes the given reference (and if necessary its reflog)\n from the refdb.  A refdb implementation must provide this\n function."
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *)",
             "name": "compress",
-            "comments": " Suggests that the given refdb compress or optimize its references.\n This mechanism is implementation specific.  (For on-disk reference\n databases, this may pack all loose references.)    A refdb\n implementation may provide this function; if it is not provided,\n nothing will be done."
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, const char *)",
             "name": "has_log",
-            "comments": " Query whether a particular reference has a log (may be empty)"
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, const char *)",
             "name": "ensure_log",
-            "comments": " Make sure a particular reference will have a reflog which\n will be appended to on writes."
+            "comments": ""
           },
           {
             "type": "void (*)(git_refdb_backend *)",
             "name": "free",
-            "comments": " Frees any resources held by the refdb (including the `git_refdb_backend`\n itself). A refdb backend implementation must provide this function."
+            "comments": ""
           },
           {
             "type": "int (*)(git_reflog **, git_refdb_backend *, const char *)",
             "name": "reflog_read",
-            "comments": " Read the reflog for the given reference name."
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, git_reflog *)",
             "name": "reflog_write",
-            "comments": " Write a reflog to disk."
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, const char *, const char *)",
             "name": "reflog_rename",
-            "comments": " Rename a reflog"
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, const char *)",
             "name": "reflog_delete",
-            "comments": " Remove a reflog."
+            "comments": ""
           },
           {
             "type": "int (*)(void **, git_refdb_backend *, const char *)",
             "name": "lock",
-            "comments": " Lock a reference. The opaque parameter will be passed to the unlock function"
+            "comments": ""
           },
           {
             "type": "int (*)(git_refdb_backend *, void *, int, int, const git_reference *, const git_signature *, const char *)",
             "name": "unlock",
-            "comments": " Unlock a reference. Only one of target or symbolic_target\n will be set. success indicates whether to update the\n reference or discard the lock (if it's false)"
+            "comments": ""
           }
         ],
         "used": {
@@ -37569,8 +38009,8 @@
         "type": "struct",
         "value": "git_reference",
         "file": "git2/types.h",
-        "line": 176,
-        "lineto": 176,
+        "line": 177,
+        "lineto": 177,
         "tdef": "typedef",
         "description": " In-memory representation of a reference. ",
         "comments": "",
@@ -37578,7 +38018,8 @@
         "used": {
           "returns": [
             "git_reference__alloc",
-            "git_reference__alloc_symbolic"
+            "git_reference__alloc_symbolic",
+            "git_reference_type"
           ],
           "needs": [
             "git_annotated_commit_from_ref",
@@ -37593,6 +38034,7 @@
             "git_branch_next",
             "git_branch_set_upstream",
             "git_branch_upstream",
+            "git_merge_analysis_for_ref",
             "git_reference_cmp",
             "git_reference_create",
             "git_reference_create_matching",
@@ -37636,14 +38078,63 @@
       }
     ],
     [
+      "git_reference_format_t",
+      {
+        "decl": [
+          "GIT_REFERENCE_FORMAT_NORMAL",
+          "GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL",
+          "GIT_REFERENCE_FORMAT_REFSPEC_PATTERN",
+          "GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND"
+        ],
+        "type": "enum",
+        "file": "git2/refs.h",
+        "line": 639,
+        "lineto": 668,
+        "block": "GIT_REFERENCE_FORMAT_NORMAL\nGIT_REFERENCE_FORMAT_ALLOW_ONELEVEL\nGIT_REFERENCE_FORMAT_REFSPEC_PATTERN\nGIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND",
+        "tdef": "typedef",
+        "description": " Normalization options for reference lookup",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_REFERENCE_FORMAT_NORMAL",
+            "comments": "<p>No particular normalization.</p>\n",
+            "value": 0
+          },
+          {
+            "type": "int",
+            "name": "GIT_REFERENCE_FORMAT_ALLOW_ONELEVEL",
+            "comments": "<p>Control whether one-level refnames are accepted\n (i.e., refnames that do not contain multiple /-separated\n components). Those are expected to be written only using\n uppercase letters and underscore (FETCH_HEAD, ...)</p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_REFERENCE_FORMAT_REFSPEC_PATTERN",
+            "comments": "<p>Interpret the provided name as a reference pattern for a\n refspec (as used with remote repositories). If this option\n is enabled, the name is allowed to contain a single * (\n&lt;star</p>\n\n<blockquote>\n<p>)\n in place of a one full pathname component\n (e.g., foo/\n&lt;star\n/bar but not foo/bar\n&lt;star\n).</p>\n</blockquote>\n",
+            "value": 2
+          },
+          {
+            "type": "int",
+            "name": "GIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND",
+            "comments": "<p>Interpret the name as part of a refspec in shorthand form\n so the <code>ONELEVEL</code> naming rules aren&#39;t enforced and &#39;master&#39;\n becomes a valid name.</p>\n",
+            "value": 4
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
       "git_reference_iterator",
       {
         "decl": "git_reference_iterator",
         "type": "struct",
         "value": "git_reference_iterator",
         "file": "git2/types.h",
-        "line": 179,
-        "lineto": 179,
+        "line": 180,
+        "lineto": 180,
         "block": "git_refdb * db\nint (*)(git_reference **, git_reference_iterator *) next\nint (*)(const char **, git_reference_iterator *) next_name\nvoid (*)(git_reference_iterator *) free",
         "tdef": "typedef",
         "description": " Iterator for references ",
@@ -37657,17 +38148,17 @@
           {
             "type": "int (*)(git_reference **, git_reference_iterator *)",
             "name": "next",
-            "comments": " Return the current reference and advance the iterator."
+            "comments": ""
           },
           {
             "type": "int (*)(const char **, git_reference_iterator *)",
             "name": "next_name",
-            "comments": " Return the name of the current reference and advance the iterator"
+            "comments": ""
           },
           {
             "type": "void (*)(git_reference_iterator *)",
             "name": "free",
-            "comments": " Free the iterator"
+            "comments": ""
           }
         ],
         "used": {
@@ -37683,50 +38174,52 @@
       }
     ],
     [
-      "git_reference_normalize_t",
+      "git_reference_t",
       {
         "decl": [
-          "GIT_REF_FORMAT_NORMAL",
-          "GIT_REF_FORMAT_ALLOW_ONELEVEL",
-          "GIT_REF_FORMAT_REFSPEC_PATTERN",
-          "GIT_REF_FORMAT_REFSPEC_SHORTHAND"
+          "GIT_REFERENCE_INVALID",
+          "GIT_REFERENCE_DIRECT",
+          "GIT_REFERENCE_SYMBOLIC",
+          "GIT_REFERENCE_ALL"
         ],
         "type": "enum",
-        "file": "git2/refs.h",
-        "line": 639,
-        "lineto": 668,
-        "block": "GIT_REF_FORMAT_NORMAL\nGIT_REF_FORMAT_ALLOW_ONELEVEL\nGIT_REF_FORMAT_REFSPEC_PATTERN\nGIT_REF_FORMAT_REFSPEC_SHORTHAND",
+        "file": "git2/types.h",
+        "line": 195,
+        "lineto": 200,
+        "block": "GIT_REFERENCE_INVALID\nGIT_REFERENCE_DIRECT\nGIT_REFERENCE_SYMBOLIC\nGIT_REFERENCE_ALL",
         "tdef": "typedef",
-        "description": " Normalization options for reference lookup",
+        "description": " Basic type of any Git reference. ",
         "comments": "",
         "fields": [
           {
             "type": "int",
-            "name": "GIT_REF_FORMAT_NORMAL",
-            "comments": "<p>No particular normalization.</p>\n",
+            "name": "GIT_REFERENCE_INVALID",
+            "comments": "<p>Invalid reference </p>\n",
             "value": 0
           },
           {
             "type": "int",
-            "name": "GIT_REF_FORMAT_ALLOW_ONELEVEL",
-            "comments": "<p>Control whether one-level refnames are accepted\n (i.e., refnames that do not contain multiple /-separated\n components). Those are expected to be written only using\n uppercase letters and underscore (FETCH_HEAD, ...)</p>\n",
+            "name": "GIT_REFERENCE_DIRECT",
+            "comments": "<p>A reference that points at an object id </p>\n",
             "value": 1
           },
           {
             "type": "int",
-            "name": "GIT_REF_FORMAT_REFSPEC_PATTERN",
-            "comments": "<p>Interpret the provided name as a reference pattern for a\n refspec (as used with remote repositories). If this option\n is enabled, the name is allowed to contain a single * (\n&lt;star</p>\n\n<blockquote>\n<p>)\n in place of a one full pathname component\n (e.g., foo/\n&lt;star\n/bar but not foo/bar\n&lt;star\n).</p>\n</blockquote>\n",
+            "name": "GIT_REFERENCE_SYMBOLIC",
+            "comments": "<p>A reference that points at another reference </p>\n",
             "value": 2
           },
           {
             "type": "int",
-            "name": "GIT_REF_FORMAT_REFSPEC_SHORTHAND",
-            "comments": "<p>Interpret the name as part of a refspec in shorthand form\n so the <code>ONELEVEL</code> naming rules aren&#39;t enforced and &#39;master&#39;\n becomes a valid name.</p>\n",
-            "value": 4
+            "name": "GIT_REFERENCE_ALL",
+            "comments": "",
+            "value": 3
           }
         ],
         "used": {
-          "returns": [],
+          "returns": [
+            "git_reference_type"
+          ],
           "needs": []
         }
       }
@@ -37738,8 +38231,8 @@
         "type": "struct",
         "value": "git_reflog",
         "file": "git2/types.h",
-        "line": 153,
-        "lineto": 153,
+        "line": 154,
+        "lineto": 154,
         "tdef": "typedef",
         "description": " Representation of a reference log ",
         "comments": "",
@@ -37774,8 +38267,8 @@
         "type": "struct",
         "value": "git_reflog_entry",
         "file": "git2/types.h",
-        "line": 150,
-        "lineto": 150,
+        "line": 151,
+        "lineto": 151,
         "tdef": "typedef",
         "description": " Representation of a reference log entry ",
         "comments": "",
@@ -37802,8 +38295,8 @@
         "type": "struct",
         "value": "git_refspec",
         "file": "git2/types.h",
-        "line": 222,
-        "lineto": 222,
+        "line": 223,
+        "lineto": 223,
         "tdef": "typedef",
         "description": " A refspec specifies the mapping between remote and local reference\n names when fetch or pushing.",
         "comments": "",
@@ -37835,8 +38328,8 @@
         "type": "struct",
         "value": "git_remote",
         "file": "git2/types.h",
-        "line": 228,
-        "lineto": 228,
+        "line": 229,
+        "lineto": 229,
         "tdef": "typedef",
         "description": " Git's idea of a remote repository. A remote can be anonymous (in\n which case it does not have backing configuration entires).",
         "comments": "",
@@ -37854,7 +38347,9 @@
             "git_remote_create_anonymous",
             "git_remote_create_cb",
             "git_remote_create_detached",
+            "git_remote_create_init_options",
             "git_remote_create_with_fetchspec",
+            "git_remote_create_with_opts",
             "git_remote_default_branch",
             "git_remote_disconnect",
             "git_remote_download",
@@ -37901,8 +38396,8 @@
         ],
         "type": "enum",
         "file": "git2/remote.h",
-        "line": 527,
-        "lineto": 545,
+        "line": 601,
+        "lineto": 619,
         "block": "GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED\nGIT_REMOTE_DOWNLOAD_TAGS_AUTO\nGIT_REMOTE_DOWNLOAD_TAGS_NONE\nGIT_REMOTE_DOWNLOAD_TAGS_ALL",
         "tdef": "typedef",
         "description": " Automatic tag following option",
@@ -37951,8 +38446,8 @@
         "type": "struct",
         "value": "git_remote_callbacks",
         "file": "git2/types.h",
-        "line": 244,
-        "lineto": 244,
+        "line": 245,
+        "lineto": 245,
         "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_type, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_transfer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress push_transfer_progress\ngit_push_update_reference_cb push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload",
         "tdef": "typedef",
         "description": "",
@@ -37971,7 +38466,7 @@
           {
             "type": "int (*)(git_remote_completion_type, void *)",
             "name": "completion",
-            "comments": " Completion is called when different parts of the download\n process are done (currently unused)."
+            "comments": ""
           },
           {
             "type": "git_cred_acquire_cb",
@@ -37991,7 +38486,7 @@
           {
             "type": "int (*)(const char *, const git_oid *, const git_oid *, void *)",
             "name": "update_tips",
-            "comments": " Each time a reference is updated locally, this function\n will be called with information about it."
+            "comments": ""
           },
           {
             "type": "git_packbuilder_progress",
@@ -38045,8 +38540,8 @@
         ],
         "type": "enum",
         "file": "git2/remote.h",
-        "line": 344,
-        "lineto": 348,
+        "line": 418,
+        "lineto": 422,
         "block": "GIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR\nGIT_REMOTE_COMPLETION_DOWNLOAD\nGIT_REMOTE_COMPLETION_INDEXING\nGIT_REMOTE_COMPLETION_ERROR",
         "tdef": "typedef",
         "description": " Argument to the completion callback which tells it which operation\n finished.",
@@ -38078,14 +38573,104 @@
       }
     ],
     [
+      "git_remote_create_flags",
+      {
+        "decl": [
+          "GIT_REMOTE_CREATE_SKIP_INSTEADOF",
+          "GIT_REMOTE_CREATE_SKIP_DEFAULT_FETCHSPEC"
+        ],
+        "type": "enum",
+        "file": "git2/remote.h",
+        "line": 47,
+        "lineto": 53,
+        "block": "GIT_REMOTE_CREATE_SKIP_INSTEADOF\nGIT_REMOTE_CREATE_SKIP_DEFAULT_FETCHSPEC",
+        "tdef": "typedef",
+        "description": " Remote creation options flags",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_REMOTE_CREATE_SKIP_INSTEADOF",
+            "comments": "<p>Ignore the repository apply.insteadOf configuration </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_REMOTE_CREATE_SKIP_DEFAULT_FETCHSPEC",
+            "comments": "<p>Don&#39;t build a fetchspec from the name if none is set </p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": []
+        }
+      }
+    ],
+    [
+      "git_remote_create_options",
+      {
+        "decl": [
+          "unsigned int version",
+          "git_repository * repository",
+          "const char * name",
+          "const char * fetchspec",
+          "unsigned int flags"
+        ],
+        "type": "struct",
+        "value": "git_remote_create_options",
+        "file": "git2/remote.h",
+        "line": 62,
+        "lineto": 82,
+        "block": "unsigned int version\ngit_repository * repository\nconst char * name\nconst char * fetchspec\nunsigned int flags",
+        "tdef": "typedef",
+        "description": " Remote creation options structure",
+        "comments": "<p>Initialize with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_remote_create_init_options</code>.</p>\n",
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "version",
+            "comments": ""
+          },
+          {
+            "type": "git_repository *",
+            "name": "repository",
+            "comments": " The repository that should own the remote.\n Setting this to NULL results in a detached remote."
+          },
+          {
+            "type": "const char *",
+            "name": "name",
+            "comments": " The remote's name.\n Setting this to NULL results in an in-memory/anonymous remote."
+          },
+          {
+            "type": "const char *",
+            "name": "fetchspec",
+            "comments": " The fetchspec the remote should use. "
+          },
+          {
+            "type": "unsigned int",
+            "name": "flags",
+            "comments": " Additional flags for the remote. See git_remote_create_flags. "
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_remote_create_init_options",
+            "git_remote_create_with_opts"
+          ]
+        }
+      }
+    ],
+    [
       "git_remote_head",
       {
         "decl": "git_remote_head",
         "type": "struct",
         "value": "git_remote_head",
         "file": "git2/types.h",
-        "line": 243,
-        "lineto": 243,
+        "line": 244,
+        "lineto": 244,
         "block": "int local\ngit_oid oid\ngit_oid loid\nchar * name\nchar * symref_target",
         "tdef": "typedef",
         "description": "",
@@ -38133,8 +38718,8 @@
         "type": "struct",
         "value": "git_repository",
         "file": "git2/types.h",
-        "line": 108,
-        "lineto": 108,
+        "line": 106,
+        "lineto": 106,
         "tdef": "typedef",
         "description": " Representation of an existing git repository,\n including all its object contents",
         "comments": "",
@@ -38159,6 +38744,8 @@
             "git_annotated_commit_from_ref",
             "git_annotated_commit_from_revspec",
             "git_annotated_commit_lookup",
+            "git_apply",
+            "git_apply_to_tree",
             "git_attr_add_macro",
             "git_attr_cache_flush",
             "git_attr_foreach",
@@ -38217,6 +38804,7 @@
             "git_mempack_dump",
             "git_merge",
             "git_merge_analysis",
+            "git_merge_analysis_for_ref",
             "git_merge_base",
             "git_merge_base_many",
             "git_merge_base_octopus",
@@ -38399,8 +38987,8 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 232,
-        "lineto": 240,
+        "line": 245,
+        "lineto": 253,
         "block": "GIT_REPOSITORY_INIT_BARE\nGIT_REPOSITORY_INIT_NO_REINIT\nGIT_REPOSITORY_INIT_NO_DOTGIT_DIR\nGIT_REPOSITORY_INIT_MKDIR\nGIT_REPOSITORY_INIT_MKPATH\nGIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE\nGIT_REPOSITORY_INIT_RELATIVE_GITLINK",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_init_ext`.",
@@ -38465,8 +39053,8 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 255,
-        "lineto": 259,
+        "line": 268,
+        "lineto": 272,
         "block": "GIT_REPOSITORY_INIT_SHARED_UMASK\nGIT_REPOSITORY_INIT_SHARED_GROUP\nGIT_REPOSITORY_INIT_SHARED_ALL",
         "tdef": "typedef",
         "description": " Mode options for `git_repository_init_ext`.",
@@ -38502,8 +39090,8 @@
       {
         "decl": [
           "unsigned int version",
-          "uint32_t flags",
-          "uint32_t mode",
+          "int flags",
+          "int mode",
           "const char * workdir_path",
           "const char * description",
           "const char * template_path",
@@ -38513,12 +39101,12 @@
         "type": "struct",
         "value": "git_repository_init_options",
         "file": "git2/repository.h",
-        "line": 289,
-        "lineto": 298,
-        "block": "unsigned int version\nuint32_t flags\nuint32_t mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
+        "line": 302,
+        "lineto": 311,
+        "block": "unsigned int version\nint flags\nint mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
         "tdef": "typedef",
-        "description": " Extended options structure for `git_repository_init_ext`.",
-        "comments": "<p>This contains extra options for <code>git_repository_init_ext</code> that enable\n additional initialization features.  The fields are:</p>\n\n<ul>\n<li>flags - Combination of GIT_REPOSITORY_INIT flags above.</li>\n<li>mode  - Set to one of the standard GIT_REPOSITORY_INIT_SHARED_...\n    constants above, or to a custom value that you would like.</li>\n<li>workdir_path - The path to the working dir or NULL for default (i.e.\n    repo_path parent on non-bare repos).  IF THIS IS RELATIVE PATH,\n    IT WILL BE EVALUATED RELATIVE TO THE REPO_PATH.  If this is not\n    the &quot;natural&quot; working directory, a .git gitlink file will be\n    created here linking to the repo_path.</li>\n<li>description - If set, this will be used to initialize the &quot;description&quot;\n    file in the repository, instead of using the template content.</li>\n<li>template_path - When GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE is set,\n    this contains the path to use for the template directory.  If\n    this is NULL, the config or default directory options will be\n    used instead.</li>\n<li>initial_head - The name of the head to point HEAD at.  If NULL, then\n    this will be treated as &quot;master&quot; and the HEAD ref will be set\n    to &quot;refs/heads/master&quot;.  If this begins with &quot;refs/&quot; it will be\n    used verbatim; otherwise &quot;refs/heads/&quot; will be prefixed.</li>\n<li>origin_url - If this is non-NULL, then after the rest of the\n    repository initialization is completed, an &quot;origin&quot; remote\n    will be added pointing to this URL.</li>\n</ul>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -38526,12 +39114,12 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "mode",
             "comments": ""
           },
@@ -38591,8 +39179,8 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 414,
-        "lineto": 429,
+        "line": 427,
+        "lineto": 442,
         "block": "GIT_REPOSITORY_ITEM_GITDIR\nGIT_REPOSITORY_ITEM_WORKDIR\nGIT_REPOSITORY_ITEM_COMMONDIR\nGIT_REPOSITORY_ITEM_INDEX\nGIT_REPOSITORY_ITEM_OBJECTS\nGIT_REPOSITORY_ITEM_REFS\nGIT_REPOSITORY_ITEM_PACKED_REFS\nGIT_REPOSITORY_ITEM_REMOTES\nGIT_REPOSITORY_ITEM_CONFIG\nGIT_REPOSITORY_ITEM_INFO\nGIT_REPOSITORY_ITEM_HOOKS\nGIT_REPOSITORY_ITEM_LOGS\nGIT_REPOSITORY_ITEM_MODULES\nGIT_REPOSITORY_ITEM_WORKTREES",
         "tdef": "typedef",
         "description": " List of items which belong to the git repository layout",
@@ -38703,41 +39291,41 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 126,
-        "lineto": 132,
+        "line": 98,
+        "lineto": 145,
         "block": "GIT_REPOSITORY_OPEN_NO_SEARCH\nGIT_REPOSITORY_OPEN_CROSS_FS\nGIT_REPOSITORY_OPEN_BARE\nGIT_REPOSITORY_OPEN_NO_DOTGIT\nGIT_REPOSITORY_OPEN_FROM_ENV",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_open_ext`.",
-        "comments": "<ul>\n<li>GIT_REPOSITORY_OPEN_NO_SEARCH - Only open the repository if it can be\nimmediately found in the start_path.  Do not walk up from the\nstart_path looking at parent directories.</li>\n<li>GIT_REPOSITORY_OPEN_CROSS_FS - Unless this flag is set, open will not\ncontinue searching across filesystem boundaries (i.e. when <code>st_dev</code>\nchanges from the <code>stat</code> system call).  (E.g. Searching in a user&#39;s home\ndirectory &quot;/home/user/source/&quot; will not return &quot;/.git/&quot; as the found\nrepo if &quot;/&quot; is a different filesystem than &quot;/home&quot;.)</li>\n<li>GIT_REPOSITORY_OPEN_BARE - Open repository as a bare repo regardless\nof core.bare config, and defer loading config file for faster setup.\nUnlike <code>git_repository_open_bare</code>, this can follow gitlinks.</li>\n<li>GIT_REPOSITORY_OPEN_NO_DOTGIT - Do not check for a repository by\nappending /.git to the start_path; only open the repository if\nstart_path itself points to the git directory.</li>\n<li>GIT_REPOSITORY_OPEN_FROM_ENV - Find and open a git repository,\nrespecting the environment variables used by the git command-line\ntools. If set, <code>git_repository_open_ext</code> will ignore the other\nflags and the <code>ceiling_dirs</code> argument, and will allow a NULL <code>path</code>\nto use <code>GIT_DIR</code> or search from the current directory. The search\nfor a repository will respect $GIT_CEILING_DIRECTORIES and\n$GIT_DISCOVERY_ACROSS_FILESYSTEM.  The opened repository will\nrespect $GIT_INDEX_FILE, $GIT_NAMESPACE, $GIT_OBJECT_DIRECTORY, and\n$GIT_ALTERNATE_OBJECT_DIRECTORIES.  In the future, this flag will\nalso cause <code>git_repository_open_ext</code> to respect $GIT_WORK_TREE and\n$GIT_COMMON_DIR; currently, <code>git_repository_open_ext</code> with this\nflag will error out if either $GIT_WORK_TREE or $GIT_COMMON_DIR is\nset.</li>\n</ul>\n",
+        "comments": "",
         "fields": [
           {
             "type": "int",
             "name": "GIT_REPOSITORY_OPEN_NO_SEARCH",
-            "comments": "",
+            "comments": "<p>Only open the repository if it can be immediately found in the\n start_path. Do not walk up from the start_path looking at parent\n directories.</p>\n",
             "value": 1
           },
           {
             "type": "int",
             "name": "GIT_REPOSITORY_OPEN_CROSS_FS",
-            "comments": "",
+            "comments": "<p>Unless this flag is set, open will not continue searching across\n filesystem boundaries (i.e. when <code>st_dev</code> changes from the <code>stat</code>\n system call).  For example, searching in a user&#39;s home directory at\n &quot;/home/user/source/&quot; will not return &quot;/.git/&quot; as the found repo if\n &quot;/&quot; is a different filesystem than &quot;/home&quot;.</p>\n",
             "value": 2
           },
           {
             "type": "int",
             "name": "GIT_REPOSITORY_OPEN_BARE",
-            "comments": "",
+            "comments": "<p>Open repository as a bare repo regardless of core.bare config, and\n defer loading config file for faster setup.\n Unlike <code>git_repository_open_bare</code>, this can follow gitlinks.</p>\n",
             "value": 4
           },
           {
             "type": "int",
             "name": "GIT_REPOSITORY_OPEN_NO_DOTGIT",
-            "comments": "",
+            "comments": "<p>Do not check for a repository by appending /.git to the start_path;\n only open the repository if start_path itself points to the git\n directory.</p>\n",
             "value": 8
           },
           {
             "type": "int",
             "name": "GIT_REPOSITORY_OPEN_FROM_ENV",
-            "comments": "",
+            "comments": "<p>Find and open a git repository, respecting the environment variables\n used by the git command-line tools.\n If set, <code>git_repository_open_ext</code> will ignore the other flags and\n the <code>ceiling_dirs</code> argument, and will allow a NULL <code>path</code> to use\n <code>GIT_DIR</code> or search from the current directory.\n The search for a repository will respect $GIT_CEILING_DIRECTORIES and\n $GIT_DISCOVERY_ACROSS_FILESYSTEM.  The opened repository will\n respect $GIT_INDEX_FILE, $GIT_NAMESPACE, $GIT_OBJECT_DIRECTORY, and\n $GIT_ALTERNATE_OBJECT_DIRECTORIES.\n In the future, this flag will also cause <code>git_repository_open_ext</code>\n to respect $GIT_WORK_TREE and $GIT_COMMON_DIR; currently,\n <code>git_repository_open_ext</code> with this flag will error out if either\n $GIT_WORK_TREE or $GIT_COMMON_DIR is set.</p>\n",
             "value": 16
           }
         ],
@@ -38766,8 +39354,8 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 786,
-        "lineto": 799,
+        "line": 799,
+        "lineto": 812,
         "block": "GIT_REPOSITORY_STATE_NONE\nGIT_REPOSITORY_STATE_MERGE\nGIT_REPOSITORY_STATE_REVERT\nGIT_REPOSITORY_STATE_REVERT_SEQUENCE\nGIT_REPOSITORY_STATE_CHERRYPICK\nGIT_REPOSITORY_STATE_CHERRYPICK_SEQUENCE\nGIT_REPOSITORY_STATE_BISECT\nGIT_REPOSITORY_STATE_REBASE\nGIT_REPOSITORY_STATE_REBASE_INTERACTIVE\nGIT_REPOSITORY_STATE_REBASE_MERGE\nGIT_REPOSITORY_STATE_APPLY_MAILBOX\nGIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE",
         "tdef": "typedef",
         "description": " Repository state",
@@ -39037,8 +39625,8 @@
         "type": "struct",
         "value": "git_revwalk",
         "file": "git2/types.h",
-        "line": 117,
-        "lineto": 117,
+        "line": 115,
+        "lineto": 115,
         "tdef": "typedef",
         "description": " Representation of an in-progress walk through the commits in a repo ",
         "comments": "",
@@ -39079,8 +39667,8 @@
         "type": "struct",
         "value": "git_signature",
         "file": "git2/types.h",
-        "line": 169,
-        "lineto": 173,
+        "line": 170,
+        "lineto": 174,
         "block": "char * name\nchar * email\ngit_time when",
         "tdef": "typedef",
         "description": " An action signature (e.g. for committers, taggers, etc) ",
@@ -39154,11 +39742,11 @@
         ],
         "type": "enum",
         "file": "git2/sys/transport.h",
-        "line": 273,
-        "lineto": 278,
+        "line": 287,
+        "lineto": 292,
         "block": "GIT_SERVICE_UPLOADPACK_LS\nGIT_SERVICE_UPLOADPACK\nGIT_SERVICE_RECEIVEPACK_LS\nGIT_SERVICE_RECEIVEPACK",
         "tdef": "typedef",
-        "description": "",
+        "description": " Actions that the smart transport can ask a subtransport to perform ",
         "comments": "",
         "fields": [
           {
@@ -39199,10 +39787,10 @@
         "type": "struct",
         "value": "git_smart_subtransport",
         "file": "git2/sys/transport.h",
-        "line": 280,
-        "lineto": 280,
+        "line": 294,
+        "lineto": 294,
         "tdef": "typedef",
-        "description": "",
+        "description": " An implementation of a subtransport which carries data for the\n smart transport",
         "comments": "",
         "fields": [
           {
@@ -39243,12 +39831,12 @@
         "type": "struct",
         "value": "git_smart_subtransport_definition",
         "file": "git2/sys/transport.h",
-        "line": 336,
-        "lineto": 349,
+        "line": 383,
+        "lineto": 395,
         "block": "git_smart_subtransport_cb callback\nunsigned int rpc\nvoid * param",
         "tdef": "typedef",
         "description": " Definition for a \"subtransport\"",
-        "comments": "<p>This is used to let the smart protocol code know about the protocol\n which you are implementing.</p>\n",
+        "comments": "<p>The smart transport knows how to speak the git protocol, but it has no\n knowledge of how to establish a connection between it and another endpoint,\n or how to move data back and forth. For this, a subtransport interface is\n declared, and the smart transport delegates this work to the subtransports.</p>\n\n<p>Three subtransports are provided by libgit2: ssh, git, http(s).</p>\n\n<p>Subtransports can either be RPC = 0 (persistent connection) or RPC = 1\n (request/response). The smart transport handles the differences in its own\n logic. The git subtransport is RPC = 0, while http is RPC = 1.</p>\n",
         "fields": [
           {
             "type": "git_smart_subtransport_cb",
@@ -39263,7 +39851,7 @@
           {
             "type": "void *",
             "name": "param",
-            "comments": " Param of the callback"
+            "comments": " User-specified parameter passed to the callback "
           }
         ],
         "used": {
@@ -39279,16 +39867,16 @@
         "type": "struct",
         "value": "git_smart_subtransport_stream",
         "file": "git2/sys/transport.h",
-        "line": 281,
-        "lineto": 281,
+        "line": 295,
+        "lineto": 295,
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " A stream used by the smart transport to read and write data\n from a subtransport.",
+        "comments": "<p>This provides a customization point in case you need to\n support some other communication method.</p>\n",
         "fields": [
           {
             "type": "git_smart_subtransport *",
             "name": "subtransport",
-            "comments": ""
+            "comments": " The owning subtransport "
           },
           {
             "type": "int (*)(git_smart_subtransport_stream *, char *, size_t, size_t *)",
@@ -39629,8 +40217,8 @@
         "type": "struct",
         "value": "git_status_list",
         "file": "git2/types.h",
-        "line": 188,
-        "lineto": 188,
+        "line": 189,
+        "lineto": 189,
         "tdef": "typedef",
         "description": " Representation of a status collection ",
         "comments": "",
@@ -40062,8 +40650,7 @@
           "int (*)(struct git_stream *) connect",
           "int (*)(git_cert **, struct git_stream *) certificate",
           "int (*)(struct git_stream *, const git_proxy_options *) set_proxy",
-          "ssize_t (*)(struct git_stream *, void *, size_t) read",
-          "ssize_t (*)(struct git_stream *, const char *, size_t, int) write",
+          "int ((int *))(struct git_stream *, void *, size_t) ssize_t",
           "int (*)(struct git_stream *) close",
           "void (*)(struct git_stream *) free"
         ],
@@ -40072,10 +40659,10 @@
         "file": "git2/sys/stream.h",
         "line": 29,
         "lineto": 41,
-        "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const git_proxy_options *) set_proxy\nssize_t (*)(struct git_stream *, void *, size_t) read\nssize_t (*)(struct git_stream *, const char *, size_t, int) write\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
+        "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const git_proxy_options *) set_proxy\nint ((int *))(struct git_stream *, void *, size_t) ssize_t\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
         "tdef": "typedef",
-        "description": " Every stream must have this struct as its first element, so the\n API can talk to it. You'd define your stream as",
-        "comments": "<pre><code> struct my_stream {\n         git_stream parent;\n         ...\n }\n</code></pre>\n\n<p>and fill the functions</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "int",
@@ -40108,13 +40695,8 @@
             "comments": ""
           },
           {
-            "type": "ssize_t (*)(struct git_stream *, void *, size_t)",
-            "name": "read",
-            "comments": ""
-          },
-          {
-            "type": "ssize_t (*)(struct git_stream *, const char *, size_t, int)",
-            "name": "write",
+            "type": "int ((int *))(struct git_stream *, void *, size_t)",
+            "name": "ssize_t",
             "comments": ""
           },
           {
@@ -40132,7 +40714,87 @@
           "returns": [],
           "needs": [
             "git_stream_cb",
+            "git_stream_register",
             "git_stream_register_tls"
+          ]
+        }
+      }
+    ],
+    [
+      "git_stream_registration",
+      {
+        "decl": [
+          "int version",
+          "int (*)(git_stream **, const char *, const char *) init",
+          "int (*)(git_stream **, git_stream *, const char *) wrap"
+        ],
+        "type": "struct",
+        "value": "git_stream_registration",
+        "file": "git2/sys/stream.h",
+        "line": 43,
+        "lineto": 72,
+        "block": "int version\nint (*)(git_stream **, const char *, const char *) init\nint (*)(git_stream **, git_stream *, const char *) wrap",
+        "tdef": "typedef",
+        "description": "",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "version",
+            "comments": " The `version` field should be set to `GIT_STREAM_VERSION`. "
+          },
+          {
+            "type": "int (*)(git_stream **, const char *, const char *)",
+            "name": "init",
+            "comments": ""
+          },
+          {
+            "type": "int (*)(git_stream **, git_stream *, const char *)",
+            "name": "wrap",
+            "comments": ""
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_stream_register"
+          ]
+        }
+      }
+    ],
+    [
+      "git_stream_t",
+      {
+        "decl": [
+          "GIT_STREAM_STANDARD",
+          "GIT_STREAM_TLS"
+        ],
+        "type": "enum",
+        "file": "git2/sys/stream.h",
+        "line": 77,
+        "lineto": 83,
+        "block": "GIT_STREAM_STANDARD\nGIT_STREAM_TLS",
+        "tdef": "typedef",
+        "description": " The type of stream to register.",
+        "comments": "",
+        "fields": [
+          {
+            "type": "int",
+            "name": "GIT_STREAM_STANDARD",
+            "comments": "<p>A standard (non-TLS) socket. </p>\n",
+            "value": 1
+          },
+          {
+            "type": "int",
+            "name": "GIT_STREAM_TLS",
+            "comments": "<p>A TLS-encrypted socket. </p>\n",
+            "value": 2
+          }
+        ],
+        "used": {
+          "returns": [],
+          "needs": [
+            "git_stream_register"
           ]
         }
       }
@@ -40144,8 +40806,8 @@
         "type": "struct",
         "value": "git_submodule",
         "file": "git2/types.h",
-        "line": 339,
-        "lineto": 339,
+        "line": 343,
+        "lineto": 343,
         "tdef": "typedef",
         "description": " Opaque structure representing a submodule.",
         "comments": "",
@@ -40203,8 +40865,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 403,
-        "lineto": 410,
+        "line": 407,
+        "lineto": 414,
         "block": "GIT_SUBMODULE_IGNORE_UNSPECIFIED\nGIT_SUBMODULE_IGNORE_NONE\nGIT_SUBMODULE_IGNORE_UNTRACKED\nGIT_SUBMODULE_IGNORE_DIRTY\nGIT_SUBMODULE_IGNORE_ALL",
         "tdef": "typedef",
         "description": " Submodule ignore values",
@@ -40262,8 +40924,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 422,
-        "lineto": 426,
+        "line": 426,
+        "lineto": 430,
         "block": "GIT_SUBMODULE_RECURSE_NO\nGIT_SUBMODULE_RECURSE_YES\nGIT_SUBMODULE_RECURSE_ONDEMAND",
         "tdef": "typedef",
         "description": " Options for submodule recurse.",
@@ -40444,7 +41106,7 @@
           {
             "type": "git_checkout_options",
             "name": "checkout_opts",
-            "comments": " These options are passed to the checkout step. To disable\n checkout, set the `checkout_strategy` to\n `GIT_CHECKOUT_NONE`. Generally you will want the use\n GIT_CHECKOUT_SAFE to update files in the working\n directory. "
+            "comments": " These options are passed to the checkout step. To disable\n checkout, set the `checkout_strategy` to\n `GIT_CHECKOUT_NONE`. Generally you will want the use\n GIT_CHECKOUT_SAFE to update files in the working\n directory."
           },
           {
             "type": "git_fetch_options",
@@ -40478,8 +41140,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 367,
-        "lineto": 374,
+        "line": 371,
+        "lineto": 378,
         "block": "GIT_SUBMODULE_UPDATE_CHECKOUT\nGIT_SUBMODULE_UPDATE_REBASE\nGIT_SUBMODULE_UPDATE_MERGE\nGIT_SUBMODULE_UPDATE_NONE\nGIT_SUBMODULE_UPDATE_DEFAULT",
         "tdef": "typedef",
         "description": " Submodule update values",
@@ -40533,8 +41195,8 @@
         "type": "struct",
         "value": "git_tag",
         "file": "git2/types.h",
-        "line": 120,
-        "lineto": 120,
+        "line": 118,
+        "lineto": 118,
         "tdef": "typedef",
         "description": " Parsed representation of a tag object. ",
         "comments": "",
@@ -40571,8 +41233,8 @@
         "type": "struct",
         "value": "git_time",
         "file": "git2/types.h",
-        "line": 162,
-        "lineto": 166,
+        "line": 163,
+        "lineto": 167,
         "block": "git_time_t time\nint offset\nchar sign",
         "tdef": "typedef",
         "description": " Time in a signature ",
@@ -40684,8 +41346,8 @@
         "type": "struct",
         "value": "git_transaction",
         "file": "git2/types.h",
-        "line": 182,
-        "lineto": 182,
+        "line": 183,
+        "lineto": 183,
         "tdef": "typedef",
         "description": " Transactional interface to references ",
         "comments": "",
@@ -40721,8 +41383,8 @@
         "type": "struct",
         "value": "git_transfer_progress",
         "file": "git2/types.h",
-        "line": 257,
-        "lineto": 265,
+        "line": 258,
+        "lineto": 266,
         "block": "unsigned int total_objects\nunsigned int indexed_objects\nunsigned int received_objects\nunsigned int local_objects\nunsigned int total_deltas\nunsigned int indexed_deltas\nsize_t received_bytes",
         "tdef": "typedef",
         "description": " This is passed as the first argument to the callback to allow the\n user to see the progress.",
@@ -40785,8 +41447,8 @@
         "type": "struct",
         "value": "git_transport",
         "file": "git2/types.h",
-        "line": 234,
-        "lineto": 234,
+        "line": 235,
+        "lineto": 235,
         "block": "unsigned int version\nint (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *) set_callbacks\nint (*)(git_transport *, const git_strarray *) set_custom_headers\nint (*)(git_transport *, const char *, git_cred_acquire_cb, void *, const git_proxy_options *, int, int) connect\nint (*)(const git_remote_head ***, size_t *, git_transport *) ls\nint (*)(git_transport *, git_push *, const git_remote_callbacks *) push\nint (*)(git_transport *, git_repository *, const git_remote_head *const *, size_t) negotiate_fetch\nint (*)(git_transport *, git_repository *, git_transfer_progress *, git_transfer_progress_cb, void *) download_pack\nint (*)(git_transport *) is_connected\nint (*)(git_transport *, int *) read_flags\nvoid (*)(git_transport *) cancel\nint (*)(git_transport *) close\nvoid (*)(git_transport *) free",
         "tdef": "typedef",
         "description": " Interface which represents a transport to communicate with a\n remote.",
@@ -40795,7 +41457,7 @@
           {
             "type": "unsigned int",
             "name": "version",
-            "comments": ""
+            "comments": " The struct version "
           },
           {
             "type": "int (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *)",
@@ -40915,8 +41577,8 @@
         "type": "struct",
         "value": "git_tree",
         "file": "git2/types.h",
-        "line": 132,
-        "lineto": 132,
+        "line": 130,
+        "lineto": 130,
         "tdef": "typedef",
         "description": " Representation of a tree object. ",
         "comments": "",
@@ -40929,6 +41591,7 @@
             "git_treebuilder_get"
           ],
           "needs": [
+            "git_apply_to_tree",
             "git_commit_amend",
             "git_commit_create",
             "git_commit_create_buffer",
@@ -40986,8 +41649,8 @@
         "type": "struct",
         "value": "git_tree_entry",
         "file": "git2/types.h",
-        "line": 129,
-        "lineto": 129,
+        "line": 127,
+        "lineto": 127,
         "tdef": "typedef",
         "description": " Representation of each one of the entries in a tree object. ",
         "comments": "",
@@ -41107,8 +41770,8 @@
         "type": "struct",
         "value": "git_treebuilder",
         "file": "git2/types.h",
-        "line": 135,
-        "lineto": 135,
+        "line": 133,
+        "lineto": 133,
         "tdef": "typedef",
         "description": " Constructor for in-memory trees ",
         "comments": "",
@@ -41174,8 +41837,8 @@
         "type": "struct",
         "value": "git_worktree",
         "file": "git2/types.h",
-        "line": 111,
-        "lineto": 111,
+        "line": 109,
+        "lineto": 109,
         "tdef": "typedef",
         "description": " Representation of a working tree ",
         "comments": "",
@@ -41250,17 +41913,17 @@
       {
         "decl": [
           "unsigned int version",
-          "uint32_t flags"
+          "int flags"
         ],
         "type": "struct",
         "value": "git_worktree_prune_options",
         "file": "git2/worktree.h",
         "line": 198,
         "lineto": 202,
-        "block": "unsigned int version\nuint32_t flags",
+        "block": "unsigned int version\nint flags",
         "tdef": "typedef",
-        "description": " Worktree prune options structure",
-        "comments": "<p>Initialize with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_worktree_prune_init_options</code>.</p>\n",
+        "description": "",
+        "comments": "",
         "fields": [
           {
             "type": "unsigned int",
@@ -41268,7 +41931,7 @@
             "comments": ""
           },
           {
-            "type": "uint32_t",
+            "type": "int",
             "name": "flags",
             "comments": ""
           }
@@ -41332,8 +41995,8 @@
         "type": "struct",
         "value": "git_writestream",
         "file": "git2/types.h",
-        "line": 428,
-        "lineto": 428,
+        "line": 432,
+        "lineto": 432,
         "tdef": "typedef",
         "description": " A type to write in a streaming fashion, for example, for filters. ",
         "comments": "",
@@ -41414,6 +42077,13 @@
         "git_annotated_commit_id",
         "git_annotated_commit_lookup",
         "git_annotated_commit_ref"
+      ]
+    ],
+    [
+      "apply",
+      [
+        "git_apply",
+        "git_apply_to_tree"
       ]
     ],
     [
@@ -41673,6 +42343,15 @@
       ]
     ],
     [
+      "error",
+      [
+        "git_error_clear",
+        "git_error_last",
+        "git_error_set_oom",
+        "git_error_set_str"
+      ]
+    ],
+    [
       "fetch",
       [
         "git_fetch_init_options"
@@ -41770,6 +42449,9 @@
         "git_index_get_byindex",
         "git_index_get_bypath",
         "git_index_has_conflicts",
+        "git_index_iterator_free",
+        "git_index_iterator_new",
+        "git_index_iterator_next",
         "git_index_name_add",
         "git_index_name_clear",
         "git_index_name_entrycount",
@@ -41846,6 +42528,7 @@
       [
         "git_merge",
         "git_merge_analysis",
+        "git_merge_analysis_for_ref",
         "git_merge_base",
         "git_merge_base_many",
         "git_merge_base_octopus",
@@ -42195,7 +42878,9 @@
         "git_remote_create",
         "git_remote_create_anonymous",
         "git_remote_create_detached",
+        "git_remote_create_init_options",
         "git_remote_create_with_fetchspec",
+        "git_remote_create_with_opts",
         "git_remote_default_branch",
         "git_remote_delete",
         "git_remote_disconnect",
@@ -42395,6 +43080,7 @@
     [
       "stream",
       [
+        "git_stream_register",
         "git_stream_register_tls"
       ]
     ],
@@ -42574,103 +43260,103 @@
   "examples": [
     [
       "add.c",
-      "ex/HEAD/add.html"
+      "ex/v0.28.0/add.html"
     ],
     [
       "blame.c",
-      "ex/HEAD/blame.html"
+      "ex/v0.28.0/blame.html"
     ],
     [
       "cat-file.c",
-      "ex/HEAD/cat-file.html"
+      "ex/v0.28.0/cat-file.html"
     ],
     [
       "checkout.c",
-      "ex/HEAD/checkout.html"
+      "ex/v0.28.0/checkout.html"
     ],
     [
       "common.c",
-      "ex/HEAD/common.html"
+      "ex/v0.28.0/common.html"
     ],
     [
       "describe.c",
-      "ex/HEAD/describe.html"
+      "ex/v0.28.0/describe.html"
     ],
     [
       "diff.c",
-      "ex/HEAD/diff.html"
+      "ex/v0.28.0/diff.html"
     ],
     [
       "for-each-ref.c",
-      "ex/HEAD/for-each-ref.html"
+      "ex/v0.28.0/for-each-ref.html"
     ],
     [
       "general.c",
-      "ex/HEAD/general.html"
+      "ex/v0.28.0/general.html"
     ],
     [
       "init.c",
-      "ex/HEAD/init.html"
+      "ex/v0.28.0/init.html"
     ],
     [
       "log.c",
-      "ex/HEAD/log.html"
+      "ex/v0.28.0/log.html"
     ],
     [
       "ls-files.c",
-      "ex/HEAD/ls-files.html"
+      "ex/v0.28.0/ls-files.html"
     ],
     [
       "merge.c",
-      "ex/HEAD/merge.html"
+      "ex/v0.28.0/merge.html"
     ],
     [
       "network/clone.c",
-      "ex/HEAD/network/clone.html"
+      "ex/v0.28.0/network/clone.html"
     ],
     [
       "network/common.c",
-      "ex/HEAD/network/common.html"
+      "ex/v0.28.0/network/common.html"
     ],
     [
       "network/fetch.c",
-      "ex/HEAD/network/fetch.html"
+      "ex/v0.28.0/network/fetch.html"
     ],
     [
       "network/git2.c",
-      "ex/HEAD/network/git2.html"
+      "ex/v0.28.0/network/git2.html"
     ],
     [
       "network/index-pack.c",
-      "ex/HEAD/network/index-pack.html"
+      "ex/v0.28.0/network/index-pack.html"
     ],
     [
       "network/ls-remote.c",
-      "ex/HEAD/network/ls-remote.html"
+      "ex/v0.28.0/network/ls-remote.html"
     ],
     [
       "remote.c",
-      "ex/HEAD/remote.html"
+      "ex/v0.28.0/remote.html"
     ],
     [
       "rev-list.c",
-      "ex/HEAD/rev-list.html"
+      "ex/v0.28.0/rev-list.html"
     ],
     [
       "rev-parse.c",
-      "ex/HEAD/rev-parse.html"
+      "ex/v0.28.0/rev-parse.html"
     ],
     [
       "showindex.c",
-      "ex/HEAD/showindex.html"
+      "ex/v0.28.0/showindex.html"
     ],
     [
       "status.c",
-      "ex/HEAD/status.html"
+      "ex/v0.28.0/status.html"
     ],
     [
       "tag.c",
-      "ex/HEAD/tag.html"
+      "ex/v0.28.0/tag.html"
     ]
   ]
 }

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -86,6 +86,20 @@
   },
   "new" : {
     "functions": {
+      "git_blame_get_hunk_count": {
+        "type": "function",
+        "file": "blame.h",
+        "args": [
+          {
+            "name": "blame",
+            "type": "git_blame *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "blame"
+      },
       "git_clone": {
         "isManual": true,
         "cFile": "generate/templates/manual/clone/clone.cc",
@@ -133,6 +147,34 @@
         "isAsync": true,
         "isPrototypeMethod": false,
         "group": "filter_list"
+      },
+      "git_filter_source_filemode": {
+        "type": "function",
+        "file": "filter.h",
+        "args": [
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "return": {
+          "type": "uint16_t"
+        },
+        "group": "filter_source"
+      },
+      "git_filter_source_flags": {
+        "type": "function",
+        "file": "filter.h",
+        "args": [
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "return": {
+          "type": "uint32_t"
+        },
+        "group": "filter_source"
       },
       "git_patch_convenient_from_diff": {
         "args": [
@@ -318,7 +360,8 @@
           "git_annotated_commit_from_ref",
           "git_annotated_commit_from_revspec",
           "git_annotated_commit_id",
-          "git_annotated_commit_lookup"
+          "git_annotated_commit_lookup",
+          "git_annotated_commit_ref"
         ]
       ],
       [
@@ -350,6 +393,22 @@
           "git_filter_source_id",
           "git_filter_source_mode",
           "git_filter_source_flags"
+        ]
+      ],
+      [
+        "index_conflict_iterator",
+        [
+          "git_index_conflict_iterator_free",
+          "git_index_conflict_iterator_new",
+          "git_index_conflict_next"
+        ]
+      ],
+      [
+        "index_iterator",
+        [
+          "git_index_iterator_free",
+          "git_index_iterator_new",
+          "git_index_iterator_next"
         ]
       ],
       [
@@ -470,51 +529,32 @@
     ],
     "types": [
       [
-        "git_stash_apply_progress_t",
+        "git_apply_options",
         {
-          "type": "enum",
+          "type": "sctruct",
           "fields": [
             {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_NONE",
-              "value": 0
+              "type": "unsigned int",
+              "name": "version"
             },
             {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_LOADING_STASH",
-              "value": 1
+              "type": "git_apply_delta_cb",
+              "name": "delta_cb"
             },
             {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX",
-              "value": 2
+              "type": "git_apply_hunk_cb",
+              "name": "hunk_cb"
             },
             {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED",
-              "value": 3
-            },
-            {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED",
-              "value": 4
-            },
-            {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED",
-              "value": 5
-            },
-            {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED",
-              "value": 6
-            },
-            {
-              "type": "int",
-              "name": "GIT_STASH_APPLY_PROGRESS_DONE",
-              "value": 7
+              "type": "void *",
+              "name": "payload"
             }
-          ]
+          ],
+          "used": {
+            "needs": [
+              "git_apply_init_options"
+            ]
+          }
         }
       ],
       [
@@ -854,6 +894,39 @@
         }
       ],
       [
+        "git_remote_create_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "git_repository *",
+              "name": "repository"
+            },
+            {
+              "type": "const char *",
+              "name": "name"
+            },
+            {
+              "type": "const char *",
+              "name": "fetchspec"
+            },
+            {
+              "type": "unsigned int",
+              "name": "flags"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_remote_create_init_options"
+            ]
+          }
+        }
+      ],
+      [
         "git_remote_head",
         {
           "types": "struct",
@@ -887,15 +960,51 @@
         }
       ],
       [
-        "git_time_t",
+        "git_stash_apply_progress_t",
         {
-          "type": "enum"
-        }
-      ],
-      [
-        "git_trace_level_t",
-        {
-          "type": "enum"
+          "type": "enum",
+          "fields": [
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_NONE",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_LOADING_STASH",
+              "value": 1
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_INDEX",
+              "value": 2
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_MODIFIED",
+              "value": 3
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_ANALYZE_UNTRACKED",
+              "value": 4
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_UNTRACKED",
+              "value": 5
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_CHECKOUT_MODIFIED",
+              "value": 6
+            },
+            {
+              "type": "int",
+              "name": "GIT_STASH_APPLY_PROGRESS_DONE",
+              "value": 7
+            }
+          ]
         }
       ],
       [
@@ -964,6 +1073,18 @@
         }
       ],
       [
+        "git_time_t",
+        {
+          "type": "enum"
+        }
+      ],
+      [
+        "git_trace_level_t",
+        {
+          "type": "enum"
+        }
+      ],
+      [
         "git_worktree_add_options",
         {
           "type": "struct",
@@ -1028,7 +1149,8 @@
         "git_annotated_commit_from_ref",
         "git_annotated_commit_from_revspec",
         "git_annotated_commit_id",
-        "git_annotated_commit_lookup"
+        "git_annotated_commit_lookup",
+        "git_annotated_commit_ref"
       ]
     },
     "diff": {
@@ -1042,6 +1164,12 @@
     },
     "index": {
       "functions": [
+        "git_index_conflict_iterator_free",
+        "git_index_conflict_iterator_new",
+        "git_index_conflict_next",
+        "git_index_iterator_free",
+        "git_index_iterator_new",
+        "git_index_iterator_next",
         "git_index_name_add",
         "git_index_name_clear",
         "git_index_name_entrycount",

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,16 @@
+var util = require("util");
+var NodeGit = require("../");
+
+// Deprecated -----------------------------------------------------------------
+
+// In 0.28.0 git_error was majorly refactored to have better naming in libgit2
+// We will continue to support the old enum entries but with a deprecation
+// warning as they will go away soon.
+Object.keys(NodeGit.Error.CODE).forEach((key) => {
+  Object.defineProperty(NodeGit.Error.CODE, `GITERR_${key}`, {
+    get: util.deprecate(
+      () => NodeGit.Error.CODE[key],
+      `Use NodeGit.Error.CODE.${key} instead.`
+    )
+  });
+});

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+var util = require("util");
 var NodeGit = require("../");
 
 var Index = NodeGit.Index;
@@ -32,3 +33,67 @@ Index.prototype.removeAll = function(pathspec, matchedCallback) {
 Index.prototype.updateAll = function(pathspec, matchedCallback) {
   return _updateAll.call(this, pathspec || "*", matchedCallback, null);
 };
+
+// Deprecated -----------------------------------------------------------------
+
+NodeGit.Index.CAP = {};
+Object.keys(NodeGit.Index.CAPABILITY).forEach((key) => {
+  Object.defineProperty(NodeGit.Index.CAP, key, {
+    get: util.deprecate(
+      () => NodeGit.Index.CAPABILITY[key],
+      `Use NodeGit.Index.CAPABILITY.${key} instead.`
+    )
+  });
+});
+
+NodeGit.Enums.INDXENTRY_FLAG = {};
+Object.defineProperty(NodeGit.Enums.INDXENTRY_FLAG, "IDXENTRY_EXTENDED", {
+  get: util.deprecate(
+    () => NodeGit.Index.ENTRY_FLAG.ENTRY_EXTENDED,
+    "Use NodeGit.Index.ENTRY_FLAG.ENTRY_EXTENDED instead."
+  )
+});
+Object.defineProperty(NodeGit.Enums.INDXENTRY_FLAG, "IDXENTRY_VALID", {
+  get: util.deprecate(
+    () => NodeGit.Index.ENTRY_FLAG.ENTRY_VALID,
+    "Use NodeGit.Index.ENTRY_FLAG.ENTRY_VALID instead."
+  )
+});
+
+NodeGit.Enums.IDXENTRY_EXTENDED_FLAG = {};
+var EXTENDED_FLAGS_MAP = {
+  IDXENTRY_INTENT_TO_ADD: "ENTRY_INTENT_TO_ADD",
+  IDXENTRY_SKIP_WORKTREE: "ENTRY_SKIP_WORKTREE",
+  S: "S",
+  IDXENTRY_UPTODATE: "ENTRY_UPTODATE"
+};
+Object.keys(EXTENDED_FLAGS_MAP).forEach((key) => {
+  const newKey = EXTENDED_FLAGS_MAP[key];
+  Object.defineProperty(NodeGit.Enums.IDXENTRY_EXTENDED_FLAG, key, {
+    get: util.deprecate(
+      () => NodeGit.Index.ENTRY_EXTENDED_FLAG[newKey],
+      `Use NodeGit.Index.ENTRY_EXTENDED_FLAG.${newKey} instead.`
+    )
+  });
+});
+
+var DEPRECATED_EXTENDED_FLAGS = {
+  IDXENTRY_EXTENDED2: 32768,
+  IDXENTRY_UPDATE: 1,
+  IDXENTRY_REMOVE: 2,
+  IDXENTRY_ADDED: 8,
+  IDXENTRY_HASHED: 16,
+  IDXENTRY_UNHASHED: 32,
+  IDXENTRY_WT_REMOVE: 64,
+  IDXENTRY_CONFLICTED: 128,
+  IDXENTRY_UNPACKED: 256,
+  IDXENTRY_NEW_SKIP_WORKTREE: 512,
+};
+Object.keys(DEPRECATED_EXTENDED_FLAGS).forEach((key) => {
+  Object.defineProperty(NodeGit.Enums.IDXENTRY_EXTENDED_FLAG, key, {
+    get: util.deprecate(
+      () => DEPRECATED_EXTENDED_FLAGS[key],
+      "LibGit2 has removed this flag for public usage."
+    )
+  });
+});

--- a/lib/object.js
+++ b/lib/object.js
@@ -1,3 +1,4 @@
+var util = require("util");
 var NodeGit = require("../");
 
 var Obj = NodeGit.Object;
@@ -33,3 +34,12 @@ Obj.prototype.isTag = function() {
 Obj.prototype.isTree = function() {
   return this.type() == Obj.TYPE.TREE;
 };
+
+// Deprecated -----------------------------------------------------------------
+
+Object.defineProperty(Obj.TYPE, "BAD", {
+  get: util.deprecate(
+    () => Obj.TYPE.INVALID,
+    "Use NodeGit.Object.TYPE.INVALID instead."
+  )
+});

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -30,7 +30,7 @@ Reference.lookup = LookupWrapper(Reference);
  * @return {Boolean}
  */
 Reference.prototype.isConcrete = function() {
-  return this.type() == Reference.TYPE.OID;
+  return this.type() == Reference.TYPE.DIRECT;
 };
 
 /**
@@ -75,7 +75,7 @@ const getTerminal = (repo, refName, depth = 10, prevRef = null) => {
 
   return NodeGit.Reference.lookup(repo, refName)
     .then((ref) => {
-      if (ref.type() === NodeGit.Reference.TYPE.OID) {
+      if (ref.type() === NodeGit.Reference.TYPE.DIRECT) {
         return {
           error: NodeGit.Error.CODE.OK,
           out: ref

--- a/lib/reference.js
+++ b/lib/reference.js
@@ -1,3 +1,4 @@
+var util = require("util");
 var NodeGit = require("../");
 var LookupWrapper = NodeGit.Utils.lookupWrapper;
 
@@ -183,3 +184,29 @@ Reference.updateTerminal = function (
       return reflog.write();
     });
 };
+
+// Deprecated -----------------------------------------------------------------
+
+Object.defineProperty(NodeGit.Reference.TYPE, "OID", {
+  get: util.deprecate(
+    () => NodeGit.Reference.TYPE.DIRECT,
+    "Use NodeGit.Reference.TYPE.DIRECT instead."
+  )
+});
+
+Object.defineProperty(NodeGit.Reference.TYPE, "LISTALL", {
+  get: util.deprecate(
+    () => NodeGit.Reference.TYPE.ALL,
+    "Use NodeGit.Reference.TYPE.ALL instead."
+  )
+});
+
+NodeGit.Reference.NORMALIZE = {};
+Object.keys(NodeGit.Reference.FORMAT).forEach((key) => {
+  Object.defineProperty(NodeGit.Reference.NORMALIZE, `REF_FORMAT_${key}`, {
+    get: util.deprecate(
+      () => NodeGit.Reference.FORMAT[key],
+      `Use NodeGit.Reference.FORMAT.${key} instead.`
+    )
+  });
+});

--- a/lib/remote.js
+++ b/lib/remote.js
@@ -6,6 +6,7 @@ var shallowClone = NodeGit.Utils.shallowClone;
 
 var Remote = NodeGit.Remote;
 var _connect = Remote.prototype.connect;
+var _createWithOpts = Remote.createWithOpts;
 var _download = Remote.prototype.download;
 var _fetch = Remote.prototype.fetch;
 var _push = Remote.prototype.push;
@@ -43,6 +44,11 @@ Remote.prototype.connect = function(
   customHeaders = customHeaders || [];
 
   return _connect.call(this, direction, callbacks, proxyOpts, customHeaders);
+};
+
+Remote.createWithOpts = function(url, options) {
+  return _createWithOpts(url, normalizeOptions(
+    options, NodeGit.RemoteCreateOptions));
 };
 
 /**

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -414,7 +414,7 @@ describe("Diff", function() {
         })
         .then(function([headTree, index]) {
           const diffOptions = new NodeGit.DiffOptions();
-          if (index.caps() & Index.CAP.IGNORE_CASE !== 0) {
+          if (index.caps() & Index.CAPABILITY.IGNORE_CASE !== 0) {
             diffOptions.flags |= Diff.OPTION.IGNORE_CASE;
           }
 


### PR DESCRIPTION
Callbacks added:
- git_apply_delta_cb
- git_apply_hunk_cb

Methods added:
- git_annotated_commit_ref
- git_apply
- git_apply_to_tree
- git_merge_analysis
- git merge_analysis_for_ref
- git_remote_create_with_opts

Exposed classes:
- git_index_conflict_iterator
- git_index_iterator
