### PR TITLE
Catch errors and pass them to libgit2 as error codes in rebase signingcb

### DIFF
--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -26,17 +26,32 @@ function defaultRebaseOptions(options, checkoutStrategy) {
         signatureFieldBuf,
         commitContent
       ) {
-        return Promise.resolve(signingCb(commitContent))
-          .then(function({ code, field, signedData }) {
-            if (code === NodeGit.Error.CODE.OK) {
-              signatureBuf.setString(signedData);
-              if (field) {
-                signatureFieldBuf.setString(field);
-              }
-            }
+        try {
+          const signingCbResult = signingCb(commitContent);
 
-            return code;
-          });
+          return Promise.resolve(signingCbResult)
+            .then(function({ code, field, signedData }) {
+              if (code === NodeGit.Error.CODE.OK) {
+                signatureBuf.setString(signedData);
+                if (field) {
+                  signatureFieldBuf.setString(field);
+                }
+              }
+
+              return code;
+            })
+            .catch(function(error) {
+              if (error && error.code) {
+                return error.code;
+              }
+              return NodeGit.Error.CODE.ERROR;
+            });
+        } catch (error) {
+          if (error && error.code) {
+            return error.code;
+          }
+          return NodeGit.Error.CODE.ERROR;
+        }
       };
     }
 


### PR DESCRIPTION
It seems we expected that the signing CB would never throw or reject when returning a failure code. This PR should help alleviate unexpected behavior where throwing or rejecting should check for an error code and return that _or_ should return a generic -1 error.