### PR TITLE
Clean up some dangerous memory accesses in callbacks

### DIFF
--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -57,24 +57,6 @@
       "error": -1
     }
   },
-  "git_blob_chunk_cb": {
-    "args": [
-      {
-        "name": "entry",
-        "cType": "const git_config_entry *"
-      },
-      {
-        "name": "payload",
-        "cType": "void *"
-      }
-    ],
-    "return": {
-      "type": "int",
-      "noResults": 1,
-      "success": 0,
-      "error": -1
-    }
-  },
   "git_checkout_notify_cb": {
     "args": [
       {
@@ -326,7 +308,8 @@
     "args": [
       {
         "name": "diff_so_far",
-        "cType": "const git_diff *"
+        "cType": "const git_diff *",
+        "ignore": true
       },
       {
         "name": "delta_to_add",
@@ -347,11 +330,13 @@
       "success": 0,
       "error": -1
     }
-  },"git_diff_progress_cb": {
+  },
+  "git_diff_progress_cb": {
     "args": [
       {
         "name": "diff_so_far",
-        "cType": "const git_diff *"
+        "cType": "const git_diff *",
+        "ignore": true
       },
       {
         "name": "old_path",
@@ -551,7 +536,7 @@
     "args": [
       {
         "name": "out",
-        "cType": "git_repository **",
+        "cType": "git_remote **",
         "isReturn": true
       },
       {

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -176,6 +176,28 @@
         },
         "group": "filter_source"
       },
+      "git_filter_source_repo": {
+        "args": [
+          {
+            "name": "out",
+            "type": "git_repository **"
+          },
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "isManual": true,
+        "cFile": "generate/templates/manual/filter_source/repo.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "type": "function",
+        "group": "filter_source",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_patch_convenient_from_diff": {
         "args": [
           {

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -52,6 +52,8 @@ module.exports = function generateNativeCode() {
     argsInfo: require("../templates/filters/args_info"),
     arrayTypeToPlainType: require("../templates/filters/array_type_to_plain_type"),
     asElementPointer: require("../templates/filters/as_element_pointer"),
+    callbackArgsInfo: require("../templates/filters/callback_args_info"),
+    callbackArgsCount: require("../templates/filters/callback_args_count"),
     cppToV8: require("../templates/filters/cpp_to_v8"),
     defaultValue: require("../templates/filters/default_value"),
     fieldsInfo: require("../templates/filters/fields_info"),

--- a/generate/templates/filters/callback_args_count.js
+++ b/generate/templates/filters/callback_args_count.js
@@ -1,0 +1,18 @@
+module.exports = function(args) {
+  if (!args) {
+    return 0;
+  }
+
+  return args.reduce(
+    function(count, arg) {
+      var shouldCount = !arg.isReturn &&
+        !arg.isSelf &&
+        arg.name !== "payload" &&
+        arg.name !== "self" &&
+        !arg.ignore;
+
+      return shouldCount ? count + 1 : count;
+    },
+    0
+  );
+};

--- a/generate/templates/filters/callback_args_info.js
+++ b/generate/templates/filters/callback_args_info.js
@@ -1,0 +1,27 @@
+module.exports = function(args) {
+  var result = args.reduce(
+    function(argList, arg) {
+      var useArg = !arg.isReturn &&
+        !arg.isSelf &&
+        arg.name !== "payload" &&
+        arg.name !== "self" &&
+        !arg.ignore;
+
+      if (!useArg) {
+        return argList;
+      }
+
+      arg.firstArg = argList.length === 0;
+      argList.push(arg);
+
+      return argList;
+    },
+    []
+  );
+
+  if (result.length) {
+    result[result.length - 1].lastArg = true;
+  }
+
+  return result;
+};

--- a/generate/templates/filters/js_args_count.js
+++ b/generate/templates/filters/js_args_count.js
@@ -5,11 +5,11 @@ module.exports = function(args) {
   if (!args) {
     return 0;
   }
-  
+
   for(cArg = 0, jsArg = 0; cArg < args.length; cArg++) {
     var arg = args[cArg];
 
-    if (!arg.isReturn && !arg.isSelf && !arg.isPayload) {
+    if (!arg.isReturn && !arg.isSelf) {
       jsArg++;
     }
   }

--- a/generate/templates/manual/filter_source/repo.cc
+++ b/generate/templates/manual/filter_source/repo.cc
@@ -1,0 +1,90 @@
+// NOTE you may need to occasionally rebuild this method by calling the generators
+// if major changes are made to the templates / generator.
+
+// Due to some garbage collection issues related to submodules and git_filters, we need to clone the repository
+// pointer before giving it to a user.
+
+/*
+ * @param Repository callback
+ */
+NAN_METHOD(GitFilterSource::Repo) {
+  if (info.Length() == 0 || !info[0]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  RepoBaton *baton = new RepoBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->src = Nan::ObjectWrap::Unwrap<GitFilterSource>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(v8::Local<Function>::Cast(info[0]));
+  RepoWorker *worker = new RepoWorker(baton, callback);
+
+  worker->SaveToPersistent("src", info.This());
+
+  AsyncLibgit2QueueWorker(worker);
+  return;
+}
+
+void GitFilterSource::RepoWorker::Execute() {
+  git_error_clear();
+
+  {
+    LockMaster lockMaster(true, baton->src);
+
+    git_repository *repo = git_filter_source_repo(baton->src);
+    baton->error_code = git_repository_open(&repo, git_repository_path(repo));
+
+    if (baton->error_code == GIT_OK) {
+      baton->out = repo;
+    } else if (git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
+    }
+  }
+}
+
+void GitFilterSource::RepoWorker::HandleOKCallback() {
+  if (baton->error_code == GIT_OK) {
+    v8::Local<v8::Value> to;
+
+    if (baton->out != NULL) {
+      to = GitRepository::New(baton->out, true);
+    } else {
+      to = Nan::Null();
+    }
+
+    v8::Local<v8::Value> argv[2] = {Nan::Null(), to};
+    callback->Call(2, argv, async_resource);
+  } else {
+    if (baton->error) {
+      v8::Local<v8::Object> err;
+      if (baton->error->message) {
+        err = Nan::Error(baton->error->message)->ToObject();
+      } else {
+        err = Nan::Error("Method repo has thrown an error.")->ToObject();
+      }
+      err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(),
+               Nan::New("FilterSource.repo").ToLocalChecked());
+      v8::Local<v8::Value> argv[1] = {err};
+      callback->Call(1, argv, async_resource);
+      if (baton->error->message)
+        free((void *)baton->error->message);
+      free((void *)baton->error);
+    } else if (baton->error_code < 0) {
+      v8::Local<v8::Object> err =
+          Nan::Error("Method repo has thrown an error.")->ToObject();
+      err->Set(Nan::New("errno").ToLocalChecked(),
+               Nan::New(baton->error_code));
+      err->Set(Nan::New("errorFunction").ToLocalChecked(),
+               Nan::New("FilterSource.repo").ToLocalChecked());
+      v8::Local<v8::Value> argv[1] = {err};
+      callback->Call(1, argv, async_resource);
+    } else {
+      callback->Call(0, NULL, async_resource);
+    }
+  }
+
+  delete baton;
+}

--- a/test/tests/filter.js
+++ b/test/tests/filter.js
@@ -2,6 +2,7 @@ var assert = require("assert");
 var fse = require("fs-extra");
 var path = require("path");
 var local = path.join.bind(path, __dirname);
+var garbageCollect = require("../utils/garbage_collect.js");
 
 describe("Filter", function() {
   var NodeGit = require("../../");
@@ -216,7 +217,7 @@ describe("Filter", function() {
       }, 0)
       .then(function(result) {
         assert.strictEqual(result, NodeGit.Error.CODE.OK);
-        global.gc();
+        garbageCollect();
 
         return fse.writeFile(
           packageJsonPath,
@@ -338,7 +339,8 @@ describe("Filter", function() {
           return Checkout.head(test.repository, opts);
         })
         .then(function() {
-          global.gc();
+          garbageCollect();
+
           return Registry.unregister(filterName);
         })
         .then(function(result) {
@@ -637,7 +639,7 @@ describe("Filter", function() {
           );
           assert.notStrictEqual(readmeContent, message);
           fse.writeFileSync(readmePath, "whoa", "utf8");
-          global.gc();
+          garbageCollect();
 
           var opts = {
             checkoutStrategy: Checkout.STRATEGY.FORCE,
@@ -725,7 +727,7 @@ describe("Filter", function() {
         cleanup: function() {}
       }, 0)
         .then(function(result) {
-          global.gc();
+          garbageCollect();
           assert.strictEqual(result, NodeGit.Error.CODE.OK);
         })
         .then(function() {
@@ -742,7 +744,7 @@ describe("Filter", function() {
           );
         })
         .then(function(oid) {
-          global.gc();
+          garbageCollect();
           return test.repository.getHeadCommit();
         })
         .then(function(commit) {
@@ -755,7 +757,7 @@ describe("Filter", function() {
             postInitializeReadmeContents, "testing commit contents"
           );
           assert.strictEqual(commit.message(), "test commit");
-          global.gc();
+          garbageCollect();
 
           return commit.getEntry("README.md");
         })
@@ -842,7 +844,7 @@ describe("Filter", function() {
         );
         assert.notEqual(packageContent, "");
 
-        global.gc();
+        garbageCollect();
         return fse.writeFile(
           packageJsonPath,
           "Changing content to trigger checkout",
@@ -1131,6 +1133,9 @@ describe("Filter", function() {
             paths: "package.json"
           };
           return Checkout.head(test.repository, opts);
+        })
+        .then(function() {
+          garbageCollect();
         });
     });
   });


### PR DESCRIPTION
We don't have a very good pattern for garbage collection in callback parameters at the moment. After introducing garbage collection elsewhere in the library, we left callback parameters as not garbage collected, because they typically are owned by libgit2 anyway. So as long libgit2 is cleaning up their pointer, and we're cleaning up our v8 object, the memory ends up being cleaned up anyway.

The caveat was that callback parameters should not be trusted after a callback exits.

What sucks is that we discovered that you can access a git_repository from a git_filter_source, and that the git_repository that you can access is not guaranteed to be a git_repository that nodegit has ever seen before. In fact, it may not even be owned by NodeGit. In the case of submodules, when a git_submodule_status is performed, the filters are invoked with a repository that is internal to git_submodule_status. This means that those repos are freed by libgit2, and are never owned by nodegit.

This PR addresses that segfault, by making the git_filter_source repo getter async, and having that getter open a new repo that nodegit owns. This PR also removes access to git_diff in git_diff_notify_cb and git_diff_progress_cb, as I can't figure out a good way to handle that memory access at the moment... Something something tree invalidation :sweat_smile:.