### PR TITLE
refresh_references.cc: bust LibGit2 remote list cache by reading config

### DIFF
--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -419,11 +419,24 @@ void GitRepository::RefreshReferencesWorker::Execute()
     if (giterr_last() != NULL) {
       baton->error = git_error_dup(giterr_last());
     }
+    delete refreshData;
+    baton->out = NULL;
+    return;
+  }
+
+  git_config *config;
+  baton->error_code = git_repository_config_snapshot(&config, repo);
+  if (baton->error_code != GIT_OK) {
+    if (giterr_last() != NULL) {
+      baton->error = git_error_dup(giterr_last());
+    }
     git_odb_free(odb);
     delete refreshData;
     baton->out = NULL;
     return;
   }
+  git_config_free(config);
+
 
   // START Refresh HEAD
   git_reference *headRef = NULL;


### PR DESCRIPTION
Also removed calling `git_odb_free` when `git_repository_odb` fails.

This is a band-aid over a caching issue where LibGit2 is not checking the disk when listing the remote names. By manually reading the config, it busts whatever cache LibGit2 is holding on to.