### PR TITLE
EOL for Node 6 and Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: false
-# update to Xenial in April 2019; Trusty will be EOL, Xenial new minimum supported OS version
-dist: trusty
+dist: xenial
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
 node_js:
   - "10"
   - "8"
-  - "6"
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ environment:
     # Node.js
     - nodejs_version: "10"
     - nodejs_version: "8"
-    - nodejs_version: "6"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Both Node 6 and Ubuntu 14.04 are EOL after April 2019. This PR removes support from those from CI.