### PR TITLE
Ensures that commits from parent(*) has a repository

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -5,6 +5,7 @@ var Commit = NodeGit.Commit;
 var LookupWrapper = NodeGit.Utils.lookupWrapper;
 
 var _amend = Commit.prototype.amend;
+var _parent = Commit.prototype.parent;
 
 /**
  * Retrieves the commit pointed to by the oid
@@ -392,6 +393,21 @@ Commit.prototype.history = function() {
   };
 
   return event;
+};
+
+/**
+ * Get the specified parent of the commit.
+ * 
+ * @param {number} the position of the parent, starting from 0
+ * @async
+ * @return {Commit} the parent commit at the specified position
+ */
+Commit.prototype.parent = function (id) {
+  var repository = this.repo;
+  return _parent.call(this, id).then(function(parent) {
+    parent.repo = repository;
+    return parent;
+  });
 };
 
 /**

--- a/test/tests/commit.js
+++ b/test/tests/commit.js
@@ -128,6 +128,18 @@ describe("Commit", function() {
     assert.equal(this.commit.timeOffset(), 780);
   });
 
+  it("can call getTree on a parent commit", function() {
+    return this.commit.parent(0)
+    .then(function(parent) {
+      return parent.getTree();
+    })
+    .then(function(tree) {
+      assert.equal(
+        tree.id().toString(), "327ff68e59f94f0c25d2c62fb0938efa01e8a107"
+      );
+    });
+  });
+
   it("can create a commit", function() {
     var test = this;
     var expectedCommitId = "315e77328ef596f3bc065d8ac6dd2c72c09de8a5";


### PR DESCRIPTION
Commit has functions that requires a reference to a repository to run. Because `parent(*)` was simply calling out to libgit2's `git_commit_parent` directly, its `repo` field was not being set.

Creating a wrapper in the `Commit` class and assigning a repository to the object before returning it will fix this problem.

Fixes #1653.