### PR TITLE
Add additional getters to streamline information gathering (breaking change)

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1504,6 +1504,7 @@
         }
       },
       "dependencies": [
+        "../include/git_buf_converter.h",
         "../include/filter_registry.h"
       ]
     },
@@ -3241,7 +3242,9 @@
       "selfFreeing": true,
       "isSingleton": true,
       "dependencies": [
-        "git2/sys/repository.h"
+        "git2/sys/repository.h",
+        "../include/submodule.h",
+        "../include/remote.h"
       ],
       "functions": {
         "git_repository_config": {
@@ -4220,7 +4223,10 @@
         "git_worktree_prune_init_options": {
           "ignore": true
         }
-      }
+      },
+      "dependencies": [
+        "../include/git_buf_converter.h"
+      ]
     },
     "writestream": {
       "cType": "git_writestream",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -282,6 +282,28 @@
           "isErrorCode": true
         }
       },
+      "git_repository_get_submodules": {
+        "args": [
+          {
+            "name": "out",
+            "type": "std::vector<git_submodule *> *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/repository/get_submodules.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "repository",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_repository_get_remotes": {
         "args": [
           {
@@ -578,6 +600,7 @@
         "repository",
         [
           "git_repository_get_references",
+          "git_repository_get_submodules",
           "git_repository_get_remotes"
         ]
       ],

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -352,6 +352,32 @@
         },
         "group": "reset"
       },
+      "git_revwalk_commit_walk": {
+        "args": [
+          {
+            "name": "max_count",
+            "type": "int"
+          },
+          {
+            "name": "out",
+            "type": "std::vector<git_commit *> *"
+          },
+          {
+            "name": "walk",
+            "type": "git_revwalk *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/revwalk/commit_walk.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "revwalk",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_revwalk_fast_walk": {
         "args": [
           {
@@ -607,6 +633,7 @@
       [
         "revwalk",
         [
+          "git_revwalk_commit_walk",
           "git_revwalk_fast_walk",
           "git_revwalk_file_history_walk"
         ]

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -260,6 +260,28 @@
           "isErrorCode": true
         }
       },
+      "git_repository_get_references": {
+        "args": [
+          {
+            "name": "out",
+            "type": "std::vector<git_reference *> *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/repository/get_references.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "repository",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_repository_get_remotes": {
         "args": [
           {
@@ -555,6 +577,7 @@
       [
         "repository",
         [
+          "git_repository_get_references",
           "git_repository_get_remotes"
         ]
       ],

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -260,6 +260,28 @@
           "isErrorCode": true
         }
       },
+      "git_repository_get_remotes": {
+        "args": [
+          {
+            "name": "out",
+            "type": "std::vector<git_remote *> *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/repository/get_remotes.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "repository",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_reset": {
         "type": "function",
         "file": "reset.h",
@@ -528,6 +550,12 @@
         "remote",
         [
           "git_remote_reference_list"
+        ]
+      ],
+      [
+        "repository",
+        [
+          "git_repository_get_remotes"
         ]
       ],
       [

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -326,6 +326,28 @@
           "isErrorCode": true
         }
       },
+      "git_repository_refresh_references": {
+        "args": [
+          {
+            "name": "out",
+            "type": "void *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/repository/refresh_references.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "repository",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_reset": {
         "type": "function",
         "file": "reset.h",
@@ -627,7 +649,8 @@
         [
           "git_repository_get_references",
           "git_repository_get_submodules",
-          "git_repository_get_remotes"
+          "git_repository_get_remotes",
+          "git_repository_refresh_references"
         ]
       ],
       [

--- a/generate/templates/manual/repository/get_references.cc
+++ b/generate/templates/manual/repository/get_references.cc
@@ -1,0 +1,133 @@
+NAN_METHOD(GitRepository::GetReferences)
+{
+  if (info.Length() == 0 || !info[0]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  GetReferencesBaton* baton = new GetReferencesBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->out = new std::vector<git_reference *>;
+  baton->repo = Nan::ObjectWrap::Unwrap<GitRepository>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
+  GetReferencesWorker *worker = new GetReferencesWorker(baton, callback);
+  worker->SaveToPersistent("repo", info.This());
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+void GitRepository::GetReferencesWorker::Execute()
+{
+  giterr_clear();
+
+  LockMaster lockMaster(true, baton->repo);
+  git_repository *repo = baton->repo;
+
+  git_strarray reference_names;
+  baton->error_code = git_reference_list(&reference_names, repo);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete baton->out;
+    baton->out = NULL;
+    return;
+  }
+
+  for (size_t reference_index = 0; reference_index < reference_names.count; ++reference_index) {
+    git_reference *reference;
+    baton->error_code = git_reference_lookup(&reference, repo, reference_names.strings[reference_index]);
+
+    // stop execution and return if there is an error
+    if (baton->error_code != GIT_OK) {
+      if (giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
+
+      // unwind and return
+      while (baton->out->size()) {
+        git_reference *referenceToFree = baton->out->back();
+        baton->out->pop_back();
+        git_reference_free(referenceToFree);
+      }
+
+      git_strarray_free(&reference_names);
+      git_repository_free(repo);
+      delete baton->out;
+      baton->out = NULL;
+      return;
+    }
+
+    if (git_reference_type(reference) == GIT_REF_SYMBOLIC) {
+      git_reference *resolved_reference;
+      int resolve_result = git_reference_resolve(&resolved_reference, reference);
+      git_reference_free(reference);
+
+      // if we can't resolve the ref, then just ignore it
+      if (resolve_result == GIT_OK) {
+        baton->out->push_back(resolved_reference);
+      }
+    } else {
+      baton->out->push_back(reference);
+    }
+  }
+}
+
+void GitRepository::GetReferencesWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    unsigned int size = baton->out->size();
+    Local<Array> result = Nan::New<Array>(size);
+    for (unsigned int i = 0; i < size; i++) {
+      git_reference *reference = baton->out->at(i);
+      Nan::Set(
+        result,
+        Nan::New<Number>(i),
+        GitRefs::New(
+          reference,
+          true,
+          GitRepository::New(git_reference_owner(reference), true)->ToObject()
+        )
+      );
+    }
+
+    delete baton->out;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv, async_resource);
+    if (baton->error->message)
+    {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::Error("Repository getReferences has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Repository.getReferences").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  }
+  else
+  {
+    callback->Call(0, NULL, async_resource);
+  }
+}

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -1,0 +1,134 @@
+NAN_METHOD(GitRepository::GetRemotes)
+{
+  if (info.Length() == 0 || !info[0]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  GetRemotesBaton* baton = new GetRemotesBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->out = new std::vector<git_remote *>;
+  baton->repo = Nan::ObjectWrap::Unwrap<GitRepository>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
+  GetRemotesWorker *worker = new GetRemotesWorker(baton, callback);
+  worker->SaveToPersistent("repo", info.This());
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+void GitRepository::GetRemotesWorker::Execute()
+{
+  giterr_clear();
+
+  git_repository *repo;
+  {
+    LockMaster lockMaster(true, baton->repo);
+    baton->error_code = git_repository_open(&repo, git_repository_workdir(baton->repo));
+  }
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete baton->out;
+    baton->out = NULL;
+    return;
+  }
+
+  git_strarray remote_names;
+  baton->error_code = git_remote_list(&remote_names, repo);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete baton->out;
+    baton->out = NULL;
+    return;
+  }
+
+  for (size_t remote_index = 0; remote_index < remote_names.count; ++remote_index) {
+    git_remote *remote;
+    baton->error_code = git_remote_lookup(&remote, repo, remote_names.strings[remote_index]);
+
+    // stop execution and return if there is an error
+    if (baton->error_code != GIT_OK) {
+      if (giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
+
+      // unwind and return
+      while (baton->out->size()) {
+        git_remote *remoteToFree = baton->out->back();
+        baton->out->pop_back();
+        git_remote_free(remoteToFree);
+      }
+
+      git_strarray_free(&remote_names);
+      git_repository_free(repo);
+      delete baton->out;
+      baton->out = NULL;
+      return;
+    }
+
+    baton->out->push_back(remote);
+  }
+}
+
+void GitRepository::GetRemotesWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    unsigned int size = baton->out->size();
+    Local<Array> result = Nan::New<Array>(size);
+    for (unsigned int i = 0; i < size; i++) {
+      git_remote *remote = baton->out->at(i);
+      Nan::Set(
+        result,
+        Nan::New<Number>(i),
+        GitRemote::New(
+          remote,
+          true,
+          GitRepository::New(git_remote_owner(remote), true)->ToObject()
+        )
+      );
+    }
+
+    delete baton->out;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv, async_resource);
+    if (baton->error->message)
+    {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::Error("Repository refreshRemotes has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Repository.refreshRemotes").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  }
+  else
+  {
+    callback->Call(0, NULL, async_resource);
+  }
+}

--- a/generate/templates/manual/repository/get_submodules.cc
+++ b/generate/templates/manual/repository/get_submodules.cc
@@ -1,0 +1,115 @@
+NAN_METHOD(GitRepository::GetSubmodules)
+{
+  if (info.Length() == 0 || !info[0]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  GetSubmodulesBaton* baton = new GetSubmodulesBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->out = new std::vector<git_submodule *>;
+  baton->repo = Nan::ObjectWrap::Unwrap<GitRepository>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
+  GetSubmodulesWorker *worker = new GetSubmodulesWorker(baton, callback);
+  worker->SaveToPersistent("repo", info.This());
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+struct submodule_foreach_payload {
+  git_repository *repo;
+  std::vector<git_submodule *> *out;
+};
+
+int foreachSubmoduleCB(git_submodule *submodule, const char *name, void *void_payload) {
+  submodule_foreach_payload *payload = (submodule_foreach_payload *)void_payload;
+  git_submodule *out;
+
+  int result = git_submodule_lookup(&out, payload->repo, name);
+  if (result == GIT_OK) {
+    payload->out->push_back(out);
+  }
+
+  return result;
+}
+
+void GitRepository::GetSubmodulesWorker::Execute()
+{
+  giterr_clear();
+
+  LockMaster lockMaster(true, baton->repo);
+
+  submodule_foreach_payload payload { baton->repo, baton->out };
+  baton->error_code = git_submodule_foreach(baton->repo, foreachSubmoduleCB, (void *)&payload);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+
+    while (baton->out->size()) {
+      git_submodule_free(baton->out->back());
+      baton->out->pop_back();
+    }
+    delete baton->out;
+    baton->out = NULL;
+  }
+}
+
+void GitRepository::GetSubmodulesWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    unsigned int size = baton->out->size();
+    Local<Array> result = Nan::New<Array>(size);
+    for (unsigned int i = 0; i < size; i++) {
+      git_submodule *submodule = baton->out->at(i);
+      Nan::Set(
+        result,
+        Nan::New<Number>(i),
+        GitSubmodule::New(
+          submodule,
+          true,
+          GitRepository::New(git_submodule_owner(submodule), true)->ToObject()
+        )
+      );
+    }
+
+    delete baton->out;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv, async_resource);
+    if (baton->error->message)
+    {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::Error("Repository getSubmodules has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Repository.getSubmodules").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  }
+  else
+  {
+    callback->Call(0, NULL, async_resource);
+  }
+}

--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -1,0 +1,532 @@
+int getOidOfReferenceCommit(git_oid *commitOid, git_reference *ref) {
+  git_object *commitObject;
+  int result = git_reference_peel(&commitObject, ref, GIT_OBJ_COMMIT);
+
+  if (result != GIT_OK) {
+    return result;
+  }
+
+  git_oid_cpy(commitOid, git_object_id(commitObject));
+  git_object_free(commitObject);
+  return result;
+}
+
+int asDirectReference(git_reference **out, git_reference *ref) {
+  if (git_reference_type(ref) != GIT_REF_SYMBOLIC) {
+    return git_reference_dup(out, ref);
+  }
+
+  return git_reference_resolve(out, ref);
+}
+
+int lookupDirectReferenceByShorthand(git_reference **out, git_repository *repo, const char *shorthand) {
+  git_reference *ref = NULL;
+  int result = git_reference_dwim(&ref, repo, shorthand);
+
+  if (result != GIT_OK) {
+    return result;
+  }
+
+  result = asDirectReference(out, ref);
+  git_reference_free(ref);
+  return result;
+}
+
+int lookupDirectReferenceByFullName(git_reference **out, git_repository *repo, const char *fullName) {
+  git_reference *ref = NULL;
+  int result = git_reference_lookup(&ref, repo, fullName);
+
+  if (result != GIT_OK) {
+    return result;
+  }
+
+  result = asDirectReference(out, ref);
+  git_reference_free(ref);
+  return result;
+}
+
+char *getRemoteNameOfReference(git_reference *remoteReference) {
+  return strtok(strdup(git_reference_shorthand(remoteReference)), "/");
+}
+
+bool gitStrArrayContains(git_strarray *strarray, const char *string) {
+  for (size_t i = 0; i < strarray->count; ++i) {
+    if (strcmp(strarray->strings[i], string) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+class RefreshedRefModel {
+public:
+  RefreshedRefModel(git_reference *ref):
+    fullName(strdup(git_reference_name(ref))),
+    message(NULL),
+    sha(new char[GIT_OID_HEXSZ + 1]),
+    shorthand(strdup(git_reference_shorthand(ref))),
+    type(NULL)
+  {
+    if (git_reference_is_branch(ref)) {
+      type = "branch";
+    } else if (git_reference_is_remote(ref)) {
+      type = "remote";
+    } else {
+      type = "tag";
+    }
+  }
+
+  static int fromReference(RefreshedRefModel **out, git_reference *ref) {
+    RefreshedRefModel *refModel = new RefreshedRefModel(ref);
+    git_oid referencedTargetOid;
+
+    int result = getOidOfReferenceCommit(&referencedTargetOid, ref);
+    if (result != GIT_OK) {
+      delete refModel;
+      return result;
+    }
+
+    if (git_reference_is_tag(ref)) {
+      git_repository *repo = git_reference_owner(ref);
+
+      git_tag *referencedTag;
+      if (git_tag_lookup(&referencedTag, repo, &referencedTargetOid) == GIT_OK) {
+        refModel->message = strdup(git_tag_message(referencedTag));
+        git_tag_free(referencedTag);
+      }
+    }
+
+    git_oid_tostr(refModel->sha, GIT_OID_HEXSZ + 1, &referencedTargetOid);
+
+    *out = refModel;
+    return GIT_OK;
+  }
+
+  v8::Local<v8::Object> toJavascript() {
+    v8::Local<v8::Object> result = Nan::New<Object>();
+
+    v8::Local<v8::Value> jsFullName;
+    if (fullName == NULL) {
+      jsFullName = Nan::Null();
+    } else {
+      jsFullName = Nan::New<String>(fullName).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("fullName").ToLocalChecked(), jsFullName);
+
+    v8::Local<v8::Value> jsMessage;
+    if (message == NULL) {
+      jsMessage = Nan::Null();
+    } else {
+      jsMessage = Nan::New<String>(message).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("message").ToLocalChecked(), jsMessage);
+
+    Nan::Set(
+      result,
+      Nan::New("sha").ToLocalChecked(),
+      Nan::New<String>(sha).ToLocalChecked()
+    );
+
+    v8::Local<v8::Value> jsShorthand;
+    if (shorthand == NULL) {
+      jsShorthand = Nan::Null();
+    } else {
+      jsShorthand = Nan::New<String>(shorthand).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("shorthand").ToLocalChecked(), jsShorthand);
+
+    v8::Local<v8::Value> jsType;
+    if (type == NULL) {
+      jsType = Nan::Null();
+    } else {
+      jsType = Nan::New<String>(type).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("type").ToLocalChecked(), jsType);
+
+    return result;
+  }
+
+  ~RefreshedRefModel() {
+    if (fullName != NULL) { delete[] fullName; }
+    if (message != NULL) { delete[] message; }
+    delete[] sha;
+    if (shorthand != NULL) { delete[] shorthand; }
+  }
+
+  char *fullName, *message, *sha, *shorthand;
+  const char *type;
+};
+
+class UpstreamModel {
+public:
+  UpstreamModel(const char *inputDownstreamFullName, const char *inputUpstreamFullName):
+    downstreamFullName((char *)strdup(inputDownstreamFullName)),
+    upstreamFullName((char *)strdup(inputUpstreamFullName)),
+    ahead(0),
+    behind(0) {}
+
+  static bool fromReference(UpstreamModel **out, git_reference *ref) {
+    if (!git_reference_is_branch(ref)) {
+      return false;
+    }
+
+    git_reference *upstream;
+    int result = git_branch_upstream(&upstream, ref);
+    if (result != GIT_OK) {
+      return false;
+    }
+
+    UpstreamModel *upstreamModel = new UpstreamModel(
+      git_reference_name(ref),
+      git_reference_name(upstream)
+    );
+
+    git_oid localCommitOid;
+    result = getOidOfReferenceCommit(&localCommitOid, ref);
+    if (result != GIT_OK) {
+      delete upstreamModel;
+      return false;
+    }
+
+    git_oid upstreamCommitOid;
+    result = getOidOfReferenceCommit(&upstreamCommitOid, upstream);
+    if (result != GIT_OK) {
+      delete upstreamModel;
+      return false;
+    }
+
+    result = git_graph_ahead_behind(
+      &upstreamModel->ahead,
+      &upstreamModel->behind,
+      git_reference_owner(ref),
+      &localCommitOid,
+      &upstreamCommitOid
+    );
+
+    if (result != GIT_OK) {
+      delete upstreamModel;
+      return false;
+    }
+
+    *out = upstreamModel;
+    return true;
+  }
+
+  v8::Local<v8::Object> toJavascript() {
+    v8::Local<v8::Object> result = Nan::New<Object>();
+
+    v8::Local<v8::Value> jsDownstreamFullName;
+    if (downstreamFullName == NULL) {
+      jsDownstreamFullName = Nan::Null();
+    } else {
+      jsDownstreamFullName = Nan::New<String>(downstreamFullName).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("downstreamFullName").ToLocalChecked(), jsDownstreamFullName);
+
+    v8::Local<v8::Value> jsUpstreamFullName;
+    if (upstreamFullName == NULL) {
+      jsUpstreamFullName = Nan::Null();
+    } else {
+      jsUpstreamFullName = Nan::New<String>(upstreamFullName).ToLocalChecked();
+    }
+    Nan::Set(result, Nan::New("upstreamFullName").ToLocalChecked(), jsUpstreamFullName);
+
+    Nan::Set(result, Nan::New("ahead").ToLocalChecked(), Nan::New<Number>(ahead));
+    Nan::Set(result, Nan::New("behind").ToLocalChecked(), Nan::New<Number>(behind));
+    return result;
+  }
+
+  ~UpstreamModel() {
+    if (downstreamFullName != NULL) { delete[] downstreamFullName; }
+    if (upstreamFullName != NULL) { delete[] upstreamFullName; }
+  }
+
+  char *downstreamFullName;
+  char *upstreamFullName;
+  size_t ahead;
+  size_t behind;
+};
+
+class RefreshReferencesData {
+public:
+  RefreshReferencesData():
+    headRefFullName(NULL),
+    cherrypick(NULL),
+    merge(NULL) {}
+
+  ~RefreshReferencesData() {
+    while(refs.size()) {
+      delete refs.back();
+      refs.pop_back();
+    }
+    while(upstreamInfo.size()) {
+      delete upstreamInfo.back();
+      upstreamInfo.pop_back();
+    }
+    if (headRefFullName != NULL) { delete[] headRefFullName; }
+    if (cherrypick != NULL) { delete cherrypick; }
+    if (merge != NULL) { delete merge; }
+  }
+
+  std::vector<RefreshedRefModel *> refs;
+  std::vector<UpstreamModel *> upstreamInfo;
+  char *headRefFullName;
+  RefreshedRefModel *cherrypick;
+  RefreshedRefModel *merge;
+};
+
+NAN_METHOD(GitRepository::RefreshReferences)
+{
+  if (info.Length() == 0 || !info[0]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  RefreshReferencesBaton* baton = new RefreshReferencesBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->out = (void *)new RefreshReferencesData;
+  baton->repo = Nan::ObjectWrap::Unwrap<GitRepository>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
+  RefreshReferencesWorker *worker = new RefreshReferencesWorker(baton, callback);
+  worker->SaveToPersistent("repo", info.This());
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+void GitRepository::RefreshReferencesWorker::Execute()
+{
+  giterr_clear();
+
+  LockMaster lockMaster(true, baton->repo);
+  git_repository *repo = baton->repo;
+  RefreshReferencesData *refreshData = (RefreshReferencesData *)baton->out;
+
+  // START Refresh HEAD
+  git_reference *headRef = NULL;
+  baton->error_code = lookupDirectReferenceByShorthand(&headRef, repo, "HEAD");
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+
+  RefreshedRefModel *headModel;
+  baton->error_code = RefreshedRefModel::fromReference(&headModel, headRef);
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    git_reference_free(headRef);
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+  refreshData->refs.push_back(headModel);
+
+  refreshData->headRefFullName = strdup(git_reference_name(headRef));
+  git_reference_free(headRef);
+  // END Refresh HEAD
+
+  // START Refresh CHERRY_PICK_HEAD
+  git_reference *cherrypickRef = NULL;
+  if (lookupDirectReferenceByShorthand(&cherrypickRef, repo, "CHERRY_PICK_HEAD") == GIT_OK) {
+    baton->error_code = RefreshedRefModel::fromReference(&refreshData->cherrypick, cherrypickRef);
+    git_reference_free(cherrypickRef);
+  } else {
+    cherrypickRef = NULL;
+  }
+  // END Refresh CHERRY_PICK_HEAD
+
+  // START Refresh MERGE_HEAD
+  git_reference *mergeRef = NULL;
+  // fall through if cherry pick failed
+  if (baton->error_code == GIT_OK && lookupDirectReferenceByShorthand(&mergeRef, repo, "MERGE_HEAD") == GIT_OK) {
+    baton->error_code = RefreshedRefModel::fromReference(&refreshData->merge, mergeRef);
+    git_reference_free(mergeRef);
+  } else {
+    mergeRef = NULL;
+  }
+  // END Refresh MERGE_HEAD
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+
+  // Retrieve reference models and upstream info for each reference
+  git_strarray referenceNames;
+  baton->error_code = git_reference_list(&referenceNames, repo);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+
+  git_strarray remoteNames;
+  baton->error_code = git_remote_list(&remoteNames, repo);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    git_strarray_free(&referenceNames);
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+
+  for (size_t referenceIndex = 0; referenceIndex < referenceNames.count; ++referenceIndex) {
+    git_reference *reference;
+    baton->error_code = lookupDirectReferenceByFullName(&reference, repo, referenceNames.strings[referenceIndex]);
+
+    if (baton->error_code != GIT_OK) {
+      break;
+    }
+
+    UpstreamModel *upstreamModel;
+    if (UpstreamModel::fromReference(&upstreamModel, reference)) {
+      refreshData->upstreamInfo.push_back(upstreamModel);
+    }
+
+    bool isBranch = git_reference_is_branch(reference);
+    bool isRemote = git_reference_is_remote(reference);
+    bool isTag = git_reference_is_tag(reference);
+    if (
+      strcmp(referenceNames.strings[referenceIndex], headModel->fullName) == 0
+      || (!isBranch && !isRemote && !isTag)
+    ) {
+      git_reference_free(reference);
+      continue;
+    }
+
+    if (isRemote) {
+      char *remoteNameOfRef = getRemoteNameOfReference(reference);
+      bool isFromExistingRemote = gitStrArrayContains(&remoteNames, remoteNameOfRef);
+      delete[] remoteNameOfRef;
+      if (!isFromExistingRemote) {
+        git_reference_free(reference);
+        continue;
+      }
+    }
+
+    RefreshedRefModel *refreshedRefModel;
+    baton->error_code = RefreshedRefModel::fromReference(&refreshedRefModel, reference);
+    git_reference_free(reference);
+
+    if (baton->error_code == GIT_OK) {
+      refreshData->refs.push_back(refreshedRefModel);
+    }
+  }
+
+  git_strarray_free(&remoteNames);
+  git_strarray_free(&referenceNames);
+
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+}
+
+void GitRepository::RefreshReferencesWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    RefreshReferencesData *refreshData = (RefreshReferencesData *)baton->out;
+    v8::Local<v8::Object> result = Nan::New<Object>();
+
+    Nan::Set(
+      result,
+      Nan::New("headRefFullName").ToLocalChecked(),
+      Nan::New<String>(refreshData->headRefFullName).ToLocalChecked()
+    );
+
+    unsigned int numRefs = refreshData->refs.size();
+    v8::Local<v8::Array> refs = Nan::New<Array>(numRefs);
+    for (unsigned int i = 0; i < numRefs; ++i) {
+      RefreshedRefModel *refreshedRefModel = refreshData->refs[i];
+      Nan::Set(refs, Nan::New<Number>(i), refreshedRefModel->toJavascript());
+    }
+    Nan::Set(result, Nan::New("refs").ToLocalChecked(), refs);
+
+    unsigned int numUpstreamInfo = refreshData->upstreamInfo.size();
+    v8::Local<v8::Array> upstreamInfo = Nan::New<Array>(numUpstreamInfo);
+    for (unsigned int i = 0; i < numUpstreamInfo; ++i) {
+      UpstreamModel *upstreamModel = refreshData->upstreamInfo[i];
+      Nan::Set(upstreamInfo, Nan::New<Number>(i), upstreamModel->toJavascript());
+    }
+    Nan::Set(result, Nan::New("upstreamInfo").ToLocalChecked(), upstreamInfo);
+
+    if (refreshData->cherrypick != NULL) {
+      Nan::Set(
+        result,
+        Nan::New("cherrypick").ToLocalChecked(),
+        refreshData->cherrypick->toJavascript()
+      );
+    } else {
+      Nan::Set(result, Nan::New("cherrypick").ToLocalChecked(), Nan::Null());
+    }
+
+    if (refreshData->merge != NULL) {
+      Nan::Set(
+        result,
+        Nan::New("merge").ToLocalChecked(),
+        refreshData->merge->toJavascript()
+      );
+    } else {
+      Nan::Set(result, Nan::New("merge").ToLocalChecked(), Nan::Null());
+    }
+
+    delete refreshData;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv, async_resource);
+    if (baton->error->message)
+    {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::Error("Repository refreshReferences has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Repository.refreshReferences").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  }
+  else
+  {
+    callback->Call(0, NULL, async_resource);
+  }
+}

--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -148,7 +148,7 @@ public:
       x509Array,
       Nan::New<Number>(0),
       Nan::New<v8::RegExp>(
-        Nan::New("-----BEGIN SIGNED MESSAGE-----[\s\S]+?-----END SIGNED MESSAGE-----").ToLocalChecked(),
+        Nan::New("-----BEGIN SIGNED MESSAGE-----[\\s\\S]+?-----END SIGNED MESSAGE-----").ToLocalChecked(),
         static_cast<v8::RegExp::Flags>(v8::RegExp::Flags::kGlobal | v8::RegExp::Flags::kMultiline)
       ).ToLocalChecked()
     );
@@ -556,6 +556,8 @@ void GitRepository::RefreshReferencesWorker::Execute()
 
     if (baton->error_code == GIT_OK) {
       refreshData->refs.push_back(refreshedRefModel);
+    } else {
+      baton->error_code = GIT_OK;
     }
   }
 

--- a/generate/templates/manual/revwalk/commit_walk.cc
+++ b/generate/templates/manual/revwalk/commit_walk.cc
@@ -1,0 +1,123 @@
+NAN_METHOD(GitRevwalk::CommitWalk) {
+  if (info.Length() == 0 || !info[0]->IsNumber()) {
+    return Nan::ThrowError("Max count is required and must be a number.");
+  }
+
+  if (info.Length() == 1 || !info[1]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  CommitWalkBaton* baton = new CommitWalkBaton;
+
+  baton->error_code = GIT_OK;
+  baton->error = NULL;
+  baton->max_count = Nan::To<unsigned int>(info[0]).FromJust();
+  baton->out = new std::vector<git_commit *>;
+  baton->out->reserve(baton->max_count);
+  baton->walk = Nan::ObjectWrap::Unwrap<GitRevwalk>(info.This())->GetValue();
+
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]));
+  CommitWalkWorker *worker = new CommitWalkWorker(baton, callback);
+  worker->SaveToPersistent("fastWalk", info.This());
+
+  Nan::AsyncQueueWorker(worker);
+  return;
+}
+
+void GitRevwalk::CommitWalkWorker::Execute() {
+  giterr_clear();
+
+  for (int i = 0; i < baton->max_count; i++) {
+    git_oid next_commit_id;
+    baton->error_code = git_revwalk_next(&next_commit_id, baton->walk);
+
+    if (baton->error_code == GIT_ITEROVER) {
+      baton->error_code = GIT_OK;
+      return;
+    }
+
+    if (baton->error_code != GIT_OK) {
+      if (giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
+
+      while (baton->out->size()) {
+        git_commit_free(baton->out->back());
+        baton->out->pop_back();
+      }
+
+      delete baton->out;
+      baton->out = NULL;
+
+      return;
+    }
+
+    git_commit *commit;
+    baton->error_code = git_commit_lookup(&commit, git_revwalk_repository(baton->walk), &next_commit_id);
+
+    if (baton->error_code != GIT_OK) {
+      if (giterr_last() != NULL) {
+        baton->error = git_error_dup(giterr_last());
+      }
+
+      while (baton->out->size()) {
+        git_commit_free(baton->out->back());
+        baton->out->pop_back();
+      }
+
+      delete baton->out;
+      baton->out = NULL;
+
+      return;
+    }
+
+    baton->out->push_back(commit);
+  }
+}
+
+void GitRevwalk::CommitWalkWorker::HandleOKCallback() {
+  if (baton->out != NULL) {
+    unsigned int size = baton->out->size();
+    Local<Array> result = Nan::New<Array>(size);
+    for (unsigned int i = 0; i < size; i++) {
+      git_commit *commit = baton->out->at(i);
+      Nan::Set(
+        result,
+        Nan::New<Number>(i),
+        GitCommit::New(
+          commit,
+          true,
+          GitRepository::New(git_commit_owner(commit), true)->ToObject()
+        )
+      );
+    }
+
+    delete baton->out;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  } else if (baton->error) {
+    Local<v8::Value> argv[1] = {
+      Nan::Error(baton->error->message)
+    };
+    callback->Call(1, argv, async_resource);
+    if (baton->error->message) {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  } else if (baton->error_code < 0) {
+    Local<v8::Object> err = Nan::Error("Revwalk commitWalk has thrown an error.")->ToObject();
+    err->Set(Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    err->Set(Nan::New("errorFunction").ToLocalChecked(), Nan::New("Revwalk.commitWalk").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  } else {
+    callback->Call(0, NULL, async_resource);
+  }
+}

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -24,7 +24,6 @@ var TreeBuilder = NodeGit.Treebuilder;
 var _discover = Repository.discover;
 var _initExt = Repository.initExt;
 var _fetchheadForeach = Repository.prototype.fetchheadForeach;
-var _getReferences = Repository.prototype.getReferences;
 var _mergeheadForeach = Repository.prototype.mergeheadForeach;
 
 function applySelectedLinesToTarget
@@ -355,7 +354,7 @@ Repository.getReferences = function(repo, type, refNamesOnly) {
     var filteredRefList = refList;
 
     filteredRefList.filter(function(reference) {
-      return type == Reference.TYPE.LISTALL || ref.type === type
+      return type == Reference.TYPE.LISTALL || reference.type === type;
     });
 
     if (refNamesOnly) {

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -24,6 +24,7 @@ var TreeBuilder = NodeGit.Treebuilder;
 var _discover = Repository.discover;
 var _initExt = Repository.initExt;
 var _fetchheadForeach = Repository.prototype.fetchheadForeach;
+var _getReferences = Repository.prototype.getReferences;
 var _mergeheadForeach = Repository.prototype.mergeheadForeach;
 
 function applySelectedLinesToTarget
@@ -349,44 +350,21 @@ Repository.initExt = function(repo_path, opts) {
 };
 
 
-Repository.getReferences = function(repo, type, refNamesOnly, callback) {
-  return Reference.list(repo).then(function(refList) {
-    var refFilterPromises = [];
-    var filteredRefs = [];
+Repository.getReferences = function(repo, type, refNamesOnly) {
+  return repo.getReferences().then(function(refList) {
+    var filteredRefList = refList;
 
-    refList.forEach(function(refName) {
-      refFilterPromises.push(Reference.lookup(repo, refName)
-        .then(function(ref) {
-          if (type == Reference.TYPE.LISTALL || ref.type() == type) {
-            if (refNamesOnly) {
-              filteredRefs.push(refName);
-              return;
-            }
-
-            if (ref.isSymbolic()) {
-              return ref.resolve().then(function(resolvedRef) {
-                resolvedRef.repo = repo;
-
-                filteredRefs.push(resolvedRef);
-              })
-              .catch(function() {
-                // If we can't resolve the ref then just ignore it.
-              });
-            }
-            else {
-              filteredRefs.push(ref);
-            }
-          }
-        })
-      );
+    filteredRefList.filter(function(reference) {
+      return type == Reference.TYPE.LISTALL || ref.type === type
     });
 
-    return Promise.all(refFilterPromises).then(function() {
-      if (typeof callback === "function") {
-        callback(null, filteredRefs);
-      }
-      return filteredRefs;
-    }, callback);
+    if (refNamesOnly) {
+      filteredRefList.map(function(reference) {
+        return reference.name();
+      });
+    }
+
+    return filteredRefList;
   });
 };
 
@@ -1289,9 +1267,6 @@ Repository.prototype.getReferenceNames = function(type, callback) {
  * @param {Reference.TYPE} type Type of reference to look up
  * @return {Array<Reference>}
  */
-Repository.prototype.getReferences = function(type, callback) {
-  return Repository.getReferences(this, type, false, callback);
-};
 
 /**
  * Gets a remote from the repo

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -1068,7 +1068,7 @@ Repository.prototype.fetchAll = function(
   var certificateCheck = remoteCallbacks.certificateCheck;
   var transferProgress = remoteCallbacks.transferProgress;
 
-  return repo.getRemotes()
+  return repo.getRemoteNames()
     .then(function(remotes) {
       return remotes.reduce(function(fetchPromise, remote) {
         var wrappedFetchOptions = shallowClone(fetchOptions);
@@ -1328,7 +1328,7 @@ Repository.prototype.getRemote = function(remote, callback) {
 * @param {Function} Optional callback
 * @return {Object} Promise object.
 */
-Repository.prototype.getRemotes = function(callback) {
+Repository.prototype.getRemoteNames = function(callback) {
   return Remote.list(this).then(function(remotes) {
     if (typeof callback === "function") {
       callback(null, remotes);

--- a/test/tests/remote.js
+++ b/test/tests/remote.js
@@ -19,7 +19,7 @@ describe("Remote", function() {
   var privateUrl = "git@github.com:nodegit/private";
 
   function removeNonOrigins(repo) {
-    return repo.getRemotes()
+    return repo.getRemoteNames()
       .then(function(remotes) {
         return remotes.reduce(function(promise, remote) {
           if (remote !== "origin") {

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -95,7 +95,7 @@ describe("Repository", function() {
   });
 
   it("can list remotes", function() {
-    return this.repository.getRemotes()
+    return this.repository.getRemoteNames()
       .then(function(remotes) {
         assert.equal(remotes.length, 1);
         assert.equal(remotes[0], "origin");


### PR DESCRIPTION
Some getters are of particular concern to GitKraken, others have obvious utility to anyone getting many references or doing a commit walk.

This is breaking because `getRemotes` has been renamed to `getRemoteNames`, and now `getRemotes` returns remotes instead of strings.