### PR TITLE
Root functions should keep their function prototypes correctly

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -3408,6 +3408,7 @@
       ],
       "functions": {
         "git_reset": {
+          "isCollectionRoot": true,
           "args": {
             "checkout_opts": {
               "isOptional": true

--- a/generate/scripts/generateNativeCode.js
+++ b/generate/scripts/generateNativeCode.js
@@ -57,6 +57,8 @@ module.exports = function generateNativeCode() {
     cppToV8: require("../templates/filters/cpp_to_v8"),
     defaultValue: require("../templates/filters/default_value"),
     fieldsInfo: require("../templates/filters/fields_info"),
+    getCPPFunctionForRootProto: require("../templates/filters/get_cpp_function_for_root_proto"),
+    hasFunctionOnRootProto: require("../templates/filters/has_function_on_root_proto"),
     hasReturnType: require("../templates/filters/has_return_type"),
     hasReturnValue: require("../templates/filters/has_return_value"),
     isArrayType: require("../templates/filters/is_array_type"),

--- a/generate/templates/filters/get_cpp_function_for_root_proto.js
+++ b/generate/templates/filters/get_cpp_function_for_root_proto.js
@@ -1,0 +1,12 @@
+module.exports = function(functions) {
+  if (!functions || functions.length === 0) {
+    throw new Error("Should not be able to get function from empty function list");
+  }
+
+  const fun = functions.find(function(f) { return f.useAsOnRootProto; });
+  if (!fun) {
+    throw new Error("There is no function on the root prototype for this collection");
+  }
+
+  return fun.cppFunctionName;
+};

--- a/generate/templates/filters/has_function_on_root_proto.js
+++ b/generate/templates/filters/has_function_on_root_proto.js
@@ -1,0 +1,7 @@
+module.exports = function(functions) {
+  if (!functions || functions.length === 0) {
+    return false;
+  }
+
+  return functions.some(function(f) { return f.useAsOnRootProto; });
+};

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -79,7 +79,11 @@ using namespace node;
   void {{ cppClassName }}::InitializeComponent(v8::Local<v8::Object> target) {
     Nan::HandleScope scope;
 
-    v8::Local<Object> object = Nan::New<Object>();
+    {% if functions|hasFunctionOnRootProto %}
+      v8::Local<FunctionTemplate> object = Nan::New<FunctionTemplate>({{ functions|getCPPFunctionForRootProto }});
+    {% else %}
+      v8::Local<Object> object = Nan::New<Object>();
+    {% endif %}
 
     {% each functions as function %}
       {% if not function.ignore %}
@@ -87,7 +91,15 @@ using namespace node;
       {% endif %}
     {% endeach %}
 
-    Nan::Set(target, Nan::New<String>("{{ jsClassName }}").ToLocalChecked(), object);
+    Nan::Set(
+      target,
+      Nan::New("{{ jsClassName }}").ToLocalChecked(),
+      {% if functions|hasFunctionOnRootProto %}
+        Nan::GetFunction(object).ToLocalChecked()
+      {% else %}
+        object
+      {% endif %}
+    );
   }
 
 {% endif %}


### PR DESCRIPTION
Without treating the root of a nodegit collection as a function template when it is a function itself, when we do the importextension / fix the prototype dance, we were blowing away call, bind, and apply, as well as anything else on the prototype
