### PR TITLE
Bump libgit2 to fork of latest master

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,17 @@ In Ubuntu:
 sudo apt-get install libssl-dev
 ```
 
-Additionally, you need `curl-config` on your system. You need one of these packages:
-  * libcurl4-gnutls-dev
-  * libcurl4-nss-dev
-  * libcurl4-openssl-dev
+You will need the following libraries installed on your linux machine:
+  - libpcre
+  - libpcreposix
+  - libkrb5
+  - libk5crypto
+  - libcom_err
+
+When building locally, you will also need development packages for kerberos and pcre, so both of these utilities must be present on your machine:
+  - pcre-config
+  - krb5-config
+
 
 If you are still encountering problems while installing, you should try the
 [Building from source](http://www.nodegit.org/guides/install/from-source/)

--- a/generate/input/callbacks.json
+++ b/generate/input/callbacks.json
@@ -476,6 +476,25 @@
       "error": -1
     }
   },
+  "git_indexer_progress_cb": {
+    "args": [
+      {
+        "name": "stats",
+        "cType": "const git_indexer_progress *"
+      },
+      {
+        "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 0,
+      "success": 0,
+      "error": -1,
+      "throttle": 100
+    }
+  },
   "git_note_foreach_cb": {
     "args": [
       {
@@ -522,6 +541,28 @@
       },
       {
         "name": "payload",
+        "cType": "void *"
+      }
+    ],
+    "return": {
+      "type": "int",
+      "noResults": 1,
+      "success": 0,
+      "error": -1
+    }
+  },
+  "git_push_update_reference_cb": {
+    "args": [
+      {
+        "name": "refname",
+        "cType": "const char *"
+      },
+      {
+        "name": "status",
+        "cType": "const char *"
+      },
+      {
+        "name": "data",
         "cType": "void *"
       }
     ],
@@ -692,29 +733,6 @@
       "error": -1
     }
   },
-  "git_smart_subtransport_cb": {
-    "args": [
-      {
-        "name": "out",
-        "cType": "git_smart_subtransport **",
-        "isReturn": true
-      },
-      {
-        "name": "owner",
-        "cType": "git_transport*"
-      },
-      {
-        "name": "param",
-        "cType": "void *"
-      }
-    ],
-    "return": {
-      "type": "int",
-      "noResults": 0,
-      "success": 0,
-      "error": -1
-    }
-  },
   "git_stash_apply_progress_cb": {
     "args": [
       {
@@ -826,26 +844,7 @@
       "error": -1
     }
   },
-  "git_transfer_progress_cb": {
-    "args": [
-      {
-        "name": "stats",
-        "cType": "const git_transfer_progress *"
-      },
-      {
-        "name": "payload",
-        "cType": "void *"
-      }
-    ],
-    "return": {
-      "type": "int",
-      "noResults": 0,
-      "success": 0,
-      "error": -1,
-      "throttle": 100
-    }
-  },
-  "git_push_transfer_progress": {
+  "git_push_transfer_progress_cb": {
     "args": [
       {
         "name": "current",
@@ -983,24 +982,28 @@
       "error": -1
     }
   },
-  "git_push_update_reference_cb": {
+  "git_url_resolve_cb": {
     "args": [
       {
-        "name": "refname",
+        "name": "url_resolved",
+        "cType": "git_buf *"
+      },
+      {
+        "name": "url",
         "cType": "const char *"
       },
       {
-        "name": "status",
-        "cType": "const char *"
+        "name": "direction",
+        "cType": "int"
       },
       {
-        "name": "data",
+        "name": "payload",
         "cType": "void *"
       }
     ],
     "return": {
       "type": "int",
-      "noResults": 1,
+      "noResults": -30,
       "success": 0,
       "error": -1
     }

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -183,6 +183,9 @@
         },
         "git_blame_init_options": {
           "ignore": true
+        },
+        "git_blame_options_init": {
+          "ignore": true
         }
       }
     },
@@ -200,7 +203,7 @@
         "singletonCppClassName": "GitRepository"
       },
       "functions": {
-        "git_blob_create_frombuffer": {
+        "git_blob_create_from_buffer": {
           "isAsync": true,
           "args": {
             "id": {
@@ -215,32 +218,35 @@
             "isErrorCode": true
           }
         },
+        "git_blob_create_from_workdir": {
+          "isAsync": true,
+          "args": {
+            "id": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_blob_create_fromworkdir": {
-          "isAsync": true,
-          "args": {
-            "id": {
-              "isReturn": true
-            }
-          },
-          "return": {
-            "isErrorCode": true
-          }
-        },
-        "git_blob_create_fromdisk": {
-          "isAsync": true,
-          "args": {
-            "id": {
-              "isReturn": true
-            }
-          },
-          "return": {
-            "isErrorCode": true
-          }
-        },
-        "git_blob_create_fromstream": {
           "ignore": true
         },
-        "git_blob_create_fromstream_commit": {
+        "git_blob_create_from_disk": {
+          "isAsync": true,
+          "args": {
+            "id": {
+              "isReturn": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_blob_create_from_stream": {
+          "ignore": true
+        },
+        "git_blob_create_from_stream_commit": {
           "ignore": true
         },
         "git_blob_filtered_content": {
@@ -486,6 +492,9 @@
         "git_checkout_init_options": {
           "ignore": true
         },
+        "git_checkout_options_init": {
+          "ignore": true
+        },
         "git_checkout_tree": {
           "args": {
             "treeish": {
@@ -512,6 +521,9 @@
         },
         "git_cherrypick_init_options": {
           "ignore": true
+        },
+        "git_cherrypick_options_init": {
+          "ignore": true
         }
       }
     },
@@ -525,6 +537,9 @@
           }
         },
         "git_clone_init_options": {
+          "ignore": true
+        },
+        "git_clone_options_init": {
           "ignore": true
         }
       }
@@ -1129,6 +1144,9 @@
         "git_diff_find_init_options": {
           "ignore": true
         },
+        "git_diff_find_options_init": {
+          "ignore": true
+        },
         "git_diff_find_similar": {
           "args": {
             "diff": {
@@ -1152,6 +1170,9 @@
           "ignore": true
         },
         "git_diff_format_email_init_options": {
+          "ignore": true
+        },
+        "git_diff_format_email_options_init": {
           "ignore": true
         },
         "git_diff_free": {
@@ -1227,7 +1248,13 @@
         "git_diff_num_deltas_of_type": {
           "ignore": true
         },
+        "git_diff_options_init": {
+          "ignore": true
+        },
         "git_diff_patchid_init_options": {
+          "ignore": true
+        },
+        "git_diff_patchid_options_init": {
           "ignore": true
         },
         "git_diff_print": {
@@ -1383,6 +1410,9 @@
     "fetch": {
       "functions": {
         "git_fetch_init_options": {
+          "ignore": true
+        },
+        "git_fetch_options_init": {
           "ignore": true
         }
       }
@@ -1951,7 +1981,8 @@
         "git_index_reuc_clear": {
           "cppFunctionName": "Clear",
           "jsFunctionName": "clear",
-          "isAsync": true
+          "isAsync": true,
+          "isPrototypeMethod": false
         },
         "git_index_reuc_entrycount": {
           "cppFunctionName": "Entrycount",
@@ -1985,6 +2016,7 @@
           "cppFunctionName": "Remove",
           "jsFunctionName": "remove",
           "isAsync": true,
+          "isPrototypeMethod": false,
           "return": {
             "isErrorCode": true
           }
@@ -2177,10 +2209,22 @@
         "git_merge_file_from_index": {
           "ignore": true
         },
+        "git_merge_file_input_init": {
+          "ignore": true
+        },
+        "git_merge_file_init_input": {
+          "ignore": true
+        },
         "git_merge_file_init_options": {
           "ignore": true
         },
+        "git_merge_file_options_init": {
+          "ignore": true
+        },
         "git_merge_init_options": {
+          "ignore": true
+        },
+        "git_merge_options_init": {
           "ignore": true
         },
         "git_merge_trees": {
@@ -2744,6 +2788,9 @@
       "functions": {
         "git_proxy_init_options": {
           "ignore": true
+        },
+        "git_proxy_options_init": {
+          "ignore": true
         }
       }
     },
@@ -2751,6 +2798,7 @@
       "ignore": true
     },
     "rebase": {
+      "hasConstructor": false,
       "selfFreeing": true,
       "functions": {
         "git_rebase_abort": {
@@ -2857,6 +2905,9 @@
           "return": {
             "ownedByThis": true
           }
+        },
+        "git_rebase_options_init": {
+          "ignore": true
         }
       }
     },
@@ -3071,6 +3122,12 @@
             }
           }
         },
+        "git_remote_create_init_options": {
+          "ignore": true
+        },
+        "git_remote_create_options_init": {
+          "ignore": true
+        },
         "git_remote_create_with_opts": {
           "args": {
             "opts": {
@@ -3250,6 +3307,7 @@
       "selfFreeing": true
     },
     "repository": {
+      "hasConstructor": false,
       "selfFreeing": true,
       "isSingleton": true,
       "dependencies": [
@@ -3311,6 +3369,9 @@
           "isAsync": false
         },
         "git_repository_init_init_options": {
+          "ignore": true
+        },
+        "git_repository_init_options_init": {
           "ignore": true
         },
         "git_repository_mergehead_foreach": {
@@ -3415,6 +3476,9 @@
           }
         },
         "git_revert_init_options": {
+          "ignore": true
+        },
+        "git_revert_options_init": {
           "ignore": true
         }
       }
@@ -3560,6 +3624,12 @@
             "isErrorCode": true
           }
         },
+        "git_stash_apply_init_options": {
+          "ignore": true
+        },
+        "git_stash_apply_options_init": {
+          "ignore": true
+        },
         "git_stash_drop": {
           "isAsync": true,
           "return": {
@@ -3571,9 +3641,6 @@
           "return": {
             "isErrorCode": true
           }
-        },
-        "git_stash_apply_init_options": {
-          "ignore": true
         },
         "git_stash_pop": {
           "isAsync": true,
@@ -3633,6 +3700,9 @@
           }
         },
         "git_status_init_options": {
+          "ignore": true
+        },
+        "git_status_options_init": {
           "ignore": true
         }
       }
@@ -3695,6 +3765,7 @@
       "ignore": true
     },
     "submodule": {
+      "hasConstructor": false,
       "selfFreeing": true,
       "ownerFn": {
         "name": "git_submodule_owner",
@@ -3842,6 +3913,9 @@
         },
         "git_submodule_update_init_options": {
           "ignore": true
+        },
+        "git_submodule_update_options_init": {
+          "ignore": true
         }
       }
     },
@@ -3877,8 +3951,7 @@
           },
           "isAsync": true
         },
-        "git_tag_create_frombuffer": {
-          "jsFunctionName": "createFromBuffer",
+        "git_tag_create_from_buffer": {
           "args": {
             "oid": {
               "isReturn": true
@@ -4243,6 +4316,9 @@
         "git_worktree_add_init_options": {
           "ignore": true
         },
+        "git_worktree_add_options_init": {
+          "ignore": true
+        },
         "git_worktree_free": {
           "ignore": true
         },
@@ -4261,6 +4337,9 @@
           }
         },
         "git_worktree_prune_init_options": {
+          "ignore": true
+        },
+        "git_worktree_prune_options_init": {
           "ignore": true
         }
       },

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1539,7 +1539,20 @@
     },
     "hashsig": {
       "selfFreeing": true,
+      "freeFunctionName": "git_hashsig_free",
       "functions": {
+        "git_hashsig_create": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_hashsig_create_fromfile": {
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
+        },
         "git_hashsig_free": {
           "ignore": true
         }
@@ -2527,9 +2540,7 @@
       }
     },
     "openssl": {
-      "cDependencies": [
-        "git2/sys/openssl.h"
-      ]
+      "ignore": true
     },
     "packbuilder": {
       "selfFreeing": true,
@@ -3247,6 +3258,9 @@
         "../include/remote.h"
       ],
       "functions": {
+        "git_repository__cleanup": {
+          "isAsync": true
+        },
         "git_repository_config": {
           "args": {
             "out": {
@@ -3366,6 +3380,16 @@
         },
         "git_repository_set_refdb": {
           "ignore": true
+        },
+        "git_repository_submodule_cache_all": {
+          "return": {
+            "isErrorCode": true
+          }
+        },
+        "git_repository_submodule_cache_clear": {
+          "return": {
+            "isErrorCode": true
+          }
         }
       }
     },
@@ -3618,6 +3642,21 @@
       "functions": {
         "git_status_list_free": {
           "ignore": true
+        },
+        "git_status_list_get_perfdata": {
+          "isAsync": false,
+          "args": {
+            "out": {
+              "isReturn": true,
+              "shouldAlloc": true
+            },
+            "status": {
+              "isSelf": true
+            }
+          },
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_status_list_new": {
           "isAsync": true,

--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -1417,6 +1417,11 @@
         }
       }
     },
+    "fetch_options": {
+      "dependencies": [
+        "../include/str_array_converter.h"
+      ]
+    },
     "filter": {
       "selfFreeing": false,
       "hasConstructor": true,
@@ -1650,6 +1655,9 @@
           }
         },
         "git_index_add_frombuffer": {
+          "ignore": true
+        },
+        "git_index_add_from_buffer": {
           "ignore": true
         },
         "git_index_checksum": {
@@ -2797,6 +2805,11 @@
     "push": {
       "ignore": true
     },
+    "push_options": {
+      "dependencies": [
+        "../include/str_array_converter.h"
+      ]
+    },
     "rebase": {
       "hasConstructor": false,
       "selfFreeing": true,
@@ -2881,11 +2894,15 @@
           }
         },
         "git_rebase_next": {
+          "isAsync": true,
           "args": {
             "operation": {
               "isReturn": true,
               "ownedByThis": true
             }
+          },
+          "return": {
+            "isErrorCode": true
           }
         },
         "git_rebase_open": {
@@ -4058,9 +4075,6 @@
     },
     "time": {
       "dupFunction": "git_time_dup",
-      "dependencies": [
-        "git2/sys/time.h"
-      ],
       "functions": {
         "git_time_sign": {
           "ignore": true

--- a/generate/input/libgit2-docs.json
+++ b/generate/input/libgit2-docs.json
@@ -23,7 +23,7 @@
         "git_apply"
       ],
       "meta": {},
-      "lines": 125
+      "lines": 128
     },
     {
       "file": "git2/attr.h",
@@ -42,7 +42,7 @@
     {
       "file": "git2/blame.h",
       "functions": [
-        "git_blame_init_options",
+        "git_blame_options_init",
         "git_blame_get_hunk_count",
         "git_blame_get_hunk_byindex",
         "git_blame_get_hunk_byline",
@@ -64,11 +64,11 @@
         "git_blob_rawcontent",
         "git_blob_rawsize",
         "git_blob_filtered_content",
-        "git_blob_create_fromworkdir",
-        "git_blob_create_fromdisk",
-        "git_blob_create_fromstream",
-        "git_blob_create_fromstream_commit",
-        "git_blob_create_frombuffer",
+        "git_blob_create_from_workdir",
+        "git_blob_create_from_disk",
+        "git_blob_create_from_stream",
+        "git_blob_create_from_stream_commit",
+        "git_blob_create_from_buffer",
         "git_blob_is_binary",
         "git_blob_dup"
       ],
@@ -116,18 +116,18 @@
         "git_checkout_notify_cb",
         "git_checkout_progress_cb",
         "git_checkout_perfdata_cb",
-        "git_checkout_init_options",
+        "git_checkout_options_init",
         "git_checkout_head",
         "git_checkout_index",
         "git_checkout_tree"
       ],
       "meta": {},
-      "lines": 362
+      "lines": 375
     },
     {
       "file": "git2/cherrypick.h",
       "functions": [
-        "git_cherrypick_init_options",
+        "git_cherrypick_options_init",
         "git_cherrypick_commit",
         "git_cherrypick"
       ],
@@ -139,7 +139,7 @@
       "functions": [
         "git_remote_create_cb",
         "git_repository_create_cb",
-        "git_clone_init_options",
+        "git_clone_options_init",
         "git_clone"
       ],
       "meta": {},
@@ -191,7 +191,7 @@
         "git_libgit2_opts"
       ],
       "meta": {},
-      "lines": 402
+      "lines": 404
     },
     {
       "file": "git2/config.h",
@@ -255,20 +255,24 @@
     {
       "file": "git2/deprecated.h",
       "functions": [
+        "git_blob_create_fromworkdir",
         "git_buf_free",
         "giterr_last",
         "giterr_clear",
         "giterr_set_str",
-        "giterr_set_oom"
+        "giterr_set_oom",
+        "git_oid_iszero",
+        "git_headlist_cb",
+        "git_blame_init_options"
       ],
       "meta": {},
-      "lines": 148
+      "lines": 423
     },
     {
       "file": "git2/describe.h",
       "functions": [
-        "git_describe_init_options",
-        "git_describe_init_format_options",
+        "git_describe_options_init",
+        "git_describe_format_options_init",
         "git_describe_commit",
         "git_describe_workdir",
         "git_describe_format",
@@ -282,12 +286,12 @@
       "functions": [
         "git_diff_notify_cb",
         "git_diff_progress_cb",
-        "git_diff_init_options",
+        "git_diff_options_init",
         "git_diff_file_cb",
         "git_diff_binary_cb",
         "git_diff_hunk_cb",
         "git_diff_line_cb",
-        "git_diff_find_init_options",
+        "git_diff_find_options_init",
         "git_diff_free",
         "git_diff_tree_to_tree",
         "git_diff_tree_to_index",
@@ -317,8 +321,8 @@
         "git_diff_stats_free",
         "git_diff_format_email",
         "git_diff_commit_as_email",
-        "git_diff_format_email_init_options",
-        "git_diff_patchid_init_options",
+        "git_diff_format_email_options_init",
+        "git_diff_patchid_options_init",
         "git_diff_patchid"
       ],
       "meta": {},
@@ -411,7 +415,7 @@
         "git_index_iterator_next",
         "git_index_iterator_free",
         "git_index_add_bypath",
-        "git_index_add_frombuffer",
+        "git_index_add_from_buffer",
         "git_index_remove_bypath",
         "git_index_add_all",
         "git_index_remove_all",
@@ -428,12 +432,13 @@
         "git_index_conflict_iterator_free"
       ],
       "meta": {},
-      "lines": 829
+      "lines": 830
     },
     {
       "file": "git2/indexer.h",
       "functions": [
-        "git_indexer_init_options",
+        "git_indexer_progress_cb",
+        "git_indexer_options_init",
         "git_indexer_new",
         "git_indexer_append",
         "git_indexer_commit",
@@ -441,15 +446,7 @@
         "git_indexer_free"
       ],
       "meta": {},
-      "lines": 98
-    },
-    {
-      "file": "git2/inttypes.h",
-      "functions": [
-        "imaxdiv"
-      ],
-      "meta": {},
-      "lines": 298
+      "lines": 142
     },
     {
       "file": "git2/mailmap.h",
@@ -468,9 +465,9 @@
     {
       "file": "git2/merge.h",
       "functions": [
-        "git_merge_file_init_input",
-        "git_merge_file_init_options",
-        "git_merge_init_options",
+        "git_merge_file_input_init",
+        "git_merge_file_options_init",
+        "git_merge_options_init",
         "git_merge_analysis",
         "git_merge_analysis_for_ref",
         "git_merge_base",
@@ -486,7 +483,7 @@
         "git_merge"
       ],
       "meta": {},
-      "lines": 606
+      "lines": 602
     },
     {
       "file": "git2/message.h",
@@ -500,11 +497,9 @@
     },
     {
       "file": "git2/net.h",
-      "functions": [
-        "git_headlist_cb"
-      ],
+      "functions": [],
       "meta": {},
-      "lines": 55
+      "lines": 50
     },
     {
       "file": "git2/notes.h",
@@ -545,7 +540,7 @@
         "git_object_type2string",
         "git_object_string2type",
         "git_object_typeisloose",
-        "git_object__size",
+        "git_object_size",
         "git_object_peel",
         "git_object_dup"
       ],
@@ -590,7 +585,7 @@
         "git_odb_get_backend"
       ],
       "meta": {},
-      "lines": 544
+      "lines": 545
     },
     {
       "file": "git2/odb_backend.h",
@@ -600,7 +595,7 @@
         "git_odb_backend_one_pack"
       ],
       "meta": {},
-      "lines": 130
+      "lines": 131
     },
     {
       "file": "git2/oid.h",
@@ -620,7 +615,7 @@
         "git_oid_ncmp",
         "git_oid_streq",
         "git_oid_strcmp",
-        "git_oid_iszero",
+        "git_oid_is_zero",
         "git_oid_shorten_new",
         "git_oid_shorten_add",
         "git_oid_shorten_free"
@@ -658,7 +653,7 @@
         "git_packbuilder_free"
       ],
       "meta": {},
-      "lines": 236
+      "lines": 247
     },
     {
       "file": "git2/patch.h",
@@ -704,7 +699,7 @@
     {
       "file": "git2/proxy.h",
       "functions": [
-        "git_proxy_init_options"
+        "git_proxy_options_init"
       ],
       "meta": {},
       "lines": 92
@@ -712,9 +707,13 @@
     {
       "file": "git2/rebase.h",
       "functions": [
-        "git_rebase_init_options",
+        "git_rebase_options_init",
         "git_rebase_init",
         "git_rebase_open",
+        "git_rebase_orig_head_name",
+        "git_rebase_orig_head_id",
+        "git_rebase_onto_name",
+        "git_rebase_onto_id",
         "git_rebase_operation_entrycount",
         "git_rebase_operation_current",
         "git_rebase_operation_byindex",
@@ -726,7 +725,7 @@
         "git_rebase_free"
       ],
       "meta": {},
-      "lines": 319
+      "lines": 347
     },
     {
       "file": "git2/refdb.h",
@@ -807,7 +806,7 @@
         "git_reference_shorthand"
       ],
       "meta": {},
-      "lines": 744
+      "lines": 763
     },
     {
       "file": "git2/refspec.h",
@@ -831,7 +830,7 @@
       "file": "git2/remote.h",
       "functions": [
         "git_remote_create",
-        "git_remote_create_init_options",
+        "git_remote_create_options_init",
         "git_remote_create_with_opts",
         "git_remote_create_with_fetchspec",
         "git_remote_create_anonymous",
@@ -857,12 +856,13 @@
         "git_remote_disconnect",
         "git_remote_free",
         "git_remote_list",
-        "git_push_transfer_progress",
+        "git_push_transfer_progress_cb",
         "git_push_negotiation",
         "git_push_update_reference_cb",
+        "git_url_resolve_cb",
         "git_remote_init_callbacks",
-        "git_fetch_init_options",
-        "git_push_init_options",
+        "git_fetch_options_init",
+        "git_push_options_init",
         "git_remote_download",
         "git_remote_upload",
         "git_remote_update_tips",
@@ -879,7 +879,7 @@
         "git_remote_default_branch"
       ],
       "meta": {},
-      "lines": 926
+      "lines": 948
     },
     {
       "file": "git2/repository.h",
@@ -892,7 +892,7 @@
         "git_repository_open_bare",
         "git_repository_free",
         "git_repository_init",
-        "git_repository_init_init_options",
+        "git_repository_init_options_init",
         "git_repository_init_ext",
         "git_repository_head",
         "git_repository_head_for_worktree",
@@ -932,7 +932,7 @@
         "git_repository_set_ident"
       ],
       "meta": {},
-      "lines": 877
+      "lines": 898
     },
     {
       "file": "git2/reset.h",
@@ -947,7 +947,7 @@
     {
       "file": "git2/revert.h",
       "functions": [
-        "git_revert_init_options",
+        "git_revert_options_init",
         "git_revert_commit",
         "git_revert"
       ],
@@ -1007,7 +1007,7 @@
       "functions": [
         "git_stash_save",
         "git_stash_apply_progress_cb",
-        "git_stash_apply_init_options",
+        "git_stash_apply_options_init",
         "git_stash_apply",
         "git_stash_cb",
         "git_stash_foreach",
@@ -1021,7 +1021,7 @@
       "file": "git2/status.h",
       "functions": [
         "git_status_cb",
-        "git_status_init_options",
+        "git_status_options_init",
         "git_status_foreach",
         "git_status_foreach_ext",
         "git_status_file",
@@ -1033,12 +1033,6 @@
       ],
       "meta": {},
       "lines": 374
-    },
-    {
-      "file": "git2/stdint.h",
-      "functions": [],
-      "meta": {},
-      "lines": 124
     },
     {
       "file": "git2/strarray.h",
@@ -1053,7 +1047,7 @@
       "file": "git2/submodule.h",
       "functions": [
         "git_submodule_cb",
-        "git_submodule_update_init_options",
+        "git_submodule_update_options_init",
         "git_submodule_update",
         "git_submodule_lookup",
         "git_submodule_free",
@@ -1090,235 +1084,40 @@
       "lines": 633
     },
     {
-      "file": "git2/sys/alloc.h",
-      "functions": [
-        "git_stdalloc_init_allocator",
-        "git_win32_crtdbg_init_allocator"
-      ],
-      "meta": {},
-      "lines": 97
-    },
-    {
-      "file": "git2/sys/commit.h",
-      "functions": [
-        "git_commit_create_from_ids",
-        "git_commit_create_from_callback"
-      ],
-      "meta": {},
-      "lines": 76
-    },
-    {
-      "file": "git2/sys/config.h",
-      "functions": [
-        "git_config_init_backend",
-        "git_config_add_backend"
-      ],
-      "meta": {},
-      "lines": 126
-    },
-    {
-      "file": "git2/sys/diff.h",
-      "functions": [
-        "git_diff_print_callback__to_buf",
-        "git_diff_print_callback__to_file_handle",
-        "git_diff_get_perfdata",
-        "git_status_list_get_perfdata"
-      ],
-      "meta": {},
-      "lines": 90
-    },
-    {
       "file": "git2/sys/filter.h",
-      "functions": [
-        "git_filter_lookup",
-        "git_filter_list_new",
-        "git_filter_list_push",
-        "git_filter_list_length",
-        "git_filter_source_repo",
-        "git_filter_source_path",
-        "git_filter_source_filemode",
-        "git_filter_source_id",
-        "git_filter_source_mode",
-        "git_filter_source_flags",
-        "git_filter_init_fn",
-        "git_filter_shutdown_fn",
-        "git_filter_check_fn",
-        "git_filter_apply_fn",
-        "git_filter_stream_fn",
-        "git_filter_cleanup_fn",
-        "git_filter_init",
-        "git_filter_register",
-        "git_filter_unregister"
-      ],
+      "functions": [],
       "meta": {},
-      "lines": 328
+      "lines": 95
     },
     {
       "file": "git2/sys/hashsig.h",
-      "functions": [
-        "git_hashsig_create",
-        "git_hashsig_create_fromfile",
-        "git_hashsig_free",
-        "git_hashsig_compare"
-      ],
-      "meta": {},
-      "lines": 102
-    },
-    {
-      "file": "git2/sys/index.h",
-      "functions": [
-        "git_index_name_entrycount",
-        "git_index_name_get_byindex",
-        "git_index_name_add",
-        "git_index_name_clear",
-        "git_index_reuc_entrycount",
-        "git_index_reuc_find",
-        "git_index_reuc_get_bypath",
-        "git_index_reuc_get_byindex",
-        "git_index_reuc_add",
-        "git_index_reuc_remove",
-        "git_index_reuc_clear"
-      ],
-      "meta": {},
-      "lines": 174
-    },
-    {
-      "file": "git2/sys/mempack.h",
-      "functions": [
-        "git_mempack_new",
-        "git_mempack_dump",
-        "git_mempack_reset"
-      ],
-      "meta": {},
-      "lines": 82
-    },
-    {
-      "file": "git2/sys/merge.h",
-      "functions": [
-        "git_merge_driver_lookup",
-        "git_merge_driver_source_repo",
-        "git_merge_driver_source_ancestor",
-        "git_merge_driver_source_ours",
-        "git_merge_driver_source_theirs",
-        "git_merge_driver_source_file_options",
-        "git_merge_driver_init_fn",
-        "git_merge_driver_shutdown_fn",
-        "git_merge_driver_apply_fn",
-        "git_merge_driver_register",
-        "git_merge_driver_unregister"
-      ],
-      "meta": {},
-      "lines": 178
-    },
-    {
-      "file": "git2/sys/odb_backend.h",
-      "functions": [
-        "git_odb_init_backend",
-        "git_odb_backend_malloc"
-      ],
-      "meta": {},
-      "lines": 120
-    },
-    {
-      "file": "git2/sys/openssl.h",
-      "functions": [
-        "git_openssl_set_locking"
-      ],
-      "meta": {},
-      "lines": 34
-    },
-    {
-      "file": "git2/sys/path.h",
-      "functions": [
-        "git_path_is_gitfile"
-      ],
-      "meta": {},
-      "lines": 60
-    },
-    {
-      "file": "git2/sys/refdb_backend.h",
-      "functions": [
-        "git_refdb_init_backend",
-        "git_refdb_backend_fs",
-        "git_refdb_set_backend"
-      ],
-      "meta": {},
-      "lines": 214
-    },
-    {
-      "file": "git2/sys/reflog.h",
-      "functions": [
-        "git_reflog_entry__alloc",
-        "git_reflog_entry__free"
-      ],
-      "meta": {},
-      "lines": 17
-    },
-    {
-      "file": "git2/sys/refs.h",
-      "functions": [
-        "git_reference__alloc",
-        "git_reference__alloc_symbolic"
-      ],
+      "functions": [],
       "meta": {},
       "lines": 45
     },
     {
-      "file": "git2/sys/repository.h",
-      "functions": [
-        "git_repository_new",
-        "git_repository__cleanup",
-        "git_repository_reinit_filesystem",
-        "git_repository_set_config",
-        "git_repository_set_odb",
-        "git_repository_set_refdb",
-        "git_repository_set_index",
-        "git_repository_set_bare",
-        "git_repository_submodule_cache_all",
-        "git_repository_submodule_cache_clear"
-      ],
+      "file": "git2/sys/merge.h",
+      "functions": [],
       "meta": {},
-      "lines": 165
+      "lines": 41
+    },
+    {
+      "file": "git2/sys/path.h",
+      "functions": [],
+      "meta": {},
+      "lines": 41
     },
     {
       "file": "git2/sys/stream.h",
-      "functions": [
-        "git_stream_register",
-        "git_stream_cb",
-        "git_stream_register_tls"
-      ],
+      "functions": [],
       "meta": {},
-      "lines": 130
-    },
-    {
-      "file": "git2/sys/time.h",
-      "functions": [
-        "git_time_monotonic"
-      ],
-      "meta": {},
-      "lines": 27
+      "lines": 83
     },
     {
       "file": "git2/sys/transport.h",
-      "functions": [
-        "git_transport_init",
-        "git_transport_new",
-        "git_transport_ssh_with_paths",
-        "git_transport_register",
-        "git_transport_unregister",
-        "git_transport_dummy",
-        "git_transport_local",
-        "git_transport_smart",
-        "git_transport_smart_certificate_check",
-        "git_transport_smart_credentials",
-        "git_transport_smart_proxy_options",
-        "git_smart_subtransport_cb",
-        "git_smart_subtransport_http",
-        "git_smart_subtransport_git",
-        "git_smart_subtransport_ssh"
-      ],
+      "functions": [],
       "meta": {},
-      "lines": 435
+      "lines": 292
     },
     {
       "file": "git2/tag.h",
@@ -1336,7 +1135,7 @@
         "git_tag_message",
         "git_tag_create",
         "git_tag_annotation_create",
-        "git_tag_create_frombuffer",
+        "git_tag_create_from_buffer",
         "git_tag_create_lightweight",
         "git_tag_delete",
         "git_tag_list",
@@ -1347,12 +1146,12 @@
         "git_tag_dup"
       ],
       "meta": {},
-      "lines": 357
+      "lines": 366
     },
     {
       "file": "git2/trace.h",
       "functions": [
-        "git_trace_callback",
+        "git_trace_cb",
         "git_trace_set"
       ],
       "meta": {},
@@ -1377,8 +1176,6 @@
       "file": "git2/transport.h",
       "functions": [
         "git_transport_cb",
-        "git_cred_sign_callback",
-        "git_cred_ssh_interactive_callback",
         "git_cred_has_username",
         "git_cred_userpass_plaintext_new",
         "git_cred_ssh_key_new",
@@ -1438,12 +1235,11 @@
     {
       "file": "git2/types.h",
       "functions": [
-        "git_transfer_progress_cb",
         "git_transport_message_cb",
         "git_transport_certificate_check_cb"
       ],
       "meta": {},
-      "lines": 442
+      "lines": 412
     },
     {
       "file": "git2/worktree.h",
@@ -1453,14 +1249,14 @@
         "git_worktree_open_from_repository",
         "git_worktree_free",
         "git_worktree_validate",
-        "git_worktree_add_init_options",
+        "git_worktree_add_options_init",
         "git_worktree_add",
         "git_worktree_lock",
         "git_worktree_unlock",
         "git_worktree_is_locked",
         "git_worktree_name",
         "git_worktree_path",
-        "git_worktree_prune_init_options",
+        "git_worktree_prune_options_init",
         "git_worktree_is_prunable",
         "git_worktree_prune"
       ],
@@ -1572,7 +1368,7 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Creates a <code>git_annotated_commit</code> from the given commit id.\n The resulting git_annotated_commit must be freed with\n <code>git_annotated_commit_free</code>.</p>\n",
-      "comments": "<p>An annotated commit contains information about how it was\n looked up, which may be useful for functions like merge or\n rebase to provide context to the operation.  For example,\n conflict files will include the name of the source or target\n branches being merged.  It is therefore preferable to use the\n most specific function (eg <code>git_annotated_commit_from_ref</code>)\n instead of this one when that data is known.</p>\n",
+      "comments": "<p>An annotated commit contains information about how it was looked up, which may be useful for functions like merge or rebase to provide context to the operation.  For example, conflict files will include the name of the source or target branches being merged.  It is therefore preferable to use the most specific function (eg <code>git_annotated_commit_from_ref</code>) instead of this one when that data is known.</p>\n",
       "group": "annotated"
     },
     "git_annotated_commit_from_revspec": {
@@ -1604,7 +1400,7 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Creates a <code>git_annotated_comit</code> from a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n",
       "group": "annotated"
     },
     "git_annotated_commit_id": {
@@ -1630,12 +1426,12 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_annotated_commit_id-1"
+          "ex/HEAD/checkout.html#git_annotated_commit_id-1"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_annotated_commit_id-1",
-          "ex/v0.28.0/merge.html#git_annotated_commit_id-2",
-          "ex/v0.28.0/merge.html#git_annotated_commit_id-3"
+          "ex/HEAD/merge.html#git_annotated_commit_id-1",
+          "ex/HEAD/merge.html#git_annotated_commit_id-2",
+          "ex/HEAD/merge.html#git_annotated_commit_id-3"
         ]
       }
     },
@@ -1662,8 +1458,8 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_annotated_commit_ref-2",
-          "ex/v0.28.0/checkout.html#git_annotated_commit_ref-3"
+          "ex/HEAD/checkout.html#git_annotated_commit_ref-2",
+          "ex/HEAD/checkout.html#git_annotated_commit_ref-3"
         ]
       }
     },
@@ -1690,15 +1486,15 @@
       "group": "annotated",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_annotated_commit_free-4"
+          "ex/HEAD/checkout.html#git_annotated_commit_free-4"
         ]
       }
     },
     "git_apply_to_tree": {
       "type": "function",
       "file": "git2/apply.h",
-      "line": 85,
-      "lineto": 90,
+      "line": 87,
+      "lineto": 92,
       "args": [
         {
           "name": "out",
@@ -1739,8 +1535,8 @@
     "git_apply": {
       "type": "function",
       "file": "git2/apply.h",
-      "line": 121,
-      "lineto": 125,
+      "line": 124,
+      "lineto": 128,
       "args": [
         {
           "name": "repo",
@@ -1788,11 +1584,11 @@
       "argline": "const char *attr",
       "sig": "const char *",
       "return": {
-        "type": "git_attr_t",
+        "type": "git_attr_value_t",
         "comment": " the value type for the attribute"
       },
       "description": "<p>Return the value type for a given attribute.</p>\n",
-      "comments": "<p>This can be either <code>TRUE</code>, <code>FALSE</code>, <code>UNSPECIFIED</code> (if the attribute\n was not set at all), or <code>VALUE</code>, if the attribute was set to an\n actual string.</p>\n\n<p>If the attribute has a <code>VALUE</code> string, it can be accessed normally\n as a NULL-terminated C string.</p>\n",
+      "comments": "<p>This can be either <code>TRUE</code>, <code>FALSE</code>, <code>UNSPECIFIED</code> (if the attribute was not set at all), or <code>VALUE</code>, if the attribute was set to an actual string.</p>\n\n<p>If the attribute has a <code>VALUE</code> string, it can be accessed normally as a NULL-terminated C string.</p>\n",
       "group": "attr"
     },
     "git_attr_get": {
@@ -1804,36 +1600,36 @@
         {
           "name": "value_out",
           "type": "const char **",
-          "comment": null
+          "comment": "Output of the value of the attribute.  Use the GIT_ATTR_...\n             macros to test for TRUE, FALSE, UNSPECIFIED, etc. or just\n             use the string value for attributes set to a value.  You\n             should NOT modify or free this value."
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "The repository containing the path."
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "A combination of GIT_ATTR_CHECK... flags."
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": null
+          "comment": "The path to check for attributes.  Relative paths are\n             interpreted relative to the repo root.  The file does\n             not have to exist, but if it does not, then it will be\n             treated as a plain file (not a directory)."
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "The name of the attribute to look up."
         }
       ],
-      "argline": "const char **value_out, git_repository *repo, int flags, const char *path, const char *name",
-      "sig": "const char **::git_repository *::int::const char *::const char *",
+      "argline": "const char **value_out, git_repository *repo, uint32_t flags, const char *path, const char *name",
+      "sig": "const char **::git_repository *::uint32_t::const char *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "",
+      "description": "<p>Look up the value of one git attribute for path.</p>\n",
       "comments": "",
       "group": "attr"
     },
@@ -1846,42 +1642,42 @@
         {
           "name": "values_out",
           "type": "const char **",
-          "comment": null
+          "comment": "An array of num_attr entries that will have string\n             pointers written into it for the values of the attributes.\n             You should not modify or free the values that are written\n             into this array (although of course, you should free the\n             array itself if you allocated it)."
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "The repository containing the path."
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "A combination of GIT_ATTR_CHECK... flags."
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": null
+          "comment": "The path inside the repo to check attributes.  This\n             does not have to exist, but if it does not, then\n             it will be treated as a plain file (i.e. not a directory)."
         },
         {
           "name": "num_attr",
           "type": "size_t",
-          "comment": null
+          "comment": "The number of attributes being looked up"
         },
         {
           "name": "names",
           "type": "const char **",
-          "comment": null
+          "comment": "An array of num_attr strings containing attribute names."
         }
       ],
-      "argline": "const char **values_out, git_repository *repo, int flags, const char *path, size_t num_attr, const char **names",
-      "sig": "const char **::git_repository *::int::const char *::size_t::const char **",
+      "argline": "const char **values_out, git_repository *repo, uint32_t flags, const char *path, size_t num_attr, const char **names",
+      "sig": "const char **::git_repository *::uint32_t::const char *::size_t::const char **",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Look up a list of git attributes for path.</p>\n",
+      "comments": "<p>Use this if you have a known list of attributes that you want to look up in a single call.  This is somewhat more efficient than calling <code>git_attr_get()</code> multiple times.</p>\n\n<p>For example, you might write:</p>\n\n<pre><code> const char *attrs[] = { &quot;crlf&quot;, &quot;diff&quot;, &quot;foo&quot; };     const char **values[3];     git_attr_get_many(values, repo, 0, &quot;my/fun/file.c&quot;, 3, attrs);\n</code></pre>\n\n<p>Then you could loop through the 3 values to get the settings for the three attributes you asked about.</p>\n",
       "group": "attr"
     },
     "git_attr_foreach": {
@@ -1893,36 +1689,36 @@
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "The repository containing the path."
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "A combination of GIT_ATTR_CHECK... flags."
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": null
+          "comment": "Path inside the repo to check attributes.  This does not have\n             to exist, but if it does not, then it will be treated as a\n             plain file (i.e. not a directory)."
         },
         {
           "name": "callback",
           "type": "git_attr_foreach_cb",
-          "comment": null
+          "comment": "Function to invoke on each attribute name and value.\n                 See git_attr_foreach_cb."
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Passed on as extra parameter to callback function."
         }
       ],
-      "argline": "git_repository *repo, int flags, const char *path, git_attr_foreach_cb callback, void *payload",
-      "sig": "git_repository *::int::const char *::git_attr_foreach_cb::void *",
+      "argline": "git_repository *repo, uint32_t flags, const char *path, git_attr_foreach_cb callback, void *payload",
+      "sig": "git_repository *::uint32_t::const char *::git_attr_foreach_cb::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, non-zero callback return value, or error code"
       },
-      "description": "",
+      "description": "<p>Loop over all the git attributes for a path.</p>\n",
       "comments": "",
       "group": "attr"
     },
@@ -1945,7 +1741,7 @@
         "comment": null
       },
       "description": "<p>Flush the gitattributes cache.</p>\n",
-      "comments": "<p>Call this if you have reason to believe that the attributes files on\n disk no longer match the cached contents of memory.  This will cause\n the attributes files to be reloaded the next time that an attribute\n access function is called.</p>\n",
+      "comments": "<p>Call this if you have reason to believe that the attributes files on disk no longer match the cached contents of memory.  This will cause the attributes files to be reloaded the next time that an attribute access function is called.</p>\n",
       "group": "attr"
     },
     "git_attr_add_macro": {
@@ -1977,10 +1773,10 @@
         "comment": null
       },
       "description": "<p>Add a macro definition.</p>\n",
-      "comments": "<p>Macros will automatically be loaded from the top level <code>.gitattributes</code>\n file of the repository (plus the build-in &quot;binary&quot; macro).  This\n function allows you to add others.  For example, to add the default\n macro, you would call:</p>\n\n<pre><code> git_attr_add_macro(repo, &quot;binary&quot;, &quot;-diff -crlf&quot;);\n</code></pre>\n",
+      "comments": "<p>Macros will automatically be loaded from the top level <code>.gitattributes</code> file of the repository (plus the build-in &quot;binary&quot; macro).  This function allows you to add others.  For example, to add the default macro, you would call:</p>\n\n<pre><code> git_attr_add_macro(repo, &quot;binary&quot;, &quot;-diff -crlf&quot;);\n</code></pre>\n",
       "group": "attr"
     },
-    "git_blame_init_options": {
+    "git_blame_options_init": {
       "type": "function",
       "file": "git2/blame.h",
       "line": 103,
@@ -2004,7 +1800,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_blame_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_blame_options</code> with default values. Equivalent to creating\n an instance with GIT_BLAME_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_blame_options</code> with default values. Equivalent to creating an instance with GIT_BLAME_OPTIONS_INIT.</p>\n",
       "group": "blame"
     },
     "git_blame_get_hunk_count": {
@@ -2012,14 +1808,20 @@
       "file": "git2/blame.h",
       "line": 154,
       "lineto": 154,
-      "args": [],
-      "argline": "",
-      "sig": "",
+      "args": [
+        {
+          "name": "blame",
+          "type": "git_blame *",
+          "comment": null
+        }
+      ],
+      "argline": "git_blame *blame",
+      "sig": "git_blame *",
       "return": {
-        "type": "int",
+        "type": "uint32_t",
         "comment": null
       },
-      "description": "",
+      "description": "<p>Gets the number of hunks that exist in the blame structure.</p>\n",
       "comments": "",
       "group": "blame"
     },
@@ -2032,21 +1834,21 @@
         {
           "name": "blame",
           "type": "git_blame *",
-          "comment": null
+          "comment": "the blame structure to query"
         },
         {
           "name": "index",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "index of the hunk to retrieve"
         }
       ],
-      "argline": "git_blame *blame, int index",
-      "sig": "git_blame *::int",
+      "argline": "git_blame *blame, uint32_t index",
+      "sig": "git_blame *::uint32_t",
       "return": {
         "type": "const git_blame_hunk *",
-        "comment": null
+        "comment": " the hunk at the given index, or NULL on error"
       },
-      "description": "",
+      "description": "<p>Gets the blame hunk at the given index.</p>\n",
       "comments": "",
       "group": "blame"
     },
@@ -2078,7 +1880,7 @@
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blame_get_hunk_byline-1"
+          "ex/HEAD/blame.html#git_blame_get_hunk_byline-1"
         ]
       }
     },
@@ -2120,7 +1922,7 @@
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blame_file-2"
+          "ex/HEAD/blame.html#git_blame_file-2"
         ]
       }
     },
@@ -2158,7 +1960,7 @@
         "comment": " 0 on success, or an error code. (use git_error_last for information\n         about the error)"
       },
       "description": "<p>Get blame data for a file that has been modified in memory. The <code>reference</code>\n parameter is a pre-calculated blame for the in-odb history of the file. This\n means that once a file blame is completed (which can be expensive), updating\n the buffer blame is very fast.</p>\n",
-      "comments": "<p>Lines that differ between the buffer and the committed version are marked as\n having a zero OID for their final_commit_id.</p>\n",
+      "comments": "<p>Lines that differ between the buffer and the committed version are marked as having a zero OID for their final_commit_id.</p>\n",
       "group": "blame"
     },
     "git_blame_free": {
@@ -2184,7 +1986,7 @@
       "group": "blame",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blame_free-3"
+          "ex/HEAD/blame.html#git_blame_free-3"
         ]
       }
     },
@@ -2221,10 +2023,10 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blob_lookup-4"
+          "ex/HEAD/blame.html#git_blob_lookup-4"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_blob_lookup-1"
+          "ex/HEAD/general.html#git_blob_lookup-1"
         ]
       }
     },
@@ -2284,14 +2086,14 @@
         "comment": null
       },
       "description": "<p>Close an open blob</p>\n",
-      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop\n using a blob. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using a blob. Failure to do so will cause a memory leak.</p>\n",
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blob_free-5"
+          "ex/HEAD/blame.html#git_blob_free-5"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_blob_free-2"
+          "ex/HEAD/general.html#git_blob_free-2"
         ]
       }
     },
@@ -2358,17 +2160,17 @@
         "comment": " the pointer"
       },
       "description": "<p>Get a read-only buffer with the raw content of a blob.</p>\n",
-      "comments": "<p>A pointer to the raw content of a blob is returned;\n this pointer is owned internally by the object and shall\n not be free&#39;d. The pointer may be invalidated at a later\n time.</p>\n",
+      "comments": "<p>A pointer to the raw content of a blob is returned; this pointer is owned internally by the object and shall not be free&#39;d. The pointer may be invalidated at a later time.</p>\n",
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blob_rawcontent-6"
+          "ex/HEAD/blame.html#git_blob_rawcontent-6"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_blob_rawcontent-1"
+          "ex/HEAD/cat-file.html#git_blob_rawcontent-1"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_blob_rawcontent-3"
+          "ex/HEAD/general.html#git_blob_rawcontent-3"
         ]
       }
     },
@@ -2395,14 +2197,14 @@
       "group": "blob",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_blob_rawsize-7"
+          "ex/HEAD/blame.html#git_blob_rawsize-7"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_blob_rawsize-2"
+          "ex/HEAD/cat-file.html#git_blob_rawsize-2"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_blob_rawsize-4",
-          "ex/v0.28.0/general.html#git_blob_rawsize-5"
+          "ex/HEAD/general.html#git_blob_rawsize-4",
+          "ex/HEAD/general.html#git_blob_rawsize-5"
         ]
       }
     },
@@ -2440,10 +2242,10 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Get a buffer with the filtered content of a blob.</p>\n",
-      "comments": "<p>This applies filters as if the blob was being checked out to the\n working directory under the specified filename.  This may apply\n CRLF filtering or other types of changes depending on the file\n attributes set for the blob and the content detected in it.</p>\n\n<p>The output is written into a <code>git_buf</code> which the caller must free\n when done (via <code>git_buf_dispose</code>).</p>\n\n<p>If no filters need to be applied, then the <code>out</code> buffer will just\n be populated with a pointer to the raw content of the blob.  In\n that case, be careful to <em>not</em> free the blob until done with the\n buffer or copy it into memory you own.</p>\n",
+      "comments": "<p>This applies filters as if the blob was being checked out to the working directory under the specified filename.  This may apply CRLF filtering or other types of changes depending on the file attributes set for the blob and the content detected in it.</p>\n\n<p>The output is written into a <code>git_buf</code> which the caller must free when done (via <code>git_buf_dispose</code>).</p>\n\n<p>If no filters need to be applied, then the <code>out</code> buffer will just be populated with a pointer to the raw content of the blob.  In that case, be careful to <em>not</em> free the blob until done with the buffer or copy it into memory you own.</p>\n",
       "group": "blob"
     },
-    "git_blob_create_fromworkdir": {
+    "git_blob_create_from_workdir": {
       "type": "function",
       "file": "git2/blob.h",
       "line": 139,
@@ -2475,7 +2277,7 @@
       "comments": "",
       "group": "blob"
     },
-    "git_blob_create_fromdisk": {
+    "git_blob_create_from_disk": {
       "type": "function",
       "file": "git2/blob.h",
       "line": 151,
@@ -2507,7 +2309,7 @@
       "comments": "",
       "group": "blob"
     },
-    "git_blob_create_fromstream": {
+    "git_blob_create_from_stream": {
       "type": "function",
       "file": "git2/blob.h",
       "line": 178,
@@ -2536,10 +2338,10 @@
         "comment": " 0 or error code"
       },
       "description": "<p>Create a stream to write a new blob into the object db</p>\n",
-      "comments": "<p>This function may need to buffer the data on disk and will in\n general not be the right choice if you know the size of the data\n to write. If you have data in memory, use\n <code>git_blob_create_frombuffer()</code>. If you do not, but know the size of\n the contents (and don&#39;t want/need to perform filtering), use\n <code>git_odb_open_wstream()</code>.</p>\n\n<p>Don&#39;t close this stream yourself but pass it to\n <code>git_blob_create_fromstream_commit()</code> to commit the write to the\n object db and get the object id.</p>\n\n<p>If the <code>hintpath</code> parameter is filled, it will be used to determine\n what git filters should be applied to the object before it is written\n to the object database.</p>\n",
+      "comments": "<p>This function may need to buffer the data on disk and will in general not be the right choice if you know the size of the data to write. If you have data in memory, use <code>git_blob_create_from_buffer()</code>. If you do not, but know the size of the contents (and don&#39;t want/need to perform filtering), use <code>git_odb_open_wstream()</code>.</p>\n\n<p>Don&#39;t close this stream yourself but pass it to <code>git_blob_create_from_stream_commit()</code> to commit the write to the object db and get the object id.</p>\n\n<p>If the <code>hintpath</code> parameter is filled, it will be used to determine what git filters should be applied to the object before it is written to the object database.</p>\n",
       "group": "blob"
     },
-    "git_blob_create_fromstream_commit": {
+    "git_blob_create_from_stream_commit": {
       "type": "function",
       "file": "git2/blob.h",
       "line": 192,
@@ -2566,7 +2368,7 @@
       "comments": "<p>The stream will be closed and freed.</p>\n",
       "group": "blob"
     },
-    "git_blob_create_frombuffer": {
+    "git_blob_create_from_buffer": {
       "type": "function",
       "file": "git2/blob.h",
       "line": 205,
@@ -2622,7 +2424,7 @@
         "comment": " 1 if the content of the blob is detected\n as binary; 0 otherwise."
       },
       "description": "<p>Determine if the blob content is most certainly binary or not.</p>\n",
-      "comments": "<p>The heuristic used to guess if a file is binary is taken from core git:\n Searching for NUL bytes and looking for a reasonable ratio of printable\n to non-printable characters among the first 8000 bytes.</p>\n",
+      "comments": "<p>The heuristic used to guess if a file is binary is taken from core git: Searching for NUL bytes and looking for a reasonable ratio of printable to non-printable characters among the first 8000 bytes.</p>\n",
       "group": "blob"
     },
     "git_blob_dup": {
@@ -2691,7 +2493,7 @@
         "comment": " 0, GIT_EINVALIDSPEC or an error code.\n A proper reference is written in the refs/heads namespace\n pointing to the provided target commit."
       },
       "description": "<p>Create a new branch pointing at a target commit</p>\n",
-      "comments": "<p>A new direct reference will be created pointing to\n this target commit. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The returned reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>A new direct reference will be created pointing to this target commit. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The returned reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_create_from_annotated": {
@@ -2733,7 +2535,7 @@
         "comment": null
       },
       "description": "<p>Create a new branch pointing at a target commit</p>\n",
-      "comments": "<p>This behaves like <code>git_branch_create()</code> but takes an annotated\n commit, which lets you specify which extended sha syntax string was\n specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_branch_create()</code>.</p>\n",
+      "comments": "<p>This behaves like <code>git_branch_create()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_branch_create()</code>.</p>\n",
       "group": "branch"
     },
     "git_branch_delete": {
@@ -2755,7 +2557,7 @@
         "comment": " 0 on success, or an error code."
       },
       "description": "<p>Delete an existing branch reference.</p>\n",
-      "comments": "<p>If the branch is successfully deleted, the passed reference\n object will be invalidated. The reference must be freed manually\n by the user.</p>\n",
+      "comments": "<p>If the branch is successfully deleted, the passed reference object will be invalidated. The reference must be freed manually by the user.</p>\n",
       "group": "branch"
     },
     "git_branch_iterator_new": {
@@ -2878,7 +2680,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Move/rename an existing local branch reference.</p>\n",
-      "comments": "<p>The new branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The new branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_lookup": {
@@ -2915,7 +2717,7 @@
         "comment": " 0 on success; GIT_ENOTFOUND when no matching branch\n exists, GIT_EINVALIDSPEC, otherwise an error code."
       },
       "description": "<p>Lookup a branch by its name in a repository.</p>\n",
-      "comments": "<p>The generated reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The generated reference must be freed by the user.</p>\n\n<p>The branch name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "branch"
     },
     "git_branch_name": {
@@ -2942,11 +2744,11 @@
         "comment": " 0 on success; otherwise an error code (e.g., if the\n  ref is no local or remote branch)."
       },
       "description": "<p>Return the name of the given local or remote branch.</p>\n",
-      "comments": "<p>The name of the branch matches the definition of the name\n for git_branch_lookup. That is, if the returned name is given\n to git_branch_lookup() then the reference is returned that\n was given to this function.</p>\n",
+      "comments": "<p>The name of the branch matches the definition of the name for git_branch_lookup. That is, if the returned name is given to git_branch_lookup() then the reference is returned that was given to this function.</p>\n",
       "group": "branch",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_branch_name-4"
+          "ex/HEAD/merge.html#git_branch_name-4"
         ]
       }
     },
@@ -3163,17 +2965,14 @@
         "comment": null
       },
       "description": "<p>Free the memory referred to by the git_buf.</p>\n",
-      "comments": "<p>Note that this does not free the <code>git_buf</code> itself, just the memory\n pointed to by <code>buffer-&gt;ptr</code>.  This will not free the memory if it looks\n like it was not allocated internally, but it will clear the buffer back\n to the empty state.</p>\n",
+      "comments": "<p>Note that this does not free the <code>git_buf</code> itself, just the memory pointed to by <code>buffer-&gt;ptr</code>.  This will not free the memory if it looks like it was not allocated internally, but it will clear the buffer back to the empty state.</p>\n",
       "group": "buf",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_buf_dispose-1"
-        ],
-        "remote.c": [
-          "ex/v0.28.0/remote.html#git_buf_dispose-1"
+          "ex/HEAD/diff.html#git_buf_dispose-1"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_buf_dispose-1"
+          "ex/HEAD/tag.html#git_buf_dispose-1"
         ]
       }
     },
@@ -3201,7 +3000,7 @@
         "comment": " 0 on success, -1 on allocation failure"
       },
       "description": "<p>Resize the buffer allocation to make more space.</p>\n",
-      "comments": "<p>This will attempt to grow the buffer to accommodate the target size.</p>\n\n<p>If the buffer refers to memory that was not allocated by libgit2 (i.e.\n the <code>asize</code> field is zero), then <code>ptr</code> will be replaced with a newly\n allocated block of data.  Be careful so that memory allocated by the\n caller is not lost.  As a special variant, if you pass <code>target_size</code> as\n 0 and the memory is not allocated by libgit2, this will allocate a new\n buffer of size <code>size</code> and copy the external data into it.</p>\n\n<p>Currently, this will never shrink a buffer, only expand it.</p>\n\n<p>If the allocation fails, this will return an error and the buffer will be\n marked as invalid for future operations, invaliding the contents.</p>\n",
+      "comments": "<p>This will attempt to grow the buffer to accommodate the target size.</p>\n\n<p>If the buffer refers to memory that was not allocated by libgit2 (i.e. the <code>asize</code> field is zero), then <code>ptr</code> will be replaced with a newly allocated block of data.  Be careful so that memory allocated by the caller is not lost.  As a special variant, if you pass <code>target_size</code> as 0 and the memory is not allocated by libgit2, this will allocate a new buffer of size <code>size</code> and copy the external data into it.</p>\n\n<p>Currently, this will never shrink a buffer, only expand it.</p>\n\n<p>If the allocation fails, this will return an error and the buffer will be marked as invalid for future operations, invaliding the contents.</p>\n",
       "group": "buf"
     },
     "git_buf_set": {
@@ -3280,11 +3079,11 @@
       "comments": "",
       "group": "buf"
     },
-    "git_checkout_init_options": {
+    "git_checkout_options_init": {
       "type": "function",
       "file": "git2/checkout.h",
-      "line": 309,
-      "lineto": 311,
+      "line": 322,
+      "lineto": 324,
       "args": [
         {
           "name": "opts",
@@ -3304,14 +3103,14 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_checkout_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_checkout_options</code> with default values. Equivalent to creating\n an instance with GIT_CHECKOUT_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_checkout_options</code> with default values. Equivalent to creating an instance with GIT_CHECKOUT_OPTIONS_INIT.</p>\n",
       "group": "checkout"
     },
     "git_checkout_head": {
       "type": "function",
       "file": "git2/checkout.h",
-      "line": 330,
-      "lineto": 332,
+      "line": 343,
+      "lineto": 345,
       "args": [
         {
           "name": "repo",
@@ -3331,14 +3130,14 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH if HEAD points to a non\n         existing branch, non-zero value returned by `notify_cb`, or\n         other error code \n<\n 0 (use git_error_last for error details)"
       },
       "description": "<p>Updates files in the index and the working tree to match the content of\n the commit pointed at by HEAD.</p>\n",
-      "comments": "<p>Note that this is <em>not</em> the correct mechanism used to switch branches;\n do not change your <code>HEAD</code> and then call this method, that would leave\n you with checkout conflicts since your working directory would then\n appear to be dirty.  Instead, checkout the target of the branch and\n then update <code>HEAD</code> using <code>git_repository_set_head</code> to point to the\n branch you checked out.</p>\n",
+      "comments": "<p>Note that this is <em>not</em> the correct mechanism used to switch branches; do not change your <code>HEAD</code> and then call this method, that would leave you with checkout conflicts since your working directory would then appear to be dirty.  Instead, checkout the target of the branch and then update <code>HEAD</code> using <code>git_repository_set_head</code> to point to the branch you checked out.</p>\n",
       "group": "checkout"
     },
     "git_checkout_index": {
       "type": "function",
       "file": "git2/checkout.h",
-      "line": 343,
-      "lineto": 346,
+      "line": 356,
+      "lineto": 359,
       "args": [
         {
           "name": "repo",
@@ -3369,8 +3168,8 @@
     "git_checkout_tree": {
       "type": "function",
       "file": "git2/checkout.h",
-      "line": 359,
-      "lineto": 362,
+      "line": 372,
+      "lineto": 375,
       "args": [
         {
           "name": "repo",
@@ -3399,14 +3198,14 @@
       "group": "checkout",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_checkout_tree-5"
+          "ex/HEAD/checkout.html#git_checkout_tree-5"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_checkout_tree-5"
+          "ex/HEAD/merge.html#git_checkout_tree-5"
         ]
       }
     },
-    "git_cherrypick_init_options": {
+    "git_cherrypick_options_init": {
       "type": "function",
       "file": "git2/cherrypick.h",
       "line": 49,
@@ -3430,7 +3229,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_cherrypick_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_cherrypick_options</code> with default values. Equivalent to creating\n an instance with GIT_CHERRYPICK_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_cherrypick_options</code> with default values. Equivalent to creating an instance with GIT_CHERRYPICK_OPTIONS_INIT.</p>\n",
       "group": "cherrypick"
     },
     "git_cherrypick_commit": {
@@ -3512,7 +3311,7 @@
       "comments": "",
       "group": "cherrypick"
     },
-    "git_clone_init_options": {
+    "git_clone_options_init": {
       "type": "function",
       "file": "git2/clone.h",
       "line": 181,
@@ -3536,7 +3335,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_clone_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_clone_options</code> with default values. Equivalent to creating\n an instance with GIT_CLONE_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_clone_options</code> with default values. Equivalent to creating an instance with GIT_CLONE_OPTIONS_INIT.</p>\n",
       "group": "clone"
     },
     "git_clone": {
@@ -3573,7 +3372,7 @@
         "comment": " 0 on success, any non-zero return value from a callback\n         function, or a negative value to indicate an error (use\n         `git_error_last` for a detailed error message)"
       },
       "description": "<p>Clone a remote repository.</p>\n",
-      "comments": "<p>By default this creates its repository and initial remote to match\n git&#39;s defaults. You can use the options in the callback to\n customize how these are created.</p>\n",
+      "comments": "<p>By default this creates its repository and initial remote to match git&#39;s defaults. You can use the options in the callback to customize how these are created.</p>\n",
       "group": "clone"
     },
     "git_commit_lookup": {
@@ -3605,22 +3404,22 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a commit object from a repository.</p>\n",
-      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no\n longer needed.</p>\n",
+      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no longer needed.</p>\n",
       "group": "commit",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_commit_lookup-6"
+          "ex/HEAD/checkout.html#git_commit_lookup-6"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_lookup-6",
-          "ex/v0.28.0/general.html#git_commit_lookup-7",
-          "ex/v0.28.0/general.html#git_commit_lookup-8"
+          "ex/HEAD/general.html#git_commit_lookup-6",
+          "ex/HEAD/general.html#git_commit_lookup-7",
+          "ex/HEAD/general.html#git_commit_lookup-8"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_lookup-1"
+          "ex/HEAD/log.html#git_commit_lookup-1"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_commit_lookup-6"
+          "ex/HEAD/merge.html#git_commit_lookup-6"
         ]
       }
     },
@@ -3658,7 +3457,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a commit object from a repository, given a prefix of its\n identifier (short id).</p>\n",
-      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no\n longer needed.</p>\n",
+      "comments": "<p>The returned object should be released with <code>git_commit_free</code> when no longer needed.</p>\n",
       "group": "commit"
     },
     "git_commit_free": {
@@ -3680,24 +3479,24 @@
         "comment": null
       },
       "description": "<p>Close an open commit</p>\n",
-      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop\n using a commit. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This is a wrapper around git_object_free()</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using a commit. Failure to do so will cause a memory leak.</p>\n",
       "group": "commit",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_commit_free-7"
+          "ex/HEAD/checkout.html#git_commit_free-7"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_free-9",
-          "ex/v0.28.0/general.html#git_commit_free-10",
-          "ex/v0.28.0/general.html#git_commit_free-11",
-          "ex/v0.28.0/general.html#git_commit_free-12",
-          "ex/v0.28.0/general.html#git_commit_free-13"
+          "ex/HEAD/general.html#git_commit_free-9",
+          "ex/HEAD/general.html#git_commit_free-10",
+          "ex/HEAD/general.html#git_commit_free-11",
+          "ex/HEAD/general.html#git_commit_free-12",
+          "ex/HEAD/general.html#git_commit_free-13"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_free-2",
-          "ex/v0.28.0/log.html#git_commit_free-3",
-          "ex/v0.28.0/log.html#git_commit_free-4",
-          "ex/v0.28.0/log.html#git_commit_free-5"
+          "ex/HEAD/log.html#git_commit_free-2",
+          "ex/HEAD/log.html#git_commit_free-3",
+          "ex/HEAD/log.html#git_commit_free-4",
+          "ex/HEAD/log.html#git_commit_free-5"
         ]
       }
     },
@@ -3724,10 +3523,10 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_id-14"
+          "ex/HEAD/general.html#git_commit_id-14"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_id-6"
+          "ex/HEAD/log.html#git_commit_id-6"
         ]
       }
     },
@@ -3754,8 +3553,8 @@
       "group": "commit",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_owner-7",
-          "ex/v0.28.0/log.html#git_commit_owner-8"
+          "ex/HEAD/log.html#git_commit_owner-7",
+          "ex/HEAD/log.html#git_commit_owner-8"
         ]
       }
     },
@@ -3778,7 +3577,7 @@
         "comment": " NULL, or the encoding"
       },
       "description": "<p>Get the encoding for the message of a commit,\n as a string representing a standard encoding name.</p>\n",
-      "comments": "<p>The encoding may be NULL if the <code>encoding</code> header\n in the commit is missing; in that case UTF-8 is assumed.</p>\n",
+      "comments": "<p>The encoding may be NULL if the <code>encoding</code> header in the commit is missing; in that case UTF-8 is assumed.</p>\n",
       "group": "commit"
     },
     "git_commit_message": {
@@ -3800,25 +3599,25 @@
         "comment": " the message of a commit"
       },
       "description": "<p>Get the full message of a commit.</p>\n",
-      "comments": "<p>The returned message will be slightly prettified by removing any\n potential leading newlines.</p>\n",
+      "comments": "<p>The returned message will be slightly prettified by removing any potential leading newlines.</p>\n",
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_message-3",
-          "ex/v0.28.0/cat-file.html#git_commit_message-4"
+          "ex/HEAD/cat-file.html#git_commit_message-3",
+          "ex/HEAD/cat-file.html#git_commit_message-4"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_message-15",
-          "ex/v0.28.0/general.html#git_commit_message-16",
-          "ex/v0.28.0/general.html#git_commit_message-17"
+          "ex/HEAD/general.html#git_commit_message-15",
+          "ex/HEAD/general.html#git_commit_message-16",
+          "ex/HEAD/general.html#git_commit_message-17"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_message-9",
-          "ex/v0.28.0/log.html#git_commit_message-10",
-          "ex/v0.28.0/log.html#git_commit_message-11"
+          "ex/HEAD/log.html#git_commit_message-9",
+          "ex/HEAD/log.html#git_commit_message-10",
+          "ex/HEAD/log.html#git_commit_message-11"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_commit_message-2"
+          "ex/HEAD/tag.html#git_commit_message-2"
         ]
       }
     },
@@ -3863,7 +3662,7 @@
         "comment": " the summary of a commit or NULL on error"
       },
       "description": "<p>Get the short &quot;summary&quot; of the git commit message.</p>\n",
-      "comments": "<p>The returned message is the summary of the commit, comprising the\n first paragraph of the message with whitespace trimmed and squashed.</p>\n",
+      "comments": "<p>The returned message is the summary of the commit, comprising the first paragraph of the message with whitespace trimmed and squashed.</p>\n",
       "group": "commit"
     },
     "git_commit_body": {
@@ -3885,7 +3684,7 @@
         "comment": " the body of a commit or NULL when no the message only\n   consists of a summary"
       },
       "description": "<p>Get the long &quot;body&quot; of the git commit message.</p>\n",
-      "comments": "<p>The returned message is the body of the commit, comprising\n everything but the first paragraph of the message. Leading and\n trailing whitespaces are trimmed.</p>\n",
+      "comments": "<p>The returned message is the body of the commit, comprising everything but the first paragraph of the message. Leading and trailing whitespaces are trimmed.</p>\n",
       "group": "commit"
     },
     "git_commit_time": {
@@ -3911,8 +3710,8 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_time-18",
-          "ex/v0.28.0/general.html#git_commit_time-19"
+          "ex/HEAD/general.html#git_commit_time-18",
+          "ex/HEAD/general.html#git_commit_time-19"
         ]
       }
     },
@@ -3961,13 +3760,13 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_committer-5"
+          "ex/HEAD/cat-file.html#git_commit_committer-5"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_committer-20"
+          "ex/HEAD/general.html#git_commit_committer-20"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_committer-12"
+          "ex/HEAD/log.html#git_commit_committer-12"
         ]
       }
     },
@@ -3994,15 +3793,15 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_author-6"
+          "ex/HEAD/cat-file.html#git_commit_author-6"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_author-21",
-          "ex/v0.28.0/general.html#git_commit_author-22"
+          "ex/HEAD/general.html#git_commit_author-21",
+          "ex/HEAD/general.html#git_commit_author-22"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_author-13",
-          "ex/v0.28.0/log.html#git_commit_author-14"
+          "ex/HEAD/log.html#git_commit_author-13",
+          "ex/HEAD/log.html#git_commit_author-14"
         ]
       }
     },
@@ -4120,11 +3919,11 @@
       "group": "commit",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_tree-15",
-          "ex/v0.28.0/log.html#git_commit_tree-16",
-          "ex/v0.28.0/log.html#git_commit_tree-17",
-          "ex/v0.28.0/log.html#git_commit_tree-18",
-          "ex/v0.28.0/log.html#git_commit_tree-19"
+          "ex/HEAD/log.html#git_commit_tree-15",
+          "ex/HEAD/log.html#git_commit_tree-16",
+          "ex/HEAD/log.html#git_commit_tree-17",
+          "ex/HEAD/log.html#git_commit_tree-18",
+          "ex/HEAD/log.html#git_commit_tree-19"
         ]
       }
     },
@@ -4151,7 +3950,7 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_tree_id-7"
+          "ex/HEAD/cat-file.html#git_commit_tree_id-7"
         ]
       }
     },
@@ -4178,14 +3977,14 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_parentcount-8"
+          "ex/HEAD/cat-file.html#git_commit_parentcount-8"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_parentcount-23"
+          "ex/HEAD/general.html#git_commit_parentcount-23"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_parentcount-20",
-          "ex/v0.28.0/log.html#git_commit_parentcount-21"
+          "ex/HEAD/log.html#git_commit_parentcount-20",
+          "ex/HEAD/log.html#git_commit_parentcount-21"
         ]
       }
     },
@@ -4222,11 +4021,11 @@
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_parent-24"
+          "ex/HEAD/general.html#git_commit_parent-24"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_parent-22",
-          "ex/v0.28.0/log.html#git_commit_parent-23"
+          "ex/HEAD/log.html#git_commit_parent-22",
+          "ex/HEAD/log.html#git_commit_parent-23"
         ]
       }
     },
@@ -4258,10 +4057,10 @@
       "group": "commit",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_commit_parent_id-9"
+          "ex/HEAD/cat-file.html#git_commit_parent_id-9"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_commit_parent_id-24"
+          "ex/HEAD/log.html#git_commit_parent_id-24"
         ]
       }
     },
@@ -4294,7 +4093,7 @@
         "comment": " 0 on success; GIT_ENOTFOUND if no matching ancestor exists\n or an error code"
       },
       "description": "<p>Get the commit object that is the \n&lt;n</p>\n\n<blockquote>\n<p>th generation ancestor\n of the named commit object, following only the first parents.\n The returned commit has to be freed by the caller.</p>\n</blockquote>\n",
-      "comments": "<p>Passing <code>0</code> as the generation number returns another instance of the\n base commit itself.</p>\n",
+      "comments": "<p>Passing <code>0</code> as the generation number returns another instance of the base commit itself.</p>\n",
       "group": "commit"
     },
     "git_commit_header_field": {
@@ -4368,7 +4167,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the id is not for a commit\n or the commit does not have a signature."
       },
       "description": "<p>Extract the signature from a commit</p>\n",
-      "comments": "<p>If the id is not for a commit, the error class will be\n <code>GIT_ERROR_INVALID</code>. If the commit does not have a signature, the\n error class will be <code>GIT_ERROR_OBJECT</code>.</p>\n",
+      "comments": "<p>If the id is not for a commit, the error class will be <code>GIT_ERROR_INVALID</code>. If the commit does not have a signature, the error class will be <code>GIT_ERROR_OBJECT</code>.</p>\n",
       "group": "commit"
     },
     "git_commit_create": {
@@ -4435,11 +4234,11 @@
         "comment": " 0 or an error code\n\tThe created commit will be written to the Object Database and\n\tthe given reference will be updated to point to it"
       },
       "description": "<p>Create new commit in the repository from a list of <code>git_object</code> pointers</p>\n",
-      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that\n with the <code>git_message_prettify()</code> function.</p>\n",
+      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that with the <code>git_message_prettify()</code> function.</p>\n",
       "group": "commit",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_commit_create-7"
+          "ex/HEAD/merge.html#git_commit_create-7"
         ]
       }
     },
@@ -4502,14 +4301,14 @@
         "comment": null
       },
       "description": "<p>Create new commit in the repository using a variable argument list.</p>\n",
-      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that\n with the <code>git_message_prettify()</code> function.</p>\n\n<p>The parents for the commit are specified as a variable list of pointers\n to <code>const git_commit *</code>. Note that this is a convenience method which may\n not be safe to export for certain languages or compilers</p>\n\n<p>All other parameters remain the same as <code>git_commit_create()</code>.</p>\n",
+      "comments": "<p>The message will <strong>not</strong> be cleaned up automatically. You can do that with the <code>git_message_prettify()</code> function.</p>\n\n<p>The parents for the commit are specified as a variable list of pointers to <code>const git_commit *</code>. Note that this is a convenience method which may not be safe to export for certain languages or compilers</p>\n\n<p>All other parameters remain the same as <code>git_commit_create()</code>.</p>\n",
       "group": "commit",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_commit_create_v-25"
+          "ex/HEAD/general.html#git_commit_create_v-25"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_commit_create_v-1"
+          "ex/HEAD/init.html#git_commit_create_v-1"
         ]
       }
     },
@@ -4567,7 +4366,7 @@
         "comment": null
       },
       "description": "<p>Amend an existing commit by replacing only non-NULL values.</p>\n",
-      "comments": "<p>This creates a new commit that is exactly the same as the old commit,\n except that any non-NULL values will be updated.  The new commit has\n the same parents as the old commit.</p>\n\n<p>The <code>update_ref</code> value works as in the regular <code>git_commit_create()</code>,\n updating the ref to point to the newly rewritten commit.  If you want\n to amend a commit that is not currently the tip of the branch and then\n rewrite the following commits to reach a ref, pass this as NULL and\n update the rest of the commit chain and ref separately.</p>\n\n<p>Unlike <code>git_commit_create()</code>, the <code>author</code>, <code>committer</code>, <code>message</code>,\n <code>message_encoding</code>, and <code>tree</code> parameters can be NULL in which case this\n will use the values from the original <code>commit_to_amend</code>.</p>\n\n<p>All parameters have the same meanings as in <code>git_commit_create()</code>.</p>\n",
+      "comments": "<p>This creates a new commit that is exactly the same as the old commit, except that any non-NULL values will be updated.  The new commit has the same parents as the old commit.</p>\n\n<p>The <code>update_ref</code> value works as in the regular <code>git_commit_create()</code>, updating the ref to point to the newly rewritten commit.  If you want to amend a commit that is not currently the tip of the branch and then rewrite the following commits to reach a ref, pass this as NULL and update the rest of the commit chain and ref separately.</p>\n\n<p>Unlike <code>git_commit_create()</code>, the <code>author</code>, <code>committer</code>, <code>message</code>, <code>message_encoding</code>, and <code>tree</code> parameters can be NULL in which case this will use the values from the original <code>commit_to_amend</code>.</p>\n\n<p>All parameters have the same meanings as in <code>git_commit_create()</code>.</p>\n",
       "group": "commit"
     },
     "git_commit_create_buffer": {
@@ -4629,7 +4428,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a commit and write it into a buffer</p>\n",
-      "comments": "<p>Create a commit as with <code>git_commit_create()</code> but instead of\n writing it to the objectdb, write the contents of the object into a\n buffer.</p>\n",
+      "comments": "<p>Create a commit as with <code>git_commit_create()</code> but instead of writing it to the objectdb, write the contents of the object into a buffer.</p>\n",
       "group": "commit"
     },
     "git_commit_create_with_signature": {
@@ -4671,7 +4470,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a commit object from the given buffer and signature</p>\n",
-      "comments": "<p>Given the unsigned commit object&#39;s contents, its signature and the\n header field in which to store the signature, attach the signature\n to the commit and write it into the given repository.</p>\n",
+      "comments": "<p>Given the unsigned commit object&#39;s contents, its signature and the header field in which to store the signature, attach the signature to the commit and write it into the given repository.</p>\n",
       "group": "commit"
     },
     "git_commit_dup": {
@@ -4704,8 +4503,8 @@
     "git_libgit2_version": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 124,
-      "lineto": 124,
+      "line": 121,
+      "lineto": 121,
       "args": [
         {
           "name": "major",
@@ -4736,8 +4535,8 @@
     "git_libgit2_features": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 173,
-      "lineto": 173,
+      "line": 170,
+      "lineto": 170,
       "args": [],
       "argline": "",
       "sig": "",
@@ -4746,14 +4545,14 @@
         "comment": " A combination of GIT_FEATURE_* values."
       },
       "description": "<p>Query compile time options for libgit2.</p>\n",
-      "comments": "<ul>\n<li><p>GIT_FEATURE_THREADS\nLibgit2 was compiled with thread support. Note that thread support is\nstill to be seen as a &#39;work in progress&#39; - basic object lookups are\nbelieved to be threadsafe, but other operations may not be.</p></li>\n<li><p>GIT_FEATURE_HTTPS\nLibgit2 supports the https:// protocol. This requires the openssl\nlibrary to be found when compiling libgit2.</p></li>\n<li><p>GIT_FEATURE_SSH\nLibgit2 supports the SSH protocol for network operations. This requires\nthe libssh2 library to be found when compiling libgit2</p></li>\n</ul>\n",
+      "comments": "<ul>\n<li><p>GIT_FEATURE_THREADS   Libgit2 was compiled with thread support. Note that thread support is   still to be seen as a &#39;work in progress&#39; - basic object lookups are   believed to be threadsafe, but other operations may not be.</p></li>\n<li><p>GIT_FEATURE_HTTPS   Libgit2 supports the https:// protocol. This requires the openssl   library to be found when compiling libgit2.</p></li>\n<li><p>GIT_FEATURE_SSH   Libgit2 supports the SSH protocol for network operations. This requires   the libssh2 library to be found when compiling libgit2</p></li>\n</ul>\n",
       "group": "libgit2"
     },
     "git_libgit2_opts": {
       "type": "function",
       "file": "git2/common.h",
-      "line": 402,
-      "lineto": 402,
+      "line": 404,
+      "lineto": 404,
       "args": [
         {
           "name": "option",
@@ -4768,7 +4567,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set or query a library global option</p>\n",
-      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time\n    by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must\n    &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,\n    &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n    &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path\n    &gt; applied to shared attributes and ignore files, too.\n    &gt;\n    &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.\n    &gt;   Pass NULL to reset to the default (generally based on environment\n    &gt;   variables).  Use magic path `$PATH` to include the old value\n    &gt;   of the path (if you want to prepend or append, for instance).\n    &gt;\n    &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,\n    &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or\n    &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_object_t type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be\n    &gt; considered eligible for caching in memory.  Setting to value to\n    &gt; zero means that that type of object will not be cached.\n    &gt; Defaults to 0 for GIT_OBJECT_BLOB (i.e. won&#39;t cache blobs) and 4k\n    &gt; for GIT_OBJECT_COMMIT, GIT_OBJECT_TREE, and GIT_OBJECT_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory\n    &gt; across all repositories before libgit2 starts evicting objects\n    &gt; from the cache.  This is a soft limit, in that the library might\n    &gt; briefly exceed it, but will start aggressively evicting objects\n    &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.\n    &gt;\n    &gt; Because caches are repository-specific, disabling the cache\n    &gt; cannot immediately clear all cached objects, but each cache will\n    &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be\n    &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.\n    &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.\n    &gt;\n    &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.\n    &gt;\n    &gt; - `file` is the location of a file containing several\n    &gt;   certificates concatenated together.\n    &gt; - `path` is the location of a directory holding several\n    &gt;   certificates, one per file.\n    &gt;\n    &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be\n    &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.\n    &gt;\n    &gt; - `user_agent` is the value that will be delivered as the\n    &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.\n    &gt; For more information, see the documentation for CreateFile.\n    &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is\n    &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects\n    &gt; to ensure that all inputs to the new objects are valid.  For\n    &gt; example, when this is enabled, the parent(s) and tree inputs\n    &gt; will be validated when creating a new commit.  This defaults\n    &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For\n    &gt; example, `foobar` is not a valid ref, therefore `foobar` is\n    &gt; not a valid target for a symbolic ref by default, whereas\n    &gt; `refs/heads/foobar` is.  Disabling this bypasses validation\n    &gt; so that an arbitrary strings such as `foobar` can be used\n    &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.\n    &gt;\n    &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,\n    &gt; and the negotiation of them when talking to a remote server.\n    &gt; Offset deltas store a delta base location as an offset into the\n    &gt; packfile from the current location, which provides a shorter encoding\n    &gt; and thus smaller resultant packfiles.\n    &gt; Packfiles containing offset deltas can still be read.\n    &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`\n    &gt; (or the platform equivalent) to ensure that new object data\n    &gt; is written to permanent storage, not simply cached.  This\n    &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading\n    &gt; objects from disk. This may impact performance due to an\n    &gt; additional checksum calculation on each object. This defaults\n    &gt; to enabled.\n\n opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)\n\n    &gt; Set the memory allocator to a different memory allocator. This\n    &gt; allocator will then be used to make all memory allocations for\n    &gt; libgit2 operations.  If the given `allocator` is NULL, then the\n    &gt; system default will be restored.\n\n opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, int enabled)\n\n    &gt; Ensure that there are no unsaved changes in the index before\n    &gt; beginning any operation that reloads the index from disk (eg,\n    &gt; checkout).  If there are unsaved changes, the instruction will\n    &gt; fail.  (Using the FORCE flag to checkout will still overwrite\n    &gt; these changes.)\n\n opts(GIT_OPT_GET_PACK_MAX_OBJECTS, size_t *out)\n\n    &gt; Get the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote. This can be\n    &gt; used to limit maximum memory usage when fetching from an untrusted\n    &gt; remote.\n\n opts(GIT_OPT_SET_PACK_MAX_OBJECTS, size_t objects)\n\n    &gt; Set the maximum number of objects libgit2 will allow in a pack\n    &gt; file when downloading a pack file from a remote.\n</code></pre>\n",
+      "comments": "<p>Available options:</p>\n\n<pre><code>* opts(GIT_OPT_GET_MWINDOW_SIZE, size_t *):\n\n    &gt; Get the maximum mmap window size\n\n* opts(GIT_OPT_SET_MWINDOW_SIZE, size_t):\n\n    &gt; Set the maximum mmap window size\n\n* opts(GIT_OPT_GET_MWINDOW_MAPPED_LIMIT, size_t *):\n\n    &gt; Get the maximum memory that will be mapped in total by the library\n\n* opts(GIT_OPT_SET_MWINDOW_MAPPED_LIMIT, size_t):\n\n    &gt;Set the maximum amount of memory that can be mapped at any time        by the library\n\n* opts(GIT_OPT_GET_SEARCH_PATH, int level, git_buf *buf)\n\n    &gt; Get the search path for a given level of config data.  &quot;level&quot; must       &gt; be one of `GIT_CONFIG_LEVEL_SYSTEM`, `GIT_CONFIG_LEVEL_GLOBAL`,       &gt; `GIT_CONFIG_LEVEL_XDG`, or `GIT_CONFIG_LEVEL_PROGRAMDATA`.        &gt; The search path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_SEARCH_PATH, int level, const char *path)\n\n    &gt; Set the search path for a level of config data.  The search path      &gt; applied to shared attributes and ignore files, too.       &gt;       &gt; - `path` lists directories delimited by GIT_PATH_LIST_SEPARATOR.      &gt;   Pass NULL to reset to the default (generally based on environment       &gt;   variables).  Use magic path `$PATH` to include the old value        &gt;   of the path (if you want to prepend or append, for instance).       &gt;       &gt; - `level` must be `GIT_CONFIG_LEVEL_SYSTEM`,      &gt;   `GIT_CONFIG_LEVEL_GLOBAL`, `GIT_CONFIG_LEVEL_XDG`, or       &gt;   `GIT_CONFIG_LEVEL_PROGRAMDATA`.\n\n* opts(GIT_OPT_SET_CACHE_OBJECT_LIMIT, git_object_t type, size_t size)\n\n    &gt; Set the maximum data size for the given type of object to be      &gt; considered eligible for caching in memory.  Setting to value to       &gt; zero means that that type of object will not be cached.       &gt; Defaults to 0 for GIT_OBJECT_BLOB (i.e. won&#39;t cache blobs) and 4k     &gt; for GIT_OBJECT_COMMIT, GIT_OBJECT_TREE, and GIT_OBJECT_TAG.\n\n* opts(GIT_OPT_SET_CACHE_MAX_SIZE, ssize_t max_storage_bytes)\n\n    &gt; Set the maximum total data size that will be cached in memory     &gt; across all repositories before libgit2 starts evicting objects        &gt; from the cache.  This is a soft limit, in that the library might      &gt; briefly exceed it, but will start aggressively evicting objects       &gt; from cache when that happens.  The default cache size is 256MB.\n\n* opts(GIT_OPT_ENABLE_CACHING, int enabled)\n\n    &gt; Enable or disable caching completely.     &gt;       &gt; Because caches are repository-specific, disabling the cache       &gt; cannot immediately clear all cached objects, but each cache will      &gt; be cleared on the next attempt to update anything in it.\n\n* opts(GIT_OPT_GET_CACHED_MEMORY, ssize_t *current, ssize_t *allowed)\n\n    &gt; Get the current bytes in cache and the maximum that would be      &gt; allowed in the cache.\n\n* opts(GIT_OPT_GET_TEMPLATE_PATH, git_buf *out)\n\n    &gt; Get the default template path.        &gt; The path is written to the `out` buffer.\n\n* opts(GIT_OPT_SET_TEMPLATE_PATH, const char *path)\n\n    &gt; Set the default template path.        &gt;       &gt; - `path` directory of template.\n\n* opts(GIT_OPT_SET_SSL_CERT_LOCATIONS, const char *file, const char *path)\n\n    &gt; Set the SSL certificate-authority locations.      &gt;       &gt; - `file` is the location of a file containing several     &gt;   certificates concatenated together.     &gt; - `path` is the location of a directory holding several       &gt;   certificates, one per file.     &gt;       &gt; Either parameter may be `NULL`, but not both.\n\n* opts(GIT_OPT_SET_USER_AGENT, const char *user_agent)\n\n    &gt; Set the value of the User-Agent header.  This value will be       &gt; appended to &quot;git/1.0&quot;, for compatibility with other git clients.      &gt;       &gt; - `user_agent` is the value that will be delivered as the     &gt;   User-Agent header on HTTP requests.\n\n* opts(GIT_OPT_SET_WINDOWS_SHAREMODE, unsigned long value)\n\n    &gt; Set the share mode used when opening files on Windows.        &gt; For more information, see the documentation for CreateFile.       &gt; The default is: FILE_SHARE_READ | FILE_SHARE_WRITE.  This is      &gt; ignored and unused on non-Windows platforms.\n\n* opts(GIT_OPT_GET_WINDOWS_SHAREMODE, unsigned long *value)\n\n    &gt; Get the share mode used when opening files on Windows.\n\n* opts(GIT_OPT_ENABLE_STRICT_OBJECT_CREATION, int enabled)\n\n    &gt; Enable strict input validation when creating new objects      &gt; to ensure that all inputs to the new objects are valid.  For      &gt; example, when this is enabled, the parent(s) and tree inputs      &gt; will be validated when creating a new commit.  This defaults      &gt; to enabled.\n\n* opts(GIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION, int enabled)\n\n    &gt; Validate the target of a symbolic ref when creating it.  For      &gt; example, `foobar` is not a valid ref, therefore `foobar` is       &gt; not a valid target for a symbolic ref by default, whereas     &gt; `refs/heads/foobar` is.  Disabling this bypasses validation       &gt; so that an arbitrary strings such as `foobar` can be used     &gt; for a symbolic ref target.  This defaults to enabled.\n\n* opts(GIT_OPT_SET_SSL_CIPHERS, const char *ciphers)\n\n    &gt; Set the SSL ciphers use for HTTPS connections.        &gt;       &gt; - `ciphers` is the list of ciphers that are eanbled.\n\n* opts(GIT_OPT_ENABLE_OFS_DELTA, int enabled)\n\n    &gt; Enable or disable the use of &quot;offset deltas&quot; when creating packfiles,     &gt; and the negotiation of them when talking to a remote server.      &gt; Offset deltas store a delta base location as an offset into the       &gt; packfile from the current location, which provides a shorter encoding     &gt; and thus smaller resultant packfiles.     &gt; Packfiles containing offset deltas can still be read.     &gt; This defaults to enabled.\n\n* opts(GIT_OPT_ENABLE_FSYNC_GITDIR, int enabled)\n\n    &gt; Enable synchronized writes of files in the gitdir using `fsync`       &gt; (or the platform equivalent) to ensure that new object data       &gt; is written to permanent storage, not simply cached.  This     &gt; defaults to disabled.\n\n opts(GIT_OPT_ENABLE_STRICT_HASH_VERIFICATION, int enabled)\n\n    &gt; Enable strict verification of object hashsums when reading        &gt; objects from disk. This may impact performance due to an      &gt; additional checksum calculation on each object. This defaults     &gt; to enabled.\n\n opts(GIT_OPT_SET_ALLOCATOR, git_allocator *allocator)\n\n    &gt; Set the memory allocator to a different memory allocator. This        &gt; allocator will then be used to make all memory allocations for        &gt; libgit2 operations.  If the given `allocator` is NULL, then the       &gt; system default will be restored.\n\n opts(GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY, int enabled)\n\n    &gt; Ensure that there are no unsaved changes in the index before      &gt; beginning any operation that reloads the index from disk (eg,     &gt; checkout).  If there are unsaved changes, the instruction will        &gt; fail.  (Using the FORCE flag to checkout will still overwrite     &gt; these changes.)\n\n opts(GIT_OPT_GET_PACK_MAX_OBJECTS, size_t *out)\n\n    &gt; Get the maximum number of objects libgit2 will allow in a pack        &gt; file when downloading a pack file from a remote. This can be      &gt; used to limit maximum memory usage when fetching from an untrusted        &gt; remote.\n\n opts(GIT_OPT_SET_PACK_MAX_OBJECTS, size_t objects)\n\n    &gt; Set the maximum number of objects libgit2 will allow in a pack        &gt; file when downloading a pack file from a remote.\n\n opts(GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS, int enabled)       &gt; This will cause .keep file existence checks to be skipped when        &gt; accessing packfiles, which can help performance with remote filesystems.\n</code></pre>\n",
       "group": "libgit2"
     },
     "git_config_entry_free": {
@@ -4812,7 +4611,7 @@
         "comment": " 0 if a global configuration file has been found. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the global configuration file</p>\n",
-      "comments": "<p>The user or global configuration file is usually\n located in <code>$HOME/.gitconfig</code>.</p>\n\n<p>This method will try to guess the full path to that\n file, if the file exists. The returned path\n may be used on any <code>git_config</code> call to load the\n global configuration file.</p>\n\n<p>This method will not guess the path to the xdg compatible\n config file (.config/git/config).</p>\n",
+      "comments": "<p>The user or global configuration file is usually located in <code>$HOME/.gitconfig</code>.</p>\n\n<p>This method will try to guess the full path to that file, if the file exists. The returned path may be used on any <code>git_config</code> call to load the global configuration file.</p>\n\n<p>This method will not guess the path to the xdg compatible config file (.config/git/config).</p>\n",
       "group": "config"
     },
     "git_config_find_xdg": {
@@ -4834,7 +4633,7 @@
         "comment": " 0 if a xdg compatible configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the global xdg compatible configuration file</p>\n",
-      "comments": "<p>The xdg compatible configuration file is usually\n located in <code>$HOME/.config/git/config</code>.</p>\n\n<p>This method will try to guess the full path to that\n file, if the file exists. The returned path\n may be used on any <code>git_config</code> call to load the\n xdg compatible configuration file.</p>\n",
+      "comments": "<p>The xdg compatible configuration file is usually located in <code>$HOME/.config/git/config</code>.</p>\n\n<p>This method will try to guess the full path to that file, if the file exists. The returned path may be used on any <code>git_config</code> call to load the xdg compatible configuration file.</p>\n",
       "group": "config"
     },
     "git_config_find_system": {
@@ -4856,7 +4655,7 @@
         "comment": " 0 if a system configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the system configuration file</p>\n",
-      "comments": "<p>If /etc/gitconfig doesn&#39;t exist, it will look for\n %PROGRAMFILES%</p>\n\n<p>.</p>\n",
+      "comments": "<p>If /etc/gitconfig doesn&#39;t exist, it will look for %PROGRAMFILES%.</p>\n",
       "group": "config"
     },
     "git_config_find_programdata": {
@@ -4878,7 +4677,7 @@
         "comment": " 0 if a ProgramData configuration file has been\n\tfound. Its path will be stored in `out`."
       },
       "description": "<p>Locate the path to the configuration file in ProgramData</p>\n",
-      "comments": "<p>Look for the file in %PROGRAMDATA%</p>\n\n<p>used by portable git.</p>\n",
+      "comments": "<p>Look for the file in %PROGRAMDATA% used by portable git.</p>\n",
       "group": "config"
     },
     "git_config_open_default": {
@@ -4900,7 +4699,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open the global, XDG and system configuration files</p>\n",
-      "comments": "<p>Utility wrapper that finds the global, XDG and system configuration files\n and opens them into a single prioritized config object that can be\n used when accessing default config data outside a repository.</p>\n",
+      "comments": "<p>Utility wrapper that finds the global, XDG and system configuration files and opens them into a single prioritized config object that can be used when accessing default config data outside a repository.</p>\n",
       "group": "config"
     },
     "git_config_new": {
@@ -4922,7 +4721,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Allocate a new configuration object</p>\n",
-      "comments": "<p>This object is empty, so you have to add a file to it before you\n can do anything with it.</p>\n",
+      "comments": "<p>This object is empty, so you have to add a file to it before you can do anything with it.</p>\n",
       "group": "config"
     },
     "git_config_add_file_ondisk": {
@@ -4964,7 +4763,7 @@
         "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0),\n  GIT_ENOTFOUND when the file doesn't exist or error code"
       },
       "description": "<p>Add an on-disk config file instance to an existing config</p>\n",
-      "comments": "<p>The on-disk file pointed at by <code>path</code> will be opened and\n parsed; it&#39;s expected to be a native Git config file following\n the default Git config syntax (see man git-config).</p>\n\n<p>If the file does not exist, the file will still be added and it\n will be created the first time we write to it.</p>\n\n<p>Note that the configuration object will free the file\n automatically.</p>\n\n<p>Further queries on this config object will access each\n of the config file instances in order (instances with\n a higher priority level will be accessed first).</p>\n",
+      "comments": "<p>The on-disk file pointed at by <code>path</code> will be opened and parsed; it&#39;s expected to be a native Git config file following the default Git config syntax (see man git-config).</p>\n\n<p>If the file does not exist, the file will still be added and it will be created the first time we write to it.</p>\n\n<p>Note that the configuration object will free the file automatically.</p>\n\n<p>Further queries on this config object will access each of the config file instances in order (instances with a higher priority level will be accessed first).</p>\n",
       "group": "config"
     },
     "git_config_open_ondisk": {
@@ -4991,11 +4790,11 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Create a new config instance containing a single on-disk file</p>\n",
-      "comments": "<p>This method is a simple utility wrapper for the following sequence\n of calls:\n    - git_config_new\n    - git_config_add_file_ondisk</p>\n",
+      "comments": "<p>This method is a simple utility wrapper for the following sequence of calls:   - git_config_new    - git_config_add_file_ondisk</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_config_open_ondisk-26"
+          "ex/HEAD/general.html#git_config_open_ondisk-26"
         ]
       }
     },
@@ -5028,7 +4827,7 @@
         "comment": " 0, GIT_ENOTFOUND if the passed level cannot be found in the\n multi-level parent config, or an error code"
       },
       "description": "<p>Build a single-level focused config object from a multi-level one.</p>\n",
-      "comments": "<p>The returned config object can be used to perform get/set/delete operations\n on a single specific level.</p>\n\n<p>Getting several times the same level from the same parent multi-level config\n will return different config instances, but containing the same config_file\n instance.</p>\n",
+      "comments": "<p>The returned config object can be used to perform get/set/delete operations on a single specific level.</p>\n\n<p>Getting several times the same level from the same parent multi-level config will return different config instances, but containing the same config_file instance.</p>\n",
       "group": "config"
     },
     "git_config_open_global": {
@@ -5055,7 +4854,7 @@
         "comment": null
       },
       "description": "<p>Open the global/XDG configuration file according to git&#39;s rules</p>\n",
-      "comments": "<p>Git allows you to store your global configuration at\n <code>$HOME/.gitconfig</code> or <code>$XDG_CONFIG_HOME/git/config</code>. For backwards\n compatability, the XDG file shouldn&#39;t be used unless the use has\n created it explicitly. With this function you&#39;ll open the correct\n one to write to.</p>\n",
+      "comments": "<p>Git allows you to store your global configuration at <code>$HOME/.gitconfig</code> or <code>$XDG_CONFIG_HOME/git/config</code>. For backwards compatability, the XDG file shouldn&#39;t be used unless the use has created it explicitly. With this function you&#39;ll open the correct one to write to.</p>\n",
       "group": "config"
     },
     "git_config_snapshot": {
@@ -5082,7 +4881,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a snapshot of the configuration</p>\n",
-      "comments": "<p>Create a snapshot of the current state of a configuration, which\n allows you to look into a consistent view of the configuration for\n looking up complex values (e.g. a remote, submodule).</p>\n\n<p>The string returned when querying such a config object is valid\n until it is freed.</p>\n",
+      "comments": "<p>Create a snapshot of the current state of a configuration, which allows you to look into a consistent view of the configuration for looking up complex values (e.g. a remote, submodule).</p>\n\n<p>The string returned when querying such a config object is valid until it is freed.</p>\n",
       "group": "config"
     },
     "git_config_free": {
@@ -5108,8 +4907,8 @@
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_config_free-27",
-          "ex/v0.28.0/general.html#git_config_free-28"
+          "ex/HEAD/general.html#git_config_free-27",
+          "ex/HEAD/general.html#git_config_free-28"
         ]
       }
     },
@@ -5153,33 +4952,33 @@
       "args": [
         {
           "name": "out",
-          "type": "int *",
-          "comment": null
+          "type": "int32_t *",
+          "comment": "pointer to the variable where the value should be stored"
         },
         {
           "name": "cfg",
           "type": "const git_config *",
-          "comment": null
+          "comment": "where to look for the variable"
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "the variable's name"
         }
       ],
-      "argline": "int *out, const git_config *cfg, const char *name",
-      "sig": "int *::const git_config *::const char *",
+      "argline": "int32_t *out, const git_config *cfg, const char *name",
+      "sig": "int32_t *::const git_config *::const char *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 or an error code"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Get the value of an integer config variable.</p>\n",
+      "comments": "<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_config_get_int32-29",
-          "ex/v0.28.0/general.html#git_config_get_int32-30"
+          "ex/HEAD/general.html#git_config_get_int32-29",
+          "ex/HEAD/general.html#git_config_get_int32-30"
         ]
       }
     },
@@ -5191,28 +4990,28 @@
       "args": [
         {
           "name": "out",
-          "type": "int *",
-          "comment": null
+          "type": "int64_t *",
+          "comment": "pointer to the variable where the value should be stored"
         },
         {
           "name": "cfg",
           "type": "const git_config *",
-          "comment": null
+          "comment": "where to look for the variable"
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "the variable's name"
         }
       ],
-      "argline": "int *out, const git_config *cfg, const char *name",
-      "sig": "int *::const git_config *::const char *",
+      "argline": "int64_t *out, const git_config *cfg, const char *name",
+      "sig": "int64_t *::const git_config *::const char *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 or an error code"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Get the value of a long integer config variable.</p>\n",
+      "comments": "<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_bool": {
@@ -5244,7 +5043,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a boolean config variable.</p>\n",
-      "comments": "<p>This function uses the usual C convention of 0 being false and\n anything else true.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>This function uses the usual C convention of 0 being false and anything else true.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_path": {
@@ -5276,7 +5075,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a path config variable.</p>\n",
-      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which\n defaults to the user&#39;s home directory but can be overridden via\n <code>git_libgit2_opts()</code>.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which defaults to the user&#39;s home directory but can be overridden via <code>git_libgit2_opts()</code>.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_string": {
@@ -5308,12 +5107,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a string config variable.</p>\n",
-      "comments": "<p>This function can only be used on snapshot config objects. The\n string is owned by the config and should not be freed by the\n user. The pointer will be valid until the config is freed.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>This function can only be used on snapshot config objects. The string is owned by the config and should not be freed by the user. The pointer will be valid until the config is freed.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_config_get_string-31",
-          "ex/v0.28.0/general.html#git_config_get_string-32"
+          "ex/HEAD/general.html#git_config_get_string-31",
+          "ex/HEAD/general.html#git_config_get_string-32"
         ]
       }
     },
@@ -5346,7 +5145,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the value of a string config variable.</p>\n",
-      "comments": "<p>The value of the config will be copied into the buffer.</p>\n\n<p>All config files will be looked into, in the order of their\n defined level. A higher level means a higher priority. The\n first occurrence of the variable will be returned here.</p>\n",
+      "comments": "<p>The value of the config will be copied into the buffer.</p>\n\n<p>All config files will be looked into, in the order of their defined level. A higher level means a higher priority. The first occurrence of the variable will be returned here.</p>\n",
       "group": "config"
     },
     "git_config_get_multivar_foreach": {
@@ -5388,7 +5187,7 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar in a foreach callback</p>\n",
-      "comments": "<p>The callback will be called on each variable found</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
+      "comments": "<p>The callback will be called on each variable found</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_multivar_iterator_new": {
@@ -5425,7 +5224,7 @@
         "comment": null
       },
       "description": "<p>Get each value of a multivar</p>\n",
-      "comments": "<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
+      "comments": "<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_next": {
@@ -5452,7 +5251,7 @@
         "comment": " 0 or an error code. GIT_ITEROVER if the iteration has completed"
       },
       "description": "<p>Return the current entry and advance the iterator</p>\n",
-      "comments": "<p>The pointers returned by this function are valid until the iterator\n is freed.</p>\n",
+      "comments": "<p>The pointers returned by this function are valid until the iterator is freed.</p>\n",
       "group": "config"
     },
     "git_config_iterator_free": {
@@ -5486,26 +5285,26 @@
         {
           "name": "cfg",
           "type": "git_config *",
-          "comment": null
+          "comment": "where to look for the variable"
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "the variable's name"
         },
         {
           "name": "value",
-          "type": "int",
-          "comment": null
+          "type": "int32_t",
+          "comment": "Integer value for the variable"
         }
       ],
-      "argline": "git_config *cfg, const char *name, int value",
-      "sig": "git_config *::const char *::int",
+      "argline": "git_config *cfg, const char *name, int32_t value",
+      "sig": "git_config *::const char *::int32_t",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 or an error code"
       },
-      "description": "",
+      "description": "<p>Set the value of an integer config variable in the config file\n with the highest level (usually the local one).</p>\n",
       "comments": "",
       "group": "config"
     },
@@ -5518,26 +5317,26 @@
         {
           "name": "cfg",
           "type": "git_config *",
-          "comment": null
+          "comment": "where to look for the variable"
         },
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "the variable's name"
         },
         {
           "name": "value",
-          "type": "int",
-          "comment": null
+          "type": "int64_t",
+          "comment": "Long integer value for the variable"
         }
       ],
-      "argline": "git_config *cfg, const char *name, int value",
-      "sig": "git_config *::const char *::int",
+      "argline": "git_config *cfg, const char *name, int64_t value",
+      "sig": "git_config *::const char *::int64_t",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 or an error code"
       },
-      "description": "",
+      "description": "<p>Set the value of a long integer config variable in the config file\n with the highest level (usually the local one).</p>\n",
       "comments": "",
       "group": "config"
     },
@@ -5602,7 +5401,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Set the value of a string config variable in the config file\n with the highest level (usually the local one).</p>\n",
-      "comments": "<p>A copy of the string is made and the user is free to use it\n afterwards.</p>\n",
+      "comments": "<p>A copy of the string is made and the user is free to use it afterwards.</p>\n",
       "group": "config"
     },
     "git_config_set_multivar": {
@@ -5730,7 +5529,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform an operation on each config variable.</p>\n",
-      "comments": "<p>The callback receives the normalized name and value of each variable\n in the config backend, and the data pointer passed to this function.\n If the callback returns a non-zero value, the function stops iterating\n and returns that value to the caller.</p>\n\n<p>The pointers passed to the callback are only valid as long as the\n iteration is ongoing.</p>\n",
+      "comments": "<p>The callback receives the normalized name and value of each variable in the config backend, and the data pointer passed to this function. If the callback returns a non-zero value, the function stops iterating and returns that value to the caller.</p>\n\n<p>The pointers passed to the callback are only valid as long as the iteration is ongoing.</p>\n",
       "group": "config"
     },
     "git_config_iterator_new": {
@@ -5757,7 +5556,7 @@
         "comment": null
       },
       "description": "<p>Iterate over all the config variables</p>\n",
-      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and\n <code>git_config_iterator_free</code> when done.</p>\n",
+      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n",
       "group": "config"
     },
     "git_config_iterator_glob_new": {
@@ -5789,7 +5588,7 @@
         "comment": null
       },
       "description": "<p>Iterate over all the config variables whose name matches a pattern</p>\n",
-      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and\n <code>git_config_iterator_free</code> when done.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
+      "comments": "<p>Use <code>git_config_next</code> to advance the iteration and <code>git_config_iterator_free</code> when done.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_foreach_match": {
@@ -5826,7 +5625,7 @@
         "comment": " 0 or the return value of the callback which didn't return 0"
       },
       "description": "<p>Perform an operation on each config variable matching a regular expression.</p>\n",
-      "comments": "<p>This behaves like <code>git_config_foreach</code> with an additional filter of a\n regular expression that filters which config keys are passed to the\n callback.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the case-insensitive parts are lower-case.</p>\n",
+      "comments": "<p>This behaves like <code>git_config_foreach</code> with an additional filter of a regular expression that filters which config keys are passed to the callback.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the case-insensitive parts are lower-case.</p>\n",
       "group": "config"
     },
     "git_config_get_mapped": {
@@ -5868,7 +5667,7 @@
         "comment": " 0 on success, error code otherwise"
       },
       "description": "<p>Query the value of a config variable and return it mapped to\n an integer constant.</p>\n",
-      "comments": "<p>This is a helper method to easily map different possible values\n to a variable to integer constants that easily identify them.</p>\n\n<p>A mapping array looks as follows:</p>\n\n<pre><code>git_cvar_map autocrlf_mapping[] = {\n    {GIT_CVAR_FALSE, NULL, GIT_AUTO_CRLF_FALSE},\n    {GIT_CVAR_TRUE, NULL, GIT_AUTO_CRLF_TRUE},\n    {GIT_CVAR_STRING, &quot;input&quot;, GIT_AUTO_CRLF_INPUT},\n    {GIT_CVAR_STRING, &quot;default&quot;, GIT_AUTO_CRLF_DEFAULT}};\n</code></pre>\n\n<p>On any &quot;false&quot; value for the variable (e.g. &quot;false&quot;, &quot;FALSE&quot;, &quot;no&quot;), the\n mapping will store <code>GIT_AUTO_CRLF_FALSE</code> in the <code>out</code> parameter.</p>\n\n<p>The same thing applies for any &quot;true&quot; value such as &quot;true&quot;, &quot;yes&quot; or &quot;1&quot;, storing\n the <code>GIT_AUTO_CRLF_TRUE</code> variable.</p>\n\n<p>Otherwise, if the value matches the string &quot;input&quot; (with case insensitive comparison),\n the given constant will be stored in <code>out</code>, and likewise for &quot;default&quot;.</p>\n\n<p>If not a single match can be made to store in <code>out</code>, an error code will be\n returned.</p>\n",
+      "comments": "<p>This is a helper method to easily map different possible values to a variable to integer constants that easily identify them.</p>\n\n<p>A mapping array looks as follows:</p>\n\n<pre><code>git_cvar_map autocrlf_mapping[] = {     {GIT_CVAR_FALSE, NULL, GIT_AUTO_CRLF_FALSE},        {GIT_CVAR_TRUE, NULL, GIT_AUTO_CRLF_TRUE},      {GIT_CVAR_STRING, &quot;input&quot;, GIT_AUTO_CRLF_INPUT},        {GIT_CVAR_STRING, &quot;default&quot;, GIT_AUTO_CRLF_DEFAULT}};\n</code></pre>\n\n<p>On any &quot;false&quot; value for the variable (e.g. &quot;false&quot;, &quot;FALSE&quot;, &quot;no&quot;), the mapping will store <code>GIT_AUTO_CRLF_FALSE</code> in the <code>out</code> parameter.</p>\n\n<p>The same thing applies for any &quot;true&quot; value such as &quot;true&quot;, &quot;yes&quot; or &quot;1&quot;, storing the <code>GIT_AUTO_CRLF_TRUE</code> variable.</p>\n\n<p>Otherwise, if the value matches the string &quot;input&quot; (with case insensitive comparison), the given constant will be stored in <code>out</code>, and likewise for &quot;default&quot;.</p>\n\n<p>If not a single match can be made to store in <code>out</code>, an error code will be returned.</p>\n",
       "group": "config"
     },
     "git_config_lookup_map_value": {
@@ -5932,7 +5731,7 @@
         "comment": null
       },
       "description": "<p>Parse a string value as a bool.</p>\n",
-      "comments": "<p>Valid values for true are: &#39;true&#39;, &#39;yes&#39;, &#39;on&#39;, 1 or any\n  number different from 0\n Valid values for false are: &#39;false&#39;, &#39;no&#39;, &#39;off&#39;, 0</p>\n",
+      "comments": "<p>Valid values for true are: &#39;true&#39;, &#39;yes&#39;, &#39;on&#39;, 1 or any  number different from 0 Valid values for false are: &#39;false&#39;, &#39;no&#39;, &#39;off&#39;, 0</p>\n",
       "group": "config"
     },
     "git_config_parse_int32": {
@@ -5943,23 +5742,23 @@
       "args": [
         {
           "name": "out",
-          "type": "int *",
-          "comment": null
+          "type": "int32_t *",
+          "comment": "place to store the result of the parsing"
         },
         {
           "name": "value",
           "type": "const char *",
-          "comment": null
+          "comment": "value to parse"
         }
       ],
-      "argline": "int *out, const char *value",
-      "sig": "int *::const char *",
+      "argline": "int32_t *out, const char *value",
+      "sig": "int32_t *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Parse a string value as an int32.</p>\n",
+      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will cause the value to be multiplied by 1024, 1048576, or 1073741824 prior to output.</p>\n",
       "group": "config"
     },
     "git_config_parse_int64": {
@@ -5970,23 +5769,23 @@
       "args": [
         {
           "name": "out",
-          "type": "int *",
-          "comment": null
+          "type": "int64_t *",
+          "comment": "place to store the result of the parsing"
         },
         {
           "name": "value",
           "type": "const char *",
-          "comment": null
+          "comment": "value to parse"
         }
       ],
-      "argline": "int *out, const char *value",
-      "sig": "int *::const char *",
+      "argline": "int64_t *out, const char *value",
+      "sig": "int64_t *::const char *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Parse a string value as an int64.</p>\n",
+      "comments": "<p>An optional value suffix of &#39;k&#39;, &#39;m&#39;, or &#39;g&#39; will cause the value to be multiplied by 1024, 1048576, or 1073741824 prior to output.</p>\n",
       "group": "config"
     },
     "git_config_parse_path": {
@@ -6013,7 +5812,7 @@
         "comment": null
       },
       "description": "<p>Parse a string value as a path.</p>\n",
-      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which\n defaults to the user&#39;s home directory but can be overridden via\n <code>git_libgit2_opts()</code>.</p>\n\n<p>If the value does not begin with a tilde, the input will be\n returned.</p>\n",
+      "comments": "<p>A leading &#39;~&#39; will be expanded to the global search path (which defaults to the user&#39;s home directory but can be overridden via <code>git_libgit2_opts()</code>.</p>\n\n<p>If the value does not begin with a tilde, the input will be returned.</p>\n",
       "group": "config"
     },
     "git_config_backend_foreach_match": {
@@ -6050,7 +5849,7 @@
         "comment": null
       },
       "description": "<p>Perform an operation on each config variable in a given config backend,\n matching a regular expression.</p>\n",
-      "comments": "<p>This behaves like <code>git_config_foreach_match</code> except that only config\n entries from the given backend entry are enumerated.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of\n the variable name: the section and variable parts are lower-cased. The\n subsection is left unchanged.</p>\n",
+      "comments": "<p>This behaves like <code>git_config_foreach_match</code> except that only config entries from the given backend entry are enumerated.</p>\n\n<p>The regular expression is applied case-sensitively on the normalized form of the variable name: the section and variable parts are lower-cased. The subsection is left unchanged.</p>\n",
       "group": "config"
     },
     "git_config_lock": {
@@ -6077,7 +5876,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lock the backend with the highest priority</p>\n",
-      "comments": "<p>Locking disallows anybody else from writing to that backend. Any\n updates made after locking will not be visible to a reader until\n the file is unlocked.</p>\n\n<p>You can apply the changes by calling <code>git_transaction_commit()</code>\n before freeing the transaction. Either of these actions will unlock\n the config.</p>\n",
+      "comments": "<p>Locking disallows anybody else from writing to that backend. Any updates made after locking will not be visible to a reader until the file is unlocked.</p>\n\n<p>You can apply the changes by calling <code>git_transaction_commit()</code> before freeing the transaction. Either of these actions will unlock the config.</p>\n",
       "group": "config"
     },
     "git_cred_userpass": {
@@ -6122,11 +5921,43 @@
       "comments": "",
       "group": "cred"
     },
+    "git_blob_create_fromworkdir": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 80,
+      "lineto": 80,
+      "args": [
+        {
+          "name": "id",
+          "type": "git_oid *",
+          "comment": null
+        },
+        {
+          "name": "repo",
+          "type": "git_repository *",
+          "comment": null
+        },
+        {
+          "name": "relative_path",
+          "type": "const char *",
+          "comment": null
+        }
+      ],
+      "argline": "git_oid *id, git_repository *repo, const char *relative_path",
+      "sig": "git_oid *::git_repository *::const char *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": "<p>These functions are retained for backward compatibility.  The newer versions of these functions should be preferred in all new code.</p>\n\n<p>There is no plan to remove these backward compatibility values at this time.</p>\n\n<p>@{</p>\n",
+      "group": "blob"
+    },
     "git_buf_free": {
       "type": "function",
       "file": "git2/deprecated.h",
-      "line": 51,
-      "lineto": 51,
+      "line": 115,
+      "lineto": 115,
       "args": [
         {
           "name": "buffer",
@@ -6141,14 +5972,14 @@
         "comment": null
       },
       "description": "<p>Free the memory referred to by the git_buf.  This is an alias of\n <code>git_buf_dispose</code> and is preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this function at this time.</p>\n",
       "group": "buf"
     },
     "giterr_last": {
       "type": "function",
       "file": "git2/deprecated.h",
-      "line": 112,
-      "lineto": 112,
+      "line": 176,
+      "lineto": 176,
       "args": [],
       "argline": "",
       "sig": "",
@@ -6157,14 +5988,14 @@
         "comment": null
       },
       "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread.  This is an alias of <code>git_error_last</code> and is\n preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this function at this time.</p>\n",
       "group": "giterr"
     },
     "giterr_clear": {
       "type": "function",
       "file": "git2/deprecated.h",
-      "line": 124,
-      "lineto": 124,
+      "line": 188,
+      "lineto": 188,
       "args": [],
       "argline": "",
       "sig": "",
@@ -6173,14 +6004,14 @@
         "comment": null
       },
       "description": "<p>Clear the last error.  This is an alias of <code>git_error_last</code> and is\n preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this function at this time.</p>\n",
       "group": "giterr"
     },
     "giterr_set_str": {
       "type": "function",
       "file": "git2/deprecated.h",
-      "line": 136,
-      "lineto": 136,
+      "line": 200,
+      "lineto": 200,
       "args": [
         {
           "name": "error_class",
@@ -6200,14 +6031,14 @@
         "comment": null
       },
       "description": "<p>Sets the error message to the given string.  This is an alias of\n <code>git_error_set_str</code> and is preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this function at this time.</p>\n",
       "group": "giterr"
     },
     "giterr_set_oom": {
       "type": "function",
       "file": "git2/deprecated.h",
-      "line": 148,
-      "lineto": 148,
+      "line": 212,
+      "lineto": 212,
       "args": [],
       "argline": "",
       "sig": "",
@@ -6216,10 +6047,59 @@
         "comment": null
       },
       "description": "<p>Indicates that an out-of-memory situation occured.  This is an alias\n of <code>git_error_set_oom</code> and is preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
+      "comments": "<p>This function is deprecated, but there is no plan to remove this function at this time.</p>\n",
       "group": "giterr"
     },
-    "git_describe_init_options": {
+    "git_oid_iszero": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 364,
+      "lineto": 364,
+      "args": [
+        {
+          "name": "id",
+          "type": "const git_oid *",
+          "comment": null
+        }
+      ],
+      "argline": "const git_oid *id",
+      "sig": "const git_oid *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": "<p>These types are retained for backward compatibility.  The newer versions of these values should be preferred in all new code.</p>\n\n<p>There is no plan to remove these backward compatibility values at this time.</p>\n\n<p>@{</p>\n",
+      "group": "oid"
+    },
+    "git_blame_init_options": {
+      "type": "function",
+      "file": "git2/deprecated.h",
+      "line": 423,
+      "lineto": 423,
+      "args": [
+        {
+          "name": "opts",
+          "type": "git_blame_options *",
+          "comment": null
+        },
+        {
+          "name": "version",
+          "type": "unsigned int",
+          "comment": null
+        }
+      ],
+      "argline": "git_blame_options *opts, unsigned int version",
+      "sig": "git_blame_options *::unsigned int",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "",
+      "comments": "<p>These functions are retained for backward compatibility.  The newer versions of these functions should be preferred in all new code.</p>\n\n<p>There is no plan to remove these backward compatibility functions at this time.</p>\n\n<p>@{</p>\n",
+      "group": "blame"
+    },
+    "git_describe_options_init": {
       "type": "function",
       "file": "git2/describe.h",
       "line": 82,
@@ -6243,15 +6123,15 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_describe_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_describe_options</code> with default values. Equivalent to creating\n an instance with GIT_DESCRIBE_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_describe_options</code> with default values. Equivalent to creating an instance with GIT_DESCRIBE_OPTIONS_INIT.</p>\n",
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_describe_init_options-1"
+          "ex/HEAD/describe.html#git_describe_options_init-1"
         ]
       }
     },
-    "git_describe_init_format_options": {
+    "git_describe_format_options_init": {
       "type": "function",
       "file": "git2/describe.h",
       "line": 129,
@@ -6275,11 +6155,11 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_describe_format_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_describe_format_options</code> with default values. Equivalent to creating\n an instance with GIT_DESCRIBE_FORMAT_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_describe_format_options</code> with default values. Equivalent to creating an instance with GIT_DESCRIBE_FORMAT_OPTIONS_INIT.</p>\n",
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_describe_init_format_options-2"
+          "ex/HEAD/describe.html#git_describe_format_options_init-2"
         ]
       }
     },
@@ -6316,7 +6196,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_describe_commit-3"
+          "ex/HEAD/describe.html#git_describe_commit-3"
         ]
       }
     },
@@ -6349,11 +6229,11 @@
         "comment": null
       },
       "description": "<p>Describe a commit</p>\n",
-      "comments": "<p>Perform the describe operation on the current commit and the\n worktree. After peforming describe on HEAD, a status is run and the\n description is considered to be dirty if there are.</p>\n",
+      "comments": "<p>Perform the describe operation on the current commit and the worktree. After peforming describe on HEAD, a status is run and the description is considered to be dirty if there are.</p>\n",
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_describe_workdir-4"
+          "ex/HEAD/describe.html#git_describe_workdir-4"
         ]
       }
     },
@@ -6390,7 +6270,7 @@
       "group": "describe",
       "examples": {
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_describe_format-5"
+          "ex/HEAD/describe.html#git_describe_format-5"
         ]
       }
     },
@@ -6416,7 +6296,7 @@
       "comments": "",
       "group": "describe"
     },
-    "git_diff_init_options": {
+    "git_diff_options_init": {
       "type": "function",
       "file": "git2/diff.h",
       "line": 454,
@@ -6440,10 +6320,10 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_diff_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_diff_options</code> with default values. Equivalent to creating\n an instance with GIT_DIFF_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_options</code> with default values. Equivalent to creating an instance with GIT_DIFF_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
-    "git_diff_find_init_options": {
+    "git_diff_find_options_init": {
       "type": "function",
       "file": "git2/diff.h",
       "line": 787,
@@ -6467,7 +6347,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_diff_find_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_diff_find_options</code> with default values. Equivalent to creating\n an instance with GIT_DIFF_FIND_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_find_options</code> with default values. Equivalent to creating an instance with GIT_DIFF_FIND_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
     "git_diff_free": {
@@ -6493,11 +6373,11 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_free-2"
+          "ex/HEAD/diff.html#git_diff_free-2"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_diff_free-25",
-          "ex/v0.28.0/log.html#git_diff_free-26"
+          "ex/HEAD/log.html#git_diff_free-25",
+          "ex/HEAD/log.html#git_diff_free-26"
         ]
       }
     },
@@ -6540,15 +6420,15 @@
         "comment": null
       },
       "description": "<p>Create a diff with the difference between two tree objects.</p>\n",
-      "comments": "<p>This is equivalent to <code>git diff \n&lt;old\n-tree&gt; \n&lt;new\n-tree&gt;</code></p>\n\n<p>The first tree will be used for the &quot;old_file&quot; side of the delta and the\n second tree will be used for the &quot;new_file&quot; side of the delta.  You can\n pass NULL to indicate an empty tree, although it is an error to pass\n NULL for both the <code>old_tree</code> and <code>new_tree</code>.</p>\n",
+      "comments": "<p>This is equivalent to <code>git diff &lt;old-tree&gt; &lt;new-tree&gt;</code></p>\n\n<p>The first tree will be used for the &quot;old_file&quot; side of the delta and the second tree will be used for the &quot;new_file&quot; side of the delta.  You can pass NULL to indicate an empty tree, although it is an error to pass NULL for both the <code>old_tree</code> and <code>new_tree</code>.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_tree_to_tree-3"
+          "ex/HEAD/diff.html#git_diff_tree_to_tree-3"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_diff_tree_to_tree-27",
-          "ex/v0.28.0/log.html#git_diff_tree_to_tree-28"
+          "ex/HEAD/log.html#git_diff_tree_to_tree-27",
+          "ex/HEAD/log.html#git_diff_tree_to_tree-28"
         ]
       }
     },
@@ -6591,11 +6471,11 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and repository index.</p>\n",
-      "comments": "<p>This is equivalent to `git diff --cached \n&lt;treeish</p>\n\n<blockquote>\n<p><code>or if you pass\n the HEAD tree, then like</code>git diff --cached`.</p>\n</blockquote>\n\n<p>The tree you pass will be used for the &quot;old_file&quot; side of the delta, and\n the index will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code>\n will be used.  In this case, the index will be refreshed from disk\n (if it has changed) before the diff is generated.</p>\n",
+      "comments": "<p>This is equivalent to <code>git diff --cached &lt;treeish&gt;</code> or if you pass the HEAD tree, then like <code>git diff --cached</code>.</p>\n\n<p>The tree you pass will be used for the &quot;old_file&quot; side of the delta, and the index will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code> will be used.  In this case, the index will be refreshed from disk (if it has changed) before the diff is generated.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_tree_to_index-4"
+          "ex/HEAD/diff.html#git_diff_tree_to_index-4"
         ]
       }
     },
@@ -6633,11 +6513,11 @@
         "comment": null
       },
       "description": "<p>Create a diff between the repository index and the workdir directory.</p>\n",
-      "comments": "<p>This matches the <code>git diff</code> command.  See the note below on\n <code>git_diff_tree_to_workdir</code> for a discussion of the difference between\n <code>git diff</code> and <code>git diff HEAD</code> and how to emulate a `git diff \n&lt;treeish</p>\n\n<blockquote>\n<p>`\n using libgit2.</p>\n</blockquote>\n\n<p>The index will be used for the &quot;old_file&quot; side of the delta, and the\n working directory will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code>\n will be used.  In this case, the index will be refreshed from disk\n (if it has changed) before the diff is generated.</p>\n",
+      "comments": "<p>This matches the <code>git diff</code> command.  See the note below on <code>git_diff_tree_to_workdir</code> for a discussion of the difference between <code>git diff</code> and <code>git diff HEAD</code> and how to emulate a <code>git diff &lt;treeish&gt;</code> using libgit2.</p>\n\n<p>The index will be used for the &quot;old_file&quot; side of the delta, and the working directory will be used for the &quot;new_file&quot; side of the delta.</p>\n\n<p>If you pass NULL for the index, then the existing index of the <code>repo</code> will be used.  In this case, the index will be refreshed from disk (if it has changed) before the diff is generated.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_index_to_workdir-5"
+          "ex/HEAD/diff.html#git_diff_index_to_workdir-5"
         ]
       }
     },
@@ -6675,11 +6555,11 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and the working directory.</p>\n",
-      "comments": "<p>The tree you provide will be used for the &quot;old_file&quot; side of the delta,\n and the working directory will be used for the &quot;new_file&quot; side.</p>\n\n<p>This is not the same as `git diff \n&lt;treeish</p>\n\n<blockquote>\n<p><code>or</code>git diff-index</p>\n</blockquote>\n\n<p>&lt;treeish</p>\n\n<blockquote>\n<p><code>.  Those commands use information from the index, whereas this\n function strictly returns the differences between the tree and the files\n in the working directory, regardless of the state of the index.  Use\n</code>git_diff_tree_to_workdir_with_index` to emulate those commands.</p>\n</blockquote>\n\n<p>To see difference between this and <code>git_diff_tree_to_workdir_with_index</code>,\n consider the example of a staged file deletion where the file has then\n been put back into the working dir and further modified.  The\n tree-to-workdir diff for that file is &#39;modified&#39;, but <code>git diff</code> would\n show status &#39;deleted&#39; since there is a staged delete.</p>\n",
+      "comments": "<p>The tree you provide will be used for the &quot;old_file&quot; side of the delta, and the working directory will be used for the &quot;new_file&quot; side.</p>\n\n<p>This is not the same as <code>git diff &lt;treeish&gt;</code> or <code>git diff-index &lt;treeish&gt;</code>.  Those commands use information from the index, whereas this function strictly returns the differences between the tree and the files in the working directory, regardless of the state of the index.  Use <code>git_diff_tree_to_workdir_with_index</code> to emulate those commands.</p>\n\n<p>To see difference between this and <code>git_diff_tree_to_workdir_with_index</code>, consider the example of a staged file deletion where the file has then been put back into the working dir and further modified.  The tree-to-workdir diff for that file is &#39;modified&#39;, but <code>git diff</code> would show status &#39;deleted&#39; since there is a staged delete.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_tree_to_workdir-6"
+          "ex/HEAD/diff.html#git_diff_tree_to_workdir-6"
         ]
       }
     },
@@ -6717,11 +6597,11 @@
         "comment": null
       },
       "description": "<p>Create a diff between a tree and the working directory using index data\n to account for staged deletes, tracked files, etc.</p>\n",
-      "comments": "<p>This emulates `git diff \n&lt;tree</p>\n\n<blockquote>\n<p>` by diffing the tree to the index and\n the index to the working directory and blending the results into a\n single diff that includes staged deleted, etc.</p>\n</blockquote>\n",
+      "comments": "<p>This emulates <code>git diff &lt;tree&gt;</code> by diffing the tree to the index and the index to the working directory and blending the results into a single diff that includes staged deleted, etc.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_tree_to_workdir_with_index-7"
+          "ex/HEAD/diff.html#git_diff_tree_to_workdir_with_index-7"
         ]
       }
     },
@@ -6764,7 +6644,7 @@
         "comment": null
       },
       "description": "<p>Create a diff with the difference between two index objects.</p>\n",
-      "comments": "<p>The first index will be used for the &quot;old_file&quot; side of the delta and the\n second index will be used for the &quot;new_file&quot; side of the delta.</p>\n",
+      "comments": "<p>The first index will be used for the &quot;old_file&quot; side of the delta and the second index will be used for the &quot;new_file&quot; side of the delta.</p>\n",
       "group": "diff"
     },
     "git_diff_merge": {
@@ -6791,7 +6671,7 @@
         "comment": null
       },
       "description": "<p>Merge one diff into another.</p>\n",
-      "comments": "<p>This merges items from the &quot;from&quot; list into the &quot;onto&quot; list.  The\n resulting diff will have all items that appear in either list.\n If an item appears in both lists, then it will be &quot;merged&quot; to appear\n as if the old version was from the &quot;onto&quot; list and the new version\n is from the &quot;from&quot; list (with the exception that if the item has a\n pending DELETE in the middle, then it will show as deleted).</p>\n",
+      "comments": "<p>This merges items from the &quot;from&quot; list into the &quot;onto&quot; list.  The resulting diff will have all items that appear in either list. If an item appears in both lists, then it will be &quot;merged&quot; to appear as if the old version was from the &quot;onto&quot; list and the new version is from the &quot;from&quot; list (with the exception that if the item has a pending DELETE in the middle, then it will show as deleted).</p>\n",
       "group": "diff"
     },
     "git_diff_find_similar": {
@@ -6818,11 +6698,11 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Transform a diff marking file renames, copies, etc.</p>\n",
-      "comments": "<p>This modifies a diff in place, replacing old entries that look\n like renames or copies with new entries reflecting those changes.\n This also will, if requested, break modified files into add/remove\n pairs if the amount of change is above a threshold.</p>\n",
+      "comments": "<p>This modifies a diff in place, replacing old entries that look like renames or copies with new entries reflecting those changes. This also will, if requested, break modified files into add/remove pairs if the amount of change is above a threshold.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_find_similar-8"
+          "ex/HEAD/diff.html#git_diff_find_similar-8"
         ]
       }
     },
@@ -6849,7 +6729,7 @@
       "group": "diff",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_diff_num_deltas-29"
+          "ex/HEAD/log.html#git_diff_num_deltas-29"
         ]
       }
     },
@@ -6877,7 +6757,7 @@
         "comment": " Count of number of deltas matching delta_t type"
       },
       "description": "<p>Query how many diff deltas are there in a diff filtered by type.</p>\n",
-      "comments": "<p>This works just like <code>git_diff_entrycount()</code> with an extra parameter\n that is a <code>git_delta_t</code> and returns just the count of how many deltas\n match that particular type.</p>\n",
+      "comments": "<p>This works just like <code>git_diff_entrycount()</code> with an extra parameter that is a <code>git_delta_t</code> and returns just the count of how many deltas match that particular type.</p>\n",
       "group": "diff"
     },
     "git_diff_get_delta": {
@@ -6904,7 +6784,7 @@
         "comment": " Pointer to git_diff_delta (or NULL if `idx` out of range)"
       },
       "description": "<p>Return the diff delta for an entry in the diff list.</p>\n",
-      "comments": "<p>The <code>git_diff_delta</code> pointer points to internal data and you do not\n have to release it when you are done with it.  It will go away when\n the * <code>git_diff</code> (or any associated <code>git_patch</code>) goes away.</p>\n\n<p>Note that the flags on the delta related to whether it has binary\n content or not may not be set if there are no attributes set for the\n file and there has been no reason to load the file data at this point.\n For now, if you need those flags to be up to date, your only option is\n to either use <code>git_diff_foreach</code> or create a <code>git_patch</code>.</p>\n",
+      "comments": "<p>The <code>git_diff_delta</code> pointer points to internal data and you do not have to release it when you are done with it.  It will go away when the * <code>git_diff</code> (or any associated <code>git_patch</code>) goes away.</p>\n\n<p>Note that the flags on the delta related to whether it has binary content or not may not be set if there are no attributes set for the file and there has been no reason to load the file data at this point. For now, if you need those flags to be up to date, your only option is to either use <code>git_diff_foreach</code> or create a <code>git_patch</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_is_sorted_icase": {
@@ -6973,7 +6853,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Loop over all deltas in a diff issuing callbacks.</p>\n",
-      "comments": "<p>This will iterate through all of the files described in a diff.  You\n should provide a file callback to learn about each file.</p>\n\n<p>The &quot;hunk&quot; and &quot;line&quot; callbacks are optional, and the text diff of the\n files will only be calculated if they are not NULL.  Of course, these\n callbacks will not be invoked for binary files on the diff or for\n files whose only changed is a file mode change.</p>\n\n<p>Returning a non-zero value from any of the callbacks will terminate\n the iteration and return the value to the user.</p>\n",
+      "comments": "<p>This will iterate through all of the files described in a diff.  You should provide a file callback to learn about each file.</p>\n\n<p>The &quot;hunk&quot; and &quot;line&quot; callbacks are optional, and the text diff of the files will only be calculated if they are not NULL.  Of course, these callbacks will not be invoked for binary files on the diff or for files whose only changed is a file mode change.</p>\n\n<p>Returning a non-zero value from any of the callbacks will terminate the iteration and return the value to the user.</p>\n",
       "group": "diff"
     },
     "git_diff_status_char": {
@@ -6995,7 +6875,7 @@
         "comment": " The single character label for that code"
       },
       "description": "<p>Look up the single character abbreviation for a delta status code.</p>\n",
-      "comments": "<p>When you run <code>git diff --name-status</code> it uses single letter codes in\n the output such as &#39;A&#39; for added, &#39;D&#39; for deleted, &#39;M&#39; for modified,\n etc.  This function converts a git_delta_t value into these letters for\n your own purposes.  GIT_DELTA_UNTRACKED will return a space (i.e. &#39; &#39;).</p>\n",
+      "comments": "<p>When you run <code>git diff --name-status</code> it uses single letter codes in the output such as &#39;A&#39; for added, &#39;D&#39; for deleted, &#39;M&#39; for modified, etc.  This function converts a git_delta_t value into these letters for your own purposes.  GIT_DELTA_UNTRACKED will return a space (i.e. &#39; &#39;).</p>\n",
       "group": "diff"
     },
     "git_diff_print": {
@@ -7032,14 +6912,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Iterate over a diff generating formatted text output.</p>\n",
-      "comments": "<p>Returning a non-zero value from the callbacks will terminate the\n iteration and return the non-zero value to the caller.</p>\n",
+      "comments": "<p>Returning a non-zero value from the callbacks will terminate the iteration and return the non-zero value to the caller.</p>\n",
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_print-9"
+          "ex/HEAD/diff.html#git_diff_print-9"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_diff_print-30"
+          "ex/HEAD/log.html#git_diff_print-30"
         ]
       }
     },
@@ -7139,7 +7019,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff on two blobs.</p>\n",
-      "comments": "<p>Compared to a file, a blob lacks some contextual information. As such,\n the <code>git_diff_file</code> given to the callback will have some fake data; i.e.\n <code>mode</code> will be 0 and <code>path</code> will be NULL.</p>\n\n<p>NULL is allowed for either <code>old_blob</code> or <code>new_blob</code> and will be treated\n as an empty blob, with the <code>oid</code> set to NULL in the <code>git_diff_file</code> data.\n Passing NULL for both blobs is a noop; no callbacks will be made at all.</p>\n\n<p>We do run a binary content check on the blob content and if either blob\n looks like binary data, the <code>git_diff_delta</code> binary attribute will be set\n to 1 and no call to the hunk_cb nor line_cb will be made (unless you pass\n <code>GIT_DIFF_FORCE_TEXT</code> of course).</p>\n",
+      "comments": "<p>Compared to a file, a blob lacks some contextual information. As such, the <code>git_diff_file</code> given to the callback will have some fake data; i.e. <code>mode</code> will be 0 and <code>path</code> will be NULL.</p>\n\n<p>NULL is allowed for either <code>old_blob</code> or <code>new_blob</code> and will be treated as an empty blob, with the <code>oid</code> set to NULL in the <code>git_diff_file</code> data. Passing NULL for both blobs is a noop; no callbacks will be made at all.</p>\n\n<p>We do run a binary content check on the blob content and if either blob looks like binary data, the <code>git_diff_delta</code> binary attribute will be set to 1 and no call to the hunk_cb nor line_cb will be made (unless you pass <code>GIT_DIFF_FORCE_TEXT</code> of course).</p>\n",
       "group": "diff"
     },
     "git_diff_blob_to_buffer": {
@@ -7211,7 +7091,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff between a blob and a buffer.</p>\n",
-      "comments": "<p>As with <code>git_diff_blobs</code>, comparing a blob and buffer lacks some context,\n so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the\n rules for <code>git_diff_blobs()</code>.</p>\n\n<p>Passing NULL for <code>old_blob</code> will be treated as an empty blob (i.e. the\n <code>file_cb</code> will be invoked with GIT_DELTA_ADDED and the diff will be the\n entire content of the buffer added).  Passing NULL to the buffer will do\n the reverse, with GIT_DELTA_REMOVED and blob content removed.</p>\n",
+      "comments": "<p>As with <code>git_diff_blobs</code>, comparing a blob and buffer lacks some context, so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the rules for <code>git_diff_blobs()</code>.</p>\n\n<p>Passing NULL for <code>old_blob</code> will be treated as an empty blob (i.e. the <code>file_cb</code> will be invoked with GIT_DELTA_ADDED and the diff will be the entire content of the buffer added).  Passing NULL to the buffer will do the reverse, with GIT_DELTA_REMOVED and blob content removed.</p>\n",
       "group": "diff"
     },
     "git_diff_buffers": {
@@ -7288,7 +7168,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Directly run a diff between two buffers.</p>\n",
-      "comments": "<p>Even more than with <code>git_diff_blobs</code>, comparing two buffer lacks\n context, so the <code>git_diff_file</code> parameters to the callbacks will be\n faked a la the rules for <code>git_diff_blobs()</code>.</p>\n",
+      "comments": "<p>Even more than with <code>git_diff_blobs</code>, comparing two buffer lacks context, so the <code>git_diff_file</code> parameters to the callbacks will be faked a la the rules for <code>git_diff_blobs()</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_from_buffer": {
@@ -7320,7 +7200,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Read the contents of a git patch file into a <code>git_diff</code> object.</p>\n",
-      "comments": "<p>The diff object produced is similar to the one that would be\n produced if you actually produced it computationally by comparing\n two trees, however there may be subtle differences.  For example,\n a patch file likely contains abbreviated object IDs, so the\n object IDs in a <code>git_diff_delta</code> produced by this function will\n also be abbreviated.</p>\n\n<p>This function will only read patch files created by a git\n implementation, it will not read unified diffs produced by\n the <code>diff</code> program, nor any other types of patch files.</p>\n",
+      "comments": "<p>The diff object produced is similar to the one that would be produced if you actually produced it computationally by comparing two trees, however there may be subtle differences.  For example, a patch file likely contains abbreviated object IDs, so the object IDs in a <code>git_diff_delta</code> produced by this function will also be abbreviated.</p>\n\n<p>This function will only read patch files created by a git implementation, it will not read unified diffs produced by the <code>diff</code> program, nor any other types of patch files.</p>\n",
       "group": "diff"
     },
     "git_diff_get_stats": {
@@ -7351,7 +7231,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_get_stats-10"
+          "ex/HEAD/diff.html#git_diff_get_stats-10"
         ]
       }
     },
@@ -7459,7 +7339,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_stats_to_buf-11"
+          "ex/HEAD/diff.html#git_diff_stats_to_buf-11"
         ]
       }
     },
@@ -7486,7 +7366,7 @@
       "group": "diff",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_diff_stats_free-12"
+          "ex/HEAD/diff.html#git_diff_stats_free-12"
         ]
       }
     },
@@ -7574,7 +7454,7 @@
       "comments": "<p>Does not support creating patches for merge commits (yet).</p>\n",
       "group": "diff"
     },
-    "git_diff_format_email_init_options": {
+    "git_diff_format_email_options_init": {
       "type": "function",
       "file": "git2/diff.h",
       "line": 1451,
@@ -7598,10 +7478,10 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_diff_format_email_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_diff_format_email_options</code> with default values. Equivalent\n to creating an instance with GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT.</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_format_email_options</code> with default values. Equivalent to creating an instance with GIT_DIFF_FORMAT_EMAIL_OPTIONS_INIT.</p>\n",
       "group": "diff"
     },
-    "git_diff_patchid_init_options": {
+    "git_diff_patchid_options_init": {
       "type": "function",
       "file": "git2/diff.h",
       "line": 1479,
@@ -7625,7 +7505,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_diff_patchid_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_diff_patchid_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_diff_patchid_options</code> with default values. Equivalent to creating an instance with <code>GIT_DIFF_PATCHID_OPTIONS_INIT</code>.</p>\n",
       "group": "diff"
     },
     "git_diff_patchid": {
@@ -7657,7 +7537,7 @@
         "comment": " 0 on success, an error code otherwise."
       },
       "description": "<p>Calculate the patch ID for the given patch.</p>\n",
-      "comments": "<p>Calculate a stable patch ID for the given patch by summing the\n hash of the file diffs, ignoring whitespace and line numbers.\n This can be used to derive whether two diffs are the same with\n a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as\n defined in git-patch-id(1), and should in fact generate the\n same IDs as the upstream git project does.</p>\n",
+      "comments": "<p>Calculate a stable patch ID for the given patch by summing the hash of the file diffs, ignoring whitespace and line numbers. This can be used to derive whether two diffs are the same with a high probability.</p>\n\n<p>Currently, this function only calculates stable patch IDs, as defined in git-patch-id(1), and should in fact generate the same IDs as the upstream git project does.</p>\n",
       "group": "diff"
     },
     "git_error_last": {
@@ -7673,21 +7553,21 @@
         "comment": " A git_error object."
       },
       "description": "<p>Return the last <code>git_error</code> object that was generated for the\n current thread.</p>\n",
-      "comments": "<p>The default behaviour of this function is to return NULL if no previous error has occurred.\n However, libgit2&#39;s error strings are not cleared aggressively, so a prior\n (unrelated) error may be returned. This can be avoided by only calling\n this function if the prior call to a libgit2 API returned an error.</p>\n",
+      "comments": "<p>The default behaviour of this function is to return NULL if no previous error has occurred. However, libgit2&#39;s error strings are not cleared aggressively, so a prior (unrelated) error may be returned. This can be avoided by only calling this function if the prior call to a libgit2 API returned an error.</p>\n",
       "group": "error",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_error_last-8",
-          "ex/v0.28.0/checkout.html#git_error_last-9",
-          "ex/v0.28.0/checkout.html#git_error_last-10",
-          "ex/v0.28.0/checkout.html#git_error_last-11"
+          "ex/HEAD/checkout.html#git_error_last-8",
+          "ex/HEAD/checkout.html#git_error_last-9",
+          "ex/HEAD/checkout.html#git_error_last-10",
+          "ex/HEAD/checkout.html#git_error_last-11"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_error_last-33"
+          "ex/HEAD/general.html#git_error_last-33"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_error_last-8",
-          "ex/v0.28.0/merge.html#git_error_last-9"
+          "ex/HEAD/merge.html#git_error_last-8",
+          "ex/HEAD/merge.html#git_error_last-9"
         ]
       }
     },
@@ -7731,7 +7611,7 @@
         "comment": null
       },
       "description": "<p>Set the error message string for this thread.</p>\n",
-      "comments": "<p>This function is public so that custom ODB backends and the like can\n relay an error message through libgit2.  Most regular users of libgit2\n will never need to call this function -- actually, calling it in most\n circumstances (for example, calling from within a callback function)\n will just end up having the value overwritten by libgit2 internals.</p>\n\n<p>This error message is stored in thread-local storage and only applies\n to the particular thread that this libgit2 call is made from.</p>\n",
+      "comments": "<p>This function is public so that custom ODB backends and the like can relay an error message through libgit2.  Most regular users of libgit2 will never need to call this function -- actually, calling it in most circumstances (for example, calling from within a callback function) will just end up having the value overwritten by libgit2 internals.</p>\n\n<p>This error message is stored in thread-local storage and only applies to the particular thread that this libgit2 call is made from.</p>\n",
       "group": "error"
     },
     "git_error_set_oom": {
@@ -7747,7 +7627,7 @@
         "comment": null
       },
       "description": "<p>Set the error message to a special value for memory allocation failure.</p>\n",
-      "comments": "<p>The normal <code>git_error_set_str()</code> function attempts to <code>strdup()</code> the\n string that is passed in.  This is not a good idea when the error in\n question is a memory allocation failure.  That circumstance has a\n special setter function that sets the error string to a known and\n statically allocated internal value.</p>\n",
+      "comments": "<p>The normal <code>git_error_set_str()</code> function attempts to <code>strdup()</code> the string that is passed in.  This is not a good idea when the error in question is a memory allocation failure.  That circumstance has a special setter function that sets the error string to a known and statically allocated internal value.</p>\n",
       "group": "error"
     },
     "git_filter_list_load": {
@@ -7759,42 +7639,42 @@
         {
           "name": "filters",
           "type": "git_filter_list **",
-          "comment": null
+          "comment": "Output newly created git_filter_list (or NULL)"
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "Repository object that contains `path`"
         },
         {
           "name": "blob",
           "type": "git_blob *",
-          "comment": null
+          "comment": "The blob to which the filter will be applied (if known)"
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": null
+          "comment": "Relative path of the file to be filtered"
         },
         {
           "name": "mode",
           "type": "git_filter_mode_t",
-          "comment": null
+          "comment": "Filtering direction (WT->ODB or ODB->WT)"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of `git_filter_flag_t` flags"
         }
       ],
-      "argline": "git_filter_list **filters, git_repository *repo, git_blob *blob, const char *path, git_filter_mode_t mode, int flags",
-      "sig": "git_filter_list **::git_repository *::git_blob *::const char *::git_filter_mode_t::int",
+      "argline": "git_filter_list **filters, git_repository *repo, git_blob *blob, const char *path, git_filter_mode_t mode, uint32_t flags",
+      "sig": "git_filter_list **::git_repository *::git_blob *::const char *::git_filter_mode_t::uint32_t",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success (which could still return NULL if no filters are\n         needed for the requested file), \n<\n0 on error"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Load the filter list for a given path.</p>\n",
+      "comments": "<p>This will return 0 (success) but set the output git_filter_list to NULL if no filters are requested for the given file.</p>\n",
       "group": "filter"
     },
     "git_filter_list_contains": {
@@ -7821,7 +7701,7 @@
         "comment": " 1 if the filter is in the list, 0 otherwise"
       },
       "description": "<p>Query the filter list to see if a given filter (by name) will run.\n The built-in filters &quot;crlf&quot; and &quot;ident&quot; can be queried, otherwise this\n is the name of the filter specified by the filter attribute.</p>\n",
-      "comments": "<p>This will return 0 if the given filter is not in the list, or 1 if\n the filter will be applied.</p>\n",
+      "comments": "<p>This will return 0 if the given filter is not in the list, or 1 if the filter will be applied.</p>\n",
       "group": "filter"
     },
     "git_filter_list_apply_to_data": {
@@ -7853,7 +7733,7 @@
         "comment": " 0 on success, an error code otherwise"
       },
       "description": "<p>Apply filter list to a data buffer.</p>\n",
-      "comments": "<p>See <code>git2/buffer.h</code> for background on <code>git_buf</code> objects.</p>\n\n<p>If the <code>in</code> buffer holds data allocated by libgit2 (i.e. <code>in-&gt;asize</code> is\n not zero), then it will be overwritten when applying the filters.  If\n not, then it will be left untouched.</p>\n\n<p>If there are no filters to apply (or <code>filters</code> is NULL), then the <code>out</code>\n buffer will reference the <code>in</code> buffer data (with <code>asize</code> set to zero)\n instead of allocating data.  This keeps allocations to a minimum, but\n it means you have to be careful about freeing the <code>in</code> data since <code>out</code>\n may be pointing to it!</p>\n",
+      "comments": "<p>See <code>git2/buffer.h</code> for background on <code>git_buf</code> objects.</p>\n\n<p>If the <code>in</code> buffer holds data allocated by libgit2 (i.e. <code>in-&gt;asize</code> is not zero), then it will be overwritten when applying the filters.  If not, then it will be left untouched.</p>\n\n<p>If there are no filters to apply (or <code>filters</code> is NULL), then the <code>out</code> buffer will reference the <code>in</code> buffer data (with <code>asize</code> set to zero) instead of allocating data.  This keeps allocations to a minimum, but it means you have to be careful about freeing the <code>in</code> data since <code>out</code> may be pointing to it!</p>\n",
       "group": "filter"
     },
     "git_filter_list_apply_to_file": {
@@ -8061,50 +7941,11 @@
         "comment": " the number of initializations of the library, or an error code."
       },
       "description": "<p>Init the global state</p>\n",
-      "comments": "<p>This function must be called before any other libgit2 function in\n order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number\n of times the initialization has been called (including this one) that have\n not subsequently been shutdown.</p>\n",
+      "comments": "<p>This function must be called before any other libgit2 function in order to set up global state and threading.</p>\n\n<p>This function may be called multiple times - it will return the number of times the initialization has been called (including this one) that have not subsequently been shutdown.</p>\n",
       "group": "libgit2",
       "examples": {
-        "blame.c": [
-          "ex/v0.28.0/blame.html#git_libgit2_init-8"
-        ],
-        "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_libgit2_init-10"
-        ],
-        "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_libgit2_init-12"
-        ],
-        "describe.c": [
-          "ex/v0.28.0/describe.html#git_libgit2_init-6"
-        ],
-        "diff.c": [
-          "ex/v0.28.0/diff.html#git_libgit2_init-13"
-        ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_libgit2_init-34"
-        ],
-        "init.c": [
-          "ex/v0.28.0/init.html#git_libgit2_init-2"
-        ],
-        "log.c": [
-          "ex/v0.28.0/log.html#git_libgit2_init-31"
-        ],
-        "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_libgit2_init-1"
-        ],
-        "merge.c": [
-          "ex/v0.28.0/merge.html#git_libgit2_init-10"
-        ],
-        "remote.c": [
-          "ex/v0.28.0/remote.html#git_libgit2_init-2"
-        ],
-        "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_libgit2_init-1"
-        ],
-        "status.c": [
-          "ex/v0.28.0/status.html#git_libgit2_init-1"
-        ],
-        "tag.c": [
-          "ex/v0.28.0/tag.html#git_libgit2_init-3"
+          "ex/HEAD/general.html#git_libgit2_init-34"
         ]
       }
     },
@@ -8121,49 +7962,8 @@
         "comment": " the number of remaining initializations of the library, or an\n error code."
       },
       "description": "<p>Shutdown the global state</p>\n",
-      "comments": "<p>Clean up the global state and threading context after calling it as\n many times as <code>git_libgit2_init()</code> was called - it will return the\n number of remainining initializations that have not been shutdown\n (after this one).</p>\n",
-      "group": "libgit2",
-      "examples": {
-        "blame.c": [
-          "ex/v0.28.0/blame.html#git_libgit2_shutdown-9"
-        ],
-        "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_libgit2_shutdown-11"
-        ],
-        "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_libgit2_shutdown-13"
-        ],
-        "describe.c": [
-          "ex/v0.28.0/describe.html#git_libgit2_shutdown-7"
-        ],
-        "diff.c": [
-          "ex/v0.28.0/diff.html#git_libgit2_shutdown-14"
-        ],
-        "init.c": [
-          "ex/v0.28.0/init.html#git_libgit2_shutdown-3"
-        ],
-        "log.c": [
-          "ex/v0.28.0/log.html#git_libgit2_shutdown-32"
-        ],
-        "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_libgit2_shutdown-2"
-        ],
-        "merge.c": [
-          "ex/v0.28.0/merge.html#git_libgit2_shutdown-11"
-        ],
-        "remote.c": [
-          "ex/v0.28.0/remote.html#git_libgit2_shutdown-3"
-        ],
-        "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_libgit2_shutdown-2"
-        ],
-        "status.c": [
-          "ex/v0.28.0/status.html#git_libgit2_shutdown-2"
-        ],
-        "tag.c": [
-          "ex/v0.28.0/tag.html#git_libgit2_shutdown-4"
-        ]
-      }
+      "comments": "<p>Clean up the global state and threading context after calling it as many times as <code>git_libgit2_init()</code> was called - it will return the number of remainining initializations that have not been shutdown (after this one).</p>\n",
+      "group": "libgit2"
     },
     "git_graph_ahead_behind": {
       "type": "function",
@@ -8204,7 +8004,7 @@
         "comment": null
       },
       "description": "<p>Count the number of unique commits between two commit objects</p>\n",
-      "comments": "<p>There is no need for branches containing the commits to have any\n upstream relationship, but it helps to think of one as a branch and\n the other as its upstream, the <code>ahead</code> and <code>behind</code> values will be\n what git would report for the branches.</p>\n",
+      "comments": "<p>There is no need for branches containing the commits to have any upstream relationship, but it helps to think of one as a branch and the other as its upstream, the <code>ahead</code> and <code>behind</code> values will be what git would report for the branches.</p>\n",
       "group": "graph"
     },
     "git_graph_descendant_of": {
@@ -8236,7 +8036,7 @@
         "comment": " 1 if the given commit is a descendant of the potential ancestor,\n 0 if not, error code otherwise."
       },
       "description": "<p>Determine if a commit is the descendant of another commit.</p>\n",
-      "comments": "<p>Note that a commit is not considered a descendant of itself, in contrast\n to <code>git merge-base --is-ancestor</code>.</p>\n",
+      "comments": "<p>Note that a commit is not considered a descendant of itself, in contrast to <code>git merge-base --is-ancestor</code>.</p>\n",
       "group": "graph"
     },
     "git_ignore_add_rule": {
@@ -8263,7 +8063,7 @@
         "comment": " 0 on success"
       },
       "description": "<p>Add ignore rules for a repository.</p>\n",
-      "comments": "<p>Excludesfile rules (i.e. .gitignore rules) are generally read from\n .gitignore files in the repository tree or from a shared system file\n only if a &quot;core.excludesfile&quot; config value is set.  The library also\n keeps a set of per-repository internal ignores that can be configured\n in-memory and will not persist.  This function allows you to add to\n that internal rules list.</p>\n\n<p>Example usage:</p>\n\n<pre><code> error = git_ignore_add_rule(myrepo, &quot;*.c\n</code></pre>\n\n<p>/</p>\n\n<p>with space</p>\n\n<p>&quot;);</p>\n\n<p>This would add three rules to the ignores.</p>\n",
+      "comments": "<p>Excludesfile rules (i.e. .gitignore rules) are generally read from .gitignore files in the repository tree or from a shared system file only if a &quot;core.excludesfile&quot; config value is set.  The library also keeps a set of per-repository internal ignores that can be configured in-memory and will not persist.  This function allows you to add to that internal rules list.</p>\n\n<p>Example usage:</p>\n\n<pre><code> error = git_ignore_add_rule(myrepo, &quot;*.c/ with space&quot;);\n</code></pre>\n\n<p>This would add three rules to the ignores.</p>\n",
       "group": "ignore"
     },
     "git_ignore_clear_internal_rules": {
@@ -8285,7 +8085,7 @@
         "comment": " 0 on success"
       },
       "description": "<p>Clear ignore rules that were explicitly added.</p>\n",
-      "comments": "<p>Resets to the default internal ignore rules.  This will not turn off\n rules in .gitignore files that actually exist in the filesystem.</p>\n\n<p>The default internal ignores ignore &quot;.&quot;, &quot;..&quot; and &quot;.git&quot; entries.</p>\n",
+      "comments": "<p>Resets to the default internal ignore rules.  This will not turn off rules in .gitignore files that actually exist in the filesystem.</p>\n\n<p>The default internal ignores ignore &quot;.&quot;, &quot;..&quot; and &quot;.git&quot; entries.</p>\n",
       "group": "ignore"
     },
     "git_ignore_path_is_ignored": {
@@ -8317,14 +8117,14 @@
         "comment": " 0 if ignore rules could be processed for the file (regardless\n         of whether it exists or not), or an error \n<\n 0 if they could not."
       },
       "description": "<p>Test if the ignore rules apply to a given path.</p>\n",
-      "comments": "<p>This function checks the ignore rules to see if they would apply to the\n given file.  This indicates if the file would be ignored regardless of\n whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git check-ignore --no-index&quot;\n on the given file, would it be shown or not?</p>\n",
+      "comments": "<p>This function checks the ignore rules to see if they would apply to the given file.  This indicates if the file would be ignored regardless of whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git check-ignore --no-index&quot; on the given file, would it be shown or not?</p>\n",
       "group": "ignore"
     },
     "git_index_open": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 186,
-      "lineto": 186,
+      "line": 187,
+      "lineto": 187,
       "args": [
         {
           "name": "out",
@@ -8344,14 +8144,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new bare Git index object as a memory representation\n of the Git index file in &#39;index_path&#39;, without a repository\n to back it.</p>\n",
-      "comments": "<p>Since there is no ODB or working directory behind this index,\n any Index methods which rely on these (e.g. index_add_bypath)\n will fail with the GIT_ERROR error code.</p>\n\n<p>If you need to access the index of an actual repository,\n use the <code>git_repository_index</code> wrapper.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>Since there is no ODB or working directory behind this index, any Index methods which rely on these (e.g. index_add_bypath) will fail with the GIT_ERROR error code.</p>\n\n<p>If you need to access the index of an actual repository, use the <code>git_repository_index</code> wrapper.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
       "group": "index"
     },
     "git_index_new": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 199,
-      "lineto": 199,
+      "line": 200,
+      "lineto": 200,
       "args": [
         {
           "name": "out",
@@ -8366,14 +8166,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create an in-memory index object.</p>\n",
-      "comments": "<p>This index object cannot be read/written to the filesystem,\n but may be used to perform in-memory index operations.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This index object cannot be read/written to the filesystem, but may be used to perform in-memory index operations.</p>\n\n<p>The index must be freed once it&#39;s no longer in use.</p>\n",
       "group": "index"
     },
     "git_index_free": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 206,
-      "lineto": 206,
+      "line": 207,
+      "lineto": 207,
       "args": [
         {
           "name": "index",
@@ -8391,22 +8191,25 @@
       "comments": "",
       "group": "index",
       "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_index_free-1"
+        ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_index_free-35"
+          "ex/HEAD/general.html#git_index_free-35"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_index_free-4"
+          "ex/HEAD/init.html#git_index_free-2"
         ],
         "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_index_free-3"
+          "ex/HEAD/ls-files.html#git_index_free-1"
         ]
       }
     },
     "git_index_owner": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 214,
-      "lineto": 214,
+      "line": 215,
+      "lineto": 215,
       "args": [
         {
           "name": "index",
@@ -8427,8 +8230,8 @@
     "git_index_caps": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 222,
-      "lineto": 222,
+      "line": 223,
+      "lineto": 223,
       "args": [
         {
           "name": "index",
@@ -8449,8 +8252,8 @@
     "git_index_set_caps": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 235,
-      "lineto": 235,
+      "line": 236,
+      "lineto": 236,
       "args": [
         {
           "name": "index",
@@ -8470,14 +8273,14 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Set index capabilities flags.</p>\n",
-      "comments": "<p>If you pass <code>GIT_INDEX_CAPABILITY_FROM_OWNER</code> for the caps, then\n capabilities will be read from the config of the owner object,\n looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
+      "comments": "<p>If you pass <code>GIT_INDEX_CAPABILITY_FROM_OWNER</code> for the caps, then capabilities will be read from the config of the owner object, looking at <code>core.ignorecase</code>, <code>core.filemode</code>, <code>core.symlinks</code>.</p>\n",
       "group": "index"
     },
     "git_index_version": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 247,
-      "lineto": 247,
+      "line": 248,
+      "lineto": 248,
       "args": [
         {
           "name": "index",
@@ -8492,14 +8295,14 @@
         "comment": " the index version"
       },
       "description": "<p>Get index on-disk version.</p>\n",
-      "comments": "<p>Valid return values are 2, 3, or 4.  If 3 is returned, an index\n with version 2 may be written instead, if the extension data in\n version 3 is not necessary.</p>\n",
+      "comments": "<p>Valid return values are 2, 3, or 4.  If 3 is returned, an index with version 2 may be written instead, if the extension data in version 3 is not necessary.</p>\n",
       "group": "index"
     },
     "git_index_set_version": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 260,
-      "lineto": 260,
+      "line": 261,
+      "lineto": 261,
       "args": [
         {
           "name": "index",
@@ -8519,14 +8322,14 @@
         "comment": " 0 on success, -1 on failure"
       },
       "description": "<p>Set index on-disk version.</p>\n",
-      "comments": "<p>Valid values are 2, 3, or 4.  If 2 is given, git_index_write may\n write an index with version 3 instead, if necessary to accurately\n represent the index.</p>\n",
+      "comments": "<p>Valid values are 2, 3, or 4.  If 2 is given, git_index_write may write an index with version 3 instead, if necessary to accurately represent the index.</p>\n",
       "group": "index"
     },
     "git_index_read": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 279,
-      "lineto": 279,
+      "line": 280,
+      "lineto": 280,
       "args": [
         {
           "name": "index",
@@ -8546,14 +8349,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Update the contents of an existing index object in memory by reading\n from the hard disk.</p>\n",
-      "comments": "<p>If <code>force</code> is true, this performs a &quot;hard&quot; read that discards in-memory\n changes and always reloads the on-disk index data.  If there is no\n on-disk version, the index will be cleared.</p>\n\n<p>If <code>force</code> is false, this does a &quot;soft&quot; read that reloads the index\n data from disk only if it has changed since the last time it was\n loaded.  Purely in-memory index data will be untouched.  Be aware: if\n there are changes on disk, unwritten in-memory changes are discarded.</p>\n",
+      "comments": "<p>If <code>force</code> is true, this performs a &quot;hard&quot; read that discards in-memory changes and always reloads the on-disk index data.  If there is no on-disk version, the index will be cleared.</p>\n\n<p>If <code>force</code> is false, this does a &quot;soft&quot; read that reloads the index data from disk only if it has changed since the last time it was loaded.  Purely in-memory index data will be untouched.  Be aware: if there are changes on disk, unwritten in-memory changes are discarded.</p>\n",
       "group": "index"
     },
     "git_index_write": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 288,
-      "lineto": 288,
+      "line": 289,
+      "lineto": 289,
       "args": [
         {
           "name": "index",
@@ -8569,13 +8372,18 @@
       },
       "description": "<p>Write an existing index object from memory back to disk\n using an atomic file lock.</p>\n",
       "comments": "",
-      "group": "index"
+      "group": "index",
+      "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_index_write-2"
+        ]
+      }
     },
     "git_index_path": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 296,
-      "lineto": 296,
+      "line": 297,
+      "lineto": 297,
       "args": [
         {
           "name": "index",
@@ -8596,8 +8404,8 @@
     "git_index_checksum": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 308,
-      "lineto": 308,
+      "line": 309,
+      "lineto": 309,
       "args": [
         {
           "name": "index",
@@ -8612,14 +8420,14 @@
         "comment": " a pointer to the checksum of the index"
       },
       "description": "<p>Get the checksum of the index</p>\n",
-      "comments": "<p>This checksum is the SHA-1 hash over the index file (except the\n last 20 bytes which are the checksum itself). In cases where the\n index does not exist on-disk, it will be zeroed out.</p>\n",
+      "comments": "<p>This checksum is the SHA-1 hash over the index file (except the last 20 bytes which are the checksum itself). In cases where the index does not exist on-disk, it will be zeroed out.</p>\n",
       "group": "index"
     },
     "git_index_read_tree": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 319,
-      "lineto": 319,
+      "line": 320,
+      "lineto": 320,
       "args": [
         {
           "name": "index",
@@ -8645,8 +8453,8 @@
     "git_index_write_tree": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 340,
-      "lineto": 340,
+      "line": 341,
+      "lineto": 341,
       "args": [
         {
           "name": "out",
@@ -8666,22 +8474,22 @@
         "comment": " 0 on success, GIT_EUNMERGED when the index is not clean\n or an error code"
       },
       "description": "<p>Write the index as a tree</p>\n",
-      "comments": "<p>This method will scan the index and write a representation\n of its current state back to disk; it recursively creates\n tree objects for each of the subtrees stored in the index,\n but only returns the OID of the root tree. This is the OID\n that can be used e.g. to create a commit.</p>\n\n<p>The index instance cannot be bare, and needs to be associated\n to an existing repository.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
+      "comments": "<p>This method will scan the index and write a representation of its current state back to disk; it recursively creates tree objects for each of the subtrees stored in the index, but only returns the OID of the root tree. This is the OID that can be used e.g. to create a commit.</p>\n\n<p>The index instance cannot be bare, and needs to be associated to an existing repository.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
       "group": "index",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_index_write_tree-5"
+          "ex/HEAD/init.html#git_index_write_tree-3"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_index_write_tree-12"
+          "ex/HEAD/merge.html#git_index_write_tree-10"
         ]
       }
     },
     "git_index_write_tree_to": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 357,
-      "lineto": 357,
+      "line": 358,
+      "lineto": 358,
       "args": [
         {
           "name": "out",
@@ -8706,14 +8514,14 @@
         "comment": " 0 on success, GIT_EUNMERGED when the index is not clean\n or an error code"
       },
       "description": "<p>Write the index as a tree to the given repository</p>\n",
-      "comments": "<p>This method will do the same as <code>git_index_write_tree</code>, but\n letting the user choose the repository where the tree will\n be written.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
+      "comments": "<p>This method will do the same as <code>git_index_write_tree</code>, but letting the user choose the repository where the tree will be written.</p>\n\n<p>The index must not contain any file in conflict.</p>\n",
       "group": "index"
     },
     "git_index_entrycount": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 376,
-      "lineto": 376,
+      "line": 377,
+      "lineto": 377,
       "args": [
         {
           "name": "index",
@@ -8732,18 +8540,18 @@
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_index_entrycount-36"
+          "ex/HEAD/general.html#git_index_entrycount-36"
         ],
         "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_index_entrycount-4"
+          "ex/HEAD/ls-files.html#git_index_entrycount-2"
         ]
       }
     },
     "git_index_clear": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 387,
-      "lineto": 387,
+      "line": 388,
+      "lineto": 388,
       "args": [
         {
           "name": "index",
@@ -8758,14 +8566,14 @@
         "comment": " 0 on success, error code \n<\n 0 on failure"
       },
       "description": "<p>Clear the contents (all the entries) of an index object.</p>\n",
-      "comments": "<p>This clears the index object in memory; changes must be explicitly\n written to disk for them to take effect persistently.</p>\n",
+      "comments": "<p>This clears the index object in memory; changes must be explicitly written to disk for them to take effect persistently.</p>\n",
       "group": "index"
     },
     "git_index_get_byindex": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 400,
-      "lineto": 401,
+      "line": 401,
+      "lineto": 402,
       "args": [
         {
           "name": "index",
@@ -8785,22 +8593,22 @@
         "comment": " a pointer to the entry; NULL if out of bounds"
       },
       "description": "<p>Get a pointer to one of the entries in the index</p>\n",
-      "comments": "<p>The entry is not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
+      "comments": "<p>The entry is not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
       "group": "index",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_index_get_byindex-37"
+          "ex/HEAD/general.html#git_index_get_byindex-37"
         ],
         "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_index_get_byindex-5"
+          "ex/HEAD/ls-files.html#git_index_get_byindex-3"
         ]
       }
     },
     "git_index_get_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 415,
-      "lineto": 416,
+      "line": 416,
+      "lineto": 417,
       "args": [
         {
           "name": "index",
@@ -8825,19 +8633,19 @@
         "comment": " a pointer to the entry; NULL if it was not found"
       },
       "description": "<p>Get a pointer to one of the entries in the index</p>\n",
-      "comments": "<p>The entry is not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
+      "comments": "<p>The entry is not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
       "group": "index",
       "examples": {
         "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_index_get_bypath-6"
+          "ex/HEAD/ls-files.html#git_index_get_bypath-4"
         ]
       }
     },
     "git_index_remove": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 426,
-      "lineto": 426,
+      "line": 427,
+      "lineto": 427,
       "args": [
         {
           "name": "index",
@@ -8868,8 +8676,8 @@
     "git_index_remove_directory": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 436,
-      "lineto": 437,
+      "line": 437,
+      "lineto": 438,
       "args": [
         {
           "name": "index",
@@ -8900,8 +8708,8 @@
     "git_index_add": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 453,
-      "lineto": 453,
+      "line": 454,
+      "lineto": 454,
       "args": [
         {
           "name": "index",
@@ -8921,14 +8729,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from an in-memory struct</p>\n",
-      "comments": "<p>If a previous index entry exists that has the same path and stage\n as the given &#39;source_entry&#39;, it will be replaced.  Otherwise, the\n &#39;source_entry&#39; will be added.</p>\n\n<p>A full copy (including the &#39;path&#39; string) of the given\n &#39;source_entry&#39; will be inserted on the index.</p>\n",
+      "comments": "<p>If a previous index entry exists that has the same path and stage as the given &#39;source_entry&#39;, it will be replaced.  Otherwise, the &#39;source_entry&#39; will be added.</p>\n\n<p>A full copy (including the &#39;path&#39; string) of the given &#39;source_entry&#39; will be inserted on the index.</p>\n",
       "group": "index"
     },
     "git_index_entry_stage": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 465,
-      "lineto": 465,
+      "line": 466,
+      "lineto": 466,
       "args": [
         {
           "name": "entry",
@@ -8943,14 +8751,14 @@
         "comment": " the stage number"
       },
       "description": "<p>Return the stage number from a git index entry</p>\n",
-      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags \n</code></pre>\n\n<p>&amp;\n GIT_INDEX_ENTRY_STAGEMASK) &gt;&gt; GIT_INDEX_ENTRY_STAGESHIFT</p>\n",
+      "comments": "<p>This entry is calculated from the entry&#39;s flag attribute like this:</p>\n\n<pre><code>(entry-&gt;flags &amp; GIT_INDEX_ENTRY_STAGEMASK) &gt;&gt; GIT_INDEX_ENTRY_STAGESHIFT\n</code></pre>\n",
       "group": "index"
     },
     "git_index_entry_is_conflict": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 474,
-      "lineto": 474,
+      "line": 475,
+      "lineto": 475,
       "args": [
         {
           "name": "entry",
@@ -8971,8 +8779,8 @@
     "git_index_iterator_new": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 494,
-      "lineto": 496,
+      "line": 495,
+      "lineto": 497,
       "args": [
         {
           "name": "iterator_out",
@@ -8998,8 +8806,8 @@
     "git_index_iterator_next": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 505,
-      "lineto": 507,
+      "line": 506,
+      "lineto": 508,
       "args": [
         {
           "name": "out",
@@ -9025,8 +8833,8 @@
     "git_index_iterator_free": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 514,
-      "lineto": 514,
+      "line": 515,
+      "lineto": 515,
       "args": [
         {
           "name": "iterator",
@@ -9047,8 +8855,8 @@
     "git_index_add_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 545,
-      "lineto": 545,
+      "line": 546,
+      "lineto": 546,
       "args": [
         {
           "name": "index",
@@ -9068,14 +8876,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from a file on disk</p>\n",
-      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s\n working folder and must be readable.</p>\n\n<p>This method will fail in bare index instances.</p>\n\n<p>This forces the file to be added to the index, not looking\n at gitignore rules.  Those rules can be evaluated through\n the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s working folder and must be readable.</p>\n\n<p>This method will fail in bare index instances.</p>\n\n<p>This forces the file to be added to the index, not looking at gitignore rules.  Those rules can be evaluated through the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
-    "git_index_add_frombuffer": {
+    "git_index_add_from_buffer": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 574,
-      "lineto": 577,
+      "line": 575,
+      "lineto": 578,
       "args": [
         {
           "name": "index",
@@ -9105,14 +8913,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an index entry from a buffer in memory</p>\n",
-      "comments": "<p>This method will create a blob in the repository that owns the\n index and then add the index entry to the index.  The <code>path</code> of the\n entry represents the position of the blob relative to the\n repository&#39;s root folder.</p>\n\n<p>If a previous index entry exists that has the same path as the\n given &#39;entry&#39;, it will be replaced.  Otherwise, the &#39;entry&#39; will be\n added. The <code>id</code> and the <code>file_size</code> of the &#39;entry&#39; are updated with the\n real value of the blob.</p>\n\n<p>This forces the file to be added to the index, not looking\n at gitignore rules.  Those rules can be evaluated through\n the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>This method will create a blob in the repository that owns the index and then add the index entry to the index.  The <code>path</code> of the entry represents the position of the blob relative to the repository&#39;s root folder.</p>\n\n<p>If a previous index entry exists that has the same path as the given &#39;entry&#39;, it will be replaced.  Otherwise, the &#39;entry&#39; will be added. The <code>id</code> and the <code>file_size</code> of the &#39;entry&#39; are updated with the real value of the blob.</p>\n\n<p>This forces the file to be added to the index, not looking at gitignore rules.  Those rules can be evaluated through the git_status APIs (in status.h) before calling this.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
     "git_index_remove_bypath": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 593,
-      "lineto": 593,
+      "line": 594,
+      "lineto": 594,
       "args": [
         {
           "name": "index",
@@ -9132,14 +8940,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Remove an index entry corresponding to a file on disk</p>\n",
-      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s\n working folder.  It may exist.</p>\n\n<p>If this file currently is the result of a merge conflict, this\n file will no longer be marked as conflicting.  The data about\n the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
+      "comments": "<p>The file <code>path</code> must be relative to the repository&#39;s working folder.  It may exist.</p>\n\n<p>If this file currently is the result of a merge conflict, this file will no longer be marked as conflicting.  The data about the conflict will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n",
       "group": "index"
     },
     "git_index_add_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 641,
-      "lineto": 646,
+      "line": 642,
+      "lineto": 647,
       "args": [
         {
           "name": "index",
@@ -9174,14 +8982,19 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Add or update index entries matching files in the working directory.</p>\n",
-      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will\n be matched against files in the repository&#39;s working directory.  Each\n file that matches will be added to the index (either updating an\n existing entry or adding a new entry).  You can disable glob expansion\n and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code>\n flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>).\n If a file is already tracked in the index, then it <em>will</em> be updated\n even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip\n the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains\n the exact path of an ignored file (when not using FORCE), add the\n <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry\n in the <code>pathspec</code> that is an exact match to a filename on disk is\n either not ignored or already in the index.  If this check fails, the\n function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback\n function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files\n will no longer be marked as conflicting.  The data about the conflicts\n will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching\n item in the working directory immediately <em>before</em> it is added to /\n updated in the index.  Returning zero will add the item to the index,\n greater than zero will skip the item, and less than zero will abort the\n scan and return that value to the caller.</p>\n",
-      "group": "index"
+      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>The <code>pathspec</code> is a list of file names or shell glob patterns that will be matched against files in the repository&#39;s working directory.  Each file that matches will be added to the index (either updating an existing entry or adding a new entry).  You can disable glob expansion and force exact matching with the <code>GIT_INDEX_ADD_DISABLE_PATHSPEC_MATCH</code> flag.</p>\n\n<p>Files that are ignored will be skipped (unlike <code>git_index_add_bypath</code>). If a file is already tracked in the index, then it <em>will</em> be updated even if it is ignored.  Pass the <code>GIT_INDEX_ADD_FORCE</code> flag to skip the checking of ignore rules.</p>\n\n<p>To emulate <code>git add -A</code> and generate an error if the pathspec contains the exact path of an ignored file (when not using FORCE), add the <code>GIT_INDEX_ADD_CHECK_PATHSPEC</code> flag.  This checks that each entry in the <code>pathspec</code> that is an exact match to a filename on disk is either not ignored or already in the index.  If this check fails, the function will return GIT_EINVALIDSPEC.</p>\n\n<p>To emulate <code>git add -A</code> with the &quot;dry-run&quot; option, just use a callback function that always returns a positive value.  See below for details.</p>\n\n<p>If any files are currently the result of a merge conflict, those files will no longer be marked as conflicting.  The data about the conflicts will be moved to the &quot;resolve undo&quot; (REUC) section.</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the working directory immediately <em>before</em> it is added to / updated in the index.  Returning zero will add the item to the index, greater than zero will skip the item, and less than zero will abort the scan and return that value to the caller.</p>\n",
+      "group": "index",
+      "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_index_add_all-3"
+        ]
+      }
     },
     "git_index_remove_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 663,
-      "lineto": 667,
+      "line": 664,
+      "lineto": 668,
       "args": [
         {
           "name": "index",
@@ -9211,14 +9024,14 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Remove all matching index entries.</p>\n",
-      "comments": "<p>If you provide a callback function, it will be invoked on each matching\n item in the index immediately <em>before</em> it is removed.  Return 0 to\n remove the item, &gt; 0 to skip the item, and \n&lt;\n 0 to abort the scan.</p>\n",
+      "comments": "<p>If you provide a callback function, it will be invoked on each matching item in the index immediately <em>before</em> it is removed.  Return 0 to remove the item, &gt; 0 to skip the item, and &lt; 0 to abort the scan.</p>\n",
       "group": "index"
     },
     "git_index_update_all": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 692,
-      "lineto": 696,
+      "line": 693,
+      "lineto": 697,
       "args": [
         {
           "name": "index",
@@ -9248,14 +9061,19 @@
         "comment": " 0 on success, negative callback return value, or error code"
       },
       "description": "<p>Update all index entries to match the working directory</p>\n",
-      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>This scans the existing index entries and synchronizes them with the\n working directory, deleting them if the corresponding working directory\n file no longer exists otherwise updating the information (including\n adding the latest version of file to the ODB if needed).</p>\n\n<p>If you provide a callback function, it will be invoked on each matching\n item in the index immediately <em>before</em> it is updated (either refreshed\n or removed depending on working directory state).  Return 0 to proceed\n with updating the item, &gt; 0 to skip the item, and \n&lt;\n 0 to abort the scan.</p>\n",
-      "group": "index"
+      "comments": "<p>This method will fail in bare index instances.</p>\n\n<p>This scans the existing index entries and synchronizes them with the working directory, deleting them if the corresponding working directory file no longer exists otherwise updating the information (including adding the latest version of file to the ODB if needed).</p>\n\n<p>If you provide a callback function, it will be invoked on each matching item in the index immediately <em>before</em> it is updated (either refreshed or removed depending on working directory state).  Return 0 to proceed with updating the item, &gt; 0 to skip the item, and &lt; 0 to abort the scan.</p>\n",
+      "group": "index",
+      "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_index_update_all-4"
+        ]
+      }
     },
     "git_index_find": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 707,
-      "lineto": 707,
+      "line": 708,
+      "lineto": 708,
       "args": [
         {
           "name": "at_pos",
@@ -9286,8 +9104,8 @@
     "git_index_find_prefix": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 718,
-      "lineto": 718,
+      "line": 719,
+      "lineto": 719,
       "args": [
         {
           "name": "at_pos",
@@ -9318,8 +9136,8 @@
     "git_index_conflict_add": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 743,
-      "lineto": 747,
+      "line": 744,
+      "lineto": 748,
       "args": [
         {
           "name": "index",
@@ -9349,14 +9167,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update index entries to represent a conflict.  Any staged\n entries that exist at the given paths will be removed.</p>\n",
-      "comments": "<p>The entries are the entries from the tree included in the merge.  Any\n entry may be null to indicate that that file was not present in the\n trees during the merge.  For example, ancestor_entry may be NULL to\n indicate that a file was added in both branches and must be resolved.</p>\n",
+      "comments": "<p>The entries are the entries from the tree included in the merge.  Any entry may be null to indicate that that file was not present in the trees during the merge.  For example, ancestor_entry may be NULL to indicate that a file was added in both branches and must be resolved.</p>\n",
       "group": "index"
     },
     "git_index_conflict_get": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 763,
-      "lineto": 768,
+      "line": 764,
+      "lineto": 769,
       "args": [
         {
           "name": "ancestor_out",
@@ -9391,14 +9209,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the index entries that represent a conflict of a single file.</p>\n",
-      "comments": "<p>The entries are not modifiable and should not be freed.  Because the\n <code>git_index_entry</code> struct is a publicly defined struct, you should\n be able to make your own permanent copy of the data if necessary.</p>\n",
+      "comments": "<p>The entries are not modifiable and should not be freed.  Because the <code>git_index_entry</code> struct is a publicly defined struct, you should be able to make your own permanent copy of the data if necessary.</p>\n",
       "group": "index"
     },
     "git_index_conflict_remove": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 777,
-      "lineto": 777,
+      "line": 778,
+      "lineto": 778,
       "args": [
         {
           "name": "index",
@@ -9424,8 +9242,8 @@
     "git_index_conflict_cleanup": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 785,
-      "lineto": 785,
+      "line": 786,
+      "lineto": 786,
       "args": [
         {
           "name": "index",
@@ -9446,8 +9264,8 @@
     "git_index_has_conflicts": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 792,
-      "lineto": 792,
+      "line": 793,
+      "lineto": 793,
       "args": [
         {
           "name": "index",
@@ -9466,15 +9284,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_index_has_conflicts-13"
+          "ex/HEAD/merge.html#git_index_has_conflicts-11"
         ]
       }
     },
     "git_index_conflict_iterator_new": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 803,
-      "lineto": 805,
+      "line": 804,
+      "lineto": 806,
       "args": [
         {
           "name": "iterator_out",
@@ -9498,15 +9316,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_index_conflict_iterator_new-14"
+          "ex/HEAD/merge.html#git_index_conflict_iterator_new-12"
         ]
       }
     },
     "git_index_conflict_next": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 817,
-      "lineto": 821,
+      "line": 818,
+      "lineto": 822,
       "args": [
         {
           "name": "ancestor_out",
@@ -9540,15 +9358,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_index_conflict_next-15"
+          "ex/HEAD/merge.html#git_index_conflict_next-13"
         ]
       }
     },
     "git_index_conflict_iterator_free": {
       "type": "function",
       "file": "git2/index.h",
-      "line": 828,
-      "lineto": 829,
+      "line": 829,
+      "lineto": 830,
       "args": [
         {
           "name": "iterator",
@@ -9567,15 +9385,15 @@
       "group": "index",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_index_conflict_iterator_free-16"
+          "ex/HEAD/merge.html#git_index_conflict_iterator_free-14"
         ]
       }
     },
-    "git_indexer_init_options": {
+    "git_indexer_options_init": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 41,
-      "lineto": 43,
+      "line": 85,
+      "lineto": 87,
       "args": [
         {
           "name": "opts",
@@ -9601,8 +9419,8 @@
     "git_indexer_new": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 57,
-      "lineto": 62,
+      "line": 101,
+      "lineto": 106,
       "args": [
         {
           "name": "out",
@@ -9643,8 +9461,8 @@
     "git_indexer_append": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 72,
-      "lineto": 72,
+      "line": 116,
+      "lineto": 116,
       "args": [
         {
           "name": "idx",
@@ -9663,12 +9481,12 @@
         },
         {
           "name": "stats",
-          "type": "git_transfer_progress *",
+          "type": "git_indexer_progress *",
           "comment": "stat storage"
         }
       ],
-      "argline": "git_indexer *idx, const void *data, size_t size, git_transfer_progress *stats",
-      "sig": "git_indexer *::const void *::size_t::git_transfer_progress *",
+      "argline": "git_indexer *idx, const void *data, size_t size, git_indexer_progress *stats",
+      "sig": "git_indexer *::const void *::size_t::git_indexer_progress *",
       "return": {
         "type": "int",
         "comment": null
@@ -9680,8 +9498,8 @@
     "git_indexer_commit": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 81,
-      "lineto": 81,
+      "line": 125,
+      "lineto": 125,
       "args": [
         {
           "name": "idx",
@@ -9690,12 +9508,12 @@
         },
         {
           "name": "stats",
-          "type": "git_transfer_progress *",
+          "type": "git_indexer_progress *",
           "comment": null
         }
       ],
-      "argline": "git_indexer *idx, git_transfer_progress *stats",
-      "sig": "git_indexer *::git_transfer_progress *",
+      "argline": "git_indexer *idx, git_indexer_progress *stats",
+      "sig": "git_indexer *::git_indexer_progress *",
       "return": {
         "type": "int",
         "comment": null
@@ -9707,8 +9525,8 @@
     "git_indexer_hash": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 91,
-      "lineto": 91,
+      "line": 135,
+      "lineto": 135,
       "args": [
         {
           "name": "idx",
@@ -9723,14 +9541,14 @@
         "comment": null
       },
       "description": "<p>Get the packfile&#39;s hash</p>\n",
-      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object\n names. This is only correct after the index has been finalized.</p>\n",
+      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object names. This is only correct after the index has been finalized.</p>\n",
       "group": "indexer"
     },
     "git_indexer_free": {
       "type": "function",
       "file": "git2/indexer.h",
-      "line": 98,
-      "lineto": 98,
+      "line": 142,
+      "lineto": 142,
       "args": [
         {
           "name": "idx",
@@ -9747,33 +9565,6 @@
       "description": "<p>Free the indexer and its resources</p>\n",
       "comments": "",
       "group": "indexer"
-    },
-    "imaxdiv": {
-      "type": "function",
-      "file": "git2/inttypes.h",
-      "line": 284,
-      "lineto": 298,
-      "args": [
-        {
-          "name": "numer",
-          "type": "intmax_t",
-          "comment": null
-        },
-        {
-          "name": "denom",
-          "type": "intmax_t",
-          "comment": null
-        }
-      ],
-      "argline": "intmax_t numer, intmax_t denom",
-      "sig": "intmax_t::intmax_t",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "imaxdiv"
     },
     "git_mailmap_new": {
       "type": "function",
@@ -9794,7 +9585,7 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Allocate a new mailmap object.</p>\n",
-      "comments": "<p>This object is empty, so you&#39;ll have to add a mailmap file before you can do\n anything with it. The mailmap must be freed with &#39;git_mailmap_free&#39;.</p>\n",
+      "comments": "<p>This object is empty, so you&#39;ll have to add a mailmap file before you can do anything with it. The mailmap must be freed with &#39;git_mailmap_free&#39;.</p>\n",
       "group": "mailmap"
     },
     "git_mailmap_free": {
@@ -9917,7 +9708,7 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Create a new mailmap instance from a repository, loading mailmap files based\n on the repository&#39;s configuration.</p>\n",
-      "comments": "<p>Mailmaps are loaded in the following order:\n  1. &#39;.mailmap&#39; in the root of the repository&#39;s working directory, if present.\n  2. The blob object identified by the &#39;mailmap.blob&#39; config entry, if set.\n       [NOTE: &#39;mailmap.blob&#39; defaults to &#39;HEAD:.mailmap&#39; in bare repositories]\n  3. The path in the &#39;mailmap.file&#39; config entry, if set.</p>\n",
+      "comments": "<p>Mailmaps are loaded in the following order:  1. &#39;.mailmap&#39; in the root of the repository&#39;s working directory, if present.  2. The blob object identified by the &#39;mailmap.blob&#39; config entry, if set.      [NOTE: &#39;mailmap.blob&#39; defaults to &#39;HEAD:.mailmap&#39; in bare repositories]  3. The path in the &#39;mailmap.file&#39; config entry, if set.</p>\n",
       "group": "mailmap"
     },
     "git_mailmap_resolve": {
@@ -9994,7 +9785,7 @@
       "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n",
       "group": "mailmap"
     },
-    "git_merge_file_init_input": {
+    "git_merge_file_input_init": {
       "type": "function",
       "file": "git2/merge.h",
       "line": 60,
@@ -10021,11 +9812,11 @@
       "comments": "",
       "group": "merge"
     },
-    "git_merge_file_init_options": {
+    "git_merge_file_options_init": {
       "type": "function",
       "file": "git2/merge.h",
       "line": 215,
-      "lineto": 217,
+      "lineto": 215,
       "args": [
         {
           "name": "opts",
@@ -10045,14 +9836,14 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_merge_file_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_merge_file_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_MERGE_FILE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_merge_file_options</code> with default values. Equivalent to creating an instance with <code>GIT_MERGE_FILE_OPTIONS_INIT</code>.</p>\n",
       "group": "merge"
     },
-    "git_merge_init_options": {
+    "git_merge_options_init": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 313,
-      "lineto": 315,
+      "line": 311,
+      "lineto": 311,
       "args": [
         {
           "name": "opts",
@@ -10072,14 +9863,14 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_merge_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_merge_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_MERGE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_merge_options</code> with default values. Equivalent to creating an instance with <code>GIT_MERGE_OPTIONS_INIT</code>.</p>\n",
       "group": "merge"
     },
     "git_merge_analysis": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 384,
-      "lineto": 389,
+      "line": 380,
+      "lineto": 385,
       "args": [
         {
           "name": "analysis_out",
@@ -10118,15 +9909,15 @@
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_merge_analysis-17"
+          "ex/HEAD/merge.html#git_merge_analysis-15"
         ]
       }
     },
     "git_merge_analysis_for_ref": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 402,
-      "lineto": 408,
+      "line": 398,
+      "lineto": 404,
       "args": [
         {
           "name": "analysis_out",
@@ -10172,8 +9963,8 @@
     "git_merge_base": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 419,
-      "lineto": 423,
+      "line": 415,
+      "lineto": 419,
       "args": [
         {
           "name": "out",
@@ -10207,18 +9998,18 @@
       "group": "merge",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_merge_base-33"
+          "ex/HEAD/log.html#git_merge_base-31"
         ],
         "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_merge_base-3"
+          "ex/HEAD/rev-parse.html#git_merge_base-1"
         ]
       }
     },
     "git_merge_bases": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 434,
-      "lineto": 438,
+      "line": 430,
+      "lineto": 434,
       "args": [
         {
           "name": "out",
@@ -10254,8 +10045,8 @@
     "git_merge_base_many": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 449,
-      "lineto": 453,
+      "line": 445,
+      "lineto": 449,
       "args": [
         {
           "name": "out",
@@ -10291,8 +10082,8 @@
     "git_merge_bases_many": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 464,
-      "lineto": 468,
+      "line": 460,
+      "lineto": 464,
       "args": [
         {
           "name": "out",
@@ -10328,8 +10119,8 @@
     "git_merge_base_octopus": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 479,
-      "lineto": 483,
+      "line": 475,
+      "lineto": 479,
       "args": [
         {
           "name": "out",
@@ -10365,8 +10156,8 @@
     "git_merge_file": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 501,
-      "lineto": 506,
+      "line": 497,
+      "lineto": 502,
       "args": [
         {
           "name": "out",
@@ -10401,14 +10192,14 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Merge two files as they exist in the in-memory data structures, using\n the given common ancestor as the baseline, producing a\n <code>git_merge_file_result</code> that reflects the merge result.  The\n <code>git_merge_file_result</code> must be freed with <code>git_merge_file_result_free</code>.</p>\n",
-      "comments": "<p>Note that this function does not reference a repository and any\n configuration must be passed as <code>git_merge_file_options</code>.</p>\n",
+      "comments": "<p>Note that this function does not reference a repository and any configuration must be passed as <code>git_merge_file_options</code>.</p>\n",
       "group": "merge"
     },
     "git_merge_file_from_index": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 522,
-      "lineto": 528,
+      "line": 518,
+      "lineto": 524,
       "args": [
         {
           "name": "out",
@@ -10454,8 +10245,8 @@
     "git_merge_file_result_free": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 535,
-      "lineto": 535,
+      "line": 531,
+      "lineto": 531,
       "args": [
         {
           "name": "result",
@@ -10476,8 +10267,8 @@
     "git_merge_trees": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 553,
-      "lineto": 559,
+      "line": 549,
+      "lineto": 555,
       "args": [
         {
           "name": "out",
@@ -10523,8 +10314,8 @@
     "git_merge_commits": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 576,
-      "lineto": 581,
+      "line": 572,
+      "lineto": 577,
       "args": [
         {
           "name": "out",
@@ -10565,8 +10356,8 @@
     "git_merge": {
       "type": "function",
       "file": "git2/merge.h",
-      "line": 601,
-      "lineto": 606,
+      "line": 597,
+      "lineto": 602,
       "args": [
         {
           "name": "repo",
@@ -10601,11 +10392,11 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Merges the given commit(s) into HEAD, writing the results into the working\n directory.  Any changes are staged for commit and any conflicts are written\n to the index.  Callers should inspect the repository&#39;s index after this\n completes, resolve any conflicts and prepare a commit.</p>\n",
-      "comments": "<p>For compatibility with git, the repository is put into a merging\n state. Once the commit is done (or if the uses wishes to abort),\n you should clear this state by calling\n <code>git_repository_state_cleanup()</code>.</p>\n",
+      "comments": "<p>For compatibility with git, the repository is put into a merging state. Once the commit is done (or if the uses wishes to abort), you should clear this state by calling <code>git_repository_state_cleanup()</code>.</p>\n",
       "group": "merge",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_merge-18"
+          "ex/HEAD/merge.html#git_merge-16"
         ]
       }
     },
@@ -10670,7 +10461,7 @@
         "comment": " 0 on success, or non-zero on error."
       },
       "description": "<p>Parse trailers out of a message, filling the array pointed to by +arr+.</p>\n",
-      "comments": "<p>Trailers are key/value pairs in the last paragraph of a message, not\n including any patches or conflicts that may be present.</p>\n",
+      "comments": "<p>Trailers are key/value pairs in the last paragraph of a message, not including any patches or conflicts that may be present.</p>\n",
       "group": "message"
     },
     "git_message_trailer_array_free": {
@@ -11086,7 +10877,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a note for an object from a commit</p>\n",
-      "comments": "<p>This function will create a notes commit for a given object,\n the commit is a dangling commit, no reference is created.</p>\n",
+      "comments": "<p>This function will create a notes commit for a given object, the commit is a dangling commit, no reference is created.</p>\n",
       "group": "note"
     },
     "git_note_remove": {
@@ -11298,14 +11089,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository.</p>\n",
-      "comments": "<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The generated reference is owned by the repository and should be closed with the <code>git_object_free</code> method instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object in the odb; the method will fail otherwise. The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let the method guess the object&#39;s type.</p>\n",
       "group": "object",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_object_lookup-34"
+          "ex/HEAD/log.html#git_object_lookup-32"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_object_lookup-19"
+          "ex/HEAD/merge.html#git_object_lookup-17"
         ]
       }
     },
@@ -11348,7 +11139,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference to one of the objects in a repository,\n given a prefix of its identifier (short id).</p>\n",
-      "comments": "<p>The object obtained will be so that its identifier\n matches the first &#39;len&#39; hexadecimal characters\n (packets of 4 bits) of the given &#39;id&#39;.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and\n long enough to identify a unique object matching\n the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and\n should be closed with the <code>git_object_free</code> method\n instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object\n in the odb; the method will fail otherwise.\n The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let\n the method guess the object&#39;s type.</p>\n",
+      "comments": "<p>The object obtained will be so that its identifier matches the first &#39;len&#39; hexadecimal characters (packets of 4 bits) of the given &#39;id&#39;. &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and long enough to identify a unique object matching the prefix; otherwise the method will fail.</p>\n\n<p>The generated reference is owned by the repository and should be closed with the <code>git_object_free</code> method instead of free&#39;d manually.</p>\n\n<p>The &#39;type&#39; parameter must match the type of the object in the odb; the method will fail otherwise. The special value &#39;GIT_OBJECT_ANY&#39; may be passed to let the method guess the object&#39;s type.</p>\n",
       "group": "object"
     },
     "git_object_lookup_bypath": {
@@ -11411,27 +11202,27 @@
       "group": "object",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_object_id-10",
-          "ex/v0.28.0/blame.html#git_object_id-11",
-          "ex/v0.28.0/blame.html#git_object_id-12",
-          "ex/v0.28.0/blame.html#git_object_id-13"
+          "ex/HEAD/blame.html#git_object_id-8",
+          "ex/HEAD/blame.html#git_object_id-9",
+          "ex/HEAD/blame.html#git_object_id-10",
+          "ex/HEAD/blame.html#git_object_id-11"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_object_id-12",
-          "ex/v0.28.0/cat-file.html#git_object_id-13"
+          "ex/HEAD/cat-file.html#git_object_id-10",
+          "ex/HEAD/cat-file.html#git_object_id-11"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_object_id-35",
-          "ex/v0.28.0/log.html#git_object_id-36",
-          "ex/v0.28.0/log.html#git_object_id-37",
-          "ex/v0.28.0/log.html#git_object_id-38"
+          "ex/HEAD/log.html#git_object_id-33",
+          "ex/HEAD/log.html#git_object_id-34",
+          "ex/HEAD/log.html#git_object_id-35",
+          "ex/HEAD/log.html#git_object_id-36"
         ],
         "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_object_id-4",
-          "ex/v0.28.0/rev-parse.html#git_object_id-5",
-          "ex/v0.28.0/rev-parse.html#git_object_id-6",
-          "ex/v0.28.0/rev-parse.html#git_object_id-7",
-          "ex/v0.28.0/rev-parse.html#git_object_id-8"
+          "ex/HEAD/rev-parse.html#git_object_id-2",
+          "ex/HEAD/rev-parse.html#git_object_id-3",
+          "ex/HEAD/rev-parse.html#git_object_id-4",
+          "ex/HEAD/rev-parse.html#git_object_id-5",
+          "ex/HEAD/rev-parse.html#git_object_id-6"
         ]
       }
     },
@@ -11459,11 +11250,11 @@
         "comment": " 0 on success, \n<\n0 for error"
       },
       "description": "<p>Get a short abbreviated OID string for the object</p>\n",
-      "comments": "<p>This starts at the &quot;core.abbrev&quot; length (default 7 characters) and\n iteratively extends to a longer string if that length is ambiguous.\n The result will be unambiguous (at least until new objects are added to\n the repository).</p>\n",
+      "comments": "<p>This starts at the &quot;core.abbrev&quot; length (default 7 characters) and iteratively extends to a longer string if that length is ambiguous. The result will be unambiguous (at least until new objects are added to the repository).</p>\n",
       "group": "object",
       "examples": {
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_object_short_id-5"
+          "ex/HEAD/tag.html#git_object_short_id-3"
         ]
       }
     },
@@ -11490,12 +11281,12 @@
       "group": "object",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_object_type-14",
-          "ex/v0.28.0/cat-file.html#git_object_type-15",
-          "ex/v0.28.0/cat-file.html#git_object_type-16"
+          "ex/HEAD/cat-file.html#git_object_type-12",
+          "ex/HEAD/cat-file.html#git_object_type-13",
+          "ex/HEAD/cat-file.html#git_object_type-14"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_object_type-6"
+          "ex/HEAD/tag.html#git_object_type-4"
         ]
       }
     },
@@ -11518,7 +11309,7 @@
         "comment": " the repository who owns this object"
       },
       "description": "<p>Get the repository that owns this object</p>\n",
-      "comments": "<p>Freeing or calling <code>git_repository_close</code> on the\n returned pointer will invalidate the actual object.</p>\n\n<p>Any other operation may be run on the repository without\n affecting the object.</p>\n",
+      "comments": "<p>Freeing or calling <code>git_repository_close</code> on the returned pointer will invalidate the actual object.</p>\n\n<p>Any other operation may be run on the repository without affecting the object.</p>\n",
       "group": "object"
     },
     "git_object_free": {
@@ -11540,37 +11331,37 @@
         "comment": null
       },
       "description": "<p>Close an open object</p>\n",
-      "comments": "<p>This method instructs the library to close an existing\n object; note that git_objects are owned and cached by the repository\n so the object may or may not be freed after this library call,\n depending on how aggressive is the caching mechanism used\n by the repository.</p>\n\n<p>IMPORTANT:\n It <em>is</em> necessary to call this method when you stop using\n an object. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>This method instructs the library to close an existing object; note that git_objects are owned and cached by the repository so the object may or may not be freed after this library call, depending on how aggressive is the caching mechanism used by the repository.</p>\n\n<p>IMPORTANT: It <em>is</em> necessary to call this method when you stop using an object. Failure to do so will cause a memory leak.</p>\n",
       "group": "object",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_object_free-14",
-          "ex/v0.28.0/blame.html#git_object_free-15",
-          "ex/v0.28.0/blame.html#git_object_free-16",
-          "ex/v0.28.0/blame.html#git_object_free-17"
+          "ex/HEAD/blame.html#git_object_free-12",
+          "ex/HEAD/blame.html#git_object_free-13",
+          "ex/HEAD/blame.html#git_object_free-14",
+          "ex/HEAD/blame.html#git_object_free-15"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_object_free-17"
+          "ex/HEAD/cat-file.html#git_object_free-15"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_object_free-38"
+          "ex/HEAD/general.html#git_object_free-38"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_object_free-39"
+          "ex/HEAD/log.html#git_object_free-37"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_object_free-20"
+          "ex/HEAD/merge.html#git_object_free-18"
         ],
         "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_object_free-9",
-          "ex/v0.28.0/rev-parse.html#git_object_free-10",
-          "ex/v0.28.0/rev-parse.html#git_object_free-11"
+          "ex/HEAD/rev-parse.html#git_object_free-7",
+          "ex/HEAD/rev-parse.html#git_object_free-8",
+          "ex/HEAD/rev-parse.html#git_object_free-9"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_object_free-7",
-          "ex/v0.28.0/tag.html#git_object_free-8",
-          "ex/v0.28.0/tag.html#git_object_free-9",
-          "ex/v0.28.0/tag.html#git_object_free-10"
+          "ex/HEAD/tag.html#git_object_free-5",
+          "ex/HEAD/tag.html#git_object_free-6",
+          "ex/HEAD/tag.html#git_object_free-7",
+          "ex/HEAD/tag.html#git_object_free-8"
         ]
       }
     },
@@ -11593,18 +11384,18 @@
         "comment": " the corresponding string representation."
       },
       "description": "<p>Convert an object type to its string representation.</p>\n",
-      "comments": "<p>The result is a pointer to a string in static memory and\n should not be free()&#39;ed.</p>\n",
+      "comments": "<p>The result is a pointer to a string in static memory and should not be free()&#39;ed.</p>\n",
       "group": "object",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_object_type2string-18",
-          "ex/v0.28.0/cat-file.html#git_object_type2string-19",
-          "ex/v0.28.0/cat-file.html#git_object_type2string-20",
-          "ex/v0.28.0/cat-file.html#git_object_type2string-21"
+          "ex/HEAD/cat-file.html#git_object_type2string-16",
+          "ex/HEAD/cat-file.html#git_object_type2string-17",
+          "ex/HEAD/cat-file.html#git_object_type2string-18",
+          "ex/HEAD/cat-file.html#git_object_type2string-19"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_object_type2string-39",
-          "ex/v0.28.0/general.html#git_object_type2string-40"
+          "ex/HEAD/general.html#git_object_type2string-39",
+          "ex/HEAD/general.html#git_object_type2string-40"
         ]
       }
     },
@@ -11652,7 +11443,7 @@
       "comments": "",
       "group": "object"
     },
-    "git_object__size": {
+    "git_object_size": {
       "type": "function",
       "file": "git2/object.h",
       "line": 200,
@@ -11671,7 +11462,7 @@
         "comment": " size in bytes of the object"
       },
       "description": "<p>Get the size in bytes for the structure which\n acts as an in-memory representation of any given\n object type.</p>\n",
-      "comments": "<p>For all the core types, this would the equivalent\n of calling <code>sizeof(git_commit)</code> if the core types\n were not opaque on the external API.</p>\n",
+      "comments": "<p>For all the core types, this would the equivalent of calling <code>sizeof(git_commit)</code> if the core types were not opaque on the external API.</p>\n",
       "group": "object"
     },
     "git_object_peel": {
@@ -11703,7 +11494,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC, GIT_EPEEL, or an error code"
       },
       "description": "<p>Recursively peel an object until an object of the specified type is met.</p>\n",
-      "comments": "<p>If the query cannot be satisfied due to the object model,\n GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a\n tree).</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object will\n be peeled until the type changes. A tag will be peeled until the\n referenced object is no longer a tag, and a commit will be peeled\n to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to\n the target type due to the object model, GIT_EPEEL will be\n returned.</p>\n\n<p>You must free the returned object.</p>\n",
+      "comments": "<p>If the query cannot be satisfied due to the object model, GIT_EINVALIDSPEC will be returned (e.g. trying to peel a blob to a tree).</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object will be peeled until the type changes. A tag will be peeled until the referenced object is no longer a tag, and a commit will be peeled to a tree. Any other object type will return GIT_EINVALIDSPEC.</p>\n\n<p>If peeling a tag we discover an object which cannot be peeled to the target type due to the object model, GIT_EPEEL will be returned.</p>\n\n<p>You must free the returned object.</p>\n",
       "group": "object"
     },
     "git_object_dup": {
@@ -11736,8 +11527,8 @@
     "git_odb_new": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 39,
-      "lineto": 39,
+      "line": 40,
+      "lineto": 40,
       "args": [
         {
           "name": "out",
@@ -11752,14 +11543,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new object database with no backends.</p>\n",
-      "comments": "<p>Before the ODB can be used for read/writing, a custom database\n backend must be manually added using <code>git_odb_add_backend()</code></p>\n",
+      "comments": "<p>Before the ODB can be used for read/writing, a custom database backend must be manually added using <code>git_odb_add_backend()</code></p>\n",
       "group": "odb"
     },
     "git_odb_open": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 57,
-      "lineto": 57,
+      "line": 58,
+      "lineto": 58,
       "args": [
         {
           "name": "out",
@@ -11779,14 +11570,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new object database and automatically add\n the two default backends:</p>\n",
-      "comments": "<pre><code>- git_odb_backend_loose: read and write loose object files\n    from disk, assuming `objects_dir` as the Objects folder\n\n- git_odb_backend_pack: read objects from packfiles,\n    assuming `objects_dir` as the Objects folder which\n    contains a &#39;pack/&#39; folder with the corresponding data\n</code></pre>\n",
+      "comments": "<pre><code>- git_odb_backend_loose: read and write loose object files      from disk, assuming `objects_dir` as the Objects folder\n\n- git_odb_backend_pack: read objects from packfiles,        assuming `objects_dir` as the Objects folder which      contains a &#39;pack/&#39; folder with the corresponding data\n</code></pre>\n",
       "group": "odb"
     },
     "git_odb_add_disk_alternate": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 74,
-      "lineto": 74,
+      "line": 75,
+      "lineto": 75,
       "args": [
         {
           "name": "odb",
@@ -11806,14 +11597,14 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add an on-disk alternate to an existing Object DB.</p>\n",
-      "comments": "<p>Note that the added path must point to an <code>objects</code>, not\n to a full repository, to use it as an alternate store.</p>\n\n<p>Alternate backends are always checked for objects <em>after</em>\n all the main backends have been exhausted.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n",
+      "comments": "<p>Note that the added path must point to an <code>objects</code>, not to a full repository, to use it as an alternate store.</p>\n\n<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n",
       "group": "odb"
     },
     "git_odb_free": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 81,
-      "lineto": 81,
+      "line": 82,
+      "lineto": 82,
       "args": [
         {
           "name": "db",
@@ -11832,18 +11623,18 @@
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_odb_free-22"
+          "ex/HEAD/cat-file.html#git_odb_free-20"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_free-41"
+          "ex/HEAD/general.html#git_odb_free-41"
         ]
       }
     },
     "git_odb_read": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 100,
-      "lineto": 100,
+      "line": 101,
+      "lineto": 101,
       "args": [
         {
           "name": "out",
@@ -11868,22 +11659,22 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database."
       },
       "description": "<p>Read an object from the database.</p>\n",
-      "comments": "<p>This method queries all available ODB backends\n trying to read the given OID.</p>\n\n<p>The returned object is reference counted and\n internally cached, so it should be closed\n by the user once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This method queries all available ODB backends trying to read the given OID.</p>\n\n<p>The returned object is reference counted and internally cached, so it should be closed by the user once it&#39;s no longer in use.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_odb_read-23"
+          "ex/HEAD/cat-file.html#git_odb_read-21"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_read-42"
+          "ex/HEAD/general.html#git_odb_read-42"
         ]
       }
     },
     "git_odb_read_prefix": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 129,
-      "lineto": 129,
+      "line": 130,
+      "lineto": 130,
       "args": [
         {
           "name": "out",
@@ -11913,14 +11704,14 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database.\n - GIT_EAMBIGUOUS if the prefix is ambiguous (several objects match the prefix)"
       },
       "description": "<p>Read an object from the database, given a prefix\n of its identifier.</p>\n",
-      "comments": "<p>This method queries all available ODB backends\n trying to match the &#39;len&#39; first hexadecimal\n characters of the &#39;short_id&#39;.\n The remaining (GIT_OID_HEXSZ-len)*4 bits of\n &#39;short_id&#39; must be 0s.\n &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN,\n and the prefix must be long enough to identify\n a unique object in all the backends; the\n method will fail otherwise.</p>\n\n<p>The returned object is reference counted and\n internally cached, so it should be closed\n by the user once it&#39;s no longer in use.</p>\n",
+      "comments": "<p>This method queries all available ODB backends trying to match the &#39;len&#39; first hexadecimal characters of the &#39;short_id&#39;. The remaining (GIT_OID_HEXSZ-len)*4 bits of &#39;short_id&#39; must be 0s. &#39;len&#39; must be at least GIT_OID_MINPREFIXLEN, and the prefix must be long enough to identify a unique object in all the backends; the method will fail otherwise.</p>\n\n<p>The returned object is reference counted and internally cached, so it should be closed by the user once it&#39;s no longer in use.</p>\n",
       "group": "odb"
     },
     "git_odb_read_header": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 149,
-      "lineto": 149,
+      "line": 150,
+      "lineto": 150,
       "args": [
         {
           "name": "len_out",
@@ -11950,14 +11741,14 @@
         "comment": " - 0 if the object was read;\n - GIT_ENOTFOUND if the object is not in the database."
       },
       "description": "<p>Read the header of an object from the database, without\n reading its full contents.</p>\n",
-      "comments": "<p>The header includes the length and the type of an object.</p>\n\n<p>Note that most backends do not support reading only the header\n of an object, so the whole object will be read and then the\n header will be returned.</p>\n",
+      "comments": "<p>The header includes the length and the type of an object.</p>\n\n<p>Note that most backends do not support reading only the header of an object, so the whole object will be read and then the header will be returned.</p>\n",
       "group": "odb"
     },
     "git_odb_exists": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 160,
-      "lineto": 160,
+      "line": 161,
+      "lineto": 161,
       "args": [
         {
           "name": "db",
@@ -11983,8 +11774,8 @@
     "git_odb_exists_prefix": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 173,
-      "lineto": 174,
+      "line": 174,
+      "lineto": 175,
       "args": [
         {
           "name": "out",
@@ -12020,8 +11811,8 @@
     "git_odb_expand_ids": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 215,
-      "lineto": 218,
+      "line": 216,
+      "lineto": 219,
       "args": [
         {
           "name": "db",
@@ -12046,14 +11837,14 @@
         "comment": " 0 on success or an error code on failure"
       },
       "description": "<p>Determine if one or more objects can be found in the object database\n by their abbreviated object ID and type.  The given array will be\n updated in place:  for each abbreviated ID that is unique in the\n database, and of the given type (if specified), the full object ID,\n object ID length (<code>GIT_OID_HEXSZ</code>) and type will be written back to\n the array.  For IDs that are not found (or are ambiguous), the\n array entry will be zeroed.</p>\n",
-      "comments": "<p>Note that since this function operates on multiple objects, the\n underlying database will not be asked to be reloaded if an object is\n not found (which is unlike other object database operations.)</p>\n",
+      "comments": "<p>Note that since this function operates on multiple objects, the underlying database will not be asked to be reloaded if an object is not found (which is unlike other object database operations.)</p>\n",
       "group": "odb"
     },
     "git_odb_refresh": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 238,
-      "lineto": 238,
+      "line": 239,
+      "lineto": 239,
       "args": [
         {
           "name": "db",
@@ -12068,14 +11859,14 @@
         "comment": " 0 on success, error code otherwise"
       },
       "description": "<p>Refresh the object database to load newly added files.</p>\n",
-      "comments": "<p>If the object databases have changed on disk while the library\n is running, this function will force a reload of the underlying\n indexes.</p>\n\n<p>Use this function when you&#39;re confident that an external\n application has tampered with the ODB.</p>\n\n<p>NOTE that it is not necessary to call this function at all. The\n library will automatically attempt to refresh the ODB\n when a lookup fails, to see if the looked up object exists\n on disk but hasn&#39;t been loaded yet.</p>\n",
+      "comments": "<p>If the object databases have changed on disk while the library is running, this function will force a reload of the underlying indexes.</p>\n\n<p>Use this function when you&#39;re confident that an external application has tampered with the ODB.</p>\n\n<p>NOTE that it is not necessary to call this function at all. The library will automatically attempt to refresh the ODB when a lookup fails, to see if the looked up object exists on disk but hasn&#39;t been loaded yet.</p>\n",
       "group": "odb"
     },
     "git_odb_foreach": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 253,
-      "lineto": 253,
+      "line": 254,
+      "lineto": 254,
       "args": [
         {
           "name": "db",
@@ -12100,14 +11891,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>List all objects available in the database</p>\n",
-      "comments": "<p>The callback will be called for each object available in the\n database. Note that the objects are likely to be returned in the index\n order, which would make accessing the objects in that order inefficient.\n Return a non-zero value from the callback to stop looping.</p>\n",
+      "comments": "<p>The callback will be called for each object available in the database. Note that the objects are likely to be returned in the index order, which would make accessing the objects in that order inefficient. Return a non-zero value from the callback to stop looping.</p>\n",
       "group": "odb"
     },
     "git_odb_write": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 273,
-      "lineto": 273,
+      "line": 274,
+      "lineto": 274,
       "args": [
         {
           "name": "out",
@@ -12142,19 +11933,19 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Write an object directly into the ODB</p>\n",
-      "comments": "<p>This method writes a full object straight into the ODB.\n For most cases, it is preferred to write objects through a write\n stream, which is both faster and less memory intensive, specially\n for big objects.</p>\n\n<p>This method is provided for compatibility with custom backends\n which are not able to support streaming writes</p>\n",
+      "comments": "<p>This method writes a full object straight into the ODB. For most cases, it is preferred to write objects through a write stream, which is both faster and less memory intensive, specially for big objects.</p>\n\n<p>This method is provided for compatibility with custom backends which are not able to support streaming writes</p>\n",
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_write-43"
+          "ex/HEAD/general.html#git_odb_write-43"
         ]
       }
     },
     "git_odb_open_wstream": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 296,
-      "lineto": 296,
+      "line": 297,
+      "lineto": 297,
       "args": [
         {
           "name": "out",
@@ -12184,14 +11975,14 @@
         "comment": " 0 if the stream was created; error code otherwise"
       },
       "description": "<p>Open a stream to write an object into the ODB</p>\n",
-      "comments": "<p>The type and final length of the object must be specified\n when opening the stream.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_WRONLY</code>, and it\n won&#39;t be effective until <code>git_odb_stream_finalize_write</code> is called\n and returns without an error</p>\n\n<p>The stream must always be freed when done with <code>git_odb_stream_free</code> or\n will leak memory.</p>\n",
+      "comments": "<p>The type and final length of the object must be specified when opening the stream.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_WRONLY</code>, and it won&#39;t be effective until <code>git_odb_stream_finalize_write</code> is called and returns without an error</p>\n\n<p>The stream must always be freed when done with <code>git_odb_stream_free</code> or will leak memory.</p>\n",
       "group": "odb"
     },
     "git_odb_stream_write": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 309,
-      "lineto": 309,
+      "line": 310,
+      "lineto": 310,
       "args": [
         {
           "name": "stream",
@@ -12216,14 +12007,14 @@
         "comment": " 0 if the write succeeded; error code otherwise"
       },
       "description": "<p>Write to an odb stream</p>\n",
-      "comments": "<p>This method will fail if the total number of received bytes exceeds the\n size declared with <code>git_odb_open_wstream()</code></p>\n",
+      "comments": "<p>This method will fail if the total number of received bytes exceeds the size declared with <code>git_odb_open_wstream()</code></p>\n",
       "group": "odb"
     },
     "git_odb_stream_finalize_write": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 324,
-      "lineto": 324,
+      "line": 325,
+      "lineto": 325,
       "args": [
         {
           "name": "out",
@@ -12243,14 +12034,14 @@
         "comment": " 0 on success; an error code otherwise"
       },
       "description": "<p>Finish writing to an odb stream</p>\n",
-      "comments": "<p>The object will take its final name and will be available to the\n odb.</p>\n\n<p>This method will fail if the total number of received bytes\n differs from the size declared with <code>git_odb_open_wstream()</code></p>\n",
+      "comments": "<p>The object will take its final name and will be available to the odb.</p>\n\n<p>This method will fail if the total number of received bytes differs from the size declared with <code>git_odb_open_wstream()</code></p>\n",
       "group": "odb"
     },
     "git_odb_stream_read": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 331,
-      "lineto": 331,
+      "line": 332,
+      "lineto": 332,
       "args": [
         {
           "name": "stream",
@@ -12281,8 +12072,8 @@
     "git_odb_stream_free": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 338,
-      "lineto": 338,
+      "line": 339,
+      "lineto": 339,
       "args": [
         {
           "name": "stream",
@@ -12303,8 +12094,8 @@
     "git_odb_open_rstream": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 366,
-      "lineto": 371,
+      "line": 367,
+      "lineto": 372,
       "args": [
         {
           "name": "out",
@@ -12339,14 +12130,14 @@
         "comment": " 0 if the stream was created; error code otherwise"
       },
       "description": "<p>Open a stream to read an object from the ODB</p>\n",
-      "comments": "<p>Note that most backends do <em>not</em> support streaming reads\n because they store their objects as compressed/delta&#39;ed blobs.</p>\n\n<p>It&#39;s recommended to use <code>git_odb_read</code> instead, which is\n assured to work on all backends.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_RDONLY</code> and\n will have the following methods:</p>\n\n<pre><code>    - stream-&gt;read: read `n` bytes from the stream\n    - stream-&gt;free: free the stream\n</code></pre>\n\n<p>The stream must always be free&#39;d or will leak memory.</p>\n",
+      "comments": "<p>Note that most backends do <em>not</em> support streaming reads because they store their objects as compressed/delta&#39;ed blobs.</p>\n\n<p>It&#39;s recommended to use <code>git_odb_read</code> instead, which is assured to work on all backends.</p>\n\n<p>The returned stream will be of type <code>GIT_STREAM_RDONLY</code> and will have the following methods:</p>\n\n<pre><code>    - stream-&gt;read: read `n` bytes from the stream      - stream-&gt;free: free the stream\n</code></pre>\n\n<p>The stream must always be free&#39;d or will leak memory.</p>\n",
       "group": "odb"
     },
     "git_odb_write_pack": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 391,
-      "lineto": 395,
+      "line": 392,
+      "lineto": 396,
       "args": [
         {
           "name": "out",
@@ -12360,7 +12151,7 @@
         },
         {
           "name": "progress_cb",
-          "type": "git_transfer_progress_cb",
+          "type": "git_indexer_progress_cb",
           "comment": "function to call with progress information.\n Be aware that this is called inline with network and indexing operations,\n so performance may be affected."
         },
         {
@@ -12369,21 +12160,21 @@
           "comment": "payload for the progress callback"
         }
       ],
-      "argline": "git_odb_writepack **out, git_odb *db, git_transfer_progress_cb progress_cb, void *progress_payload",
-      "sig": "git_odb_writepack **::git_odb *::git_transfer_progress_cb::void *",
+      "argline": "git_odb_writepack **out, git_odb *db, git_indexer_progress_cb progress_cb, void *progress_payload",
+      "sig": "git_odb_writepack **::git_odb *::git_indexer_progress_cb::void *",
       "return": {
         "type": "int",
         "comment": null
       },
       "description": "<p>Open a stream for writing a pack file to the ODB.</p>\n",
-      "comments": "<p>If the ODB layer understands pack files, then the given\n packfile will likely be streamed directly to disk (and a\n corresponding index created).  If the ODB layer does not\n understand pack files, the objects will be stored in whatever\n format the ODB layer uses.</p>\n",
+      "comments": "<p>If the ODB layer understands pack files, then the given packfile will likely be streamed directly to disk (and a corresponding index created).  If the ODB layer does not understand pack files, the objects will be stored in whatever format the ODB layer uses.</p>\n",
       "group": "odb"
     },
     "git_odb_hash": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 409,
-      "lineto": 409,
+      "line": 410,
+      "lineto": 410,
       "args": [
         {
           "name": "out",
@@ -12413,14 +12204,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Determine the object-ID (sha1 hash) of a data buffer</p>\n",
-      "comments": "<p>The resulting SHA-1 OID will be the identifier for the data\n buffer as if the data buffer it were to written to the ODB.</p>\n",
+      "comments": "<p>The resulting SHA-1 OID will be the identifier for the data buffer as if the data buffer it were to written to the ODB.</p>\n",
       "group": "odb"
     },
     "git_odb_hashfile": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 424,
-      "lineto": 424,
+      "line": 425,
+      "lineto": 425,
       "args": [
         {
           "name": "out",
@@ -12451,8 +12242,8 @@
     "git_odb_object_dup": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 438,
-      "lineto": 438,
+      "line": 439,
+      "lineto": 439,
       "args": [
         {
           "name": "dest",
@@ -12472,14 +12263,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a copy of an odb_object</p>\n",
-      "comments": "<p>The returned copy must be manually freed with <code>git_odb_object_free</code>.\n Note that because of an implementation detail, the returned copy will be\n the same pointer as <code>source</code>: the object is internally refcounted, so the\n copy still needs to be freed twice.</p>\n",
+      "comments": "<p>The returned copy must be manually freed with <code>git_odb_object_free</code>. Note that because of an implementation detail, the returned copy will be the same pointer as <code>source</code>: the object is internally refcounted, so the copy still needs to be freed twice.</p>\n",
       "group": "odb"
     },
     "git_odb_object_free": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 448,
-      "lineto": 448,
+      "line": 449,
+      "lineto": 449,
       "args": [
         {
           "name": "object",
@@ -12494,22 +12285,22 @@
         "comment": null
       },
       "description": "<p>Close an ODB object</p>\n",
-      "comments": "<p>This method must always be called once a <code>git_odb_object</code> is no\n longer needed, otherwise memory will leak.</p>\n",
+      "comments": "<p>This method must always be called once a <code>git_odb_object</code> is no longer needed, otherwise memory will leak.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_odb_object_free-24"
+          "ex/HEAD/cat-file.html#git_odb_object_free-22"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_object_free-44"
+          "ex/HEAD/general.html#git_odb_object_free-44"
         ]
       }
     },
     "git_odb_object_id": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 458,
-      "lineto": 458,
+      "line": 459,
+      "lineto": 459,
       "args": [
         {
           "name": "object",
@@ -12530,8 +12321,8 @@
     "git_odb_object_data": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 471,
-      "lineto": 471,
+      "line": 472,
+      "lineto": 472,
       "args": [
         {
           "name": "object",
@@ -12546,19 +12337,19 @@
         "comment": " a pointer to the data"
       },
       "description": "<p>Return the data of an ODB object</p>\n",
-      "comments": "<p>This is the uncompressed, raw data as read from the ODB,\n without the leading header.</p>\n\n<p>This pointer is owned by the object and shall not be free&#39;d.</p>\n",
+      "comments": "<p>This is the uncompressed, raw data as read from the ODB, without the leading header.</p>\n\n<p>This pointer is owned by the object and shall not be free&#39;d.</p>\n",
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_object_data-45"
+          "ex/HEAD/general.html#git_odb_object_data-45"
         ]
       }
     },
     "git_odb_object_size": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 482,
-      "lineto": 482,
+      "line": 483,
+      "lineto": 483,
       "args": [
         {
           "name": "object",
@@ -12573,22 +12364,22 @@
         "comment": " the size"
       },
       "description": "<p>Return the size of an ODB object</p>\n",
-      "comments": "<p>This is the real size of the <code>data</code> buffer, not the\n actual size of the object.</p>\n",
+      "comments": "<p>This is the real size of the <code>data</code> buffer, not the actual size of the object.</p>\n",
       "group": "odb",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_odb_object_size-25"
+          "ex/HEAD/cat-file.html#git_odb_object_size-23"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_object_size-46"
+          "ex/HEAD/general.html#git_odb_object_size-46"
         ]
       }
     },
     "git_odb_object_type": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 490,
-      "lineto": 490,
+      "line": 491,
+      "lineto": 491,
       "args": [
         {
           "name": "object",
@@ -12607,15 +12398,15 @@
       "group": "odb",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_odb_object_type-47"
+          "ex/HEAD/general.html#git_odb_object_type-47"
         ]
       }
     },
     "git_odb_add_backend": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 505,
-      "lineto": 505,
+      "line": 506,
+      "lineto": 506,
       "args": [
         {
           "name": "odb",
@@ -12640,14 +12431,14 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB</p>\n",
-      "comments": "<p>The backends are checked in relative ordering, based on the\n value of the <code>priority</code> parameter.</p>\n\n<p>Read \n<sys\n/odb_backend.h> for more information.</p>\n",
+      "comments": "<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_add_alternate": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 526,
-      "lineto": 526,
+      "line": 527,
+      "lineto": 527,
       "args": [
         {
           "name": "odb",
@@ -12672,14 +12463,14 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Add a custom backend to an existing Object DB; this\n backend will work as an alternate.</p>\n",
-      "comments": "<p>Alternate backends are always checked for objects <em>after</em>\n all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the\n value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read \n<sys\n/odb_backend.h> for more information.</p>\n",
+      "comments": "<p>Alternate backends are always checked for objects <em>after</em> all the main backends have been exhausted.</p>\n\n<p>The backends are checked in relative ordering, based on the value of the <code>priority</code> parameter.</p>\n\n<p>Writing is disabled on alternate backends.</p>\n\n<p>Read <sys/odb_backend.h> for more information.</p>\n",
       "group": "odb"
     },
     "git_odb_num_backends": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 534,
-      "lineto": 534,
+      "line": 535,
+      "lineto": 535,
       "args": [
         {
           "name": "odb",
@@ -12700,8 +12491,8 @@
     "git_odb_get_backend": {
       "type": "function",
       "file": "git2/odb.h",
-      "line": 544,
-      "lineto": 544,
+      "line": 545,
+      "lineto": 545,
       "args": [
         {
           "name": "out",
@@ -12732,8 +12523,8 @@
     "git_odb_backend_pack": {
       "type": "function",
       "file": "git2/odb_backend.h",
-      "line": 34,
-      "lineto": 34,
+      "line": 35,
+      "lineto": 35,
       "args": [
         {
           "name": "out",
@@ -12759,8 +12550,8 @@
     "git_odb_backend_loose": {
       "type": "function",
       "file": "git2/odb_backend.h",
-      "line": 48,
-      "lineto": 54,
+      "line": 49,
+      "lineto": 55,
       "args": [
         {
           "name": "out",
@@ -12806,8 +12597,8 @@
     "git_odb_backend_one_pack": {
       "type": "function",
       "file": "git2/odb_backend.h",
-      "line": 67,
-      "lineto": 67,
+      "line": 68,
+      "lineto": 68,
       "args": [
         {
           "name": "out",
@@ -12827,7 +12618,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a backend out of a single packfile</p>\n",
-      "comments": "<p>This can be useful for inspecting the contents of a single\n packfile.</p>\n",
+      "comments": "<p>This can be useful for inspecting the contents of a single packfile.</p>\n",
       "group": "odb"
     },
     "git_oid_fromstr": {
@@ -12858,14 +12649,14 @@
       "group": "oid",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_oid_fromstr-48",
-          "ex/v0.28.0/general.html#git_oid_fromstr-49",
-          "ex/v0.28.0/general.html#git_oid_fromstr-50",
-          "ex/v0.28.0/general.html#git_oid_fromstr-51",
-          "ex/v0.28.0/general.html#git_oid_fromstr-52",
-          "ex/v0.28.0/general.html#git_oid_fromstr-53",
-          "ex/v0.28.0/general.html#git_oid_fromstr-54",
-          "ex/v0.28.0/general.html#git_oid_fromstr-55"
+          "ex/HEAD/general.html#git_oid_fromstr-48",
+          "ex/HEAD/general.html#git_oid_fromstr-49",
+          "ex/HEAD/general.html#git_oid_fromstr-50",
+          "ex/HEAD/general.html#git_oid_fromstr-51",
+          "ex/HEAD/general.html#git_oid_fromstr-52",
+          "ex/HEAD/general.html#git_oid_fromstr-53",
+          "ex/HEAD/general.html#git_oid_fromstr-54",
+          "ex/HEAD/general.html#git_oid_fromstr-55"
         ]
       }
     },
@@ -12925,7 +12716,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Parse N characters of a hex formatted object id into a git_oid.</p>\n",
-      "comments": "<p>If N is odd, the last byte&#39;s high nibble will be read in and the\n low nibble set to zero.</p>\n",
+      "comments": "<p>If N is odd, the last byte&#39;s high nibble will be read in and the low nibble set to zero.</p>\n",
       "group": "oid"
     },
     "git_oid_fromraw": {
@@ -12982,20 +12773,20 @@
       "comments": "",
       "group": "oid",
       "examples": {
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_oid_fmt-1",
+          "ex/HEAD/fetch.html#git_oid_fmt-2"
+        ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_oid_fmt-56",
-          "ex/v0.28.0/general.html#git_oid_fmt-57",
-          "ex/v0.28.0/general.html#git_oid_fmt-58",
-          "ex/v0.28.0/general.html#git_oid_fmt-59",
-          "ex/v0.28.0/general.html#git_oid_fmt-60",
-          "ex/v0.28.0/general.html#git_oid_fmt-61"
+          "ex/HEAD/general.html#git_oid_fmt-56",
+          "ex/HEAD/general.html#git_oid_fmt-57",
+          "ex/HEAD/general.html#git_oid_fmt-58",
+          "ex/HEAD/general.html#git_oid_fmt-59",
+          "ex/HEAD/general.html#git_oid_fmt-60",
+          "ex/HEAD/general.html#git_oid_fmt-61"
         ],
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_oid_fmt-1",
-          "ex/v0.28.0/network/fetch.html#git_oid_fmt-2"
-        ],
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_oid_fmt-1"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_oid_fmt-1"
         ]
       }
     },
@@ -13055,7 +12846,7 @@
         "comment": null
       },
       "description": "<p>Format a git_oid into a loose-object path string.</p>\n",
-      "comments": "<p>The resulting string is &quot;aa/...&quot;, where &quot;aa&quot; is the first two\n hex digits of the oid and &quot;...&quot; is the remaining 38 digits.</p>\n",
+      "comments": "<p>The resulting string is &quot;aa/...&quot;, where &quot;aa&quot; is the first two hex digits of the oid and &quot;...&quot; is the remaining 38 digits.</p>\n",
       "group": "oid"
     },
     "git_oid_tostr_s": {
@@ -13077,12 +12868,12 @@
         "comment": " the c-string"
       },
       "description": "<p>Format a git_oid into a statically allocated c-string.</p>\n",
-      "comments": "<p>The c-string is owned by the library and should not be freed\n by the user. If libgit2 is built with thread support, the string\n will be stored in TLS (i.e. one buffer per thread) to allow for\n concurrent calls of the function.</p>\n",
+      "comments": "<p>The c-string is owned by the library and should not be freed by the user. If libgit2 is built with thread support, the string will be stored in TLS (i.e. one buffer per thread) to allow for concurrent calls of the function.</p>\n",
       "group": "oid",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_oid_tostr_s-21",
-          "ex/v0.28.0/merge.html#git_oid_tostr_s-22"
+          "ex/HEAD/merge.html#git_oid_tostr_s-19",
+          "ex/HEAD/merge.html#git_oid_tostr_s-20"
         ]
       }
     },
@@ -13115,29 +12906,29 @@
         "comment": " the out buffer pointer, assuming no input parameter\n\t\t\terrors, otherwise a pointer to an empty string."
       },
       "description": "<p>Format a git_oid into a buffer as a hex format c-string.</p>\n",
-      "comments": "<p>If the buffer is smaller than GIT_OID_HEXSZ+1, then the resulting\n oid c-string will be truncated to n-1 characters (but will still be\n NUL-byte terminated).</p>\n\n<p>If there are any input parameter errors (out == NULL, n == 0, oid ==\n NULL), then a pointer to an empty string is returned, so that the\n return value can always be printed.</p>\n",
+      "comments": "<p>If the buffer is smaller than GIT_OID_HEXSZ+1, then the resulting oid c-string will be truncated to n-1 characters (but will still be NUL-byte terminated).</p>\n\n<p>If there are any input parameter errors (out == NULL, n == 0, oid == NULL), then a pointer to an empty string is returned, so that the return value can always be printed.</p>\n",
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_oid_tostr-18",
-          "ex/v0.28.0/blame.html#git_oid_tostr-19"
+          "ex/HEAD/blame.html#git_oid_tostr-16",
+          "ex/HEAD/blame.html#git_oid_tostr-17"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_oid_tostr-26",
-          "ex/v0.28.0/cat-file.html#git_oid_tostr-27",
-          "ex/v0.28.0/cat-file.html#git_oid_tostr-28",
-          "ex/v0.28.0/cat-file.html#git_oid_tostr-29",
-          "ex/v0.28.0/cat-file.html#git_oid_tostr-30"
+          "ex/HEAD/cat-file.html#git_oid_tostr-24",
+          "ex/HEAD/cat-file.html#git_oid_tostr-25",
+          "ex/HEAD/cat-file.html#git_oid_tostr-26",
+          "ex/HEAD/cat-file.html#git_oid_tostr-27",
+          "ex/HEAD/cat-file.html#git_oid_tostr-28"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_oid_tostr-40",
-          "ex/v0.28.0/log.html#git_oid_tostr-41"
+          "ex/HEAD/log.html#git_oid_tostr-38",
+          "ex/HEAD/log.html#git_oid_tostr-39"
         ],
         "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_oid_tostr-12",
-          "ex/v0.28.0/rev-parse.html#git_oid_tostr-13",
-          "ex/v0.28.0/rev-parse.html#git_oid_tostr-14",
-          "ex/v0.28.0/rev-parse.html#git_oid_tostr-15"
+          "ex/HEAD/rev-parse.html#git_oid_tostr-10",
+          "ex/HEAD/rev-parse.html#git_oid_tostr-11",
+          "ex/HEAD/rev-parse.html#git_oid_tostr-12",
+          "ex/HEAD/rev-parse.html#git_oid_tostr-13"
         ]
       }
     },
@@ -13169,9 +12960,9 @@
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_oid_cpy-20",
-          "ex/v0.28.0/blame.html#git_oid_cpy-21",
-          "ex/v0.28.0/blame.html#git_oid_cpy-22"
+          "ex/HEAD/blame.html#git_oid_cpy-18",
+          "ex/HEAD/blame.html#git_oid_cpy-19",
+          "ex/HEAD/blame.html#git_oid_cpy-20"
         ]
       }
     },
@@ -13315,7 +13106,7 @@
       "comments": "",
       "group": "oid"
     },
-    "git_oid_iszero": {
+    "git_oid_is_zero": {
       "type": "function",
       "file": "git2/oid.h",
       "line": 210,
@@ -13338,10 +13129,10 @@
       "group": "oid",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_oid_iszero-23"
+          "ex/HEAD/blame.html#git_oid_is_zero-21"
         ],
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_oid_iszero-3"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_oid_is_zero-3"
         ]
       }
     },
@@ -13364,7 +13155,7 @@
         "comment": " a `git_oid_shorten` instance, NULL if OOM"
       },
       "description": "<p>Create a new OID shortener.</p>\n",
-      "comments": "<p>The OID shortener is used to process a list of OIDs\n in text form and return the shortest length that would\n uniquely identify all of them.</p>\n\n<p>E.g. look at the result of <code>git log --abbrev</code>.</p>\n",
+      "comments": "<p>The OID shortener is used to process a list of OIDs in text form and return the shortest length that would uniquely identify all of them.</p>\n\n<p>E.g. look at the result of <code>git log --abbrev</code>.</p>\n",
       "group": "oid"
     },
     "git_oid_shorten_add": {
@@ -13391,7 +13182,7 @@
         "comment": " the minimal length to uniquely identify all OIDs\n\t\tadded so far to the set; or an error code (\n<\n0) if an\n\t\terror occurs."
       },
       "description": "<p>Add a new OID to set of shortened OIDs and calculate\n the minimal length to uniquely identify all the OIDs in\n the set.</p>\n",
-      "comments": "<p>The OID is expected to be a 40-char hexadecimal string.\n The OID is owned by the user and will not be modified\n or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many\n OIDs can be added to a single set (around ~32000, assuming\n a mostly randomized distribution), which should be enough\n for any kind of program, and keeps the algorithm fast and\n memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a\n GIT_ERROR_INVALID error</p>\n",
+      "comments": "<p>The OID is expected to be a 40-char hexadecimal string. The OID is owned by the user and will not be modified or freed.</p>\n\n<p>For performance reasons, there is a hard-limit of how many OIDs can be added to a single set (around ~32000, assuming a mostly randomized distribution), which should be enough for any kind of program, and keeps the algorithm fast and memory-efficient.</p>\n\n<p>Attempting to add more than those OIDs will result in a GIT_ERROR_INVALID error</p>\n",
       "group": "oid"
     },
     "git_oid_shorten_free": {
@@ -13435,14 +13226,14 @@
         "comment": null
       },
       "description": "<p>Free the OID array</p>\n",
-      "comments": "<p>This method must (and must only) be called on <code>git_oidarray</code>\n objects where the array is allocated by the library. Not doing so,\n will result in a memory leak.</p>\n\n<p>This does not free the <code>git_oidarray</code> itself, since the library will\n never allocate that object directly itself (it is more commonly embedded\n inside another struct or created on the stack).</p>\n",
+      "comments": "<p>This method must (and must only) be called on <code>git_oidarray</code> objects where the array is allocated by the library. Not doing so, will result in a memory leak.</p>\n\n<p>This does not free the <code>git_oidarray</code> itself, since the library will never allocate that object directly itself (it is more commonly embedded inside another struct or created on the stack).</p>\n",
       "group": "oidarray"
     },
     "git_packbuilder_new": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 64,
-      "lineto": 64,
+      "line": 65,
+      "lineto": 65,
       "args": [
         {
           "name": "out",
@@ -13468,8 +13259,8 @@
     "git_packbuilder_set_threads": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 77,
-      "lineto": 77,
+      "line": 78,
+      "lineto": 78,
       "args": [
         {
           "name": "pb",
@@ -13489,14 +13280,14 @@
         "comment": " number of actual threads to be used"
       },
       "description": "<p>Set number of threads to spawn</p>\n",
-      "comments": "<p>By default, libgit2 won&#39;t spawn any threads at all;\n when set to 0, libgit2 will autodetect the number of\n CPUs.</p>\n",
+      "comments": "<p>By default, libgit2 won&#39;t spawn any threads at all; when set to 0, libgit2 will autodetect the number of CPUs.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 91,
-      "lineto": 91,
+      "line": 92,
+      "lineto": 92,
       "args": [
         {
           "name": "pb",
@@ -13521,14 +13312,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Insert a single object</p>\n",
-      "comments": "<p>For an optimal pack it&#39;s mandatory to insert objects in recency order,\n commits followed by trees and blobs.</p>\n",
+      "comments": "<p>For an optimal pack it&#39;s mandatory to insert objects in recency order, commits followed by trees and blobs.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert_tree": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 103,
-      "lineto": 103,
+      "line": 104,
+      "lineto": 104,
       "args": [
         {
           "name": "pb",
@@ -13554,8 +13345,8 @@
     "git_packbuilder_insert_commit": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 115,
-      "lineto": 115,
+      "line": 116,
+      "lineto": 116,
       "args": [
         {
           "name": "pb",
@@ -13581,8 +13372,8 @@
     "git_packbuilder_insert_walk": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 128,
-      "lineto": 128,
+      "line": 129,
+      "lineto": 129,
       "args": [
         {
           "name": "pb",
@@ -13602,14 +13393,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Insert objects as given by the walk</p>\n",
-      "comments": "<p>Those commits and all objects they reference will be inserted into\n the packbuilder.</p>\n",
+      "comments": "<p>Those commits and all objects they reference will be inserted into the packbuilder.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_insert_recur": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 140,
-      "lineto": 140,
+      "line": 141,
+      "lineto": 141,
       "args": [
         {
           "name": "pb",
@@ -13640,8 +13431,8 @@
     "git_packbuilder_write_buf": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 151,
-      "lineto": 151,
+      "line": 152,
+      "lineto": 152,
       "args": [
         {
           "name": "buf",
@@ -13661,14 +13452,14 @@
         "comment": null
       },
       "description": "<p>Write the contents of the packfile to an in-memory buffer</p>\n",
-      "comments": "<p>The contents of the buffer will become a valid packfile, even though there\n will be no attached index</p>\n",
+      "comments": "<p>The contents of the buffer will become a valid packfile, even though there will be no attached index</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_write": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 164,
-      "lineto": 169,
+      "line": 165,
+      "lineto": 170,
       "args": [
         {
           "name": "pb",
@@ -13687,7 +13478,7 @@
         },
         {
           "name": "progress_cb",
-          "type": "git_transfer_progress_cb",
+          "type": "git_indexer_progress_cb",
           "comment": "function to call with progress information from the indexer (optional)"
         },
         {
@@ -13696,8 +13487,8 @@
           "comment": "payload for the progress callback (optional)"
         }
       ],
-      "argline": "git_packbuilder *pb, const char *path, unsigned int mode, git_transfer_progress_cb progress_cb, void *progress_cb_payload",
-      "sig": "git_packbuilder *::const char *::unsigned int::git_transfer_progress_cb::void *",
+      "argline": "git_packbuilder *pb, const char *path, unsigned int mode, git_indexer_progress_cb progress_cb, void *progress_cb_payload",
+      "sig": "git_packbuilder *::const char *::unsigned int::git_indexer_progress_cb::void *",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
@@ -13709,8 +13500,8 @@
     "git_packbuilder_hash": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 179,
-      "lineto": 179,
+      "line": 180,
+      "lineto": 180,
       "args": [
         {
           "name": "pb",
@@ -13725,14 +13516,14 @@
         "comment": null
       },
       "description": "<p>Get the packfile&#39;s hash</p>\n",
-      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object\n names. This is only correct after the packfile has been written.</p>\n",
+      "comments": "<p>A packfile&#39;s name is derived from the sorted hashing of all object names. This is only correct after the packfile has been written.</p>\n",
       "group": "packbuilder"
     },
     "git_packbuilder_foreach": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 191,
-      "lineto": 191,
+      "line": 202,
+      "lineto": 202,
       "args": [
         {
           "name": "pb",
@@ -13763,8 +13554,8 @@
     "git_packbuilder_object_count": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 199,
-      "lineto": 199,
+      "line": 210,
+      "lineto": 210,
       "args": [
         {
           "name": "pb",
@@ -13785,8 +13576,8 @@
     "git_packbuilder_written": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 207,
-      "lineto": 207,
+      "line": 218,
+      "lineto": 218,
       "args": [
         {
           "name": "pb",
@@ -13807,8 +13598,8 @@
     "git_packbuilder_set_callbacks": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 226,
-      "lineto": 229,
+      "line": 237,
+      "lineto": 240,
       "args": [
         {
           "name": "pb",
@@ -13839,8 +13630,8 @@
     "git_packbuilder_free": {
       "type": "function",
       "file": "git2/pack.h",
-      "line": 236,
-      "lineto": 236,
+      "line": 247,
+      "lineto": 247,
       "args": [
         {
           "name": "pb",
@@ -13887,7 +13678,7 @@
         "comment": " 0 on success, other value \n<\n 0 on error"
       },
       "description": "<p>Return a patch for an entry in the diff list.</p>\n",
-      "comments": "<p>The <code>git_patch</code> is a newly created object contains the text diffs\n for the delta.  You have to call <code>git_patch_free()</code> when you are\n done with it.  You can use the patch object to loop over all the hunks\n and lines in the diff of the one delta.</p>\n\n<p>For an unchanged file or a binary file, no <code>git_patch</code> will be\n created, the output will be set to NULL, and the <code>binary</code> flag will be\n set true in the <code>git_diff_delta</code> structure.</p>\n\n<p>It is okay to pass NULL for either of the output parameters; if you pass\n NULL for the <code>git_patch</code>, then the text diff will not be calculated.</p>\n",
+      "comments": "<p>The <code>git_patch</code> is a newly created object contains the text diffs for the delta.  You have to call <code>git_patch_free()</code> when you are done with it.  You can use the patch object to loop over all the hunks and lines in the diff of the one delta.</p>\n\n<p>For an unchanged file or a binary file, no <code>git_patch</code> will be created, the output will be set to NULL, and the <code>binary</code> flag will be set true in the <code>git_diff_delta</code> structure.</p>\n\n<p>It is okay to pass NULL for either of the output parameters; if you pass NULL for the <code>git_patch</code>, then the text diff will not be calculated.</p>\n",
       "group": "patch"
     },
     "git_patch_from_blobs": {
@@ -13934,7 +13725,7 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between two blobs.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_blobs()</code> except it generates a patch object\n for the difference instead of directly making callbacks.  You can use the\n standard <code>git_patch</code> accessor functions to read the patch data, and\n you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_blobs()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_from_blob_and_buffer": {
@@ -13986,7 +13777,7 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between a blob and a buffer.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_blob_to_buffer()</code> except it generates a patch\n object for the difference instead of directly making callbacks.  You can\n use the standard <code>git_patch</code> accessor functions to read the patch\n data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_blob_to_buffer()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_from_buffers": {
@@ -14043,7 +13834,7 @@
         "comment": " 0 on success or error code \n<\n 0"
       },
       "description": "<p>Directly generate a patch from the difference between two buffers.</p>\n",
-      "comments": "<p>This is just like <code>git_diff_buffers()</code> except it generates a patch\n object for the difference instead of directly making callbacks.  You can\n use the standard <code>git_patch</code> accessor functions to read the patch\n data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
+      "comments": "<p>This is just like <code>git_diff_buffers()</code> except it generates a patch object for the difference instead of directly making callbacks.  You can use the standard <code>git_patch</code> accessor functions to read the patch data, and you must call <code>git_patch_free()</code> on the patch when done.</p>\n",
       "group": "patch"
     },
     "git_patch_free": {
@@ -14146,7 +13937,7 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get line counts of each type in a patch.</p>\n",
-      "comments": "<p>This helps imitate a diff --numstat type of output.  For that purpose,\n you only need the <code>total_additions</code> and <code>total_deletions</code> values, but we\n include the <code>total_context</code> line count in case you want the total number\n of lines of diff output that will be generated.</p>\n\n<p>All outputs are optional. Pass NULL if you don&#39;t need a particular count.</p>\n",
+      "comments": "<p>This helps imitate a diff --numstat type of output.  For that purpose, you only need the <code>total_additions</code> and <code>total_deletions</code> values, but we include the <code>total_context</code> line count in case you want the total number of lines of diff output that will be generated.</p>\n\n<p>All outputs are optional. Pass NULL if you don&#39;t need a particular count.</p>\n",
       "group": "patch"
     },
     "git_patch_get_hunk": {
@@ -14183,7 +13974,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if hunk_idx out of range, \n<\n0 on error"
       },
       "description": "<p>Get the information about a hunk in a patch</p>\n",
-      "comments": "<p>Given a patch and a hunk index into the patch, this returns detailed\n information about that hunk.  Any of the output pointers can be passed\n as NULL if you don&#39;t care about that particular piece of information.</p>\n",
+      "comments": "<p>Given a patch and a hunk index into the patch, this returns detailed information about that hunk.  Any of the output pointers can be passed as NULL if you don&#39;t care about that particular piece of information.</p>\n",
       "group": "patch"
     },
     "git_patch_num_lines_in_hunk": {
@@ -14247,7 +14038,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Get data about a line in a hunk of a patch.</p>\n",
-      "comments": "<p>Given a patch, a hunk index, and a line index in the hunk, this\n will return a lot of details about that line.  If you pass a hunk\n index larger than the number of hunks or a line index larger than\n the number of lines in the hunk, this will return -1.</p>\n",
+      "comments": "<p>Given a patch, a hunk index, and a line index in the hunk, this will return a lot of details about that line.  If you pass a hunk index larger than the number of hunks or a line index larger than the number of lines in the hunk, this will return -1.</p>\n",
       "group": "patch"
     },
     "git_patch_size": {
@@ -14284,7 +14075,7 @@
         "comment": " The number of bytes of data"
       },
       "description": "<p>Look up size of patch diff data in bytes</p>\n",
-      "comments": "<p>This returns the raw size of the patch data.  This only includes the\n actual data from the lines of the diff, not the file or hunk headers.</p>\n\n<p>If you pass <code>include_context</code> as true (non-zero), this will be the size\n of all of the diff output; if you pass it as false (zero), this will\n only include the actual changed lines (as if <code>context_lines</code> was 0).</p>\n",
+      "comments": "<p>This returns the raw size of the patch data.  This only includes the actual data from the lines of the diff, not the file or hunk headers.</p>\n\n<p>If you pass <code>include_context</code> as true (non-zero), this will be the size of all of the diff output; if you pass it as false (zero), this will only include the actual changed lines (as if <code>context_lines</code> was 0).</p>\n",
       "group": "patch"
     },
     "git_patch_print": {
@@ -14316,7 +14107,7 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Serialize the patch to text via callback.</p>\n",
-      "comments": "<p>Returning a non-zero value from the callback will terminate the iteration\n and return that value to the caller.</p>\n",
+      "comments": "<p>Returning a non-zero value from the callback will terminate the iteration and return that value to the caller.</p>\n",
       "group": "patch"
     },
     "git_patch_to_buf": {
@@ -14374,7 +14165,7 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_pathspec_new-42"
+          "ex/HEAD/log.html#git_pathspec_new-40"
         ]
       }
     },
@@ -14401,7 +14192,7 @@
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_pathspec_free-43"
+          "ex/HEAD/log.html#git_pathspec_free-41"
         ]
       }
     },
@@ -14414,27 +14205,27 @@
         {
           "name": "ps",
           "type": "const git_pathspec *",
-          "comment": null
+          "comment": "The compiled pathspec"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of git_pathspec_flag_t options to control match"
         },
         {
           "name": "path",
           "type": "const char *",
-          "comment": null
+          "comment": "The pathname to attempt to match"
         }
       ],
-      "argline": "const git_pathspec *ps, int flags, const char *path",
-      "sig": "const git_pathspec *::int::const char *",
+      "argline": "const git_pathspec *ps, uint32_t flags, const char *path",
+      "sig": "const git_pathspec *::uint32_t::const char *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 1 is path matches spec, 0 if it does not"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Try to match a path against a pathspec</p>\n",
+      "comments": "<p>Unlike most of the other pathspec matching functions, this will not fall back on the native case-sensitivity for your platform.  You must explicitly pass flags to control case sensitivity or else this will fall back on being case sensitive.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_workdir": {
@@ -14446,32 +14237,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": null
+          "comment": "Output list of matches; pass NULL to just get return value"
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "The repository in which to match; bare repo is an error"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of git_pathspec_flag_t options to control match"
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": null
+          "comment": "Pathspec to be matched"
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_repository *repo, int flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_repository *::int::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_repository *repo, uint32_t flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_repository *::uint32_t::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag was given"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Match a pathspec against the working directory of a repository.</p>\n",
+      "comments": "<p>This matches the pathspec against the current files in the working directory of the repository.  It is an error to invoke this on a bare repo.  This handles git ignores (i.e. ignored files will not be considered to match the <code>pathspec</code> unless the file is tracked in the index).</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_index": {
@@ -14483,32 +14274,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": null
+          "comment": "Output list of matches; pass NULL to just get return value"
         },
         {
           "name": "index",
           "type": "git_index *",
-          "comment": null
+          "comment": "The index to match against"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of git_pathspec_flag_t options to control match"
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": null
+          "comment": "Pathspec to be matched"
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_index *index, int flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_index *::int::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_index *index, uint32_t flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_index *::uint32_t::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Match a pathspec against entries in an index.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the repository index.</p>\n\n<p>NOTE: At the moment, the case sensitivity of this match is controlled by the current case-sensitivity of the index object itself and the USE_CASE and IGNORE_CASE flags will have no effect.  This behavior will be corrected in a future release.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_tree": {
@@ -14520,36 +14311,36 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": null
+          "comment": "Output list of matches; pass NULL to just get return value"
         },
         {
           "name": "tree",
           "type": "git_tree *",
-          "comment": null
+          "comment": "The root-level tree to match against"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of git_pathspec_flag_t options to control match"
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": null
+          "comment": "Pathspec to be matched"
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_tree *tree, int flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_tree *::int::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_tree *tree, uint32_t flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_tree *::uint32_t::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Match a pathspec against files in a tree.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the given tree.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_pathspec_match_tree-44"
+          "ex/HEAD/log.html#git_pathspec_match_tree-42"
         ]
       }
     },
@@ -14562,32 +14353,32 @@
         {
           "name": "out",
           "type": "git_pathspec_match_list **",
-          "comment": null
+          "comment": "Output list of matches; pass NULL to just get return value"
         },
         {
           "name": "diff",
           "type": "git_diff *",
-          "comment": null
+          "comment": "A generated diff list"
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Combination of git_pathspec_flag_t options to control match"
         },
         {
           "name": "ps",
           "type": "git_pathspec *",
-          "comment": null
+          "comment": "Pathspec to be matched"
         }
       ],
-      "argline": "git_pathspec_match_list **out, git_diff *diff, int flags, git_pathspec *ps",
-      "sig": "git_pathspec_match_list **::git_diff *::int::git_pathspec *",
+      "argline": "git_pathspec_match_list **out, git_diff *diff, uint32_t flags, git_pathspec *ps",
+      "sig": "git_pathspec_match_list **::git_diff *::uint32_t::git_pathspec *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, -1 on error, GIT_ENOTFOUND if no matches and\n         the GIT_PATHSPEC_NO_MATCH_ERROR flag is used"
       },
-      "description": "",
-      "comments": "",
+      "description": "<p>Match a pathspec against files in a diff list.</p>\n",
+      "comments": "<p>This matches the pathspec against the files in the given diff list.</p>\n\n<p>If <code>out</code> is not NULL, this returns a <code>git_patchspec_match_list</code>.  That contains the list of all matched filenames (unless you pass the <code>GIT_PATHSPEC_FAILURES_ONLY</code> flag) and may also contain the list of pathspecs with no match (if you used the <code>GIT_PATHSPEC_FIND_FAILURES</code> flag).  You must call <code>git_pathspec_match_list_free()</code> on this object.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_free": {
@@ -14658,7 +14449,7 @@
         "comment": " The filename of the match"
       },
       "description": "<p>Get a matching filename by position.</p>\n",
-      "comments": "<p>This routine cannot be used if the match list was generated by\n <code>git_pathspec_match_diff</code>.  If so, it will always return NULL.</p>\n",
+      "comments": "<p>This routine cannot be used if the match list was generated by <code>git_pathspec_match_diff</code>.  If so, it will always return NULL.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_diff_entry": {
@@ -14685,7 +14476,7 @@
         "comment": " The filename of the match"
       },
       "description": "<p>Get a matching diff delta by position.</p>\n",
-      "comments": "<p>This routine can only be used if the match list was generated by\n <code>git_pathspec_match_diff</code>.  Otherwise it will always return NULL.</p>\n",
+      "comments": "<p>This routine can only be used if the match list was generated by <code>git_pathspec_match_diff</code>.  Otherwise it will always return NULL.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_failed_entrycount": {
@@ -14707,7 +14498,7 @@
         "comment": " Number of items in original pathspec that had no matches"
       },
       "description": "<p>Get the number of pathspec items that did not match.</p>\n",
-      "comments": "<p>This will be zero unless you passed GIT_PATHSPEC_FIND_FAILURES when\n generating the git_pathspec_match_list.</p>\n",
+      "comments": "<p>This will be zero unless you passed GIT_PATHSPEC_FIND_FAILURES when generating the git_pathspec_match_list.</p>\n",
       "group": "pathspec"
     },
     "git_pathspec_match_list_failed_entry": {
@@ -14737,7 +14528,7 @@
       "comments": "<p>This will be return NULL for positions out of range.</p>\n",
       "group": "pathspec"
     },
-    "git_proxy_init_options": {
+    "git_proxy_options_init": {
       "type": "function",
       "file": "git2/proxy.h",
       "line": 92,
@@ -14761,10 +14552,10 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_proxy_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_proxy_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_PROXY_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_proxy_options</code> with default values. Equivalent to creating an instance with <code>GIT_PROXY_OPTIONS_INIT</code>.</p>\n",
       "group": "proxy"
     },
-    "git_rebase_init_options": {
+    "git_rebase_options_init": {
       "type": "function",
       "file": "git2/rebase.h",
       "line": 159,
@@ -14788,7 +14579,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_rebase_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_rebase_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REBASE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_rebase_options</code> with default values. Equivalent to creating an instance with <code>GIT_REBASE_OPTIONS_INIT</code>.</p>\n",
       "group": "rebase"
     },
     "git_rebase_init": {
@@ -14870,11 +14661,99 @@
       "comments": "",
       "group": "rebase"
     },
+    "git_rebase_orig_head_name": {
+      "type": "function",
+      "file": "git2/rebase.h",
+      "line": 207,
+      "lineto": 207,
+      "args": [
+        {
+          "name": "rebase",
+          "type": "git_rebase *",
+          "comment": null
+        }
+      ],
+      "argline": "git_rebase *rebase",
+      "sig": "git_rebase *",
+      "return": {
+        "type": "const char *",
+        "comment": " The original `HEAD` ref name"
+      },
+      "description": "<p>Gets the original <code>HEAD</code> ref name for merge rebases.</p>\n",
+      "comments": "",
+      "group": "rebase"
+    },
+    "git_rebase_orig_head_id": {
+      "type": "function",
+      "file": "git2/rebase.h",
+      "line": 214,
+      "lineto": 214,
+      "args": [
+        {
+          "name": "rebase",
+          "type": "git_rebase *",
+          "comment": null
+        }
+      ],
+      "argline": "git_rebase *rebase",
+      "sig": "git_rebase *",
+      "return": {
+        "type": "const git_oid *",
+        "comment": " The original `HEAD` id"
+      },
+      "description": "<p>Gets the original <code>HEAD</code> id for merge rebases.</p>\n",
+      "comments": "",
+      "group": "rebase"
+    },
+    "git_rebase_onto_name": {
+      "type": "function",
+      "file": "git2/rebase.h",
+      "line": 221,
+      "lineto": 221,
+      "args": [
+        {
+          "name": "rebase",
+          "type": "git_rebase *",
+          "comment": null
+        }
+      ],
+      "argline": "git_rebase *rebase",
+      "sig": "git_rebase *",
+      "return": {
+        "type": "const char *",
+        "comment": " The `onto` ref name"
+      },
+      "description": "<p>Gets the <code>onto</code> ref name for merge rebases.</p>\n",
+      "comments": "",
+      "group": "rebase"
+    },
+    "git_rebase_onto_id": {
+      "type": "function",
+      "file": "git2/rebase.h",
+      "line": 228,
+      "lineto": 228,
+      "args": [
+        {
+          "name": "rebase",
+          "type": "git_rebase *",
+          "comment": null
+        }
+      ],
+      "argline": "git_rebase *rebase",
+      "sig": "git_rebase *",
+      "return": {
+        "type": "const git_oid *",
+        "comment": " The `onto` id"
+      },
+      "description": "<p>Gets the <code>onto</code> id for merge rebases.</p>\n",
+      "comments": "",
+      "group": "rebase"
+    },
     "git_rebase_operation_entrycount": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 208,
-      "lineto": 208,
+      "line": 236,
+      "lineto": 236,
       "args": [
         {
           "name": "rebase",
@@ -14895,8 +14774,8 @@
     "git_rebase_operation_current": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 219,
-      "lineto": 219,
+      "line": 247,
+      "lineto": 247,
       "args": [
         {
           "name": "rebase",
@@ -14917,8 +14796,8 @@
     "git_rebase_operation_byindex": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 228,
-      "lineto": 230,
+      "line": 256,
+      "lineto": 258,
       "args": [
         {
           "name": "rebase",
@@ -14944,8 +14823,8 @@
     "git_rebase_next": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 243,
-      "lineto": 245,
+      "line": 271,
+      "lineto": 273,
       "args": [
         {
           "name": "operation",
@@ -14971,8 +14850,8 @@
     "git_rebase_inmemory_index": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 258,
-      "lineto": 260,
+      "line": 286,
+      "lineto": 288,
       "args": [
         {
           "name": "index",
@@ -14992,14 +14871,14 @@
         "comment": null
       },
       "description": "<p>Gets the index produced by the last operation, which is the result\n of <code>git_rebase_next</code> and which will be committed by the next\n invocation of <code>git_rebase_commit</code>.  This is useful for resolving\n conflicts in an in-memory rebase before committing them.  You must\n call <code>git_index_free</code> when you are finished with this.</p>\n",
-      "comments": "<p>This is only applicable for in-memory rebases; for rebases within\n a working directory, the changes were applied to the repository&#39;s\n index.</p>\n",
+      "comments": "<p>This is only applicable for in-memory rebases; for rebases within a working directory, the changes were applied to the repository&#39;s index.</p>\n",
       "group": "rebase"
     },
     "git_rebase_commit": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 284,
-      "lineto": 290,
+      "line": 312,
+      "lineto": 318,
       "args": [
         {
           "name": "id",
@@ -15045,8 +14924,8 @@
     "git_rebase_abort": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 300,
-      "lineto": 300,
+      "line": 328,
+      "lineto": 328,
       "args": [
         {
           "name": "rebase",
@@ -15067,8 +14946,8 @@
     "git_rebase_finish": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 310,
-      "lineto": 312,
+      "line": 338,
+      "lineto": 340,
       "args": [
         {
           "name": "rebase",
@@ -15094,8 +14973,8 @@
     "git_rebase_free": {
       "type": "function",
       "file": "git2/rebase.h",
-      "line": 319,
-      "lineto": 319,
+      "line": 347,
+      "lineto": 347,
       "args": [
         {
           "name": "rebase",
@@ -15137,7 +15016,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new reference database with no backends.</p>\n",
-      "comments": "<p>Before the Ref DB can be used for read/writing, a custom database\n backend must be manually set using <code>git_refdb_set_backend()</code></p>\n",
+      "comments": "<p>Before the Ref DB can be used for read/writing, a custom database backend must be manually set using <code>git_refdb_set_backend()</code></p>\n",
       "group": "refdb"
     },
     "git_refdb_open": {
@@ -15164,7 +15043,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new reference database and automatically add\n the default backends:</p>\n",
-      "comments": "<ul>\n<li>git_refdb_dir: read and write loose and packed refs\n  from disk, assuming the repository dir as the folder</li>\n</ul>\n",
+      "comments": "<ul>\n<li>git_refdb_dir: read and write loose and packed refs      from disk, assuming the repository dir as the folder</li>\n</ul>\n",
       "group": "refdb"
     },
     "git_refdb_compress": {
@@ -15240,7 +15119,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Read the reflog for the given reference</p>\n",
-      "comments": "<p>If there is no reflog file for the given\n reference yet, an empty reflog object will\n be returned.</p>\n\n<p>The reflog must be freed manually by using\n git_reflog_free().</p>\n",
+      "comments": "<p>If there is no reflog file for the given reference yet, an empty reflog object will be returned.</p>\n\n<p>The reflog must be freed manually by using git_reflog_free().</p>\n",
       "group": "reflog"
     },
     "git_reflog_write": {
@@ -15331,7 +15210,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Rename a reflog</p>\n",
-      "comments": "<p>The reflog to be renamed is expected to already exist</p>\n\n<p>The new name will be checked for validity.\n See <code>git_reference_create_symbolic()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The reflog to be renamed is expected to already exist</p>\n\n<p>The new name will be checked for validity. See <code>git_reference_create_symbolic()</code> for rules about valid names.</p>\n",
       "group": "reflog"
     },
     "git_reflog_delete": {
@@ -15407,7 +15286,7 @@
         "comment": " the entry; NULL if not found"
       },
       "description": "<p>Lookup an entry by its index</p>\n",
-      "comments": "<p>Requesting the reflog entry with an index of 0 (zero) will\n return the most recently created entry.</p>\n",
+      "comments": "<p>Requesting the reflog entry with an index of 0 (zero) will return the most recently created entry.</p>\n",
       "group": "reflog"
     },
     "git_reflog_drop": {
@@ -15439,7 +15318,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the entry doesn't exist\n or an error code."
       },
       "description": "<p>Remove an entry from the reflog by its index</p>\n",
-      "comments": "<p>To ensure there&#39;s no gap in the log history, set <code>rewrite_previous_entry</code>\n param value to 1. When deleting entry <code>n</code>, member old_oid of entry <code>n-1</code>\n (if any) will be updated with the value of member new_oid of entry <code>n+1</code>.</p>\n",
+      "comments": "<p>To ensure there&#39;s no gap in the log history, set <code>rewrite_previous_entry</code> param value to 1. When deleting entry <code>n</code>, member old_oid of entry <code>n-1</code> (if any) will be updated with the value of member new_oid of entry <code>n+1</code>.</p>\n",
       "group": "reflog"
     },
     "git_reflog_entry_id_old": {
@@ -15581,14 +15460,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Lookup a reference by name in a repository.</p>\n",
-      "comments": "<p>The returned reference must be freed by the user.</p>\n\n<p>The name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The returned reference must be freed by the user.</p>\n\n<p>The name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_lookup-62"
+          "ex/HEAD/general.html#git_reference_lookup-62"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_lookup-23"
+          "ex/HEAD/merge.html#git_reference_lookup-21"
         ]
       }
     },
@@ -15621,7 +15500,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code."
       },
       "description": "<p>Lookup a reference by name and resolve immediately to OID.</p>\n",
-      "comments": "<p>This function provides a quick way to resolve a reference name straight\n through to the object id that it refers to.  This avoids having to\n allocate or free any <code>git_reference</code> objects for simple situations.</p>\n\n<p>The name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>This function provides a quick way to resolve a reference name straight through to the object id that it refers to.  This avoids having to allocate or free any <code>git_reference</code> objects for simple situations.</p>\n\n<p>The name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference"
     },
     "git_reference_dwim": {
@@ -15653,11 +15532,11 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Lookup a reference by DWIMing its short name</p>\n",
-      "comments": "<p>Apply the git precendence rules to the given shorthand to determine\n which reference the user is referring to.</p>\n",
+      "comments": "<p>Apply the git precendence rules to the given shorthand to determine which reference the user is referring to.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_dwim-24"
+          "ex/HEAD/merge.html#git_reference_dwim-22"
         ]
       }
     },
@@ -15710,7 +15589,7 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC, GIT_EMODIFIED or an error code"
       },
       "description": "<p>Conditionally create a new symbolic reference.</p>\n",
-      "comments": "<p>A symbolic reference is a reference name that refers to another\n reference name.  If the other name moves, the symbolic name will move,\n too.  As a simple example, the &quot;HEAD&quot; reference might refer to\n &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time\n of updating does not match the one passed through <code>current_value</code>\n (i.e. if the ref has changed since the user read it).</p>\n",
+      "comments": "<p>A symbolic reference is a reference name that refers to another reference name.  If the other name moves, the symbolic name will move, too.  As a simple example, the &quot;HEAD&quot; reference might refer to &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time of updating does not match the one passed through <code>current_value</code> (i.e. if the ref has changed since the user read it).</p>\n",
       "group": "reference"
     },
     "git_reference_symbolic_create": {
@@ -15757,7 +15636,7 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new symbolic reference.</p>\n",
-      "comments": "<p>A symbolic reference is a reference name that refers to another\n reference name.  If the other name moves, the symbolic name will move,\n too.  As a simple example, the &quot;HEAD&quot; reference might refer to\n &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and it does not have a reflog.</p>\n",
+      "comments": "<p>A symbolic reference is a reference name that refers to another reference name.  If the other name moves, the symbolic name will move, too.  As a simple example, the &quot;HEAD&quot; reference might refer to &quot;refs/heads/master&quot; while on the &quot;master&quot; branch of a repository.</p>\n\n<p>The symbolic reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and it does not have a reflog.</p>\n",
       "group": "reference"
     },
     "git_reference_create": {
@@ -15804,11 +15683,11 @@
         "comment": " 0 on success, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new direct reference.</p>\n",
-      "comments": "<p>A direct reference (also called an object id reference) refers directly\n to a specific object id (a.k.a. OID or SHA) in the repository.  The id\n permanently refers to the object (although the reference itself can be\n moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot;\n refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n",
+      "comments": "<p>A direct reference (also called an object id reference) refers directly to a specific object id (a.k.a. OID or SHA) in the repository.  The id permanently refers to the object (although the reference itself can be moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot; refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_create-25"
+          "ex/HEAD/merge.html#git_reference_create-23"
         ]
       }
     },
@@ -15861,7 +15740,7 @@
         "comment": " 0 on success, GIT_EMODIFIED if the value of the reference\n has changed, GIT_EEXISTS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Conditionally create new direct reference</p>\n",
-      "comments": "<p>A direct reference (also called an object id reference) refers directly\n to a specific object id (a.k.a. OID or SHA) in the repository.  The id\n permanently refers to the object (although the reference itself can be\n moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot;\n refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to\n the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the\n given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time\n of updating does not match the one passed through <code>current_id</code>\n (i.e. if the ref has changed since the user read it).</p>\n",
+      "comments": "<p>A direct reference (also called an object id reference) refers directly to a specific object id (a.k.a. OID or SHA) in the repository.  The id permanently refers to the object (although the reference itself can be moved).  For example, in libgit2 the direct ref &quot;refs/tags/v0.17.0&quot; refers to OID 5b9fac39d8a76b9139667c26a63e6b3f204b3977.</p>\n\n<p>The direct reference will be created in the repository and written to the disk.  The generated reference object must be freed by the user.</p>\n\n<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n\n<p>This function will return an error if a reference already exists with the given name unless <code>force</code> is true, in which case it will be overwritten.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n\n<p>It will return GIT_EMODIFIED if the reference&#39;s value at the time of updating does not match the one passed through <code>current_id</code> (i.e. if the ref has changed since the user read it).</p>\n",
       "group": "reference"
     },
     "git_reference_target": {
@@ -15883,11 +15762,11 @@
         "comment": " a pointer to the oid if available, NULL otherwise"
       },
       "description": "<p>Get the OID pointed to by a direct reference.</p>\n",
-      "comments": "<p>Only available if the reference is direct (i.e. an object id reference,\n not a symbolic one).</p>\n\n<p>To find the OID of a symbolic ref, call <code>git_reference_resolve()</code> and\n then this function (or maybe use <code>git_reference_name_to_id()</code> to\n directly resolve a reference name all the way through to an OID).</p>\n",
+      "comments": "<p>Only available if the reference is direct (i.e. an object id reference, not a symbolic one).</p>\n\n<p>To find the OID of a symbolic ref, call <code>git_reference_resolve()</code> and then this function (or maybe use <code>git_reference_name_to_id()</code> to directly resolve a reference name all the way through to an OID).</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_target-63"
+          "ex/HEAD/general.html#git_reference_target-63"
         ]
       }
     },
@@ -15910,7 +15789,7 @@
         "comment": " a pointer to the oid if available, NULL otherwise"
       },
       "description": "<p>Return the peeled OID target of this reference.</p>\n",
-      "comments": "<p>This peeled OID only applies to direct references that point to\n a hard Tag object: it is the result of peeling such Tag.</p>\n",
+      "comments": "<p>This peeled OID only applies to direct references that point to a hard Tag object: it is the result of peeling such Tag.</p>\n",
       "group": "reference"
     },
     "git_reference_symbolic_target": {
@@ -15936,10 +15815,10 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_symbolic_target-64"
+          "ex/HEAD/general.html#git_reference_symbolic_target-64"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_symbolic_target-26"
+          "ex/HEAD/merge.html#git_reference_symbolic_target-24"
         ]
       }
     },
@@ -15966,7 +15845,7 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_type-65"
+          "ex/HEAD/general.html#git_reference_type-65"
         ]
       }
     },
@@ -15993,7 +15872,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_name-27"
+          "ex/HEAD/merge.html#git_reference_name-25"
         ]
       }
     },
@@ -16021,7 +15900,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Resolve a symbolic reference to a direct reference.</p>\n",
-      "comments": "<p>This method iteratively peels a symbolic reference until it resolves to\n a direct reference to an OID.</p>\n\n<p>The peeled reference is returned in the <code>resolved_ref</code> argument, and\n must be freed manually once it&#39;s no longer needed.</p>\n\n<p>If a direct reference is passed as an argument, a copy of that\n reference is returned. This copy must be manually freed too.</p>\n",
+      "comments": "<p>This method iteratively peels a symbolic reference until it resolves to a direct reference to an OID.</p>\n\n<p>The peeled reference is returned in the <code>resolved_ref</code> argument, and must be freed manually once it&#39;s no longer needed.</p>\n\n<p>If a direct reference is passed as an argument, a copy of that reference is returned. This copy must be manually freed too.</p>\n",
       "group": "reference"
     },
     "git_reference_owner": {
@@ -16080,7 +15959,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Create a new reference with the same name as the given reference but a\n different symbolic target. The reference must be a symbolic reference,\n otherwise this will fail.</p>\n",
-      "comments": "<p>The new reference will be written to disk, overwriting the given reference.</p>\n\n<p>The target name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>The message for the reflog will be ignored if the reference does\n not belong in the standard set (HEAD, branches and remote-tracking\n branches) and and it does not have a reflog.</p>\n",
+      "comments": "<p>The new reference will be written to disk, overwriting the given reference.</p>\n\n<p>The target name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>The message for the reflog will be ignored if the reference does not belong in the standard set (HEAD, branches and remote-tracking branches) and and it does not have a reflog.</p>\n",
       "group": "reference"
     },
     "git_reference_set_target": {
@@ -16121,7 +16000,7 @@
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_set_target-28"
+          "ex/HEAD/merge.html#git_reference_set_target-26"
         ]
       }
     },
@@ -16164,7 +16043,7 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>Rename an existing reference.</p>\n",
-      "comments": "<p>This method works for both direct and symbolic references.</p>\n\n<p>The new name will be checked for validity.\n See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>If the <code>force</code> flag is not enabled, and there&#39;s already\n a reference with the given name, the renaming will fail.</p>\n\n<p>IMPORTANT:\n The user needs to write a proper reflog entry if the\n reflog is enabled for the repository. We only rename\n the reflog if it exists.</p>\n",
+      "comments": "<p>This method works for both direct and symbolic references.</p>\n\n<p>The new name will be checked for validity. See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n\n<p>If the <code>force</code> flag is not enabled, and there&#39;s already a reference with the given name, the renaming will fail.</p>\n\n<p>IMPORTANT: The user needs to write a proper reflog entry if the reflog is enabled for the repository. We only rename the reflog if it exists.</p>\n",
       "group": "reference"
     },
     "git_reference_delete": {
@@ -16186,7 +16065,7 @@
         "comment": " 0, GIT_EMODIFIED or an error code"
       },
       "description": "<p>Delete an existing reference.</p>\n",
-      "comments": "<p>This method works for both direct and symbolic references.  The reference\n will be immediately removed on disk but the memory will not be freed.\n Callers must call <code>git_reference_free</code>.</p>\n\n<p>This function will return an error if the reference has changed\n from the time it was looked up.</p>\n",
+      "comments": "<p>This method works for both direct and symbolic references.  The reference will be immediately removed on disk but the memory will not be freed. Callers must call <code>git_reference_free</code>.</p>\n\n<p>This function will return an error if the reference has changed from the time it was looked up.</p>\n",
       "group": "reference"
     },
     "git_reference_remove": {
@@ -16213,7 +16092,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Delete an existing reference by name</p>\n",
-      "comments": "<p>This method removes the named reference from the repository without\n looking at its old value.</p>\n",
+      "comments": "<p>This method removes the named reference from the repository without looking at its old value.</p>\n",
       "group": "reference"
     },
     "git_reference_list": {
@@ -16240,19 +16119,19 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the references that can be found in a repository.</p>\n",
-      "comments": "<p>The string array will be filled with the names of all references; these\n values are owned by the user and should be free&#39;d manually when no\n longer needed, using <code>git_strarray_free()</code>.</p>\n",
+      "comments": "<p>The string array will be filled with the names of all references; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free()</code>.</p>\n",
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_list-66"
+          "ex/HEAD/general.html#git_reference_list-66"
         ]
       }
     },
     "git_reference_foreach": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 444,
-      "lineto": 447,
+      "line": 463,
+      "lineto": 466,
       "args": [
         {
           "name": "repo",
@@ -16277,14 +16156,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform a callback on each reference in the repository.</p>\n",
-      "comments": "<p>The <code>callback</code> function will be called for each reference in the\n repository, receiving the reference object and the <code>payload</code> value\n passed to this method.  Returning a non-zero value from the callback\n will terminate the iteration.</p>\n\n<p>Note that the callback function is responsible to call <code>git_reference_free</code>\n on each reference passed to it.</p>\n",
+      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the reference object and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n\n<p>Note that the callback function is responsible to call <code>git_reference_free</code> on each reference passed to it.</p>\n",
       "group": "reference"
     },
     "git_reference_foreach_name": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 462,
-      "lineto": 465,
+      "line": 481,
+      "lineto": 484,
       "args": [
         {
           "name": "repo",
@@ -16309,14 +16188,14 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Perform a callback on the fully-qualified name of each reference.</p>\n",
-      "comments": "<p>The <code>callback</code> function will be called for each reference in the\n repository, receiving the name of the reference and the <code>payload</code> value\n passed to this method.  Returning a non-zero value from the callback\n will terminate the iteration.</p>\n",
+      "comments": "<p>The <code>callback</code> function will be called for each reference in the repository, receiving the name of the reference and the <code>payload</code> value passed to this method.  Returning a non-zero value from the callback will terminate the iteration.</p>\n",
       "group": "reference"
     },
     "git_reference_dup": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 476,
-      "lineto": 476,
+      "line": 495,
+      "lineto": 495,
       "args": [
         {
           "name": "dest",
@@ -16342,8 +16221,8 @@
     "git_reference_free": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 483,
-      "lineto": 483,
+      "line": 502,
+      "lineto": 502,
       "args": [
         {
           "name": "ref",
@@ -16362,23 +16241,23 @@
       "group": "reference",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_reference_free-67"
+          "ex/HEAD/general.html#git_reference_free-67"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_free-29",
-          "ex/v0.28.0/merge.html#git_reference_free-30",
-          "ex/v0.28.0/merge.html#git_reference_free-31"
+          "ex/HEAD/merge.html#git_reference_free-27",
+          "ex/HEAD/merge.html#git_reference_free-28",
+          "ex/HEAD/merge.html#git_reference_free-29"
         ],
         "status.c": [
-          "ex/v0.28.0/status.html#git_reference_free-3"
+          "ex/HEAD/status.html#git_reference_free-1"
         ]
       }
     },
     "git_reference_cmp": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 492,
-      "lineto": 494,
+      "line": 511,
+      "lineto": 513,
       "args": [
         {
           "name": "ref1",
@@ -16404,8 +16283,8 @@
     "git_reference_iterator_new": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 503,
-      "lineto": 505,
+      "line": 522,
+      "lineto": 524,
       "args": [
         {
           "name": "out",
@@ -16431,8 +16310,8 @@
     "git_reference_iterator_glob_new": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 516,
-      "lineto": 519,
+      "line": 535,
+      "lineto": 538,
       "args": [
         {
           "name": "out",
@@ -16463,8 +16342,8 @@
     "git_reference_next": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 528,
-      "lineto": 528,
+      "line": 547,
+      "lineto": 547,
       "args": [
         {
           "name": "out",
@@ -16490,8 +16369,8 @@
     "git_reference_next_name": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 541,
-      "lineto": 541,
+      "line": 560,
+      "lineto": 560,
       "args": [
         {
           "name": "out",
@@ -16511,14 +16390,14 @@
         "comment": " 0, GIT_ITEROVER if there are no more; or an error code"
       },
       "description": "<p>Get the next reference&#39;s name</p>\n",
-      "comments": "<p>This function is provided for convenience in case only the names\n are interesting as it avoids the allocation of the <code>git_reference</code>\n object which <code>git_reference_next()</code> needs.</p>\n",
+      "comments": "<p>This function is provided for convenience in case only the names are interesting as it avoids the allocation of the <code>git_reference</code> object which <code>git_reference_next()</code> needs.</p>\n",
       "group": "reference"
     },
     "git_reference_iterator_free": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 548,
-      "lineto": 548,
+      "line": 567,
+      "lineto": 567,
       "args": [
         {
           "name": "iter",
@@ -16539,8 +16418,8 @@
     "git_reference_foreach_glob": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 568,
-      "lineto": 572,
+      "line": 587,
+      "lineto": 591,
       "args": [
         {
           "name": "repo",
@@ -16570,14 +16449,14 @@
         "comment": " 0 on success, GIT_EUSER on non-zero callback, or error code"
       },
       "description": "<p>Perform a callback on each reference in the repository whose name\n matches the given pattern.</p>\n",
-      "comments": "<p>This function acts like <code>git_reference_foreach()</code> with an additional\n pattern match being applied to the reference name before issuing the\n callback function.  See that function for more information.</p>\n\n<p>The pattern is matched using fnmatch or &quot;glob&quot; style where a &#39;*&#39; matches\n any sequence of letters, a &#39;?&#39; matches any letter, and square brackets\n can be used to define character ranges (such as &quot;[0-9]&quot; for digits).</p>\n",
+      "comments": "<p>This function acts like <code>git_reference_foreach()</code> with an additional pattern match being applied to the reference name before issuing the callback function.  See that function for more information.</p>\n\n<p>The pattern is matched using fnmatch or &quot;glob&quot; style where a &#39;*&#39; matches any sequence of letters, a &#39;?&#39; matches any letter, and square brackets can be used to define character ranges (such as &quot;[0-9]&quot; for digits).</p>\n",
       "group": "reference"
     },
     "git_reference_has_log": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 582,
-      "lineto": 582,
+      "line": 601,
+      "lineto": 601,
       "args": [
         {
           "name": "repo",
@@ -16603,8 +16482,8 @@
     "git_reference_ensure_log": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 594,
-      "lineto": 594,
+      "line": 613,
+      "lineto": 613,
       "args": [
         {
           "name": "repo",
@@ -16624,14 +16503,14 @@
         "comment": " 0 or an error code."
       },
       "description": "<p>Ensure there is a reflog for a particular reference.</p>\n",
-      "comments": "<p>Make sure that successive updates to the reference will append to\n its log.</p>\n",
+      "comments": "<p>Make sure that successive updates to the reference will append to its log.</p>\n",
       "group": "reference"
     },
     "git_reference_is_branch": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 604,
-      "lineto": 604,
+      "line": 623,
+      "lineto": 623,
       "args": [
         {
           "name": "ref",
@@ -16652,8 +16531,8 @@
     "git_reference_is_remote": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 614,
-      "lineto": 614,
+      "line": 633,
+      "lineto": 633,
       "args": [
         {
           "name": "ref",
@@ -16674,8 +16553,8 @@
     "git_reference_is_tag": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 624,
-      "lineto": 624,
+      "line": 643,
+      "lineto": 643,
       "args": [
         {
           "name": "ref",
@@ -16696,8 +16575,8 @@
     "git_reference_is_note": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 634,
-      "lineto": 634,
+      "line": 653,
+      "lineto": 653,
       "args": [
         {
           "name": "ref",
@@ -16718,8 +16597,8 @@
     "git_reference_normalize_name": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 690,
-      "lineto": 694,
+      "line": 709,
+      "lineto": 713,
       "args": [
         {
           "name": "buffer_out",
@@ -16749,14 +16628,14 @@
         "comment": " 0 on success, GIT_EBUFS if buffer is too small, GIT_EINVALIDSPEC\n or an error code."
       },
       "description": "<p>Normalize reference name and check validity.</p>\n",
-      "comments": "<p>This will normalize the reference name by removing any leading slash\n &#39;/&#39; characters and collapsing runs of adjacent slashes between name\n components into a single slash.</p>\n\n<p>Once normalized, if the reference name is valid, it will be returned in\n the user allocated buffer.</p>\n\n<p>See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>This will normalize the reference name by removing any leading slash &#39;/&#39; characters and collapsing runs of adjacent slashes between name components into a single slash.</p>\n\n<p>Once normalized, if the reference name is valid, it will be returned in the user allocated buffer.</p>\n\n<p>See <code>git_reference_symbolic_create()</code> for rules about valid names.</p>\n",
       "group": "reference"
     },
     "git_reference_peel": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 711,
-      "lineto": 714,
+      "line": 730,
+      "lineto": 733,
       "args": [
         {
           "name": "out",
@@ -16781,19 +16660,19 @@
         "comment": " 0 on success, GIT_EAMBIGUOUS, GIT_ENOTFOUND or an error code"
       },
       "description": "<p>Recursively peel reference until object of the specified type is found.</p>\n",
-      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object\n will be peeled until a non-tag object is met.</p>\n",
+      "comments": "<p>The retrieved <code>peeled</code> object is owned by the repository and should be closed with the <code>git_object_free</code> method.</p>\n\n<p>If you pass <code>GIT_OBJECT_ANY</code> as the target type, then the object will be peeled until a non-tag object is met.</p>\n",
       "group": "reference",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_reference_peel-32"
+          "ex/HEAD/merge.html#git_reference_peel-30"
         ]
       }
     },
     "git_reference_is_valid_name": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 730,
-      "lineto": 730,
+      "line": 749,
+      "lineto": 749,
       "args": [
         {
           "name": "refname",
@@ -16808,14 +16687,14 @@
         "comment": " 1 if the reference name is acceptable; 0 if it isn't"
       },
       "description": "<p>Ensure the reference name is well-formed.</p>\n",
-      "comments": "<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,\nand must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;).</li>\n<li>Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid\nthe characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\nsequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</li>\n</ol>\n",
+      "comments": "<p>Valid reference names must follow one of two patterns:</p>\n\n<ol>\n<li>Top-level names must contain only capital letters and underscores,    and must begin and end with a letter. (e.g. &quot;HEAD&quot;, &quot;ORIG_HEAD&quot;). 2. Names prefixed with &quot;refs/&quot; can be almost anything.  You must avoid    the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the    sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</li>\n</ol>\n",
       "group": "reference"
     },
     "git_reference_shorthand": {
       "type": "function",
       "file": "git2/refs.h",
-      "line": 744,
-      "lineto": 744,
+      "line": 763,
+      "lineto": 763,
       "args": [
         {
           "name": "ref",
@@ -16830,11 +16709,11 @@
         "comment": " the human-readable version of the name"
       },
       "description": "<p>Get the reference&#39;s short name</p>\n",
-      "comments": "<p>This will transform the reference name into a name &quot;human-readable&quot;\n version. If no shortname is appropriate, it will return the full\n name.</p>\n\n<p>The memory is owned by the reference and must not be freed.</p>\n",
+      "comments": "<p>This will transform the reference name into a name &quot;human-readable&quot; version. If no shortname is appropriate, it will return the full name.</p>\n\n<p>The memory is owned by the reference and must not be freed.</p>\n",
       "group": "reference",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_reference_shorthand-4"
+          "ex/HEAD/status.html#git_reference_shorthand-2"
         ]
       }
     },
@@ -17158,11 +17037,11 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_create-4"
+          "ex/HEAD/remote.html#git_remote_create-1"
         ]
       }
     },
-    "git_remote_create_init_options": {
+    "git_remote_create_options_init": {
       "type": "function",
       "file": "git2/remote.h",
       "line": 97,
@@ -17186,7 +17065,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_remote_create_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_remote_create_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_remote_create_options</code> with default values. Equivalent to creating an instance with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>.</p>\n",
       "group": "remote"
     },
     "git_remote_create_with_opts": {
@@ -17292,14 +17171,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create an anonymous remote</p>\n",
-      "comments": "<p>Create a remote with the given url in-memory. You can use this when\n you have a URL instead of a remote&#39;s name.</p>\n",
+      "comments": "<p>Create a remote with the given url in-memory. You can use this when you have a URL instead of a remote&#39;s name.</p>\n",
       "group": "remote",
       "examples": {
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_remote_create_anonymous-4"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_remote_create_anonymous-4"
         ],
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_remote_create_anonymous-2"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_remote_create_anonymous-2"
         ]
       }
     },
@@ -17327,7 +17206,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a remote without a connected local repo</p>\n",
-      "comments": "<p>Create a remote with the given url in-memory. You can use this when\n you have a URL instead of a remote&#39;s name.</p>\n\n<p>Contrasted with git_remote_create_anonymous, a detached remote\n will not consider any repo configuration values (such as insteadof url\n substitutions).</p>\n",
+      "comments": "<p>Create a remote with the given url in-memory. You can use this when you have a URL instead of a remote&#39;s name.</p>\n\n<p>Contrasted with git_remote_create_anonymous, a detached remote will not consider any repo configuration values (such as insteadof url substitutions).</p>\n",
       "group": "remote"
     },
     "git_remote_lookup": {
@@ -17359,17 +17238,17 @@
         "comment": " 0, GIT_ENOTFOUND, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Get the information for a particular remote</p>\n",
-      "comments": "<p>The name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "remote",
       "examples": {
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_remote_lookup-5"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_remote_lookup-5"
         ],
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_remote_lookup-3"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_remote_lookup-3"
         ],
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_lookup-5"
+          "ex/HEAD/remote.html#git_remote_lookup-2"
         ]
       }
     },
@@ -17463,11 +17342,11 @@
         "comment": " a pointer to the url"
       },
       "description": "<p>Get the remote&#39;s url</p>\n",
-      "comments": "<p>If url.*.insteadOf has been configured for this URL, it will\n return the modified URL.</p>\n",
+      "comments": "<p>If url.*.insteadOf has been configured for this URL, it will return the modified URL.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_url-6"
+          "ex/HEAD/remote.html#git_remote_url-3"
         ]
       }
     },
@@ -17490,11 +17369,11 @@
         "comment": " a pointer to the url or NULL if no special url for pushing is set"
       },
       "description": "<p>Get the remote&#39;s url for pushing</p>\n",
-      "comments": "<p>If url.*.pushInsteadOf has been configured for this URL, it\n will return the modified URL.</p>\n",
+      "comments": "<p>If url.*.pushInsteadOf has been configured for this URL, it will return the modified URL.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_pushurl-7"
+          "ex/HEAD/remote.html#git_remote_pushurl-4"
         ]
       }
     },
@@ -17527,11 +17406,11 @@
         "comment": " 0 or an error value"
       },
       "description": "<p>Set the remote&#39;s url in the configuration</p>\n",
-      "comments": "<p>Remote objects already in memory will not be affected. This assumes\n the common case of a single-url remote and will otherwise return an error.</p>\n",
+      "comments": "<p>Remote objects already in memory will not be affected. This assumes the common case of a single-url remote and will otherwise return an error.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_set_url-8"
+          "ex/HEAD/remote.html#git_remote_set_url-5"
         ]
       }
     },
@@ -17564,11 +17443,11 @@
         "comment": null
       },
       "description": "<p>Set the remote&#39;s url for pushing in the configuration.</p>\n",
-      "comments": "<p>Remote objects already in memory will not be affected. This assumes\n the common case of a single-url remote and will otherwise return an error.</p>\n",
+      "comments": "<p>Remote objects already in memory will not be affected. This assumes the common case of a single-url remote and will otherwise return an error.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_set_pushurl-9"
+          "ex/HEAD/remote.html#git_remote_set_pushurl-6"
         ]
       }
     },
@@ -17601,7 +17480,7 @@
         "comment": " 0, GIT_EINVALIDSPEC if refspec is invalid or an error value"
       },
       "description": "<p>Add a fetch refspec to the remote&#39;s configuration</p>\n",
-      "comments": "<p>Add the given refspec to the fetch list in the configuration. No\n loaded remote instances will be affected.</p>\n",
+      "comments": "<p>Add the given refspec to the fetch list in the configuration. No loaded remote instances will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_get_fetch_refspecs": {
@@ -17628,7 +17507,7 @@
         "comment": null
       },
       "description": "<p>Get the remote&#39;s list of fetch refspecs</p>\n",
-      "comments": "<p>The memory is owned by the user and should be freed with\n <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The memory is owned by the user and should be freed with <code>git_strarray_free</code>.</p>\n",
       "group": "remote"
     },
     "git_remote_add_push": {
@@ -17660,7 +17539,7 @@
         "comment": " 0, GIT_EINVALIDSPEC if refspec is invalid or an error value"
       },
       "description": "<p>Add a push refspec to the remote&#39;s configuration</p>\n",
-      "comments": "<p>Add the given refspec to the push list in the configuration. No\n loaded remote instances will be affected.</p>\n",
+      "comments": "<p>Add the given refspec to the push list in the configuration. No loaded remote instances will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_get_push_refspecs": {
@@ -17687,7 +17566,7 @@
         "comment": null
       },
       "description": "<p>Get the remote&#39;s list of push refspecs</p>\n",
-      "comments": "<p>The memory is owned by the user and should be freed with\n <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The memory is owned by the user and should be freed with <code>git_strarray_free</code>.</p>\n",
       "group": "remote"
     },
     "git_remote_refspec_count": {
@@ -17778,11 +17657,11 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open a connection to a remote</p>\n",
-      "comments": "<p>The transport is selected based on the URL. The direction argument\n is due to a limitation of the git protocol (over TCP or SSH) which\n starts up a specific binary which can only do the one or the other.</p>\n",
+      "comments": "<p>The transport is selected based on the URL. The direction argument is due to a limitation of the git protocol (over TCP or SSH) which starts up a specific binary which can only do the one or the other.</p>\n",
       "group": "remote",
       "examples": {
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_remote_connect-4"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_remote_connect-4"
         ]
       }
     },
@@ -17815,11 +17694,11 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Get the remote repository&#39;s reference advertisement list</p>\n",
-      "comments": "<p>Get the list of references with which the server responds to a new\n connection.</p>\n\n<p>The remote (or more exactly its transport) must have connected to\n the remote repository. This list is available as soon as the\n connection to the remote is initiated and it remains available\n after disconnecting.</p>\n\n<p>The memory belongs to the remote. The pointer will be valid as long\n as a new connection is not initiated, but it is recommended that\n you make a copy in order to make use of the data.</p>\n",
+      "comments": "<p>Get the list of references with which the server responds to a new connection.</p>\n\n<p>The remote (or more exactly its transport) must have connected to the remote repository. This list is available as soon as the connection to the remote is initiated and it remains available after disconnecting.</p>\n\n<p>The memory belongs to the remote. The pointer will be valid as long as a new connection is not initiated, but it is recommended that you make a copy in order to make use of the data.</p>\n",
       "group": "remote",
       "examples": {
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_remote_ls-5"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_remote_ls-5"
         ]
       }
     },
@@ -17842,7 +17721,7 @@
         "comment": " 1 if it's connected, 0 otherwise."
       },
       "description": "<p>Check whether the remote is connected</p>\n",
-      "comments": "<p>Check whether the remote&#39;s underlying transport is connected to the\n remote host.</p>\n",
+      "comments": "<p>Check whether the remote&#39;s underlying transport is connected to the remote host.</p>\n",
       "group": "remote"
     },
     "git_remote_stop": {
@@ -17864,7 +17743,7 @@
         "comment": null
       },
       "description": "<p>Cancel the operation</p>\n",
-      "comments": "<p>At certain points in its operation, the network code checks whether\n the operation has been cancelled and if so stops the operation.</p>\n",
+      "comments": "<p>At certain points in its operation, the network code checks whether the operation has been cancelled and if so stops the operation.</p>\n",
       "group": "remote"
     },
     "git_remote_disconnect": {
@@ -17908,18 +17787,18 @@
         "comment": null
       },
       "description": "<p>Free the memory associated with a remote</p>\n",
-      "comments": "<p>This also disconnects from the remote, if the connection\n has not been closed yet (using git_remote_disconnect).</p>\n",
+      "comments": "<p>This also disconnects from the remote, if the connection has not been closed yet (using git_remote_disconnect).</p>\n",
       "group": "remote",
       "examples": {
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_remote_free-6",
-          "ex/v0.28.0/network/fetch.html#git_remote_free-7"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_remote_free-6",
+          "ex/HEAD/fetch.html#git_remote_free-7"
         ],
-        "network/ls-remote.c": [
-          "ex/v0.28.0/network/ls-remote.html#git_remote_free-6"
+        "ls-remote.c": [
+          "ex/HEAD/ls-remote.html#git_remote_free-6"
         ],
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_free-10"
+          "ex/HEAD/remote.html#git_remote_free-7"
         ]
       }
     },
@@ -17951,15 +17830,15 @@
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_list-11"
+          "ex/HEAD/remote.html#git_remote_list-8"
         ]
       }
     },
     "git_remote_init_callbacks": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 577,
-      "lineto": 579,
+      "line": 598,
+      "lineto": 600,
       "args": [
         {
           "name": "opts",
@@ -17982,11 +17861,11 @@
       "comments": "",
       "group": "remote"
     },
-    "git_fetch_init_options": {
+    "git_fetch_options_init": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 682,
-      "lineto": 684,
+      "line": 704,
+      "lineto": 706,
       "args": [
         {
           "name": "opts",
@@ -18006,14 +17885,14 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_fetch_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_fetch_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_FETCH_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_fetch_options</code> with default values. Equivalent to creating an instance with <code>GIT_FETCH_OPTIONS_INIT</code>.</p>\n",
       "group": "fetch"
     },
-    "git_push_init_options": {
+    "git_push_options_init": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 732,
-      "lineto": 734,
+      "line": 754,
+      "lineto": 756,
       "args": [
         {
           "name": "opts",
@@ -18033,14 +17912,14 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_push_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_push_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_PUSH_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_push_options</code> with default values. Equivalent to creating an instance with <code>GIT_PUSH_OPTIONS_INIT</code>.</p>\n",
       "group": "push"
     },
     "git_remote_download": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 752,
-      "lineto": 752,
+      "line": 774,
+      "lineto": 774,
       "args": [
         {
           "name": "remote",
@@ -18065,14 +17944,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Download and index the packfile</p>\n",
-      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with\n the remote git which objects are missing, download and index the\n packfile.</p>\n\n<p>The .idx file will be created and both it and the packfile with be\n renamed to their final name.</p>\n",
+      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with the remote git which objects are missing, download and index the packfile.</p>\n\n<p>The .idx file will be created and both it and the packfile with be renamed to their final name.</p>\n",
       "group": "remote"
     },
     "git_remote_upload": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 766,
-      "lineto": 766,
+      "line": 788,
+      "lineto": 788,
       "args": [
         {
           "name": "remote",
@@ -18097,14 +17976,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a packfile and send it to the server</p>\n",
-      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with\n the remote git which objects are missing, create a packfile with the missing objects and send it.</p>\n",
+      "comments": "<p>Connect to the remote if it hasn&#39;t been done yet, negotiate with the remote git which objects are missing, create a packfile with the missing objects and send it.</p>\n",
       "group": "remote"
     },
     "git_remote_update_tips": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 782,
-      "lineto": 787,
+      "line": 804,
+      "lineto": 809,
       "args": [
         {
           "name": "remote",
@@ -18145,8 +18024,8 @@
     "git_remote_fetch": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 803,
-      "lineto": 807,
+      "line": 825,
+      "lineto": 829,
       "args": [
         {
           "name": "remote",
@@ -18176,19 +18055,19 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Download new data and update tips</p>\n",
-      "comments": "<p>Convenience function to connect to a remote, download the data,\n disconnect and update the remote-tracking branches.</p>\n",
+      "comments": "<p>Convenience function to connect to a remote, download the data, disconnect and update the remote-tracking branches.</p>\n",
       "group": "remote",
       "examples": {
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_remote_fetch-8"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_remote_fetch-8"
         ]
       }
     },
     "git_remote_prune": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 816,
-      "lineto": 816,
+      "line": 838,
+      "lineto": 838,
       "args": [
         {
           "name": "remote",
@@ -18214,8 +18093,8 @@
     "git_remote_push": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 828,
-      "lineto": 830,
+      "line": 850,
+      "lineto": 852,
       "args": [
         {
           "name": "remote",
@@ -18246,8 +18125,8 @@
     "git_remote_stats": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 835,
-      "lineto": 835,
+      "line": 857,
+      "lineto": 857,
       "args": [
         {
           "name": "remote",
@@ -18258,23 +18137,23 @@
       "argline": "git_remote *remote",
       "sig": "git_remote *",
       "return": {
-        "type": "const git_transfer_progress *",
+        "type": "const git_indexer_progress *",
         "comment": null
       },
       "description": "<p>Get the statistics structure that is filled in by the fetch operation.</p>\n",
       "comments": "",
       "group": "remote",
       "examples": {
-        "network/fetch.c": [
-          "ex/v0.28.0/network/fetch.html#git_remote_stats-9"
+        "fetch.c": [
+          "ex/HEAD/fetch.html#git_remote_stats-9"
         ]
       }
     },
     "git_remote_autotag": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 843,
-      "lineto": 843,
+      "line": 865,
+      "lineto": 865,
       "args": [
         {
           "name": "remote",
@@ -18295,8 +18174,8 @@
     "git_remote_set_autotag": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 855,
-      "lineto": 855,
+      "line": 877,
+      "lineto": 877,
       "args": [
         {
           "name": "repo",
@@ -18321,14 +18200,14 @@
         "comment": null
       },
       "description": "<p>Set the remote&#39;s tag following setting.</p>\n",
-      "comments": "<p>The change will be made in the configuration. No loaded remotes\n will be affected.</p>\n",
+      "comments": "<p>The change will be made in the configuration. No loaded remotes will be affected.</p>\n",
       "group": "remote"
     },
     "git_remote_prune_refs": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 862,
-      "lineto": 862,
+      "line": 884,
+      "lineto": 884,
       "args": [
         {
           "name": "remote",
@@ -18349,8 +18228,8 @@
     "git_remote_rename": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 884,
-      "lineto": 888,
+      "line": 906,
+      "lineto": 910,
       "args": [
         {
           "name": "problems",
@@ -18380,19 +18259,19 @@
         "comment": " 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>Give the remote a new name</p>\n",
-      "comments": "<p>All remote-tracking branches and configuration settings\n for the remote are updated.</p>\n\n<p>The new name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n\n<p>No loaded instances of a the remote with the old name will change\n their name or their list of refspecs.</p>\n",
+      "comments": "<p>All remote-tracking branches and configuration settings for the remote are updated.</p>\n\n<p>The new name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n\n<p>No loaded instances of a the remote with the old name will change their name or their list of refspecs.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_rename-12"
+          "ex/HEAD/remote.html#git_remote_rename-9"
         ]
       }
     },
     "git_remote_is_valid_name": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 896,
-      "lineto": 896,
+      "line": 918,
+      "lineto": 918,
       "args": [
         {
           "name": "remote_name",
@@ -18413,8 +18292,8 @@
     "git_remote_delete": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 908,
-      "lineto": 908,
+      "line": 930,
+      "lineto": 930,
       "args": [
         {
           "name": "repo",
@@ -18434,19 +18313,19 @@
         "comment": " 0 on success, or an error code."
       },
       "description": "<p>Delete an existing persisted remote.</p>\n",
-      "comments": "<p>All remote-tracking branches and configuration settings\n for the remote will be removed.</p>\n",
+      "comments": "<p>All remote-tracking branches and configuration settings for the remote will be removed.</p>\n",
       "group": "remote",
       "examples": {
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_remote_delete-13"
+          "ex/HEAD/remote.html#git_remote_delete-10"
         ]
       }
     },
     "git_remote_default_branch": {
       "type": "function",
       "file": "git2/remote.h",
-      "line": 926,
-      "lineto": 926,
+      "line": 948,
+      "lineto": 948,
       "args": [
         {
           "name": "out",
@@ -18466,7 +18345,7 @@
         "comment": " 0, GIT_ENOTFOUND if the remote does not have any references\n or none of them point to HEAD's commit, or an error message."
       },
       "description": "<p>Retrieve the name of the remote&#39;s default branch</p>\n",
-      "comments": "<p>The default branch of a repository is the branch which HEAD points\n to. If the remote does not support reporting this information\n directly, it performs the guess as git does; that is, if there are\n multiple branches which point to the same commit, the first one is\n chosen. If the master branch is a candidate, it wins.</p>\n\n<p>This function must only be called after connecting.</p>\n",
+      "comments": "<p>The default branch of a repository is the branch which HEAD points to. If the remote does not support reporting this information directly, it performs the guess as git does; that is, if there are multiple branches which point to the same commit, the first one is chosen. If the master branch is a candidate, it wins.</p>\n\n<p>This function must only be called after connecting.</p>\n",
       "group": "remote"
     },
     "git_repository_open": {
@@ -18493,14 +18372,11 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open a git repository.</p>\n",
-      "comments": "<p>The &#39;path&#39; argument must point to either a git repository\n folder, or an existing work dir.</p>\n\n<p>The method will automatically detect if &#39;path&#39; is a normal\n or bare repository or fail is &#39;path&#39; is neither.</p>\n",
+      "comments": "<p>The &#39;path&#39; argument must point to either a git repository folder, or an existing work dir.</p>\n\n<p>The method will automatically detect if &#39;path&#39; is a normal or bare repository or fail is &#39;path&#39; is neither.</p>\n",
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_repository_open-68"
-        ],
-        "remote.c": [
-          "ex/v0.28.0/remote.html#git_repository_open-14"
+          "ex/HEAD/general.html#git_repository_open-68"
         ]
       }
     },
@@ -18528,7 +18404,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Open working tree as a repository</p>\n",
-      "comments": "<p>Open the working directory of the working tree as a normal\n repository that can then be worked on.</p>\n",
+      "comments": "<p>Open the working directory of the working tree as a normal repository that can then be worked on.</p>\n",
       "group": "repository"
     },
     "git_repository_wrap_odb": {
@@ -18555,7 +18431,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a &quot;fake&quot; repository to wrap an object database</p>\n",
-      "comments": "<p>Create a repository object to wrap an object database to be used\n with the API when all you have is an object database. This doesn&#39;t\n have any paths associated with it, so use with care.</p>\n",
+      "comments": "<p>Create a repository object to wrap an object database to be used with the API when all you have is an object database. This doesn&#39;t have any paths associated with it, so use with care.</p>\n",
       "group": "repository"
     },
     "git_repository_discover": {
@@ -18592,13 +18468,8 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Look for a git repository and copy its path in the given buffer.\n The lookup start from base_path and walk across parent directories\n if nothing has been found. The lookup ends when the first repository\n is found, or when reaching a directory referenced in ceiling_dirs\n or when the filesystem changes (in case across_fs is true).</p>\n",
-      "comments": "<p>The method will automatically detect if the repository is bare\n (if there is a repository).</p>\n",
-      "group": "repository",
-      "examples": {
-        "remote.c": [
-          "ex/v0.28.0/remote.html#git_repository_discover-15"
-        ]
-      }
+      "comments": "<p>The method will automatically detect if the repository is bare (if there is a repository).</p>\n",
+      "group": "repository"
     },
     "git_repository_open_ext": {
       "type": "function",
@@ -18637,39 +18508,8 @@
       "comments": "",
       "group": "repository",
       "examples": {
-        "blame.c": [
-          "ex/v0.28.0/blame.html#git_repository_open_ext-24"
-        ],
-        "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_repository_open_ext-31"
-        ],
-        "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_repository_open_ext-14"
-        ],
-        "describe.c": [
-          "ex/v0.28.0/describe.html#git_repository_open_ext-8"
-        ],
-        "diff.c": [
-          "ex/v0.28.0/diff.html#git_repository_open_ext-15"
-        ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_repository_open_ext-45",
-          "ex/v0.28.0/log.html#git_repository_open_ext-46"
-        ],
-        "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_repository_open_ext-7"
-        ],
-        "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_open_ext-33"
-        ],
-        "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_repository_open_ext-16"
-        ],
-        "status.c": [
-          "ex/v0.28.0/status.html#git_repository_open_ext-5"
-        ],
-        "tag.c": [
-          "ex/v0.28.0/tag.html#git_repository_open_ext-11"
+          "ex/HEAD/log.html#git_repository_open_ext-43"
         ]
       }
     },
@@ -18697,7 +18537,7 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Open a bare repository on the serverside.</p>\n",
-      "comments": "<p>This is a fast open for bare repositories that will come in handy\n if you&#39;re e.g. hosting git repositories and need to access them\n efficiently</p>\n",
+      "comments": "<p>This is a fast open for bare repositories that will come in handy if you&#39;re e.g. hosting git repositories and need to access them efficiently</p>\n",
       "group": "repository"
     },
     "git_repository_free": {
@@ -18719,47 +18559,14 @@
         "comment": null
       },
       "description": "<p>Free a previously allocated repository</p>\n",
-      "comments": "<p>Note that after a repository is free&#39;d, all the objects it has spawned\n will still exist until they are manually closed by the user\n with <code>git_object_free</code>, but accessing any of the attributes of\n an object without a backing repository will result in undefined\n behavior</p>\n",
+      "comments": "<p>Note that after a repository is free&#39;d, all the objects it has spawned will still exist until they are manually closed by the user with <code>git_object_free</code>, but accessing any of the attributes of an object without a backing repository will result in undefined behavior</p>\n",
       "group": "repository",
       "examples": {
-        "blame.c": [
-          "ex/v0.28.0/blame.html#git_repository_free-25"
-        ],
-        "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_repository_free-32"
-        ],
-        "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_repository_free-15"
-        ],
-        "describe.c": [
-          "ex/v0.28.0/describe.html#git_repository_free-9"
-        ],
-        "diff.c": [
-          "ex/v0.28.0/diff.html#git_repository_free-16"
-        ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_repository_free-69"
+          "ex/HEAD/general.html#git_repository_free-69"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_free-6"
-        ],
-        "log.c": [
-          "ex/v0.28.0/log.html#git_repository_free-47"
-        ],
-        "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_repository_free-8"
-        ],
-        "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_free-34"
-        ],
-        "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_repository_free-17"
-        ],
-        "status.c": [
-          "ex/v0.28.0/status.html#git_repository_free-6"
-        ],
-        "tag.c": [
-          "ex/v0.28.0/tag.html#git_repository_free-12"
+          "ex/HEAD/init.html#git_repository_free-4"
         ]
       }
     },
@@ -18792,15 +18599,15 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Creates a new Git repository in the given folder.</p>\n",
-      "comments": "<p>TODO:\n    - Reinit the repository</p>\n",
+      "comments": "<p>TODO:  - Reinit the repository</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_init-7"
+          "ex/HEAD/init.html#git_repository_init-5"
         ]
       }
     },
-    "git_repository_init_init_options": {
+    "git_repository_init_options_init": {
       "type": "function",
       "file": "git2/repository.h",
       "line": 326,
@@ -18824,7 +18631,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_repository_init_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_repository_init_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REPOSITORY_INIT_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_repository_init_options</code> with default values. Equivalent to creating an instance with <code>GIT_REPOSITORY_INIT_OPTIONS_INIT</code>.</p>\n",
       "group": "repository"
     },
     "git_repository_init_ext": {
@@ -18856,11 +18663,11 @@
         "comment": " 0 or an error code on failure."
       },
       "description": "<p>Create a new Git repository in the given folder with extended controls.</p>\n",
-      "comments": "<p>This will initialize a new git repository (creating the repo_path\n if requested by flags) and working directory as needed.  It will\n auto-detect the case sensitivity of the file system and if the\n file system supports file mode bits correctly.</p>\n",
+      "comments": "<p>This will initialize a new git repository (creating the repo_path if requested by flags) and working directory as needed.  It will auto-detect the case sensitivity of the file system and if the file system supports file mode bits correctly.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_init_ext-8"
+          "ex/HEAD/init.html#git_repository_init_ext-6"
         ]
       }
     },
@@ -18888,15 +18695,15 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing\n branch, GIT_ENOTFOUND when HEAD is missing; an error code otherwise"
       },
       "description": "<p>Retrieve and resolve the reference pointed at by HEAD.</p>\n",
-      "comments": "<p>The returned <code>git_reference</code> will be owned by caller and\n <code>git_reference_free()</code> must be called when done with it to release the\n allocated memory and prevent a leak.</p>\n",
+      "comments": "<p>The returned <code>git_reference</code> will be owned by caller and <code>git_reference_free()</code> must be called when done with it to release the allocated memory and prevent a leak.</p>\n",
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_head-35",
-          "ex/v0.28.0/merge.html#git_repository_head-36"
+          "ex/HEAD/merge.html#git_repository_head-31",
+          "ex/HEAD/merge.html#git_repository_head-32"
         ],
         "status.c": [
-          "ex/v0.28.0/status.html#git_repository_head-7"
+          "ex/HEAD/status.html#git_repository_head-3"
         ]
       }
     },
@@ -18951,7 +18758,7 @@
         "comment": " 1 if HEAD is detached, 0 if it's not; error code if there\n was an error."
       },
       "description": "<p>Check if a repository&#39;s HEAD is detached</p>\n",
-      "comments": "<p>A repository&#39;s HEAD is detached when it points directly to a commit\n instead of a branch.</p>\n",
+      "comments": "<p>A repository&#39;s HEAD is detached when it points directly to a commit instead of a branch.</p>\n",
       "group": "repository"
     },
     "git_repository_head_detached_for_worktree": {
@@ -18978,7 +18785,7 @@
         "comment": " 1 if HEAD is detached, 0 if its not; error code if\n  there was an error"
       },
       "description": "<p>Check if a worktree&#39;s HEAD is detached</p>\n",
-      "comments": "<p>A worktree&#39;s HEAD is detached when it points directly to a\n commit instead of a branch.</p>\n",
+      "comments": "<p>A worktree&#39;s HEAD is detached when it points directly to a commit instead of a branch.</p>\n",
       "group": "repository"
     },
     "git_repository_head_unborn": {
@@ -19000,7 +18807,7 @@
         "comment": " 1 if the current branch is unborn, 0 if it's not; error\n code if there was an error"
       },
       "description": "<p>Check if the current branch is unborn</p>\n",
-      "comments": "<p>An unborn branch is one named from HEAD but which doesn&#39;t exist in\n the refs namespace, because it doesn&#39;t have any commit to point to.</p>\n",
+      "comments": "<p>An unborn branch is one named from HEAD but which doesn&#39;t exist in the refs namespace, because it doesn&#39;t have any commit to point to.</p>\n",
       "group": "repository"
     },
     "git_repository_is_empty": {
@@ -19022,7 +18829,7 @@
         "comment": " 1 if the repository is empty, 0 if it isn't, error code\n if the repository is corrupted"
       },
       "description": "<p>Check if a repository is empty</p>\n",
-      "comments": "<p>An empty repository has just been initialized and contains no references\n apart from HEAD, which must be pointing to the unborn master branch.</p>\n",
+      "comments": "<p>An empty repository has just been initialized and contains no references apart from HEAD, which must be pointing to the unborn master branch.</p>\n",
       "group": "repository"
     },
     "git_repository_item_path": {
@@ -19054,7 +18861,7 @@
         "comment": " 0, GIT_ENOTFOUND if the path cannot exist or an error code"
       },
       "description": "<p>Get the location of a specific repository file or directory</p>\n",
-      "comments": "<p>This function will retrieve the path of a specific repository\n item. It will thereby honor things like the repository&#39;s\n common directory, gitdir, etc. In case a file path cannot\n exist for a given item (e.g. the working directory of a bare\n repository), GIT_ENOTFOUND is returned.</p>\n",
+      "comments": "<p>This function will retrieve the path of a specific repository item. It will thereby honor things like the repository&#39;s common directory, gitdir, etc. In case a file path cannot exist for a given item (e.g. the working directory of a bare repository), GIT_ENOTFOUND is returned.</p>\n",
       "group": "repository"
     },
     "git_repository_path": {
@@ -19076,14 +18883,14 @@
         "comment": " the path to the repository"
       },
       "description": "<p>Get the path of this repository</p>\n",
-      "comments": "<p>This is the path of the <code>.git</code> folder for normal repositories,\n or of the repository itself for bare repositories.</p>\n",
+      "comments": "<p>This is the path of the <code>.git</code> folder for normal repositories, or of the repository itself for bare repositories.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_path-9"
+          "ex/HEAD/init.html#git_repository_path-7"
         ],
         "status.c": [
-          "ex/v0.28.0/status.html#git_repository_path-8"
+          "ex/HEAD/status.html#git_repository_path-4"
         ]
       }
     },
@@ -19106,11 +18913,11 @@
         "comment": " the path to the working dir, if it exists"
       },
       "description": "<p>Get the path of the working directory for this repository</p>\n",
-      "comments": "<p>If the repository is bare, this function will always return\n NULL.</p>\n",
+      "comments": "<p>If the repository is bare, this function will always return NULL.</p>\n",
       "group": "repository",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_workdir-10"
+          "ex/HEAD/init.html#git_repository_workdir-8"
         ]
       }
     },
@@ -19133,7 +18940,7 @@
         "comment": " the path to the common dir"
       },
       "description": "<p>Get the path of the shared common directory for this repository</p>\n",
-      "comments": "<p>If the repository is bare is not a worktree, the git directory\n path is returned.</p>\n",
+      "comments": "<p>If the repository is bare is not a worktree, the git directory path is returned.</p>\n",
       "group": "repository"
     },
     "git_repository_set_workdir": {
@@ -19165,7 +18972,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Set the path to the working directory for this repository</p>\n",
-      "comments": "<p>The working directory doesn&#39;t need to be the same one\n that contains the <code>.git</code> folder for this repository.</p>\n\n<p>If this repository is bare, setting its working directory\n will turn it into a normal repository, capable of performing\n all the common workdir operations (checkout, status, index\n manipulation, etc).</p>\n",
+      "comments": "<p>The working directory doesn&#39;t need to be the same one that contains the <code>.git</code> folder for this repository.</p>\n\n<p>If this repository is bare, setting its working directory will turn it into a normal repository, capable of performing all the common workdir operations (checkout, status, index manipulation, etc).</p>\n",
       "group": "repository"
     },
     "git_repository_is_bare": {
@@ -19191,7 +18998,7 @@
       "group": "repository",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_repository_is_bare-9"
+          "ex/HEAD/status.html#git_repository_is_bare-5"
         ]
       }
     },
@@ -19241,7 +19048,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the configuration file for this repository.</p>\n",
-      "comments": "<p>If a configuration file has not been set, the default\n config set for the repository will be returned, including\n global and system configurations (if they are available).</p>\n\n<p>The configuration file must be freed once it&#39;s no longer\n being used by the user.</p>\n",
+      "comments": "<p>If a configuration file has not been set, the default config set for the repository will be returned, including global and system configurations (if they are available).</p>\n\n<p>The configuration file must be freed once it&#39;s no longer being used by the user.</p>\n",
       "group": "repository"
     },
     "git_repository_config_snapshot": {
@@ -19268,12 +19075,12 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get a snapshot of the repository&#39;s configuration</p>\n",
-      "comments": "<p>Convenience function to take a snapshot from the repository&#39;s\n configuration.  The contents of this snapshot will not change,\n even if the underlying config files are modified.</p>\n\n<p>The configuration file must be freed once it&#39;s no longer\n being used by the user.</p>\n",
+      "comments": "<p>Convenience function to take a snapshot from the repository&#39;s configuration.  The contents of this snapshot will not change, even if the underlying config files are modified.</p>\n\n<p>The configuration file must be freed once it&#39;s no longer being used by the user.</p>\n",
       "group": "repository",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_repository_config_snapshot-70",
-          "ex/v0.28.0/general.html#git_repository_config_snapshot-71"
+          "ex/HEAD/general.html#git_repository_config_snapshot-70",
+          "ex/HEAD/general.html#git_repository_config_snapshot-71"
         ]
       }
     },
@@ -19301,14 +19108,14 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Object Database for this repository.</p>\n",
-      "comments": "<p>If a custom ODB has not been set, the default\n database for the repository will be returned (the one\n located in <code>.git/objects</code>).</p>\n\n<p>The ODB must be freed once it&#39;s no longer being used by\n the user.</p>\n",
+      "comments": "<p>If a custom ODB has not been set, the default database for the repository will be returned (the one located in <code>.git/objects</code>).</p>\n\n<p>The ODB must be freed once it&#39;s no longer being used by the user.</p>\n",
       "group": "repository",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_repository_odb-33"
+          "ex/HEAD/cat-file.html#git_repository_odb-29"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_repository_odb-72"
+          "ex/HEAD/general.html#git_repository_odb-72"
         ]
       }
     },
@@ -19336,7 +19143,7 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Reference Database Backend for this repository.</p>\n",
-      "comments": "<p>If a custom refsdb has not been set, the default database for\n the repository will be returned (the one that manipulates loose\n and packed references in the <code>.git</code> directory).</p>\n\n<p>The refdb must be freed once it&#39;s no longer being used by\n the user.</p>\n",
+      "comments": "<p>If a custom refsdb has not been set, the default database for the repository will be returned (the one that manipulates loose and packed references in the <code>.git</code> directory).</p>\n\n<p>The refdb must be freed once it&#39;s no longer being used by the user.</p>\n",
       "group": "repository"
     },
     "git_repository_index": {
@@ -19363,20 +19170,23 @@
         "comment": " 0, or an error code"
       },
       "description": "<p>Get the Index file for this repository.</p>\n",
-      "comments": "<p>If a custom index has not been set, the default\n index for the repository will be returned (the one\n located in <code>.git/index</code>).</p>\n\n<p>The index must be freed once it&#39;s no longer being used by\n the user.</p>\n",
+      "comments": "<p>If a custom index has not been set, the default index for the repository will be returned (the one located in <code>.git/index</code>).</p>\n\n<p>The index must be freed once it&#39;s no longer being used by the user.</p>\n",
       "group": "repository",
       "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_repository_index-5"
+        ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_repository_index-73"
+          "ex/HEAD/general.html#git_repository_index-73"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_repository_index-11"
+          "ex/HEAD/init.html#git_repository_index-9"
         ],
         "ls-files.c": [
-          "ex/v0.28.0/ls-files.html#git_repository_index-9"
+          "ex/HEAD/ls-files.html#git_repository_index-5"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_index-37"
+          "ex/HEAD/merge.html#git_repository_index-33"
         ]
       }
     },
@@ -19404,7 +19214,7 @@
         "comment": " 0, GIT_ENOTFOUND if no message exists or an error code"
       },
       "description": "<p>Retrieve git&#39;s prepared message</p>\n",
-      "comments": "<p>Operations such as git revert/cherry-pick/merge with the -n option\n stop just short of creating a commit with the changes and save\n their prepared message in .git/MERGE_MSG so the next git-commit\n execution can present it to the user for them to amend if they\n wish.</p>\n\n<p>Use this function to get the contents of this file. Don&#39;t forget to\n remove the file after you create the commit.</p>\n",
+      "comments": "<p>Operations such as git revert/cherry-pick/merge with the -n option stop just short of creating a commit with the changes and save their prepared message in .git/MERGE_MSG so the next git-commit execution can present it to the user for them to amend if they wish.</p>\n\n<p>Use this function to get the contents of this file. Don&#39;t forget to remove the file after you create the commit.</p>\n",
       "group": "repository"
     },
     "git_repository_message_remove": {
@@ -19452,15 +19262,15 @@
       "group": "repository",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_state_cleanup-38"
+          "ex/HEAD/merge.html#git_repository_state_cleanup-34"
         ]
       }
     },
     "git_repository_fetchhead_foreach": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 660,
-      "lineto": 663,
+      "line": 672,
+      "lineto": 675,
       "args": [
         {
           "name": "repo",
@@ -19491,8 +19301,8 @@
     "git_repository_mergehead_foreach": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 680,
-      "lineto": 683,
+      "line": 701,
+      "lineto": 704,
       "args": [
         {
           "name": "repo",
@@ -19523,8 +19333,8 @@
     "git_repository_hashfile": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 708,
-      "lineto": 713,
+      "line": 729,
+      "lineto": 734,
       "args": [
         {
           "name": "out",
@@ -19559,14 +19369,14 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Calculate hash of file using repository filtering rules.</p>\n",
-      "comments": "<p>If you simply want to calculate the hash of a file on disk with no filters,\n you can just use the <code>git_odb_hashfile()</code> API.  However, if you want to\n hash a file in the repository and you want to apply filtering rules (e.g.\n crlf filters) before generating the SHA, then use this function.</p>\n\n<p>Note: if the repository has <code>core.safecrlf</code> set to fail and the\n filtering triggers that failure, then this function will return an\n error and not calculate the hash of the file.</p>\n",
+      "comments": "<p>If you simply want to calculate the hash of a file on disk with no filters, you can just use the <code>git_odb_hashfile()</code> API.  However, if you want to hash a file in the repository and you want to apply filtering rules (e.g. crlf filters) before generating the SHA, then use this function.</p>\n\n<p>Note: if the repository has <code>core.safecrlf</code> set to fail and the filtering triggers that failure, then this function will return an error and not calculate the hash of the file.</p>\n",
       "group": "repository"
     },
     "git_repository_set_head": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 733,
-      "lineto": 735,
+      "line": 754,
+      "lineto": 756,
       "args": [
         {
           "name": "repo",
@@ -19586,19 +19396,19 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Make the repository HEAD point to the specified reference.</p>\n",
-      "comments": "<p>If the provided reference points to a Tree or a Blob, the HEAD is\n unaltered and -1 is returned.</p>\n\n<p>If the provided reference points to a branch, the HEAD will point\n to that branch, staying attached, or become attached if it isn&#39;t yet.\n If the branch doesn&#39;t exist yet, no error will be return. The HEAD\n will then be attached to an unborn branch.</p>\n\n<p>Otherwise, the HEAD will be detached and will directly point to\n the Commit.</p>\n",
+      "comments": "<p>If the provided reference points to a Tree or a Blob, the HEAD is unaltered and -1 is returned.</p>\n\n<p>If the provided reference points to a branch, the HEAD will point to that branch, staying attached, or become attached if it isn&#39;t yet. If the branch doesn&#39;t exist yet, no error will be return. The HEAD will then be attached to an unborn branch.</p>\n\n<p>Otherwise, the HEAD will be detached and will directly point to the Commit.</p>\n",
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_repository_set_head-16"
+          "ex/HEAD/checkout.html#git_repository_set_head-12"
         ]
       }
     },
     "git_repository_set_head_detached": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 753,
-      "lineto": 755,
+      "line": 774,
+      "lineto": 776,
       "args": [
         {
           "name": "repo",
@@ -19618,14 +19428,14 @@
         "comment": " 0 on success, or an error code"
       },
       "description": "<p>Make the repository HEAD directly point to the Commit.</p>\n",
-      "comments": "<p>If the provided committish cannot be found in the repository, the HEAD\n is unaltered and GIT_ENOTFOUND is returned.</p>\n\n<p>If the provided commitish cannot be peeled into a commit, the HEAD\n is unaltered and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will eventually be detached and will directly point to\n the peeled Commit.</p>\n",
+      "comments": "<p>If the provided committish cannot be found in the repository, the HEAD is unaltered and GIT_ENOTFOUND is returned.</p>\n\n<p>If the provided commitish cannot be peeled into a commit, the HEAD is unaltered and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will eventually be detached and will directly point to the peeled Commit.</p>\n",
       "group": "repository"
     },
     "git_repository_set_head_detached_from_annotated": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 769,
-      "lineto": 771,
+      "line": 790,
+      "lineto": 792,
       "args": [
         {
           "name": "repo",
@@ -19645,19 +19455,19 @@
         "comment": null
       },
       "description": "<p>Make the repository HEAD directly point to the Commit.</p>\n",
-      "comments": "<p>This behaves like <code>git_repository_set_head_detached()</code> but takes an\n annotated commit, which lets you specify which extended sha syntax\n string was specified by a user, allowing for more exact reflog\n messages.</p>\n\n<p>See the documentation for <code>git_repository_set_head_detached()</code>.</p>\n",
+      "comments": "<p>This behaves like <code>git_repository_set_head_detached()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_repository_set_head_detached()</code>.</p>\n",
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_repository_set_head_detached_from_annotated-17"
+          "ex/HEAD/checkout.html#git_repository_set_head_detached_from_annotated-13"
         ]
       }
     },
     "git_repository_detach_head": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 790,
-      "lineto": 791,
+      "line": 811,
+      "lineto": 812,
       "args": [
         {
           "name": "repo",
@@ -19672,14 +19482,14 @@
         "comment": " 0 on success, GIT_EUNBORNBRANCH when HEAD points to a non existing\n branch or an error code"
       },
       "description": "<p>Detach the HEAD.</p>\n",
-      "comments": "<p>If the HEAD is already detached and points to a Commit, 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a Tag, the HEAD is\n updated into making it point to the peeled Commit, and 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a non commitish, the HEAD is\n unaltered, and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will be detached and point to the peeled Commit.</p>\n",
+      "comments": "<p>If the HEAD is already detached and points to a Commit, 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a Tag, the HEAD is updated into making it point to the peeled Commit, and 0 is returned.</p>\n\n<p>If the HEAD is already detached and points to a non commitish, the HEAD is unaltered, and -1 is returned.</p>\n\n<p>Otherwise, the HEAD will be detached and point to the peeled Commit.</p>\n",
       "group": "repository"
     },
     "git_repository_state": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 821,
-      "lineto": 821,
+      "line": 842,
+      "lineto": 842,
       "args": [
         {
           "name": "repo",
@@ -19698,18 +19508,18 @@
       "group": "repository",
       "examples": {
         "checkout.c": [
-          "ex/v0.28.0/checkout.html#git_repository_state-18"
+          "ex/HEAD/checkout.html#git_repository_state-14"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_repository_state-39"
+          "ex/HEAD/merge.html#git_repository_state-35"
         ]
       }
     },
     "git_repository_set_namespace": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 835,
-      "lineto": 835,
+      "line": 856,
+      "lineto": 856,
       "args": [
         {
           "name": "repo",
@@ -19729,14 +19539,14 @@
         "comment": " 0 on success, -1 on error"
       },
       "description": "<p>Sets the active namespace for this Git Repository</p>\n",
-      "comments": "<p>This namespace affects all reference operations for the repo.\n See <code>man gitnamespaces</code></p>\n",
+      "comments": "<p>This namespace affects all reference operations for the repo. See <code>man gitnamespaces</code></p>\n",
       "group": "repository"
     },
     "git_repository_get_namespace": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 843,
-      "lineto": 843,
+      "line": 864,
+      "lineto": 864,
       "args": [
         {
           "name": "repo",
@@ -19757,8 +19567,8 @@
     "git_repository_is_shallow": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 852,
-      "lineto": 852,
+      "line": 873,
+      "lineto": 873,
       "args": [
         {
           "name": "repo",
@@ -19779,8 +19589,8 @@
     "git_repository_ident": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 864,
-      "lineto": 864,
+      "line": 885,
+      "lineto": 885,
       "args": [
         {
           "name": "name",
@@ -19805,14 +19615,14 @@
         "comment": null
       },
       "description": "<p>Retrieve the configured identity to use for reflogs</p>\n",
-      "comments": "<p>The memory is owned by the repository and must not be freed by the\n user.</p>\n",
+      "comments": "<p>The memory is owned by the repository and must not be freed by the user.</p>\n",
       "group": "repository"
     },
     "git_repository_set_ident": {
       "type": "function",
       "file": "git2/repository.h",
-      "line": 877,
-      "lineto": 877,
+      "line": 898,
+      "lineto": 898,
       "args": [
         {
           "name": "repo",
@@ -19837,7 +19647,7 @@
         "comment": null
       },
       "description": "<p>Set the identity to be used for writing reflogs</p>\n",
-      "comments": "<p>If both are set, this name and email will be used to write to the\n reflog. Pass NULL to unset. When unset, the identity will be taken\n from the repository&#39;s configuration.</p>\n",
+      "comments": "<p>If both are set, this name and email will be used to write to the reflog. Pass NULL to unset. When unset, the identity will be taken from the repository&#39;s configuration.</p>\n",
       "group": "repository"
     },
     "git_reset": {
@@ -19874,7 +19684,7 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Sets the current head to the specified commit oid and optionally\n resets the index and working tree to match.</p>\n",
-      "comments": "<p>SOFT reset means the Head will be moved to the commit.</p>\n\n<p>MIXED reset will trigger a SOFT reset, plus the index will be replaced\n with the content of the commit tree.</p>\n\n<p>HARD reset will trigger a MIXED reset and the working directory will be\n replaced with the content of the index.  (Untracked and ignored files\n will be left alone, however.)</p>\n\n<p>TODO: Implement remaining kinds of resets.</p>\n",
+      "comments": "<p>SOFT reset means the Head will be moved to the commit.</p>\n\n<p>MIXED reset will trigger a SOFT reset, plus the index will be replaced with the content of the commit tree.</p>\n\n<p>HARD reset will trigger a MIXED reset and the working directory will be replaced with the content of the index.  (Untracked and ignored files will be left alone, however.)</p>\n\n<p>TODO: Implement remaining kinds of resets.</p>\n",
       "group": "reset"
     },
     "git_reset_from_annotated": {
@@ -19911,7 +19721,7 @@
         "comment": null
       },
       "description": "<p>Sets the current head to the specified commit oid and optionally\n resets the index and working tree to match.</p>\n",
-      "comments": "<p>This behaves like <code>git_reset()</code> but takes an annotated commit,\n which lets you specify which extended sha syntax string was\n specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_reset()</code>.</p>\n",
+      "comments": "<p>This behaves like <code>git_reset()</code> but takes an annotated commit, which lets you specify which extended sha syntax string was specified by a user, allowing for more exact reflog messages.</p>\n\n<p>See the documentation for <code>git_reset()</code>.</p>\n",
       "group": "reset"
     },
     "git_reset_default": {
@@ -19943,10 +19753,10 @@
         "comment": " 0 on success or an error code \n<\n 0"
       },
       "description": "<p>Updates some entries in the index from the target commit tree.</p>\n",
-      "comments": "<p>The scope of the updated entries is determined by the paths\n being passed in the <code>pathspec</code> parameters.</p>\n\n<p>Passing a NULL <code>target</code> will result in removing\n entries in the index matching the provided pathspecs.</p>\n",
+      "comments": "<p>The scope of the updated entries is determined by the paths being passed in the <code>pathspec</code> parameters.</p>\n\n<p>Passing a NULL <code>target</code> will result in removing entries in the index matching the provided pathspecs.</p>\n",
       "group": "reset"
     },
-    "git_revert_init_options": {
+    "git_revert_options_init": {
       "type": "function",
       "file": "git2/revert.h",
       "line": 49,
@@ -19970,7 +19780,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_revert_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_revert_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_REVERT_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_revert_options</code> with default values. Equivalent to creating an instance with <code>GIT_REVERT_OPTIONS_INIT</code>.</p>\n",
       "group": "revert"
     },
     "git_revert_commit": {
@@ -20081,26 +19891,26 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EAMBIGUOUS, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Find a single object, as specified by a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> when no\n longer needed.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> when no longer needed.</p>\n",
       "group": "revparse",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_revparse_single-26"
+          "ex/HEAD/blame.html#git_revparse_single-22"
         ],
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_revparse_single-34"
+          "ex/HEAD/cat-file.html#git_revparse_single-30"
         ],
         "describe.c": [
-          "ex/v0.28.0/describe.html#git_revparse_single-10"
+          "ex/HEAD/describe.html#git_revparse_single-6"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revparse_single-48"
+          "ex/HEAD/log.html#git_revparse_single-44"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_revparse_single-13",
-          "ex/v0.28.0/tag.html#git_revparse_single-14",
-          "ex/v0.28.0/tag.html#git_revparse_single-15",
-          "ex/v0.28.0/tag.html#git_revparse_single-16"
+          "ex/HEAD/tag.html#git_revparse_single-9",
+          "ex/HEAD/tag.html#git_revparse_single-10",
+          "ex/HEAD/tag.html#git_revparse_single-11",
+          "ex/HEAD/tag.html#git_revparse_single-12"
         ]
       }
     },
@@ -20138,7 +19948,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND, GIT_EAMBIGUOUS, GIT_EINVALIDSPEC\n or an error code"
       },
       "description": "<p>Find a single object and intermediate reference by a revision string.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code>, or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n\n<p>In some cases (<code>\n@\n{\n&lt;\n-n&gt;}</code> or `\n&lt;branchname</p>\n\n<blockquote>\n<p>@\n{upstream}<code>), the expression may\n point to an intermediate reference. When such expressions are being passed\n in,</code>reference_out` will be valued as well.</p>\n</blockquote>\n\n<p>The returned object should be released with <code>git_object_free</code> and the\n returned reference with <code>git_reference_free</code> when no longer needed.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code>, or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n\n<p>In some cases (<code>@{&lt;-n&gt;}</code> or <code>&lt;branchname&gt;@{upstream}</code>), the expression may point to an intermediate reference. When such expressions are being passed in, <code>reference_out</code> will be valued as well.</p>\n\n<p>The returned object should be released with <code>git_object_free</code> and the returned reference with <code>git_reference_free</code> when no longer needed.</p>\n",
       "group": "revparse"
     },
     "git_revparse": {
@@ -20170,18 +19980,18 @@
         "comment": " 0 on success, GIT_INVALIDSPEC, GIT_ENOTFOUND, GIT_EAMBIGUOUS or an error code"
       },
       "description": "<p>Parse a revision string for <code>from</code>, <code>to</code>, and intent.</p>\n",
-      "comments": "<p>See <code>man gitrevisions</code> or\n http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for\n information on the syntax accepted.</p>\n",
+      "comments": "<p>See <code>man gitrevisions</code> or http://git-scm.com/docs/git-rev-parse.html#_specifying_revisions for information on the syntax accepted.</p>\n",
       "group": "revparse",
       "examples": {
         "blame.c": [
-          "ex/v0.28.0/blame.html#git_revparse-27"
+          "ex/HEAD/blame.html#git_revparse-23"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revparse-49"
+          "ex/HEAD/log.html#git_revparse-45"
         ],
         "rev-parse.c": [
-          "ex/v0.28.0/rev-parse.html#git_revparse-18",
-          "ex/v0.28.0/rev-parse.html#git_revparse-19"
+          "ex/HEAD/rev-parse.html#git_revparse-14",
+          "ex/HEAD/rev-parse.html#git_revparse-15"
         ]
       }
     },
@@ -20209,15 +20019,15 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Allocate a new revision walker to iterate through a repo.</p>\n",
-      "comments": "<p>This revision walker uses a custom memory pool and an internal\n commit cache, so it is relatively expensive to allocate.</p>\n\n<p>For maximum performance, this revision walker should be\n reused for different walks.</p>\n\n<p>This revision walker is <em>not</em> thread safe: it may only be\n used to walk a repository on a single thread; however,\n it is possible to have several revision walkers in\n several different threads walking the same repository.</p>\n",
+      "comments": "<p>This revision walker uses a custom memory pool and an internal commit cache, so it is relatively expensive to allocate.</p>\n\n<p>For maximum performance, this revision walker should be reused for different walks.</p>\n\n<p>This revision walker is <em>not</em> thread safe: it may only be used to walk a repository on a single thread; however, it is possible to have several revision walkers in several different threads walking the same repository.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_revwalk_new-74"
+          "ex/HEAD/general.html#git_revwalk_new-74"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_new-50",
-          "ex/v0.28.0/log.html#git_revwalk_new-51"
+          "ex/HEAD/log.html#git_revwalk_new-46",
+          "ex/HEAD/log.html#git_revwalk_new-47"
         ]
       }
     },
@@ -20240,7 +20050,7 @@
         "comment": null
       },
       "description": "<p>Reset the revision walker for reuse.</p>\n",
-      "comments": "<p>This will clear all the pushed and hidden commits, and\n leave the walker in a blank state (just like at\n creation) ready to receive new commit pushes and\n start a new walk.</p>\n\n<p>The revision walk is automatically reset when a walk\n is over.</p>\n",
+      "comments": "<p>This will clear all the pushed and hidden commits, and leave the walker in a blank state (just like at creation) ready to receive new commit pushes and start a new walk.</p>\n\n<p>The revision walk is automatically reset when a walk is over.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_push": {
@@ -20267,14 +20077,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a new root for the traversal</p>\n",
-      "comments": "<p>The pushed commit will be marked as one of the roots from which to\n start the walk. This commit may not be walked if it or a child is\n hidden.</p>\n\n<p>At least one commit must be pushed onto the walker before a walk\n can be started.</p>\n\n<p>The given id must belong to a committish on the walked\n repository.</p>\n",
+      "comments": "<p>The pushed commit will be marked as one of the roots from which to start the walk. This commit may not be walked if it or a child is hidden.</p>\n\n<p>At least one commit must be pushed onto the walker before a walk can be started.</p>\n\n<p>The given id must belong to a committish on the walked repository.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_revwalk_push-75"
+          "ex/HEAD/general.html#git_revwalk_push-75"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_push-52"
+          "ex/HEAD/log.html#git_revwalk_push-48"
         ]
       }
     },
@@ -20302,7 +20112,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Push matching references</p>\n",
-      "comments": "<p>The OIDs pointed to by the references that match the given glob\n pattern will be pushed to the revision walker.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing\n &#39;/\n\\\n*&#39; if the glob lacks &#39;?&#39;, &#39;\n\\\n*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a\n committish will be ignored.</p>\n",
+      "comments": "<p>The OIDs pointed to by the references that match the given glob pattern will be pushed to the revision walker.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing &#39;/*&#39; if the glob lacks &#39;?&#39;, &#39;*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a committish will be ignored.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_push_head": {
@@ -20328,7 +20138,7 @@
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_push_head-53"
+          "ex/HEAD/log.html#git_revwalk_push_head-49"
         ]
       }
     },
@@ -20356,11 +20166,11 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Mark a commit (and its ancestors) uninteresting for the output.</p>\n",
-      "comments": "<p>The given id must belong to a committish on the walked\n repository.</p>\n\n<p>The resolved commit and all its parents will be hidden from the\n output on the revision walk.</p>\n",
+      "comments": "<p>The given id must belong to a committish on the walked repository.</p>\n\n<p>The resolved commit and all its parents will be hidden from the output on the revision walk.</p>\n",
       "group": "revwalk",
       "examples": {
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_hide-54"
+          "ex/HEAD/log.html#git_revwalk_hide-50"
         ]
       }
     },
@@ -20388,7 +20198,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Hide matching references.</p>\n",
-      "comments": "<p>The OIDs pointed to by the references that match the given glob\n pattern and their ancestors will be hidden from the output on the\n revision walk.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing\n &#39;/\n\\\n*&#39; if the glob lacks &#39;?&#39;, &#39;\n\\\n*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a\n committish will be ignored.</p>\n",
+      "comments": "<p>The OIDs pointed to by the references that match the given glob pattern and their ancestors will be hidden from the output on the revision walk.</p>\n\n<p>A leading &#39;refs/&#39; is implied if not present as well as a trailing &#39;/*&#39; if the glob lacks &#39;?&#39;, &#39;*&#39; or &#39;[&#39;.</p>\n\n<p>Any references matching this glob which do not point to a committish will be ignored.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_hide_head": {
@@ -20491,14 +20301,14 @@
         "comment": " 0 if the next commit was found;\n\tGIT_ITEROVER if there are no commits left to iterate"
       },
       "description": "<p>Get the next commit from the revision walk.</p>\n",
-      "comments": "<p>The initial call to this method is <em>not</em> blocking when\n iterating through a repo with a time-sorting mode.</p>\n\n<p>Iterating with Topological or inverted modes makes the initial\n call blocking to preprocess the commit list, but this block should be\n mostly unnoticeable on most repositories (topological preprocessing\n times at 0.3s on the git.git repo).</p>\n\n<p>The revision walker is reset when the walk is over.</p>\n",
+      "comments": "<p>The initial call to this method is <em>not</em> blocking when iterating through a repo with a time-sorting mode.</p>\n\n<p>Iterating with Topological or inverted modes makes the initial call blocking to preprocess the commit list, but this block should be mostly unnoticeable on most repositories (topological preprocessing times at 0.3s on the git.git repo).</p>\n\n<p>The revision walker is reset when the walk is over.</p>\n",
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_revwalk_next-76"
+          "ex/HEAD/general.html#git_revwalk_next-76"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_next-55"
+          "ex/HEAD/log.html#git_revwalk_next-51"
         ]
       }
     },
@@ -20530,11 +20340,11 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_revwalk_sorting-77"
+          "ex/HEAD/general.html#git_revwalk_sorting-77"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_sorting-56",
-          "ex/v0.28.0/log.html#git_revwalk_sorting-57"
+          "ex/HEAD/log.html#git_revwalk_sorting-52",
+          "ex/HEAD/log.html#git_revwalk_sorting-53"
         ]
       }
     },
@@ -20562,7 +20372,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Push and hide the respective endpoints of the given range.</p>\n",
-      "comments": "<p>The range should be of the form</p>\n\n<p>&lt;commit</p>\n\n<blockquote>\n<p>..\n&lt;commit</p>\n\n<p>where each \n&lt;commit\nis in the form accepted by &#39;git_revparse_single&#39;.\n The left-hand commit will be hidden and the right-hand commit pushed.</p>\n</blockquote>\n",
+      "comments": "<p>The range should be of the form   <commit>..<commit> where each <commit> is in the form accepted by &#39;git_revparse_single&#39;. The left-hand commit will be hidden and the right-hand commit pushed.</p>\n",
       "group": "revwalk"
     },
     "git_revwalk_simplify_first_parent": {
@@ -20610,10 +20420,10 @@
       "group": "revwalk",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_revwalk_free-78"
+          "ex/HEAD/general.html#git_revwalk_free-78"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_revwalk_free-58"
+          "ex/HEAD/log.html#git_revwalk_free-54"
         ]
       }
     },
@@ -20710,12 +20520,12 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new action signature.</p>\n",
-      "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n\n<p>Note: angle brackets (&#39;\n&lt;\n&#39; and &#39;&gt;&#39;) characters are not allowed\n to be used in either the <code>name</code> or the <code>email</code> parameter.</p>\n",
+      "comments": "<p>Call <code>git_signature_free()</code> to free the data.</p>\n\n<p>Note: angle brackets (&#39;&lt;&#39; and &#39;&gt;&#39;) characters are not allowed to be used in either the <code>name</code> or the <code>email</code> parameter.</p>\n",
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_signature_new-79",
-          "ex/v0.28.0/general.html#git_signature_new-80"
+          "ex/HEAD/general.html#git_signature_new-79",
+          "ex/HEAD/general.html#git_signature_new-80"
         ]
       }
     },
@@ -20752,7 +20562,7 @@
       "group": "signature",
       "examples": {
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_signature_now-40"
+          "ex/HEAD/merge.html#git_signature_now-36"
         ]
       }
     },
@@ -20780,14 +20590,14 @@
         "comment": " 0 on success, GIT_ENOTFOUND if config is missing, or error code"
       },
       "description": "<p>Create a new action signature with default user and now timestamp.</p>\n",
-      "comments": "<p>This looks up the user.name and user.email from the configuration and\n uses the current time as the timestamp, and creates a new signature\n based on that information.  It will return GIT_ENOTFOUND if either the\n user.name or user.email are not set.</p>\n",
+      "comments": "<p>This looks up the user.name and user.email from the configuration and uses the current time as the timestamp, and creates a new signature based on that information.  It will return GIT_ENOTFOUND if either the user.name or user.email are not set.</p>\n",
       "group": "signature",
       "examples": {
         "init.c": [
-          "ex/v0.28.0/init.html#git_signature_default-12"
+          "ex/HEAD/init.html#git_signature_default-10"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_signature_default-17"
+          "ex/HEAD/tag.html#git_signature_default-13"
         ]
       }
     },
@@ -20864,18 +20674,18 @@
         "comment": null
       },
       "description": "<p>Free an existing signature.</p>\n",
-      "comments": "<p>Because the signature is not an opaque structure, it is legal to free it\n manually, but be sure to free the &quot;name&quot; and &quot;email&quot; strings in addition\n to the structure itself.</p>\n",
+      "comments": "<p>Because the signature is not an opaque structure, it is legal to free it manually, but be sure to free the &quot;name&quot; and &quot;email&quot; strings in addition to the structure itself.</p>\n",
       "group": "signature",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_signature_free-81",
-          "ex/v0.28.0/general.html#git_signature_free-82"
+          "ex/HEAD/general.html#git_signature_free-81",
+          "ex/HEAD/general.html#git_signature_free-82"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_signature_free-13"
+          "ex/HEAD/init.html#git_signature_free-11"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_signature_free-18"
+          "ex/HEAD/tag.html#git_signature_free-14"
         ]
       }
     },
@@ -20888,40 +20698,40 @@
         {
           "name": "out",
           "type": "git_oid *",
-          "comment": null
+          "comment": "Object id of the commit containing the stashed state.\n This commit is also the target of the direct reference refs/stash."
         },
         {
           "name": "repo",
           "type": "git_repository *",
-          "comment": null
+          "comment": "The owning repository."
         },
         {
           "name": "stasher",
           "type": "const git_signature *",
-          "comment": null
+          "comment": "The identity of the person performing the stashing."
         },
         {
           "name": "message",
           "type": "const char *",
-          "comment": null
+          "comment": "Optional description along with the stashed state."
         },
         {
           "name": "flags",
-          "type": "int",
-          "comment": null
+          "type": "uint32_t",
+          "comment": "Flags to control the stashing process. (see GIT_STASH_* above)"
         }
       ],
-      "argline": "git_oid *out, git_repository *repo, const git_signature *stasher, const char *message, int flags",
-      "sig": "git_oid *::git_repository *::const git_signature *::const char *::int",
+      "argline": "git_oid *out, git_repository *repo, const git_signature *stasher, const char *message, uint32_t flags",
+      "sig": "git_oid *::git_repository *::const git_signature *::const char *::uint32_t",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " 0 on success, GIT_ENOTFOUND where there's nothing to stash,\n or error code."
       },
-      "description": "",
+      "description": "<p>Save the local modifications to a new stash.</p>\n",
       "comments": "",
       "group": "stash"
     },
-    "git_stash_apply_init_options": {
+    "git_stash_apply_options_init": {
       "type": "function",
       "file": "git2/stash.h",
       "line": 156,
@@ -20945,7 +20755,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_stash_apply_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_stash_apply_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_stash_apply_options</code> with default values. Equivalent to creating an instance with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>.</p>\n",
       "group": "stash"
     },
     "git_stash_apply": {
@@ -20977,7 +20787,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if there's no stashed state for the\n         given index, GIT_EMERGECONFLICT if changes exist in the working\n         directory, or an error code"
       },
       "description": "<p>Apply a single stashed state from the stash list.</p>\n",
-      "comments": "<p>If local changes in the working directory conflict with changes in the\n stash then GIT_EMERGECONFLICT will be returned.  In this case, the index\n will always remain unmodified and all files in the working directory will\n remain unmodified.  However, if you are restoring untracked files or\n ignored files and there is a conflict when applying the modified files,\n then those files will remain in the working directory.</p>\n\n<p>If passing the GIT_STASH_APPLY_REINSTATE_INDEX flag and there would be\n conflicts when reinstating the index, the function will return\n GIT_EMERGECONFLICT and both the working directory and index will be left\n unmodified.</p>\n\n<p>Note that a minimum checkout strategy of <code>GIT_CHECKOUT_SAFE</code> is implied.</p>\n",
+      "comments": "<p>If local changes in the working directory conflict with changes in the stash then GIT_EMERGECONFLICT will be returned.  In this case, the index will always remain unmodified and all files in the working directory will remain unmodified.  However, if you are restoring untracked files or ignored files and there is a conflict when applying the modified files, then those files will remain in the working directory.</p>\n\n<p>If passing the GIT_STASH_APPLY_REINSTATE_INDEX flag and there would be conflicts when reinstating the index, the function will return GIT_EMERGECONFLICT and both the working directory and index will be left unmodified.</p>\n\n<p>Note that a minimum checkout strategy of <code>GIT_CHECKOUT_SAFE</code> is implied.</p>\n",
       "group": "stash"
     },
     "git_stash_foreach": {
@@ -21071,7 +20881,7 @@
       "comments": "",
       "group": "stash"
     },
-    "git_status_init_options": {
+    "git_status_options_init": {
       "type": "function",
       "file": "git2/status.h",
       "line": 203,
@@ -21095,7 +20905,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_status_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_status_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_STATUS_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_status_options</code> with default values. Equivalent to creating an instance with <code>GIT_STATUS_OPTIONS_INIT</code>.</p>\n",
       "group": "status"
     },
     "git_status_foreach": {
@@ -21127,11 +20937,11 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Gather file statuses and run a callback for each one.</p>\n",
-      "comments": "<p>The callback is passed the path of the file, the status (a combination of\n the <code>git_status_t</code> values above) and the <code>payload</code> data pointer passed\n into this function.</p>\n\n<p>If the callback returns a non-zero value, this function will stop looping\n and return that value to caller.</p>\n",
+      "comments": "<p>The callback is passed the path of the file, the status (a combination of the <code>git_status_t</code> values above) and the <code>payload</code> data pointer passed into this function.</p>\n\n<p>If the callback returns a non-zero value, this function will stop looping and return that value to caller.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_foreach-10"
+          "ex/HEAD/status.html#git_status_foreach-6"
         ]
       }
     },
@@ -21169,11 +20979,11 @@
         "comment": " 0 on success, non-zero callback return value, or error code"
       },
       "description": "<p>Gather file status information and run callbacks as requested.</p>\n",
-      "comments": "<p>This is an extended version of the <code>git_status_foreach()</code> API that\n allows for more granular control over which paths will be processed and\n in what order.  See the <code>git_status_options</code> structure for details\n about the additional controls that this makes available.</p>\n\n<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter\n the status, then the results from rename detection (if you enable it) may\n not be accurate.  To do rename detection properly, this must be called\n with no <code>pathspec</code> so that all files can be considered.</p>\n",
+      "comments": "<p>This is an extended version of the <code>git_status_foreach()</code> API that allows for more granular control over which paths will be processed and in what order.  See the <code>git_status_options</code> structure for details about the additional controls that this makes available.</p>\n\n<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter the status, then the results from rename detection (if you enable it) may not be accurate.  To do rename detection properly, this must be called with no <code>pathspec</code> so that all files can be considered.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_foreach_ext-11"
+          "ex/HEAD/status.html#git_status_foreach_ext-7"
         ]
       }
     },
@@ -21206,8 +21016,13 @@
         "comment": " 0 on success, GIT_ENOTFOUND if the file is not found in the HEAD,\n      index, and work tree, GIT_EAMBIGUOUS if `path` matches multiple files\n      or if it refers to a folder, and -1 on other errors."
       },
       "description": "<p>Get file status for a single file.</p>\n",
-      "comments": "<p>This tries to get status for the filename that you give.  If no files\n match that name (in either the HEAD, index, or working directory), this\n returns GIT_ENOTFOUND.</p>\n\n<p>If the name matches multiple files (for example, if the <code>path</code> names a\n directory or if running on a case- insensitive filesystem and yet the\n HEAD has two entries that both match the path), then this returns\n GIT_EAMBIGUOUS because it cannot give correct results.</p>\n\n<p>This does not do any sort of rename detection.  Renames require a set of\n targets and because of the path filtering, there is not enough\n information to check renames correctly.  To check file status with rename\n detection, there is no choice but to do a full <code>git_status_list_new</code> and\n scan through looking for the path that you are interested in.</p>\n",
-      "group": "status"
+      "comments": "<p>This tries to get status for the filename that you give.  If no files match that name (in either the HEAD, index, or working directory), this returns GIT_ENOTFOUND.</p>\n\n<p>If the name matches multiple files (for example, if the <code>path</code> names a directory or if running on a case- insensitive filesystem and yet the HEAD has two entries that both match the path), then this returns GIT_EAMBIGUOUS because it cannot give correct results.</p>\n\n<p>This does not do any sort of rename detection.  Renames require a set of targets and because of the path filtering, there is not enough information to check renames correctly.  To check file status with rename detection, there is no choice but to do a full <code>git_status_list_new</code> and scan through looking for the path that you are interested in.</p>\n",
+      "group": "status",
+      "examples": {
+        "add.c": [
+          "ex/HEAD/add.html#git_status_file-6"
+        ]
+      }
     },
     "git_status_list_new": {
       "type": "function",
@@ -21238,12 +21053,12 @@
         "comment": " 0 on success or error code"
       },
       "description": "<p>Gather file status information and populate the <code>git_status_list</code>.</p>\n",
-      "comments": "<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter\n the status, then the results from rename detection (if you enable it) may\n not be accurate.  To do rename detection properly, this must be called\n with no <code>pathspec</code> so that all files can be considered.</p>\n",
+      "comments": "<p>Note that if a <code>pathspec</code> is given in the <code>git_status_options</code> to filter the status, then the results from rename detection (if you enable it) may not be accurate.  To do rename detection properly, this must be called with no <code>pathspec</code> so that all files can be considered.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_list_new-12",
-          "ex/v0.28.0/status.html#git_status_list_new-13"
+          "ex/HEAD/status.html#git_status_list_new-8",
+          "ex/HEAD/status.html#git_status_list_new-9"
         ]
       }
     },
@@ -21266,12 +21081,12 @@
         "comment": " the number of status entries"
       },
       "description": "<p>Gets the count of status entries in this list.</p>\n",
-      "comments": "<p>If there are no changes in status (at least according the options given\n when the status list was created), this can return 0.</p>\n",
+      "comments": "<p>If there are no changes in status (at least according the options given when the status list was created), this can return 0.</p>\n",
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_list_entrycount-14",
-          "ex/v0.28.0/status.html#git_status_list_entrycount-15"
+          "ex/HEAD/status.html#git_status_list_entrycount-10",
+          "ex/HEAD/status.html#git_status_list_entrycount-11"
         ]
       }
     },
@@ -21303,12 +21118,12 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_byindex-16",
-          "ex/v0.28.0/status.html#git_status_byindex-17",
-          "ex/v0.28.0/status.html#git_status_byindex-18",
-          "ex/v0.28.0/status.html#git_status_byindex-19",
-          "ex/v0.28.0/status.html#git_status_byindex-20",
-          "ex/v0.28.0/status.html#git_status_byindex-21"
+          "ex/HEAD/status.html#git_status_byindex-12",
+          "ex/HEAD/status.html#git_status_byindex-13",
+          "ex/HEAD/status.html#git_status_byindex-14",
+          "ex/HEAD/status.html#git_status_byindex-15",
+          "ex/HEAD/status.html#git_status_byindex-16",
+          "ex/HEAD/status.html#git_status_byindex-17"
         ]
       }
     },
@@ -21335,7 +21150,7 @@
       "group": "status",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_status_list_free-22"
+          "ex/HEAD/status.html#git_status_list_free-18"
         ]
       }
     },
@@ -21368,7 +21183,7 @@
         "comment": " 0 if ignore rules could be processed for the file (regardless\n         of whether it exists or not), or an error \n<\n 0 if they could not."
       },
       "description": "<p>Test if the ignore rules apply to a given file.</p>\n",
-      "comments": "<p>This function checks the ignore rules to see if they would apply to the\n given file.  This indicates if the file would be ignored regardless of\n whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git add .&quot; on the\n directory containing the file, would it be added or not?</p>\n",
+      "comments": "<p>This function checks the ignore rules to see if they would apply to the given file.  This indicates if the file would be ignored regardless of whether the file is already in the index or committed to the repository.</p>\n\n<p>One way to think of this is if you were to do &quot;git add .&quot; on the directory containing the file, would it be added or not?</p>\n",
       "group": "status"
     },
     "git_strarray_free": {
@@ -21390,18 +21205,18 @@
         "comment": null
       },
       "description": "<p>Close a string array object</p>\n",
-      "comments": "<p>This method should be called on <code>git_strarray</code> objects where the strings\n array is allocated and contains allocated strings, such as what you\n would get from <code>git_strarray_copy()</code>.  Not doing so, will result in a\n memory leak.</p>\n\n<p>This does not free the <code>git_strarray</code> itself, since the library will\n never allocate that object directly itself (it is more commonly embedded\n inside another struct or created on the stack).</p>\n",
+      "comments": "<p>This method should be called on <code>git_strarray</code> objects where the strings array is allocated and contains allocated strings, such as what you would get from <code>git_strarray_copy()</code>.  Not doing so, will result in a memory leak.</p>\n\n<p>This does not free the <code>git_strarray</code> itself, since the library will never allocate that object directly itself (it is more commonly embedded inside another struct or created on the stack).</p>\n",
       "group": "strarray",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_strarray_free-83"
+          "ex/HEAD/general.html#git_strarray_free-83"
         ],
         "remote.c": [
-          "ex/v0.28.0/remote.html#git_strarray_free-16",
-          "ex/v0.28.0/remote.html#git_strarray_free-17"
+          "ex/HEAD/remote.html#git_strarray_free-11",
+          "ex/HEAD/remote.html#git_strarray_free-12"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_strarray_free-19"
+          "ex/HEAD/tag.html#git_strarray_free-15"
         ]
       }
     },
@@ -21429,10 +21244,10 @@
         "comment": " 0 on success, \n<\n 0 on allocation failure"
       },
       "description": "<p>Copy a string array object from source to target.</p>\n",
-      "comments": "<p>Note: target is overwritten and hence should be empty, otherwise its\n contents are leaked.  Call git_strarray_free() if necessary.</p>\n",
+      "comments": "<p>Note: target is overwritten and hence should be empty, otherwise its contents are leaked.  Call git_strarray_free() if necessary.</p>\n",
       "group": "strarray"
     },
-    "git_submodule_update_init_options": {
+    "git_submodule_update_options_init": {
       "type": "function",
       "file": "git2/submodule.h",
       "line": 171,
@@ -21456,7 +21271,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_submodule_update_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_submodule_update_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_submodule_update_options</code> with default values. Equivalent to creating an instance with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>.</p>\n",
       "group": "submodule"
     },
     "git_submodule_update": {
@@ -21520,7 +21335,7 @@
         "comment": " 0 on success, GIT_ENOTFOUND if submodule does not exist,\n         GIT_EEXISTS if a repository is found in working directory only,\n         -1 on other errors."
       },
       "description": "<p>Lookup submodule information by name or path.</p>\n",
-      "comments": "<p>Given either the submodule name or path (they are usually the same), this\n returns a structure describing the submodule.</p>\n\n<p>There are two expected error scenarios:</p>\n\n<ul>\n<li>The submodule is not mentioned in the HEAD, the index, and the config,\nbut does &quot;exist&quot; in the working directory (i.e. there is a subdirectory\nthat appears to be a Git repository).  In this case, this function\nreturns GIT_EEXISTS to indicate a sub-repository exists but not in a\nstate where a git_submodule can be instantiated.</li>\n<li>The submodule is not mentioned in the HEAD, index, or config and the\nworking directory doesn&#39;t contain a value git repo at that path.\nThere may or may not be anything else at that path, but nothing that\nlooks like a submodule.  In this case, this returns GIT_ENOTFOUND.</li>\n</ul>\n\n<p>You must call <code>git_submodule_free</code> when done with the submodule.</p>\n",
+      "comments": "<p>Given either the submodule name or path (they are usually the same), this returns a structure describing the submodule.</p>\n\n<p>There are two expected error scenarios:</p>\n\n<ul>\n<li>The submodule is not mentioned in the HEAD, the index, and the config,   but does &quot;exist&quot; in the working directory (i.e. there is a subdirectory   that appears to be a Git repository).  In this case, this function   returns GIT_EEXISTS to indicate a sub-repository exists but not in a   state where a git_submodule can be instantiated. - The submodule is not mentioned in the HEAD, index, or config and the   working directory doesn&#39;t contain a value git repo at that path.   There may or may not be anything else at that path, but nothing that   looks like a submodule.  In this case, this returns GIT_ENOTFOUND.</li>\n</ul>\n\n<p>You must call <code>git_submodule_free</code> when done with the submodule.</p>\n",
       "group": "submodule"
     },
     "git_submodule_free": {
@@ -21574,11 +21389,11 @@
         "comment": " 0 on success, -1 on error, or non-zero return value of callback"
       },
       "description": "<p>Iterate over all tracked submodules of a repository.</p>\n",
-      "comments": "<p>See the note on <code>git_submodule</code> above.  This iterates over the tracked\n submodules as described therein.</p>\n\n<p>If you are concerned about items in the working directory that look like\n submodules but are not tracked, the diff API will generate a diff record\n for workdir items that look like submodules but are not tracked, showing\n them as added in the workdir.  Also, the status API will treat the entire\n subdirectory of a contained git repo as a single GIT_STATUS_WT_NEW item.</p>\n",
+      "comments": "<p>See the note on <code>git_submodule</code> above.  This iterates over the tracked submodules as described therein.</p>\n\n<p>If you are concerned about items in the working directory that look like submodules but are not tracked, the diff API will generate a diff record for workdir items that look like submodules but are not tracked, showing them as added in the workdir.  Also, the status API will treat the entire subdirectory of a contained git repo as a single GIT_STATUS_WT_NEW item.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_submodule_foreach-23"
+          "ex/HEAD/status.html#git_submodule_foreach-19"
         ]
       }
     },
@@ -21621,7 +21436,7 @@
         "comment": " 0 on success, GIT_EEXISTS if submodule already exists,\n         -1 on other errors."
       },
       "description": "<p>Set up a new git submodule for checkout.</p>\n",
-      "comments": "<p>This does &quot;git submodule add&quot; up to the fetch and checkout of the\n submodule contents.  It preps a new submodule, creates an entry in\n .gitmodules and creates an empty initialized repository either at the\n given path in the working directory or in .git/modules with a gitlink\n from the working directory to the new repo.</p>\n\n<p>To fully emulate &quot;git submodule add&quot; call this function, then open the\n submodule repo and perform the clone step as needed.  Lastly, call\n <code>git_submodule_add_finalize()</code> to wrap up adding the new submodule and\n .gitmodules to the index to be ready to commit.</p>\n\n<p>You must call <code>git_submodule_free</code> on the submodule object when done.</p>\n",
+      "comments": "<p>This does &quot;git submodule add&quot; up to the fetch and checkout of the submodule contents.  It preps a new submodule, creates an entry in .gitmodules and creates an empty initialized repository either at the given path in the working directory or in .git/modules with a gitlink from the working directory to the new repo.</p>\n\n<p>To fully emulate &quot;git submodule add&quot; call this function, then open the submodule repo and perform the clone step as needed.  Lastly, call <code>git_submodule_add_finalize()</code> to wrap up adding the new submodule and .gitmodules to the index to be ready to commit.</p>\n\n<p>You must call <code>git_submodule_free</code> on the submodule object when done.</p>\n",
       "group": "submodule"
     },
     "git_submodule_add_finalize": {
@@ -21643,7 +21458,7 @@
         "comment": null
       },
       "description": "<p>Resolve the setup of a new git submodule.</p>\n",
-      "comments": "<p>This should be called on a submodule once you have called add setup\n and done the clone of the submodule.  This adds the .gitmodules file\n and the newly cloned submodule to the index to be ready to be committed\n (but doesn&#39;t actually do the commit).</p>\n",
+      "comments": "<p>This should be called on a submodule once you have called add setup and done the clone of the submodule.  This adds the .gitmodules file and the newly cloned submodule to the index to be ready to be committed (but doesn&#39;t actually do the commit).</p>\n",
       "group": "submodule"
     },
     "git_submodule_add_to_index": {
@@ -21692,7 +21507,7 @@
         "comment": " Pointer to `git_repository`"
       },
       "description": "<p>Get the containing repository for a submodule.</p>\n",
-      "comments": "<p>This returns a pointer to the repository that contains the submodule.\n This is a just a reference to the repository that was passed to the\n original <code>git_submodule_lookup()</code> call, so if that repository has been\n freed, then this may be a dangling reference.</p>\n",
+      "comments": "<p>This returns a pointer to the repository that contains the submodule. This is a just a reference to the repository that was passed to the original <code>git_submodule_lookup()</code> call, so if that repository has been freed, then this may be a dangling reference.</p>\n",
       "group": "submodule"
     },
     "git_submodule_name": {
@@ -21718,7 +21533,7 @@
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_submodule_name-24"
+          "ex/HEAD/status.html#git_submodule_name-20"
         ]
       }
     },
@@ -21741,11 +21556,11 @@
         "comment": " Pointer to the submodule path"
       },
       "description": "<p>Get the path to the submodule.</p>\n",
-      "comments": "<p>The path is almost always the same as the submodule name, but the\n two are actually not required to match.</p>\n",
+      "comments": "<p>The path is almost always the same as the submodule name, but the two are actually not required to match.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_submodule_path-25"
+          "ex/HEAD/status.html#git_submodule_path-21"
         ]
       }
     },
@@ -21854,7 +21669,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set the branch for the submodule in the configuration</p>\n",
-      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to\n write the changes to the checked out submodule repository.</p>\n",
+      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to write the changes to the checked out submodule repository.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_url": {
@@ -21886,7 +21701,7 @@
         "comment": " 0 on success, \n<\n0 on failure"
       },
       "description": "<p>Set the URL for the submodule in the configuration</p>\n",
-      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to\n write the changes to the checked out submodule repository.</p>\n",
+      "comments": "<p>After calling this, you may wish to call <code>git_submodule_sync()</code> to write the changes to the checked out submodule repository.</p>\n",
       "group": "submodule"
     },
     "git_submodule_index_id": {
@@ -21952,7 +21767,7 @@
         "comment": " Pointer to git_oid or NULL if submodule is not checked out."
       },
       "description": "<p>Get the OID for the submodule in the current working directory.</p>\n",
-      "comments": "<p>This returns the OID that corresponds to looking up &#39;HEAD&#39; in the checked\n out submodule.  If there are pending changes in the index or anything\n else, this won&#39;t notice that.  You should call <code>git_submodule_status()</code>\n for a more complete picture about the state of the working directory.</p>\n",
+      "comments": "<p>This returns the OID that corresponds to looking up &#39;HEAD&#39; in the checked out submodule.  If there are pending changes in the index or anything else, this won&#39;t notice that.  You should call <code>git_submodule_status()</code> for a more complete picture about the state of the working directory.</p>\n",
       "group": "submodule"
     },
     "git_submodule_ignore": {
@@ -21974,7 +21789,7 @@
         "comment": " The current git_submodule_ignore_t valyue what will be used for\n         this submodule."
       },
       "description": "<p>Get the ignore rule that will be used for the submodule.</p>\n",
-      "comments": "<p>These values control the behavior of <code>git_submodule_status()</code> for this\n submodule.  There are four ignore values:</p>\n\n<ul>\n<li><strong>GIT_SUBMODULE_IGNORE_NONE</strong> will consider any change to the contents\nof the submodule from a clean checkout to be dirty, including the\naddition of untracked files.  This is the default if unspecified.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_UNTRACKED</strong> examines the contents of the\nworking tree (i.e. call <code>git_status_foreach()</code> on the submodule) but\nUNTRACKED files will not count as making the submodule dirty.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_DIRTY</strong> means to only check if the HEAD of the\nsubmodule has moved for status.  This is fast since it does not need to\nscan the working tree of the submodule at all.</li>\n<li><strong>GIT_SUBMODULE_IGNORE_ALL</strong> means not to open the submodule repo.\nThe working directory will be consider clean so long as there is a\nchecked out version present.</li>\n</ul>\n",
+      "comments": "<p>These values control the behavior of <code>git_submodule_status()</code> for this submodule.  There are four ignore values:</p>\n\n<ul>\n<li><strong>GIT_SUBMODULE_IGNORE_NONE</strong> will consider any change to the contents    of the submodule from a clean checkout to be dirty, including the    addition of untracked files.  This is the default if unspecified.  - <strong>GIT_SUBMODULE_IGNORE_UNTRACKED</strong> examines the contents of the    working tree (i.e. call <code>git_status_foreach()</code> on the submodule) but    UNTRACKED files will not count as making the submodule dirty.  - <strong>GIT_SUBMODULE_IGNORE_DIRTY</strong> means to only check if the HEAD of the    submodule has moved for status.  This is fast since it does not need to    scan the working tree of the submodule at all.  - <strong>GIT_SUBMODULE_IGNORE_ALL</strong> means not to open the submodule repo.    The working directory will be consider clean so long as there is a    checked out version present.</li>\n</ul>\n",
       "group": "submodule"
     },
     "git_submodule_set_ignore": {
@@ -22028,7 +21843,7 @@
         "comment": " The current git_submodule_update_t value that will be used\n         for this submodule."
       },
       "description": "<p>Get the update rule that will be used for the submodule.</p>\n",
-      "comments": "<p>This value controls the behavior of the <code>git submodule update</code> command.\n There are four useful values documented with <code>git_submodule_update_t</code>.</p>\n",
+      "comments": "<p>This value controls the behavior of the <code>git submodule update</code> command. There are four useful values documented with <code>git_submodule_update_t</code>.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_update": {
@@ -22082,7 +21897,7 @@
         "comment": " 0 if fetchRecurseSubmodules is false, 1 if true"
       },
       "description": "<p>Read the fetchRecurseSubmodules rule for a submodule.</p>\n",
-      "comments": "<p>This accesses the submodule.\n&lt;name</p>\n\n<blockquote>\n<p>.fetchRecurseSubmodules value for\n the submodule that controls fetching behavior for the submodule.</p>\n</blockquote>\n\n<p>Note that at this time, libgit2 does not honor this setting and the\n fetch functionality current ignores submodules.</p>\n",
+      "comments": "<p>This accesses the submodule.<name>.fetchRecurseSubmodules value for the submodule that controls fetching behavior for the submodule.</p>\n\n<p>Note that at this time, libgit2 does not honor this setting and the fetch functionality current ignores submodules.</p>\n",
       "group": "submodule"
     },
     "git_submodule_set_fetch_recurse_submodules": {
@@ -22141,7 +21956,7 @@
         "comment": " 0 on success, \n<\n0 on failure."
       },
       "description": "<p>Copy submodule info into &quot;.git/config&quot; file.</p>\n",
-      "comments": "<p>Just like &quot;git submodule init&quot;, this copies information about the\n submodule into &quot;.git/config&quot;.  You can use the accessor functions\n above to alter the in-memory git_submodule object and control what\n is written to the config, overriding what is in .gitmodules.</p>\n",
+      "comments": "<p>Just like &quot;git submodule init&quot;, this copies information about the submodule into &quot;.git/config&quot;.  You can use the accessor functions above to alter the in-memory git_submodule object and control what is written to the config, overriding what is in .gitmodules.</p>\n",
       "group": "submodule"
     },
     "git_submodule_repo_init": {
@@ -22173,7 +21988,7 @@
         "comment": " 0 on success, \n<\n0 on failure."
       },
       "description": "<p>Set up the subrepository for a submodule in preparation for clone.</p>\n",
-      "comments": "<p>This function can be called to init and set up a submodule\n repository from a submodule in preparation to clone it from\n its remote.</p>\n",
+      "comments": "<p>This function can be called to init and set up a submodule repository from a submodule in preparation to clone it from its remote.</p>\n",
       "group": "submodule"
     },
     "git_submodule_sync": {
@@ -22195,7 +22010,7 @@
         "comment": null
       },
       "description": "<p>Copy submodule remote info into submodule repo.</p>\n",
-      "comments": "<p>This copies the information about the submodules URL into the checked out\n submodule config, acting like &quot;git submodule sync&quot;.  This is useful if\n you have altered the URL for the submodule (or it has been altered by a\n fetch of upstream changes) and you need to update your local repo.</p>\n",
+      "comments": "<p>This copies the information about the submodules URL into the checked out submodule config, acting like &quot;git submodule sync&quot;.  This is useful if you have altered the URL for the submodule (or it has been altered by a fetch of upstream changes) and you need to update your local repo.</p>\n",
       "group": "submodule"
     },
     "git_submodule_open": {
@@ -22222,7 +22037,7 @@
         "comment": " 0 on success, \n<\n0 if submodule repo could not be opened."
       },
       "description": "<p>Open the repository for a submodule.</p>\n",
-      "comments": "<p>This is a newly opened repository object.  The caller is responsible for\n calling <code>git_repository_free()</code> on it when done.  Multiple calls to this\n function will return distinct <code>git_repository</code> objects.  This will only\n work if the submodule is checked out into the working directory.</p>\n",
+      "comments": "<p>This is a newly opened repository object.  The caller is responsible for calling <code>git_repository_free()</code> on it when done.  Multiple calls to this function will return distinct <code>git_repository</code> objects.  This will only work if the submodule is checked out into the working directory.</p>\n",
       "group": "submodule"
     },
     "git_submodule_reload": {
@@ -22249,7 +22064,7 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Reread submodule info from config, index, and HEAD.</p>\n",
-      "comments": "<p>Call this to reread cached submodule information for this submodule if\n you have reason to believe that it has changed.</p>\n",
+      "comments": "<p>Call this to reread cached submodule information for this submodule if you have reason to believe that it has changed.</p>\n",
       "group": "submodule"
     },
     "git_submodule_status": {
@@ -22286,11 +22101,11 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get the status for a submodule.</p>\n",
-      "comments": "<p>This looks at a submodule and tries to determine the status.  It\n will return a combination of the <code>GIT_SUBMODULE_STATUS</code> values above.\n How deeply it examines the working directory to do this will depend\n on the <code>git_submodule_ignore_t</code> value for the submodule.</p>\n",
+      "comments": "<p>This looks at a submodule and tries to determine the status.  It will return a combination of the <code>GIT_SUBMODULE_STATUS</code> values above. How deeply it examines the working directory to do this will depend on the <code>git_submodule_ignore_t</code> value for the submodule.</p>\n",
       "group": "submodule",
       "examples": {
         "status.c": [
-          "ex/v0.28.0/status.html#git_submodule_status-26"
+          "ex/HEAD/status.html#git_submodule_status-22"
         ]
       }
     },
@@ -22318,2427 +22133,8 @@
         "comment": " 0 on success, \n<\n0 on error"
       },
       "description": "<p>Get the locations of submodule information.</p>\n",
-      "comments": "<p>This is a bit like a very lightweight version of <code>git_submodule_status</code>.\n It just returns a made of the first four submodule status values (i.e.\n the ones like GIT_SUBMODULE_STATUS_IN_HEAD, etc) that tell you where the\n submodule data comes from (i.e. the HEAD commit, gitmodules file, etc.).\n This can be useful if you want to know if the submodule is present in the\n working directory at this point in time, etc.</p>\n",
+      "comments": "<p>This is a bit like a very lightweight version of <code>git_submodule_status</code>. It just returns a made of the first four submodule status values (i.e. the ones like GIT_SUBMODULE_STATUS_IN_HEAD, etc) that tell you where the submodule data comes from (i.e. the HEAD commit, gitmodules file, etc.). This can be useful if you want to know if the submodule is present in the working directory at this point in time, etc.</p>\n",
       "group": "submodule"
-    },
-    "git_stdalloc_init_allocator": {
-      "type": "function",
-      "file": "git2/sys/alloc.h",
-      "line": 85,
-      "lineto": 85,
-      "args": [
-        {
-          "name": "allocator",
-          "type": "git_allocator *",
-          "comment": "The allocator that is to be initialized."
-        }
-      ],
-      "argline": "git_allocator *allocator",
-      "sig": "git_allocator *",
-      "return": {
-        "type": "int",
-        "comment": " An error code or 0."
-      },
-      "description": "<p>Initialize the allocator structure to use the <code>stdalloc</code> pointer.</p>\n",
-      "comments": "<p>Set up the structure so that all of its members are using the standard\n &quot;stdalloc&quot; allocator functions. The structure can then be used with\n <code>git_allocator_setup</code>.</p>\n",
-      "group": "stdalloc"
-    },
-    "git_win32_crtdbg_init_allocator": {
-      "type": "function",
-      "file": "git2/sys/alloc.h",
-      "line": 97,
-      "lineto": 97,
-      "args": [
-        {
-          "name": "allocator",
-          "type": "git_allocator *",
-          "comment": "The allocator that is to be initialized."
-        }
-      ],
-      "argline": "git_allocator *allocator",
-      "sig": "git_allocator *",
-      "return": {
-        "type": "int",
-        "comment": " An error code or 0."
-      },
-      "description": "<p>Initialize the allocator structure to use the <code>crtdbg</code> pointer.</p>\n",
-      "comments": "<p>Set up the structure so that all of its members are using the &quot;crtdbg&quot;\n allocator functions. Note that this allocator is only available on Windows\n platforms and only if libgit2 is being compiled with &quot;-DMSVC_CRTDBG&quot;.</p>\n",
-      "group": "win32"
-    },
-    "git_commit_create_from_ids": {
-      "type": "function",
-      "file": "git2/sys/commit.h",
-      "line": 34,
-      "lineto": 44,
-      "args": [
-        {
-          "name": "id",
-          "type": "git_oid *",
-          "comment": null
-        },
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": null
-        },
-        {
-          "name": "update_ref",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "author",
-          "type": "const git_signature *",
-          "comment": null
-        },
-        {
-          "name": "committer",
-          "type": "const git_signature *",
-          "comment": null
-        },
-        {
-          "name": "message_encoding",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "message",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "tree",
-          "type": "const git_oid *",
-          "comment": null
-        },
-        {
-          "name": "parent_count",
-          "type": "size_t",
-          "comment": null
-        },
-        {
-          "name": "parents",
-          "type": "const git_oid *[]",
-          "comment": null
-        }
-      ],
-      "argline": "git_oid *id, git_repository *repo, const char *update_ref, const git_signature *author, const git_signature *committer, const char *message_encoding, const char *message, const git_oid *tree, size_t parent_count, const git_oid *[] parents",
-      "sig": "git_oid *::git_repository *::const char *::const git_signature *::const git_signature *::const char *::const char *::const git_oid *::size_t::const git_oid *[]",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Create new commit in the repository from a list of <code>git_oid</code> values.</p>\n",
-      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the\n parameters, as the meaning is identical excepting that <code>tree</code> and\n <code>parents</code> now take <code>git_oid</code>.  This is a dangerous API in that nor\n the <code>tree</code>, neither the <code>parents</code> list of <code>git_oid</code>s are checked for\n validity.</p>\n",
-      "group": "commit"
-    },
-    "git_commit_create_from_callback": {
-      "type": "function",
-      "file": "git2/sys/commit.h",
-      "line": 66,
-      "lineto": 76,
-      "args": [
-        {
-          "name": "id",
-          "type": "git_oid *",
-          "comment": null
-        },
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": null
-        },
-        {
-          "name": "update_ref",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "author",
-          "type": "const git_signature *",
-          "comment": null
-        },
-        {
-          "name": "committer",
-          "type": "const git_signature *",
-          "comment": null
-        },
-        {
-          "name": "message_encoding",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "message",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "tree",
-          "type": "const git_oid *",
-          "comment": null
-        },
-        {
-          "name": "parent_cb",
-          "type": "git_commit_parent_callback",
-          "comment": null
-        },
-        {
-          "name": "parent_payload",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_oid *id, git_repository *repo, const char *update_ref, const git_signature *author, const git_signature *committer, const char *message_encoding, const char *message, const git_oid *tree, git_commit_parent_callback parent_cb, void *parent_payload",
-      "sig": "git_oid *::git_repository *::const char *::const git_signature *::const git_signature *::const char *::const char *::const git_oid *::git_commit_parent_callback::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Create a new commit in the repository with an callback to supply parents.</p>\n",
-      "comments": "<p>See documentation for <code>git_commit_create()</code> for information about the\n parameters, as the meaning is identical excepting that <code>tree</code> takes a\n <code>git_oid</code> and doesn&#39;t check for validity, and <code>parent_cb</code> is invoked\n with <code>parent_payload</code> and should return <code>git_oid</code> values or NULL to\n indicate that all parents are accounted for.</p>\n",
-      "group": "commit"
-    },
-    "git_config_init_backend": {
-      "type": "function",
-      "file": "git2/sys/config.h",
-      "line": 97,
-      "lineto": 99,
-      "args": [
-        {
-          "name": "backend",
-          "type": "git_config_backend *",
-          "comment": "the `git_config_backend` struct to initialize."
-        },
-        {
-          "name": "version",
-          "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_CONFIG_BACKEND_VERSION`"
-        }
-      ],
-      "argline": "git_config_backend *backend, unsigned int version",
-      "sig": "git_config_backend *::unsigned int",
-      "return": {
-        "type": "int",
-        "comment": " Zero on success; -1 on failure."
-      },
-      "description": "<p>Initializes a <code>git_config_backend</code> with default values. Equivalent to\n creating an instance with GIT_CONFIG_BACKEND_INIT.</p>\n",
-      "comments": "",
-      "group": "config"
-    },
-    "git_config_add_backend": {
-      "type": "function",
-      "file": "git2/sys/config.h",
-      "line": 121,
-      "lineto": 126,
-      "args": [
-        {
-          "name": "cfg",
-          "type": "git_config *",
-          "comment": "the configuration to add the file to"
-        },
-        {
-          "name": "file",
-          "type": "git_config_backend *",
-          "comment": "the configuration file (backend) to add"
-        },
-        {
-          "name": "level",
-          "type": "git_config_level_t",
-          "comment": "the priority level of the backend"
-        },
-        {
-          "name": "repo",
-          "type": "const git_repository *",
-          "comment": "optional repository to allow parsing of\n  conditional includes"
-        },
-        {
-          "name": "force",
-          "type": "int",
-          "comment": "if a config file already exists for the given\n  priority level, replace it"
-        }
-      ],
-      "argline": "git_config *cfg, git_config_backend *file, git_config_level_t level, const git_repository *repo, int force",
-      "sig": "git_config *::git_config_backend *::git_config_level_t::const git_repository *::int",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, GIT_EEXISTS when adding more than one file\n  for a given priority level (and force_replace set to 0), or error code"
-      },
-      "description": "<p>Add a generic config file instance to an existing config</p>\n",
-      "comments": "<p>Note that the configuration object will free the file\n automatically.</p>\n\n<p>Further queries on this config object will access each\n of the config file instances in order (instances with\n a higher priority level will be accessed first).</p>\n",
-      "group": "config"
-    },
-    "git_diff_print_callback__to_buf": {
-      "type": "function",
-      "file": "git2/sys/diff.h",
-      "line": 37,
-      "lineto": 41,
-      "args": [
-        {
-          "name": "delta",
-          "type": "const git_diff_delta *",
-          "comment": null
-        },
-        {
-          "name": "hunk",
-          "type": "const git_diff_hunk *",
-          "comment": null
-        },
-        {
-          "name": "line",
-          "type": "const git_diff_line *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload",
-      "sig": "const git_diff_delta *::const git_diff_hunk *::const git_diff_line *::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Diff print callback that writes to a git_buf.</p>\n",
-      "comments": "<p>This function is provided not for you to call it directly, but instead\n so you can use it as a function pointer to the <code>git_diff_print</code> or\n <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback\n to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a <code>git_buf</code> buffer.  You\n must pass a <code>git_buf *</code> value as the payload to the <code>git_diff_print</code>\n and/or <code>git_patch_print</code> function.  The data will be appended to the\n buffer (after any existing content).</p>\n",
-      "group": "diff"
-    },
-    "git_diff_print_callback__to_file_handle": {
-      "type": "function",
-      "file": "git2/sys/diff.h",
-      "line": 57,
-      "lineto": 61,
-      "args": [
-        {
-          "name": "delta",
-          "type": "const git_diff_delta *",
-          "comment": null
-        },
-        {
-          "name": "hunk",
-          "type": "const git_diff_hunk *",
-          "comment": null
-        },
-        {
-          "name": "line",
-          "type": "const git_diff_line *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_diff_delta *delta, const git_diff_hunk *hunk, const git_diff_line *line, void *payload",
-      "sig": "const git_diff_delta *::const git_diff_hunk *::const git_diff_line *::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Diff print callback that writes to stdio FILE handle.</p>\n",
-      "comments": "<p>This function is provided not for you to call it directly, but instead\n so you can use it as a function pointer to the <code>git_diff_print</code> or\n <code>git_patch_print</code> APIs.  When using those APIs, you specify a callback\n to actually handle the diff and/or patch data.</p>\n\n<p>Use this callback to easily write that data to a stdio FILE handle.  You\n must pass a <code>FILE *</code> value (such as <code>stdout</code> or <code>stderr</code> or the return\n value from <code>fopen()</code>) as the payload to the <code>git_diff_print</code>\n and/or <code>git_patch_print</code> function.  If you pass NULL, this will write\n data to <code>stdout</code>.</p>\n",
-      "group": "diff"
-    },
-    "git_diff_get_perfdata": {
-      "type": "function",
-      "file": "git2/sys/diff.h",
-      "line": 83,
-      "lineto": 84,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_diff_perfdata *",
-          "comment": "Structure to be filled with diff performance data"
-        },
-        {
-          "name": "diff",
-          "type": "const git_diff *",
-          "comment": "Diff to read performance data from"
-        }
-      ],
-      "argline": "git_diff_perfdata *out, const git_diff *diff",
-      "sig": "git_diff_perfdata *::const git_diff *",
-      "return": {
-        "type": "int",
-        "comment": " 0 for success, \n<\n0 for error"
-      },
-      "description": "<p>Get performance data for a diff object.</p>\n",
-      "comments": "",
-      "group": "diff"
-    },
-    "git_status_list_get_perfdata": {
-      "type": "function",
-      "file": "git2/sys/diff.h",
-      "line": 89,
-      "lineto": 90,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_diff_perfdata *",
-          "comment": null
-        },
-        {
-          "name": "status",
-          "type": "const git_status_list *",
-          "comment": null
-        }
-      ],
-      "argline": "git_diff_perfdata *out, const git_status_list *status",
-      "sig": "git_diff_perfdata *::const git_status_list *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Get performance data for diffs from a git_status_list</p>\n",
-      "comments": "",
-      "group": "status"
-    },
-    "git_filter_lookup": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 27,
-      "lineto": 27,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "The name of the filter"
-        }
-      ],
-      "argline": "const char *name",
-      "sig": "const char *",
-      "return": {
-        "type": "git_filter *",
-        "comment": " Pointer to the filter object or NULL if not found"
-      },
-      "description": "<p>Look up a filter by name</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_list_new": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 57,
-      "lineto": 61,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_filter_list **",
-          "comment": null
-        },
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": null
-        },
-        {
-          "name": "mode",
-          "type": "git_filter_mode_t",
-          "comment": null
-        },
-        {
-          "name": "options",
-          "type": "int",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter_list **out, git_repository *repo, git_filter_mode_t mode, int options",
-      "sig": "git_filter_list **::git_repository *::git_filter_mode_t::int",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_list_push": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 76,
-      "lineto": 77,
-      "args": [
-        {
-          "name": "fl",
-          "type": "git_filter_list *",
-          "comment": null
-        },
-        {
-          "name": "filter",
-          "type": "git_filter *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter_list *fl, git_filter *filter, void *payload",
-      "sig": "git_filter_list *::git_filter *::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Add a filter to a filter list with the given payload.</p>\n",
-      "comments": "<p>Normally you won&#39;t have to do this because the filter list is created\n by calling the &quot;check&quot; function on registered filters when the filter\n attributes are set, but this does allow more direct manipulation of\n filter lists when desired.</p>\n\n<p>Note that normally the &quot;check&quot; function can set up a payload for the\n filter.  Using this function, you can either pass in a payload if you\n know the expected payload format, or you can pass NULL.  Some filters\n may fail with a NULL payload.  Good luck!</p>\n",
-      "group": "filter"
-    },
-    "git_filter_list_length": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 90,
-      "lineto": 90,
-      "args": [
-        {
-          "name": "fl",
-          "type": "const git_filter_list *",
-          "comment": "A filter list"
-        }
-      ],
-      "argline": "const git_filter_list *fl",
-      "sig": "const git_filter_list *",
-      "return": {
-        "type": "size_t",
-        "comment": " The number of filters in the list"
-      },
-      "description": "<p>Look up how many filters are in the list</p>\n",
-      "comments": "<p>We will attempt to apply all of these filters to any data passed in,\n but note that the filter apply action still has the option of skipping\n data that is passed in (for example, the CRLF filter will skip data\n that appears to be binary).</p>\n",
-      "group": "filter"
-    },
-    "git_filter_source_repo": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 100,
-      "lineto": 100,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
-      "return": {
-        "type": "git_repository *",
-        "comment": null
-      },
-      "description": "<p>Get the repository that the source data is coming from.</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_source_path": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 105,
-      "lineto": 105,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
-      "return": {
-        "type": "const char *",
-        "comment": null
-      },
-      "description": "<p>Get the path that the source data is coming from.</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_source_filemode": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 111,
-      "lineto": 111,
-      "args": [],
-      "argline": "",
-      "sig": "",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_source_id": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 118,
-      "lineto": 118,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
-      "return": {
-        "type": "const git_oid *",
-        "comment": null
-      },
-      "description": "<p>Get the OID of the source\n If the OID is unknown (often the case with GIT_FILTER_CLEAN) then\n this will return NULL.</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_source_mode": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 123,
-      "lineto": 123,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_filter_source *src",
-      "sig": "const git_filter_source *",
-      "return": {
-        "type": "git_filter_mode_t",
-        "comment": null
-      },
-      "description": "<p>Get the git_filter_mode_t to be used</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_source_flags": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 128,
-      "lineto": 128,
-      "args": [],
-      "argline": "",
-      "sig": "",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_init": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 284,
-      "lineto": 284,
-      "args": [
-        {
-          "name": "filter",
-          "type": "git_filter *",
-          "comment": "the `git_filter` struct to initialize."
-        },
-        {
-          "name": "version",
-          "type": "unsigned int",
-          "comment": "Version the struct; pass `GIT_FILTER_VERSION`"
-        }
-      ],
-      "argline": "git_filter *filter, unsigned int version",
-      "sig": "git_filter *::unsigned int",
-      "return": {
-        "type": "int",
-        "comment": " Zero on success; -1 on failure."
-      },
-      "description": "<p>Initializes a <code>git_filter</code> with default values. Equivalent to\n creating an instance with GIT_FILTER_INIT.</p>\n",
-      "comments": "",
-      "group": "filter"
-    },
-    "git_filter_register": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 312,
-      "lineto": 313,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "A name by which the filter can be referenced.  Attempting\n \t\t\tto register with an in-use name will return GIT_EEXISTS."
-        },
-        {
-          "name": "filter",
-          "type": "git_filter *",
-          "comment": "The filter definition.  This pointer will be stored as is\n \t\t\tby libgit2 so it must be a durable allocation (either static\n \t\t\tor on the heap)."
-        },
-        {
-          "name": "priority",
-          "type": "int",
-          "comment": "The priority for filter application"
-        }
-      ],
-      "argline": "const char *name, git_filter *filter, int priority",
-      "sig": "const char *::git_filter *::int",
-      "return": {
-        "type": "int",
-        "comment": " 0 on successful registry, error code \n<\n0 on failure"
-      },
-      "description": "<p>Register a filter under a given name with a given priority.</p>\n",
-      "comments": "<p>As mentioned elsewhere, the initialize callback will not be invoked\n immediately.  It is deferred until the filter is used in some way.</p>\n\n<p>A filter&#39;s attribute checks and <code>check</code> and <code>apply</code> callbacks will be\n issued in order of <code>priority</code> on smudge (to workdir), and in reverse\n order of <code>priority</code> on clean (to odb).</p>\n\n<p>Two filters are preregistered with libgit2:\n - GIT_FILTER_CRLF with priority 0\n - GIT_FILTER_IDENT with priority 100</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or\n deregistering of filters must be done outside of any possible usage of\n the filters (i.e. during application setup or shutdown).</p>\n",
-      "group": "filter"
-    },
-    "git_filter_unregister": {
-      "type": "function",
-      "file": "git2/sys/filter.h",
-      "line": 328,
-      "lineto": 328,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "The name under which the filter was registered"
-        }
-      ],
-      "argline": "const char *name",
-      "sig": "const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, error code \n<\n0 on failure"
-      },
-      "description": "<p>Remove the filter with the given name</p>\n",
-      "comments": "<p>Attempting to remove the builtin libgit2 filters is not permitted and\n will return an error.</p>\n\n<p>Currently the filter registry is not thread safe, so any registering or\n deregistering of filters must be done outside of any possible usage of\n the filters (i.e. during application setup or shutdown).</p>\n",
-      "group": "filter"
-    },
-    "git_hashsig_create": {
-      "type": "function",
-      "file": "git2/sys/hashsig.h",
-      "line": 62,
-      "lineto": 66,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_hashsig **",
-          "comment": "The computed similarity signature."
-        },
-        {
-          "name": "buf",
-          "type": "const char *",
-          "comment": "The input buffer."
-        },
-        {
-          "name": "buflen",
-          "type": "size_t",
-          "comment": "The input buffer size."
-        },
-        {
-          "name": "opts",
-          "type": "git_hashsig_option_t",
-          "comment": "The signature computation options (see above)."
-        }
-      ],
-      "argline": "git_hashsig **out, const char *buf, size_t buflen, git_hashsig_option_t opts",
-      "sig": "git_hashsig **::const char *::size_t::git_hashsig_option_t",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, GIT_EBUFS if the buffer doesn't contain enough data to\n compute a valid signature (unless GIT_HASHSIG_ALLOW_SMALL_FILES is set), or\n error code."
-      },
-      "description": "<p>Compute a similarity signature for a text buffer</p>\n",
-      "comments": "<p>If you have passed the option GIT_HASHSIG_IGNORE_WHITESPACE, then the\n whitespace will be removed from the buffer while it is being processed,\n modifying the buffer in place. Sorry about that!</p>\n",
-      "group": "hashsig"
-    },
-    "git_hashsig_create_fromfile": {
-      "type": "function",
-      "file": "git2/sys/hashsig.h",
-      "line": 81,
-      "lineto": 84,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_hashsig **",
-          "comment": "The computed similarity signature."
-        },
-        {
-          "name": "path",
-          "type": "const char *",
-          "comment": "The path to the input file."
-        },
-        {
-          "name": "opts",
-          "type": "git_hashsig_option_t",
-          "comment": "The signature computation options (see above)."
-        }
-      ],
-      "argline": "git_hashsig **out, const char *path, git_hashsig_option_t opts",
-      "sig": "git_hashsig **::const char *::git_hashsig_option_t",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, GIT_EBUFS if the buffer doesn't contain enough data to\n compute a valid signature (unless GIT_HASHSIG_ALLOW_SMALL_FILES is set), or\n error code."
-      },
-      "description": "<p>Compute a similarity signature for a text file</p>\n",
-      "comments": "<p>This walks through the file, only loading a maximum of 4K of file data at\n a time. Otherwise, it acts just like <code>git_hashsig_create</code>.</p>\n",
-      "group": "hashsig"
-    },
-    "git_hashsig_free": {
-      "type": "function",
-      "file": "git2/sys/hashsig.h",
-      "line": 91,
-      "lineto": 91,
-      "args": [
-        {
-          "name": "sig",
-          "type": "git_hashsig *",
-          "comment": "The similarity signature to free."
-        }
-      ],
-      "argline": "git_hashsig *sig",
-      "sig": "git_hashsig *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Release memory for a content similarity signature</p>\n",
-      "comments": "",
-      "group": "hashsig"
-    },
-    "git_hashsig_compare": {
-      "type": "function",
-      "file": "git2/sys/hashsig.h",
-      "line": 100,
-      "lineto": 102,
-      "args": [
-        {
-          "name": "a",
-          "type": "const git_hashsig *",
-          "comment": "The first similarity signature to compare."
-        },
-        {
-          "name": "b",
-          "type": "const git_hashsig *",
-          "comment": "The second similarity signature to compare."
-        }
-      ],
-      "argline": "const git_hashsig *a, const git_hashsig *b",
-      "sig": "const git_hashsig *::const git_hashsig *",
-      "return": {
-        "type": "int",
-        "comment": " [0 to 100] on success as the similarity score, or error code."
-      },
-      "description": "<p>Measure similarity score between two similarity signatures</p>\n",
-      "comments": "",
-      "group": "hashsig"
-    },
-    "git_index_name_entrycount": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 48,
-      "lineto": 48,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        }
-      ],
-      "argline": "git_index *index",
-      "sig": "git_index *",
-      "return": {
-        "type": "size_t",
-        "comment": " integer of count of current filename conflict entries"
-      },
-      "description": "<p>Get the count of filename conflict entries currently in the index.</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_name_get_byindex": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 60,
-      "lineto": 61,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "n",
-          "type": "size_t",
-          "comment": "the position of the entry"
-        }
-      ],
-      "argline": "git_index *index, size_t n",
-      "sig": "git_index *::size_t",
-      "return": {
-        "type": "const git_index_name_entry *",
-        "comment": " a pointer to the filename conflict entry; NULL if out of bounds"
-      },
-      "description": "<p>Get a filename conflict entry from the index.</p>\n",
-      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
-      "group": "index"
-    },
-    "git_index_name_add": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 71,
-      "lineto": 72,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "ancestor",
-          "type": "const char *",
-          "comment": "the path of the file as it existed in the ancestor"
-        },
-        {
-          "name": "ours",
-          "type": "const char *",
-          "comment": "the path of the file as it existed in our tree"
-        },
-        {
-          "name": "theirs",
-          "type": "const char *",
-          "comment": "the path of the file as it existed in their tree"
-        }
-      ],
-      "argline": "git_index *index, const char *ancestor, const char *ours, const char *theirs",
-      "sig": "git_index *::const char *::const char *::const char *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Record the filenames involved in a rename conflict.</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_name_clear": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 79,
-      "lineto": 79,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        }
-      ],
-      "argline": "git_index *index",
-      "sig": "git_index *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Remove all filename conflict entries.</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_reuc_entrycount": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 96,
-      "lineto": 96,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        }
-      ],
-      "argline": "git_index *index",
-      "sig": "git_index *",
-      "return": {
-        "type": "size_t",
-        "comment": " integer of count of current resolve undo entries"
-      },
-      "description": "<p>Get the count of resolve undo entries currently in the index.</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_reuc_find": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 107,
-      "lineto": 107,
-      "args": [
-        {
-          "name": "at_pos",
-          "type": "size_t *",
-          "comment": "the address to which the position of the reuc entry is written (optional)"
-        },
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "path",
-          "type": "const char *",
-          "comment": "path to search"
-        }
-      ],
-      "argline": "size_t *at_pos, git_index *index, const char *path",
-      "sig": "size_t *::git_index *::const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 if found, \n<\n 0 otherwise (GIT_ENOTFOUND)"
-      },
-      "description": "<p>Finds the resolve undo entry that points to the given path in the Git\n index.</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_reuc_get_bypath": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 119,
-      "lineto": 119,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "path",
-          "type": "const char *",
-          "comment": "path to search"
-        }
-      ],
-      "argline": "git_index *index, const char *path",
-      "sig": "git_index *::const char *",
-      "return": {
-        "type": "const git_index_reuc_entry *",
-        "comment": " the resolve undo entry; NULL if not found"
-      },
-      "description": "<p>Get a resolve undo entry from the index.</p>\n",
-      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
-      "group": "index"
-    },
-    "git_index_reuc_get_byindex": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 131,
-      "lineto": 131,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "n",
-          "type": "size_t",
-          "comment": "the position of the entry"
-        }
-      ],
-      "argline": "git_index *index, size_t n",
-      "sig": "git_index *::size_t",
-      "return": {
-        "type": "const git_index_reuc_entry *",
-        "comment": " a pointer to the resolve undo entry; NULL if out of bounds"
-      },
-      "description": "<p>Get a resolve undo entry from the index.</p>\n",
-      "comments": "<p>The returned entry is read-only and should not be modified\n or freed by the caller.</p>\n",
-      "group": "index"
-    },
-    "git_index_reuc_add": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 155,
-      "lineto": 158,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "path",
-          "type": "const char *",
-          "comment": "filename to add"
-        },
-        {
-          "name": "ancestor_mode",
-          "type": "int",
-          "comment": "mode of the ancestor file"
-        },
-        {
-          "name": "ancestor_id",
-          "type": "const git_oid *",
-          "comment": "oid of the ancestor file"
-        },
-        {
-          "name": "our_mode",
-          "type": "int",
-          "comment": "mode of our file"
-        },
-        {
-          "name": "our_id",
-          "type": "const git_oid *",
-          "comment": "oid of our file"
-        },
-        {
-          "name": "their_mode",
-          "type": "int",
-          "comment": "mode of their file"
-        },
-        {
-          "name": "their_id",
-          "type": "const git_oid *",
-          "comment": "oid of their file"
-        }
-      ],
-      "argline": "git_index *index, const char *path, int ancestor_mode, const git_oid *ancestor_id, int our_mode, const git_oid *our_id, int their_mode, const git_oid *their_id",
-      "sig": "git_index *::const char *::int::const git_oid *::int::const git_oid *::int::const git_oid *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Adds a resolve undo entry for a file based on the given parameters.</p>\n",
-      "comments": "<p>The resolve undo entry contains the OIDs of files that were involved\n in a merge conflict after the conflict has been resolved.  This allows\n conflicts to be re-resolved later.</p>\n\n<p>If there exists a resolve undo entry for the given path in the index,\n it will be removed.</p>\n\n<p>This method will fail in bare index instances.</p>\n",
-      "group": "index"
-    },
-    "git_index_reuc_remove": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 167,
-      "lineto": 167,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        },
-        {
-          "name": "n",
-          "type": "size_t",
-          "comment": "position of the resolve undo entry to remove"
-        }
-      ],
-      "argline": "git_index *index, size_t n",
-      "sig": "git_index *::size_t",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Remove an resolve undo entry from the index</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_index_reuc_clear": {
-      "type": "function",
-      "file": "git2/sys/index.h",
-      "line": 174,
-      "lineto": 174,
-      "args": [
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "an existing index object"
-        }
-      ],
-      "argline": "git_index *index",
-      "sig": "git_index *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Remove all resolve undo entries from the index</p>\n",
-      "comments": "",
-      "group": "index"
-    },
-    "git_mempack_new": {
-      "type": "function",
-      "file": "git2/sys/mempack.h",
-      "line": 45,
-      "lineto": 45,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_odb_backend **",
-          "comment": "Pointer where to store the ODB backend"
-        }
-      ],
-      "argline": "git_odb_backend **out",
-      "sig": "git_odb_backend **",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success; error code otherwise"
-      },
-      "description": "<p>Instantiate a new mempack backend.</p>\n",
-      "comments": "<p>The backend must be added to an existing ODB with the highest\n priority.</p>\n\n<pre><code> git_mempack_new(\n</code></pre>\n\n<p>&amp;mempacker\n);\n     git_repository_odb(\n&amp;odb\n, repository);\n     git_odb_add_backend(odb, mempacker, 999);</p>\n\n<p>Once the backend has been loaded, all writes to the ODB will\n instead be queued in memory, and can be finalized with\n <code>git_mempack_dump</code>.</p>\n\n<p>Subsequent reads will also be served from the in-memory store\n to ensure consistency, until the memory store is dumped.</p>\n",
-      "group": "mempack"
-    },
-    "git_mempack_dump": {
-      "type": "function",
-      "file": "git2/sys/mempack.h",
-      "line": 68,
-      "lineto": 68,
-      "args": [
-        {
-          "name": "pack",
-          "type": "git_buf *",
-          "comment": "Buffer where to store the raw packfile"
-        },
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "The active repository where the backend is loaded"
-        },
-        {
-          "name": "backend",
-          "type": "git_odb_backend *",
-          "comment": "The mempack backend"
-        }
-      ],
-      "argline": "git_buf *pack, git_repository *repo, git_odb_backend *backend",
-      "sig": "git_buf *::git_repository *::git_odb_backend *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success; error code otherwise"
-      },
-      "description": "<p>Dump all the queued in-memory writes to a packfile.</p>\n",
-      "comments": "<p>The contents of the packfile will be stored in the given buffer.\n It is the caller&#39;s responsibility to ensure that the generated\n packfile is available to the repository (e.g. by writing it\n to disk, or doing something crazy like distributing it across\n several copies of the repository over a network).</p>\n\n<p>Once the generated packfile is available to the repository,\n call <code>git_mempack_reset</code> to cleanup the memory store.</p>\n\n<p>Calling <code>git_mempack_reset</code> before the packfile has been\n written to disk will result in an inconsistent repository\n (the objects in the memory store won&#39;t be accessible).</p>\n",
-      "group": "mempack"
-    },
-    "git_mempack_reset": {
-      "type": "function",
-      "file": "git2/sys/mempack.h",
-      "line": 82,
-      "lineto": 82,
-      "args": [
-        {
-          "name": "backend",
-          "type": "git_odb_backend *",
-          "comment": "The mempack backend"
-        }
-      ],
-      "argline": "git_odb_backend *backend",
-      "sig": "git_odb_backend *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Reset the memory packer by clearing all the queued objects.</p>\n",
-      "comments": "<p>This assumes that <code>git_mempack_dump</code> has been called before to\n store all the queued objects into a single packfile.</p>\n\n<p>Alternatively, call <code>reset</code> without a previous dump to &quot;undo&quot;\n all the recently written objects, giving transaction-like\n semantics to the Git repository.</p>\n",
-      "group": "mempack"
-    },
-    "git_merge_driver_lookup": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 32,
-      "lineto": 32,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "The name of the merge driver"
-        }
-      ],
-      "argline": "const char *name",
-      "sig": "const char *",
-      "return": {
-        "type": "git_merge_driver *",
-        "comment": " Pointer to the merge driver object or NULL if not found"
-      },
-      "description": "<p>Look up a merge driver by name</p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_source_repo": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 44,
-      "lineto": 45,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_merge_driver_source *src",
-      "sig": "const git_merge_driver_source *",
-      "return": {
-        "type": "const git_repository *",
-        "comment": null
-      },
-      "description": "<p>Get the repository that the source data is coming from. </p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_source_ancestor": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 48,
-      "lineto": 49,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_merge_driver_source *src",
-      "sig": "const git_merge_driver_source *",
-      "return": {
-        "type": "const git_index_entry *",
-        "comment": null
-      },
-      "description": "<p>Gets the ancestor of the file to merge. </p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_source_ours": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 52,
-      "lineto": 53,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_merge_driver_source *src",
-      "sig": "const git_merge_driver_source *",
-      "return": {
-        "type": "const git_index_entry *",
-        "comment": null
-      },
-      "description": "<p>Gets the ours side of the file to merge. </p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_source_theirs": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 56,
-      "lineto": 57,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_merge_driver_source *src",
-      "sig": "const git_merge_driver_source *",
-      "return": {
-        "type": "const git_index_entry *",
-        "comment": null
-      },
-      "description": "<p>Gets the theirs side of the file to merge. </p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_source_file_options": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 60,
-      "lineto": 61,
-      "args": [
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "const git_merge_driver_source *src",
-      "sig": "const git_merge_driver_source *",
-      "return": {
-        "type": "const git_merge_file_options *",
-        "comment": null
-      },
-      "description": "<p>Gets the merge file options that the merge was invoked with </p>\n",
-      "comments": "",
-      "group": "merge"
-    },
-    "git_merge_driver_register": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 162,
-      "lineto": 163,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "The name of this driver to match an attribute.  Attempting\n \t\t\tto register with an in-use name will return GIT_EEXISTS."
-        },
-        {
-          "name": "driver",
-          "type": "git_merge_driver *",
-          "comment": "The merge driver definition.  This pointer will be stored\n\t\t\tas is by libgit2 so it must be a durable allocation (either\n\t\t\tstatic or on the heap)."
-        }
-      ],
-      "argline": "const char *name, git_merge_driver *driver",
-      "sig": "const char *::git_merge_driver *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on successful registry, error code \n<\n0 on failure"
-      },
-      "description": "<p>Register a merge driver under a given name.</p>\n",
-      "comments": "<p>As mentioned elsewhere, the initialize callback will not be invoked\n immediately.  It is deferred until the driver is used in some way.</p>\n\n<p>Currently the merge driver registry is not thread safe, so any\n registering or deregistering of merge drivers must be done outside of\n any possible usage of the drivers (i.e. during application setup or\n shutdown).</p>\n",
-      "group": "merge"
-    },
-    "git_merge_driver_unregister": {
-      "type": "function",
-      "file": "git2/sys/merge.h",
-      "line": 178,
-      "lineto": 178,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "The name under which the merge driver was registered"
-        }
-      ],
-      "argline": "const char *name",
-      "sig": "const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, error code \n<\n0 on failure"
-      },
-      "description": "<p>Remove the merge driver with the given name.</p>\n",
-      "comments": "<p>Attempting to remove the builtin libgit2 merge drivers is not permitted\n and will return an error.</p>\n\n<p>Currently the merge driver registry is not thread safe, so any\n registering or deregistering of drivers must be done outside of any\n possible usage of the drivers (i.e. during application setup or shutdown).</p>\n",
-      "group": "merge"
-    },
-    "git_odb_init_backend": {
-      "type": "function",
-      "file": "git2/sys/odb_backend.h",
-      "line": 116,
-      "lineto": 118,
-      "args": [
-        {
-          "name": "backend",
-          "type": "git_odb_backend *",
-          "comment": "the `git_odb_backend` struct to initialize."
-        },
-        {
-          "name": "version",
-          "type": "unsigned int",
-          "comment": "Version the struct; pass `GIT_ODB_BACKEND_VERSION`"
-        }
-      ],
-      "argline": "git_odb_backend *backend, unsigned int version",
-      "sig": "git_odb_backend *::unsigned int",
-      "return": {
-        "type": "int",
-        "comment": " Zero on success; -1 on failure."
-      },
-      "description": "<p>Initializes a <code>git_odb_backend</code> with default values. Equivalent to\n creating an instance with GIT_ODB_BACKEND_INIT.</p>\n",
-      "comments": "",
-      "group": "odb"
-    },
-    "git_odb_backend_malloc": {
-      "type": "function",
-      "file": "git2/sys/odb_backend.h",
-      "line": 120,
-      "lineto": 120,
-      "args": [
-        {
-          "name": "backend",
-          "type": "git_odb_backend *",
-          "comment": null
-        },
-        {
-          "name": "len",
-          "type": "size_t",
-          "comment": null
-        }
-      ],
-      "argline": "git_odb_backend *backend, size_t len",
-      "sig": "git_odb_backend *::size_t",
-      "return": {
-        "type": "void *",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "odb"
-    },
-    "git_openssl_set_locking": {
-      "type": "function",
-      "file": "git2/sys/openssl.h",
-      "line": 34,
-      "lineto": 34,
-      "args": [],
-      "argline": "",
-      "sig": "",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, -1 if there are errors or if libgit2 was not\n built with OpenSSL and threading support."
-      },
-      "description": "<p>Initialize the OpenSSL locks</p>\n",
-      "comments": "<p>OpenSSL requires the application to determine how it performs\n locking.</p>\n\n<p>This is a last-resort convenience function which libgit2 provides for\n allocating and initializing the locks as well as setting the\n locking function to use the system&#39;s native locking functions.</p>\n\n<p>The locking function will be cleared and the memory will be freed\n when you call git_threads_sutdown().</p>\n\n<p>If your programming language has an OpenSSL package/bindings, it\n likely sets up locking. You should very strongly prefer that over\n this function.</p>\n",
-      "group": "openssl"
-    },
-    "git_path_is_gitfile": {
-      "type": "function",
-      "file": "git2/sys/path.h",
-      "line": 60,
-      "lineto": 60,
-      "args": [
-        {
-          "name": "path",
-          "type": "const char *",
-          "comment": "the path component to check"
-        },
-        {
-          "name": "pathlen",
-          "type": "size_t",
-          "comment": "the length of `path` that is to be checked"
-        },
-        {
-          "name": "gitfile",
-          "type": "git_path_gitfile",
-          "comment": "which file to check against"
-        },
-        {
-          "name": "fs",
-          "type": "git_path_fs",
-          "comment": "which filesystem-specific checks to use"
-        }
-      ],
-      "argline": "const char *path, size_t pathlen, git_path_gitfile gitfile, git_path_fs fs",
-      "sig": "const char *::size_t::git_path_gitfile::git_path_fs",
-      "return": {
-        "type": "int",
-        "comment": " 0 in case the file does not match, a positive value if\n         it does; -1 in case of an error"
-      },
-      "description": "<p>Check whether a path component corresponds to a .git$SUFFIX\n file.</p>\n",
-      "comments": "<p>As some filesystems do special things to filenames when\n writing files to disk, you cannot always do a plain string\n comparison to verify whether a file name matches an expected\n path or not. This function can do the comparison for you,\n depending on the filesystem you&#39;re on.</p>\n",
-      "group": "path"
-    },
-    "git_refdb_init_backend": {
-      "type": "function",
-      "file": "git2/sys/refdb_backend.h",
-      "line": 183,
-      "lineto": 185,
-      "args": [
-        {
-          "name": "backend",
-          "type": "git_refdb_backend *",
-          "comment": "the `git_refdb_backend` struct to initialize"
-        },
-        {
-          "name": "version",
-          "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_REFDB_BACKEND_VERSION`"
-        }
-      ],
-      "argline": "git_refdb_backend *backend, unsigned int version",
-      "sig": "git_refdb_backend *::unsigned int",
-      "return": {
-        "type": "int",
-        "comment": " Zero on success; -1 on failure."
-      },
-      "description": "<p>Initializes a <code>git_refdb_backend</code> with default values. Equivalent to\n creating an instance with GIT_REFDB_BACKEND_INIT.</p>\n",
-      "comments": "",
-      "group": "refdb"
-    },
-    "git_refdb_backend_fs": {
-      "type": "function",
-      "file": "git2/sys/refdb_backend.h",
-      "line": 198,
-      "lineto": 200,
-      "args": [
-        {
-          "name": "backend_out",
-          "type": "git_refdb_backend **",
-          "comment": "Output pointer to the git_refdb_backend object"
-        },
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "Git repository to access"
-        }
-      ],
-      "argline": "git_refdb_backend **backend_out, git_repository *repo",
-      "sig": "git_refdb_backend **::git_repository *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, \n<\n0 error code on failure"
-      },
-      "description": "<p>Constructors for default filesystem-based refdb backend</p>\n",
-      "comments": "<p>Under normal usage, this is called for you when the repository is\n opened / created, but you can use this to explicitly construct a\n filesystem refdb backend for a repository.</p>\n",
-      "group": "refdb"
-    },
-    "git_refdb_set_backend": {
-      "type": "function",
-      "file": "git2/sys/refdb_backend.h",
-      "line": 212,
-      "lineto": 214,
-      "args": [
-        {
-          "name": "refdb",
-          "type": "git_refdb *",
-          "comment": "database to add the backend to"
-        },
-        {
-          "name": "backend",
-          "type": "git_refdb_backend *",
-          "comment": "pointer to a git_refdb_backend instance"
-        }
-      ],
-      "argline": "git_refdb *refdb, git_refdb_backend *backend",
-      "sig": "git_refdb *::git_refdb_backend *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success; error code otherwise"
-      },
-      "description": "<p>Sets the custom backend to an existing reference DB</p>\n",
-      "comments": "<p>The <code>git_refdb</code> will take ownership of the <code>git_refdb_backend</code> so you\n should NOT free it after calling this function.</p>\n",
-      "group": "refdb"
-    },
-    "git_reflog_entry__alloc": {
-      "type": "function",
-      "file": "git2/sys/reflog.h",
-      "line": 16,
-      "lineto": 16,
-      "args": [],
-      "argline": "",
-      "sig": "",
-      "return": {
-        "type": "git_reflog_entry *",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "reflog"
-    },
-    "git_reflog_entry__free": {
-      "type": "function",
-      "file": "git2/sys/reflog.h",
-      "line": 17,
-      "lineto": 17,
-      "args": [
-        {
-          "name": "entry",
-          "type": "git_reflog_entry *",
-          "comment": null
-        }
-      ],
-      "argline": "git_reflog_entry *entry",
-      "sig": "git_reflog_entry *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "",
-      "comments": "",
-      "group": "reflog"
-    },
-    "git_reference__alloc": {
-      "type": "function",
-      "file": "git2/sys/refs.h",
-      "line": 31,
-      "lineto": 34,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "the reference name"
-        },
-        {
-          "name": "oid",
-          "type": "const git_oid *",
-          "comment": "the object id for a direct reference"
-        },
-        {
-          "name": "peel",
-          "type": "const git_oid *",
-          "comment": "the first non-tag object's OID, or NULL"
-        }
-      ],
-      "argline": "const char *name, const git_oid *oid, const git_oid *peel",
-      "sig": "const char *::const git_oid *::const git_oid *",
-      "return": {
-        "type": "git_reference *",
-        "comment": " the created git_reference or NULL on error"
-      },
-      "description": "<p>Create a new direct reference from an OID.</p>\n",
-      "comments": "",
-      "group": "reference"
-    },
-    "git_reference__alloc_symbolic": {
-      "type": "function",
-      "file": "git2/sys/refs.h",
-      "line": 43,
-      "lineto": 45,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": "the reference name"
-        },
-        {
-          "name": "target",
-          "type": "const char *",
-          "comment": "the target for a symbolic reference"
-        }
-      ],
-      "argline": "const char *name, const char *target",
-      "sig": "const char *::const char *",
-      "return": {
-        "type": "git_reference *",
-        "comment": " the created git_reference or NULL on error"
-      },
-      "description": "<p>Create a new symbolic reference.</p>\n",
-      "comments": "",
-      "group": "reference"
-    },
-    "git_repository_new": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 31,
-      "lineto": 31,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_repository **",
-          "comment": "The blank repository"
-        }
-      ],
-      "argline": "git_repository **out",
-      "sig": "git_repository **",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, or an error code"
-      },
-      "description": "<p>Create a new repository with neither backends nor config object</p>\n",
-      "comments": "<p>Note that this is only useful if you wish to associate the repository\n with a non-filesystem-backed object database and config store.</p>\n",
-      "group": "repository"
-    },
-    "git_repository__cleanup": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 44,
-      "lineto": 44,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": null
-        }
-      ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Reset all the internal state in a repository.</p>\n",
-      "comments": "<p>This will free all the mapped memory and internal objects\n of the repository and leave it in a &quot;blank&quot; state.</p>\n\n<p>There&#39;s no need to call this function directly unless you&#39;re\n trying to aggressively cleanup the repo before its\n deallocation. <code>git_repository_free</code> already performs this operation\n before deallocation the repo.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_reinit_filesystem": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 61,
-      "lineto": 63,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "A repository object"
-        },
-        {
-          "name": "recurse_submodules",
-          "type": "int",
-          "comment": "Should submodules be updated recursively"
-        }
-      ],
-      "argline": "git_repository *repo, int recurse_submodules",
-      "sig": "git_repository *::int",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, \n<\n 0 on error"
-      },
-      "description": "<p>Update the filesystem config settings for an open repository</p>\n",
-      "comments": "<p>When a repository is initialized, config values are set based on the\n properties of the filesystem that the repository is on, such as\n &quot;core.ignorecase&quot;, &quot;core.filemode&quot;, &quot;core.symlinks&quot;, etc.  If the\n repository is moved to a new filesystem, these properties may no\n longer be correct and API calls may not behave as expected.  This\n call reruns the phase of repository initialization that sets those\n properties to compensate for the current filesystem of the repo.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_set_config": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 78,
-      "lineto": 78,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "A repository object"
-        },
-        {
-          "name": "config",
-          "type": "git_config *",
-          "comment": "A Config object"
-        }
-      ],
-      "argline": "git_repository *repo, git_config *config",
-      "sig": "git_repository *::git_config *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Set the configuration file for this repository</p>\n",
-      "comments": "<p>This configuration file will be used for all configuration\n queries involving this repository.</p>\n\n<p>The repository will keep a reference to the config file;\n the user must still free the config after setting it\n to the repository, or it will leak.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_set_odb": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 93,
-      "lineto": 93,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "A repository object"
-        },
-        {
-          "name": "odb",
-          "type": "git_odb *",
-          "comment": "An ODB object"
-        }
-      ],
-      "argline": "git_repository *repo, git_odb *odb",
-      "sig": "git_repository *::git_odb *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Set the Object Database for this repository</p>\n",
-      "comments": "<p>The ODB will be used for all object-related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the ODB; the user\n must still free the ODB object after setting it to the\n repository, or it will leak.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_set_refdb": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 108,
-      "lineto": 108,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "A repository object"
-        },
-        {
-          "name": "refdb",
-          "type": "git_refdb *",
-          "comment": "An refdb object"
-        }
-      ],
-      "argline": "git_repository *repo, git_refdb *refdb",
-      "sig": "git_repository *::git_refdb *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Set the Reference Database Backend for this repository</p>\n",
-      "comments": "<p>The refdb will be used for all reference related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the refdb; the user\n must still free the refdb object after setting it to the\n repository, or it will leak.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_set_index": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 123,
-      "lineto": 123,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "A repository object"
-        },
-        {
-          "name": "index",
-          "type": "git_index *",
-          "comment": "An index object"
-        }
-      ],
-      "argline": "git_repository *repo, git_index *index",
-      "sig": "git_repository *::git_index *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Set the index file for this repository</p>\n",
-      "comments": "<p>This index will be used for all index-related operations\n involving this repository.</p>\n\n<p>The repository will keep a reference to the index file;\n the user must still free the index after setting it\n to the repository, or it will leak.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_set_bare": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 136,
-      "lineto": 136,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "Repo to make bare"
-        }
-      ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
-      "return": {
-        "type": "int",
-        "comment": " 0 on success, \n<\n0 on failure"
-      },
-      "description": "<p>Set a repository to be bare.</p>\n",
-      "comments": "<p>Clear the working directory and set core.bare to true.  You may also\n want to call <code>git_repository_set_index(repo, NULL)</code> since a bare repo\n typically does not have an index, but this function will not do that\n for you.</p>\n",
-      "group": "repository"
-    },
-    "git_repository_submodule_cache_all": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 149,
-      "lineto": 150,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "the repository whose submodules will be cached."
-        }
-      ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Load and cache all submodules.</p>\n",
-      "comments": "<p>Because the <code>.gitmodules</code> file is unstructured, loading submodules is an\n O(N) operation.  Any operation (such as <code>git_rebase_init</code>) that requires\n accessing all submodules is O(N^2) in the number of submodules, if it\n has to look each one up individually.  This function loads all submodules\n and caches them so that subsequent calls to <code>git_submodule_lookup</code> are O(1).</p>\n",
-      "group": "repository"
-    },
-    "git_repository_submodule_cache_clear": {
-      "type": "function",
-      "file": "git2/sys/repository.h",
-      "line": 164,
-      "lineto": 165,
-      "args": [
-        {
-          "name": "repo",
-          "type": "git_repository *",
-          "comment": "the repository whose submodule cache will be cleared"
-        }
-      ],
-      "argline": "git_repository *repo",
-      "sig": "git_repository *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Clear the submodule cache.</p>\n",
-      "comments": "<p>Clear the submodule cache populated by <code>git_repository_submodule_cache_all</code>.\n If there is no cache, do nothing.</p>\n\n<p>The cache incorporates data from the repository&#39;s configuration, as well\n as the state of the working tree, the index, and HEAD.  So any time any\n of these has changed, the cache might become invalid.</p>\n",
-      "group": "repository"
-    },
-    "git_stream_register": {
-      "type": "function",
-      "file": "git2/sys/stream.h",
-      "line": 98,
-      "lineto": 99,
-      "args": [
-        {
-          "name": "type",
-          "type": "git_stream_t",
-          "comment": "the type or types of stream to register"
-        },
-        {
-          "name": "registration",
-          "type": "git_stream_registration *",
-          "comment": "the registration data"
-        }
-      ],
-      "argline": "git_stream_t type, git_stream_registration *registration",
-      "sig": "git_stream_t::git_stream_registration *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Register stream constructors for the library to use</p>\n",
-      "comments": "<p>If a registration structure is already set, it will be overwritten.\n Pass <code>NULL</code> in order to deregister the current constructor and return\n to the system defaults.</p>\n\n<p>The type parameter may be a bitwise AND of types.</p>\n",
-      "group": "stream"
-    },
-    "git_stream_register_tls": {
-      "type": "function",
-      "file": "git2/sys/stream.h",
-      "line": 130,
-      "lineto": 130,
-      "args": [
-        {
-          "name": "ctor",
-          "type": "git_stream_cb",
-          "comment": null
-        }
-      ],
-      "argline": "git_stream_cb ctor",
-      "sig": "git_stream_cb",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Register a TLS stream constructor for the library to use.  This stream\n will not support HTTP CONNECT proxies.  This internally calls\n <code>git_stream_register</code> and is preserved for backward compatibility.</p>\n",
-      "comments": "<p>This function is deprecated, but there is no plan to remove this\n function at this time.</p>\n",
-      "group": "stream"
-    },
-    "git_time_monotonic": {
-      "type": "function",
-      "file": "git2/sys/time.h",
-      "line": 27,
-      "lineto": 27,
-      "args": [],
-      "argline": "",
-      "sig": "",
-      "return": {
-        "type": "double",
-        "comment": null
-      },
-      "description": "<p>Return a monotonic time value, useful for measuring running time\n and setting up timeouts.</p>\n",
-      "comments": "<p>The returned value is an arbitrary point in time -- it can only be\n used when comparing it to another <code>git_time_monotonic</code> call.</p>\n\n<p>The time is returned in seconds, with a decimal fraction that differs\n on accuracy based on the underlying system, but should be least\n accurate to Nanoseconds.</p>\n\n<p>This function cannot fail.</p>\n",
-      "group": "time"
-    },
-    "git_transport_init": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 137,
-      "lineto": 139,
-      "args": [
-        {
-          "name": "opts",
-          "type": "git_transport *",
-          "comment": "the `git_transport` struct to initialize"
-        },
-        {
-          "name": "version",
-          "type": "unsigned int",
-          "comment": "Version of struct; pass `GIT_TRANSPORT_VERSION`"
-        }
-      ],
-      "argline": "git_transport *opts, unsigned int version",
-      "sig": "git_transport *::unsigned int",
-      "return": {
-        "type": "int",
-        "comment": " Zero on success; -1 on failure."
-      },
-      "description": "<p>Initializes a <code>git_transport</code> with default values. Equivalent to\n creating an instance with GIT_TRANSPORT_INIT.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_new": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 151,
-      "lineto": 151,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_transport **",
-          "comment": "The newly created transport (out)"
-        },
-        {
-          "name": "owner",
-          "type": "git_remote *",
-          "comment": "The git_remote which will own this transport"
-        },
-        {
-          "name": "url",
-          "type": "const char *",
-          "comment": "The URL to connect to"
-        }
-      ],
-      "argline": "git_transport **out, git_remote *owner, const char *url",
-      "sig": "git_transport **::git_remote *::const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Function to use to create a transport from a URL. The transport database\n is scanned to find a transport that implements the scheme of the URI (i.e.\n git:// or http://) and a transport object is returned to the caller.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_ssh_with_paths": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 167,
-      "lineto": 167,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_transport **",
-          "comment": "the resulting transport"
-        },
-        {
-          "name": "owner",
-          "type": "git_remote *",
-          "comment": "the owning remote"
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": "a strarray with the paths"
-        }
-      ],
-      "argline": "git_transport **out, git_remote *owner, void *payload",
-      "sig": "git_transport **::git_remote *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an ssh transport with custom git command paths</p>\n",
-      "comments": "<p>This is a factory function suitable for setting as the transport\n callback in a remote (or for a clone in the options).</p>\n\n<p>The payload argument must be a strarray pointer with the paths for\n the <code>git-upload-pack</code> and <code>git-receive-pack</code> at index 0 and 1.</p>\n",
-      "group": "transport"
-    },
-    "git_transport_register": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 182,
-      "lineto": 185,
-      "args": [
-        {
-          "name": "prefix",
-          "type": "const char *",
-          "comment": "The scheme (ending in \"://\") to match, i.e. \"git://\""
-        },
-        {
-          "name": "cb",
-          "type": "git_transport_cb",
-          "comment": "The callback used to create an instance of the transport"
-        },
-        {
-          "name": "param",
-          "type": "void *",
-          "comment": "A fixed parameter to pass to cb at creation time"
-        }
-      ],
-      "argline": "const char *prefix, git_transport_cb cb, void *param",
-      "sig": "const char *::git_transport_cb::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Add a custom transport definition, to be used in addition to the built-in\n set of transports that come with libgit2.</p>\n",
-      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register\n and git_transport_unregister with other calls to the library that\n instantiate transports.</p>\n",
-      "group": "transport"
-    },
-    "git_transport_unregister": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 198,
-      "lineto": 199,
-      "args": [
-        {
-          "name": "prefix",
-          "type": "const char *",
-          "comment": "From the previous call to git_transport_register"
-        }
-      ],
-      "argline": "const char *prefix",
-      "sig": "const char *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Unregister a custom transport definition which was previously registered\n with git_transport_register.</p>\n",
-      "comments": "<p>The caller is responsible for synchronizing calls to git_transport_register\n and git_transport_unregister with other calls to the library that\n instantiate transports.</p>\n",
-      "group": "transport"
-    },
-    "git_transport_dummy": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 212,
-      "lineto": 215,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_transport **",
-          "comment": "The newly created transport (out)"
-        },
-        {
-          "name": "owner",
-          "type": "git_remote *",
-          "comment": "The git_remote which will own this transport"
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": "You must pass NULL for this parameter."
-        }
-      ],
-      "argline": "git_transport **out, git_remote *owner, void *payload",
-      "sig": "git_transport **::git_remote *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the dummy transport.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_local": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 225,
-      "lineto": 228,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_transport **",
-          "comment": "The newly created transport (out)"
-        },
-        {
-          "name": "owner",
-          "type": "git_remote *",
-          "comment": "The git_remote which will own this transport"
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": "You must pass NULL for this parameter."
-        }
-      ],
-      "argline": "git_transport **out, git_remote *owner, void *payload",
-      "sig": "git_transport **::git_remote *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the local transport.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_smart": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 238,
-      "lineto": 241,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_transport **",
-          "comment": "The newly created transport (out)"
-        },
-        {
-          "name": "owner",
-          "type": "git_remote *",
-          "comment": "The git_remote which will own this transport"
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": "A pointer to a git_smart_subtransport_definition"
-        }
-      ],
-      "argline": "git_transport **out, git_remote *owner, void *payload",
-      "sig": "git_transport **::git_remote *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the smart transport.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_smart_certificate_check": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 255,
-      "lineto": 255,
-      "args": [
-        {
-          "name": "transport",
-          "type": "git_transport *",
-          "comment": "a smart transport"
-        },
-        {
-          "name": "cert",
-          "type": "git_cert *",
-          "comment": "the certificate to pass to the caller"
-        },
-        {
-          "name": "valid",
-          "type": "int",
-          "comment": "whether we believe the certificate is valid"
-        },
-        {
-          "name": "hostname",
-          "type": "const char *",
-          "comment": "the hostname we connected to"
-        }
-      ],
-      "argline": "git_transport *transport, git_cert *cert, int valid, const char *hostname",
-      "sig": "git_transport *::git_cert *::int::const char *",
-      "return": {
-        "type": "int",
-        "comment": " the return value of the callback: 0 for no error, GIT_PASSTHROUGH\n         to indicate that there is no callback registered (or the callback\n         refused to validate the certificate and callers should behave as\n         if no callback was set), or \n<\n 0 for an error"
-      },
-      "description": "<p>Call the certificate check for this transport.</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_smart_credentials": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 269,
-      "lineto": 269,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_cred **",
-          "comment": "the pointer where the creds are to be stored"
-        },
-        {
-          "name": "transport",
-          "type": "git_transport *",
-          "comment": "a smart transport"
-        },
-        {
-          "name": "user",
-          "type": "const char *",
-          "comment": "the user we saw on the url (if any)"
-        },
-        {
-          "name": "methods",
-          "type": "int",
-          "comment": "available methods for authentication"
-        }
-      ],
-      "argline": "git_cred **out, git_transport *transport, const char *user, int methods",
-      "sig": "git_cred **::git_transport *::const char *::int",
-      "return": {
-        "type": "int",
-        "comment": " the return value of the callback: 0 for no error, GIT_PASSTHROUGH\n         to indicate that there is no callback registered (or the callback\n         refused to provide credentials and callers should behave as if no\n         callback was set), or \n<\n 0 for an error"
-      },
-      "description": "<p>Call the credentials callback for this transport</p>\n",
-      "comments": "",
-      "group": "transport"
-    },
-    "git_transport_smart_proxy_options": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 279,
-      "lineto": 279,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_proxy_options *",
-          "comment": "options struct to fill"
-        },
-        {
-          "name": "transport",
-          "type": "git_transport *",
-          "comment": "the transport to extract the data from."
-        }
-      ],
-      "argline": "git_proxy_options *out, git_transport *transport",
-      "sig": "git_proxy_options *::git_transport *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Get a copy of the proxy options</p>\n",
-      "comments": "<p>The url is copied and must be freed by the caller.</p>\n",
-      "group": "transport"
-    },
-    "git_smart_subtransport_http": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 408,
-      "lineto": 411,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_smart_subtransport **",
-          "comment": "The newly created subtransport"
-        },
-        {
-          "name": "owner",
-          "type": "git_transport *",
-          "comment": "The smart transport to own this subtransport"
-        },
-        {
-          "name": "param",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_smart_subtransport **out, git_transport *owner, void *param",
-      "sig": "git_smart_subtransport **::git_transport *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the http subtransport.</p>\n",
-      "comments": "<p>This subtransport also supports https.</p>\n",
-      "group": "smart"
-    },
-    "git_smart_subtransport_git": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 420,
-      "lineto": 423,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_smart_subtransport **",
-          "comment": "The newly created subtransport"
-        },
-        {
-          "name": "owner",
-          "type": "git_transport *",
-          "comment": "The smart transport to own this subtransport"
-        },
-        {
-          "name": "param",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_smart_subtransport **out, git_transport *owner, void *param",
-      "sig": "git_smart_subtransport **::git_transport *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the git subtransport.</p>\n",
-      "comments": "",
-      "group": "smart"
-    },
-    "git_smart_subtransport_ssh": {
-      "type": "function",
-      "file": "git2/sys/transport.h",
-      "line": 432,
-      "lineto": 435,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_smart_subtransport **",
-          "comment": "The newly created subtransport"
-        },
-        {
-          "name": "owner",
-          "type": "git_transport *",
-          "comment": "The smart transport to own this subtransport"
-        },
-        {
-          "name": "param",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_smart_subtransport **out, git_transport *owner, void *param",
-      "sig": "git_smart_subtransport **::git_transport *::void *",
-      "return": {
-        "type": "int",
-        "comment": " 0 or an error code"
-      },
-      "description": "<p>Create an instance of the ssh subtransport.</p>\n",
-      "comments": "",
-      "group": "smart"
     },
     "git_tag_lookup": {
       "type": "function",
@@ -24773,7 +22169,7 @@
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_lookup-84"
+          "ex/HEAD/general.html#git_tag_lookup-84"
         ]
       }
     },
@@ -24833,11 +22229,11 @@
         "comment": null
       },
       "description": "<p>Close an open tag</p>\n",
-      "comments": "<p>You can no longer use the git_tag pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you are through with a tag to\n release memory. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>You can no longer use the git_tag pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you are through with a tag to release memory. Failure to do so will cause a memory leak.</p>\n",
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_free-85"
+          "ex/HEAD/general.html#git_tag_free-85"
         ]
       }
     },
@@ -24909,11 +22305,11 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Get the tagged object of a tag</p>\n",
-      "comments": "<p>This method performs a repository lookup for the\n given object and returns it</p>\n",
+      "comments": "<p>This method performs a repository lookup for the given object and returns it</p>\n",
       "group": "tag",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_target-86"
+          "ex/HEAD/general.html#git_tag_target-86"
         ]
       }
     },
@@ -24940,7 +22336,7 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tag_target_id-35"
+          "ex/HEAD/cat-file.html#git_tag_target_id-31"
         ]
       }
     },
@@ -24967,10 +22363,10 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tag_target_type-36"
+          "ex/HEAD/cat-file.html#git_tag_target_type-32"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_target_type-87"
+          "ex/HEAD/general.html#git_tag_target_type-87"
         ]
       }
     },
@@ -24997,13 +22393,13 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tag_name-37"
+          "ex/HEAD/cat-file.html#git_tag_name-33"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_name-88"
+          "ex/HEAD/general.html#git_tag_name-88"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_name-20"
+          "ex/HEAD/tag.html#git_tag_name-16"
         ]
       }
     },
@@ -25030,7 +22426,7 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tag_tagger-38"
+          "ex/HEAD/cat-file.html#git_tag_tagger-34"
         ]
       }
     },
@@ -25057,14 +22453,14 @@
       "group": "tag",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tag_message-39",
-          "ex/v0.28.0/cat-file.html#git_tag_message-40"
+          "ex/HEAD/cat-file.html#git_tag_message-35",
+          "ex/HEAD/cat-file.html#git_tag_message-36"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tag_message-89"
+          "ex/HEAD/general.html#git_tag_message-89"
         ],
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_message-21"
+          "ex/HEAD/tag.html#git_tag_message-17"
         ]
       }
     },
@@ -25117,11 +22513,11 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code\n\tA tag object is written to the ODB, and a proper reference\n\tis written in the /refs/tags folder, pointing to it"
       },
       "description": "<p>Create a new tag in the repository from an object</p>\n",
-      "comments": "<p>A new reference will also be created pointing to\n this tag object. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The message will not be cleaned up. This can be achieved\n through <code>git_message_prettify()</code>.</p>\n\n<p>The tag name will be checked for validity. You must avoid\n the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\n\\\n&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the\n sequences &quot;..&quot; and &quot;\n@\n{&quot; which have special meaning to revparse.</p>\n",
+      "comments": "<p>A new reference will also be created pointing to this tag object. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The message will not be cleaned up. This can be achieved through <code>git_message_prettify()</code>.</p>\n\n<p>The tag name will be checked for validity. You must avoid the characters &#39;~&#39;, &#39;^&#39;, &#39;:&#39;, &#39;\\&#39;, &#39;?&#39;, &#39;[&#39;, and &#39;*&#39;, and the sequences &quot;..&quot; and &quot;@{&quot; which have special meaning to revparse.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_create-22"
+          "ex/HEAD/tag.html#git_tag_create-18"
         ]
       }
     },
@@ -25169,10 +22565,10 @@
         "comment": " 0 on success or an error code"
       },
       "description": "<p>Create a new tag in the object database pointing to a git_object</p>\n",
-      "comments": "<p>The message will not be cleaned up. This can be achieved\n through <code>git_message_prettify()</code>.</p>\n",
+      "comments": "<p>The message will not be cleaned up. This can be achieved through <code>git_message_prettify()</code>.</p>\n",
       "group": "tag"
     },
-    "git_tag_create_frombuffer": {
+    "git_tag_create_from_buffer": {
       "type": "function",
       "file": "git2/tag.h",
       "line": 220,
@@ -25248,11 +22644,11 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code\n\tA proper reference is written in the /refs/tags folder,\n pointing to the provided target object"
       },
       "description": "<p>Create a new lightweight tag pointing at a target object</p>\n",
-      "comments": "<p>A new direct reference will be created pointing to\n this target object. If <code>force</code> is true and a reference\n already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The tag name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>A new direct reference will be created pointing to this target object. If <code>force</code> is true and a reference already exists with the given name, it&#39;ll be replaced.</p>\n\n<p>The tag name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_create_lightweight-23"
+          "ex/HEAD/tag.html#git_tag_create_lightweight-19"
         ]
       }
     },
@@ -25280,11 +22676,11 @@
         "comment": " 0 on success, GIT_EINVALIDSPEC or an error code"
       },
       "description": "<p>Delete an existing tag reference.</p>\n",
-      "comments": "<p>The tag name will be checked for validity.\n See <code>git_tag_create()</code> for rules about valid names.</p>\n",
+      "comments": "<p>The tag name will be checked for validity. See <code>git_tag_create()</code> for rules about valid names.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_delete-24"
+          "ex/HEAD/tag.html#git_tag_delete-20"
         ]
       }
     },
@@ -25312,7 +22708,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the tags in the Repository</p>\n",
-      "comments": "<p>The string array will be filled with the names of the\n matching tags; these values are owned by the user and\n should be free&#39;d manually when no longer needed, using\n <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>The string array will be filled with the names of the matching tags; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free</code>.</p>\n",
       "group": "tag"
     },
     "git_tag_list_match": {
@@ -25344,19 +22740,19 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Fill a list with all the tags in the Repository\n which name match a defined pattern</p>\n",
-      "comments": "<p>If an empty pattern is provided, all the tags\n will be returned.</p>\n\n<p>The string array will be filled with the names of the\n matching tags; these values are owned by the user and\n should be free&#39;d manually when no longer needed, using\n <code>git_strarray_free</code>.</p>\n",
+      "comments": "<p>If an empty pattern is provided, all the tags will be returned.</p>\n\n<p>The string array will be filled with the names of the matching tags; these values are owned by the user and should be free&#39;d manually when no longer needed, using <code>git_strarray_free</code>.</p>\n",
       "group": "tag",
       "examples": {
         "tag.c": [
-          "ex/v0.28.0/tag.html#git_tag_list_match-25"
+          "ex/HEAD/tag.html#git_tag_list_match-21"
         ]
       }
     },
     "git_tag_foreach": {
       "type": "function",
       "file": "git2/tag.h",
-      "line": 330,
-      "lineto": 333,
+      "line": 339,
+      "lineto": 342,
       "args": [
         {
           "name": "repo",
@@ -25387,8 +22783,8 @@
     "git_tag_peel": {
       "type": "function",
       "file": "git2/tag.h",
-      "line": 346,
-      "lineto": 348,
+      "line": 355,
+      "lineto": 357,
       "args": [
         {
           "name": "tag_target_out",
@@ -25408,14 +22804,14 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Recursively peel a tag until a non tag git_object is found</p>\n",
-      "comments": "<p>The retrieved <code>tag_target</code> object is owned by the repository\n and should be closed with the <code>git_object_free</code> method.</p>\n",
+      "comments": "<p>The retrieved <code>tag_target</code> object is owned by the repository and should be closed with the <code>git_object_free</code> method.</p>\n",
       "group": "tag"
     },
     "git_tag_dup": {
       "type": "function",
       "file": "git2/tag.h",
-      "line": 357,
-      "lineto": 357,
+      "line": 366,
+      "lineto": 366,
       "args": [
         {
           "name": "out",
@@ -25451,12 +22847,12 @@
         },
         {
           "name": "cb",
-          "type": "git_trace_callback",
+          "type": "git_trace_cb",
           "comment": "Function to call with trace data"
         }
       ],
-      "argline": "git_trace_level_t level, git_trace_callback cb",
-      "sig": "git_trace_level_t::git_trace_callback",
+      "argline": "git_trace_level_t level, git_trace_cb cb",
+      "sig": "git_trace_level_t::git_trace_cb",
       "return": {
         "type": "int",
         "comment": " 0 or an error code"
@@ -25489,7 +22885,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Create a new transaction object</p>\n",
-      "comments": "<p>This does not lock anything, but sets up the transaction object to\n know from which repository to lock.</p>\n",
+      "comments": "<p>This does not lock anything, but sets up the transaction object to know from which repository to lock.</p>\n",
       "group": "transaction"
     },
     "git_transaction_lock_ref": {
@@ -25516,7 +22912,7 @@
         "comment": " 0 or an error message"
       },
       "description": "<p>Lock a reference</p>\n",
-      "comments": "<p>Lock the specified reference. This is the first step to updating a\n reference.</p>\n",
+      "comments": "<p>Lock the specified reference. This is the first step to updating a reference.</p>\n",
       "group": "transaction"
     },
     "git_transaction_set_target": {
@@ -25558,7 +22954,7 @@
         "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
       },
       "description": "<p>Set the target of a reference</p>\n",
-      "comments": "<p>Set the target of the specified reference. This reference must be\n locked.</p>\n",
+      "comments": "<p>Set the target of the specified reference. This reference must be locked.</p>\n",
       "group": "transaction"
     },
     "git_transaction_set_symbolic_target": {
@@ -25600,7 +22996,7 @@
         "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
       },
       "description": "<p>Set the target of a reference</p>\n",
-      "comments": "<p>Set the target of the specified reference. This reference must be\n locked.</p>\n",
+      "comments": "<p>Set the target of the specified reference. This reference must be locked.</p>\n",
       "group": "transaction"
     },
     "git_transaction_set_reflog": {
@@ -25632,7 +23028,7 @@
         "comment": " 0, GIT_ENOTFOUND if the reference is not among the locked ones, or an error code"
       },
       "description": "<p>Set the reflog of a reference</p>\n",
-      "comments": "<p>Set the specified reference&#39;s reflog. If this is combined with\n setting the target, that update won&#39;t be written to the reflog.</p>\n",
+      "comments": "<p>Set the specified reference&#39;s reflog. If this is combined with setting the target, that update won&#39;t be written to the reflog.</p>\n",
       "group": "transaction"
     },
     "git_transaction_remove": {
@@ -25681,7 +23077,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Commit the changes from the transaction</p>\n",
-      "comments": "<p>Perform the changes that have been queued. The updates will be made\n one by one, and the first failure will stop the processing.</p>\n",
+      "comments": "<p>Perform the changes that have been queued. The updates will be made one by one, and the first failure will stop the processing.</p>\n",
       "group": "transaction"
     },
     "git_transaction_free": {
@@ -25703,7 +23099,7 @@
         "comment": null
       },
       "description": "<p>Free the resources allocated by this transaction</p>\n",
-      "comments": "<p>If any references remain locked, they will be unlocked without any\n changes made to them.</p>\n",
+      "comments": "<p>If any references remain locked, they will be unlocked without any changes made to them.</p>\n",
       "group": "transaction"
     },
     "git_cred_has_username": {
@@ -25820,7 +23216,7 @@
         },
         {
           "name": "prompt_callback",
-          "type": "git_cred_ssh_interactive_callback",
+          "type": "git_cred_ssh_interactive_cb",
           "comment": "The callback method used for prompts."
         },
         {
@@ -25829,8 +23225,8 @@
           "comment": "Additional data to pass to the callback."
         }
       ],
-      "argline": "git_cred **out, const char *username, git_cred_ssh_interactive_callback prompt_callback, void *payload",
-      "sig": "git_cred **::const char *::git_cred_ssh_interactive_callback::void *",
+      "argline": "git_cred **out, const char *username, git_cred_ssh_interactive_cb prompt_callback, void *payload",
+      "sig": "git_cred **::const char *::git_cred_ssh_interactive_cb::void *",
       "return": {
         "type": "int",
         "comment": " 0 for success or an error code for failure."
@@ -25894,7 +23290,7 @@
         },
         {
           "name": "sign_callback",
-          "type": "git_cred_sign_callback",
+          "type": "git_cred_sign_cb",
           "comment": "The callback method to sign the data during the challenge."
         },
         {
@@ -25903,14 +23299,14 @@
           "comment": "Additional data to pass to the callback."
         }
       ],
-      "argline": "git_cred **out, const char *username, const char *publickey, size_t publickey_len, git_cred_sign_callback sign_callback, void *payload",
-      "sig": "git_cred **::const char *::const char *::size_t::git_cred_sign_callback::void *",
+      "argline": "git_cred **out, const char *username, const char *publickey, size_t publickey_len, git_cred_sign_cb sign_callback, void *payload",
+      "sig": "git_cred **::const char *::const char *::size_t::git_cred_sign_cb::void *",
       "return": {
         "type": "int",
         "comment": " 0 for success or an error code for failure"
       },
       "description": "<p>Create an ssh key credential with a custom signing function.</p>\n",
-      "comments": "<p>This lets you use your own function to sign the challenge.</p>\n\n<p>This function and its credential type is provided for completeness\n and wraps <code>libssh2_userauth_publickey()</code>, which is undocumented.</p>\n\n<p>The supplied credential parameter will be internally duplicated.</p>\n",
+      "comments": "<p>This lets you use your own function to sign the challenge.</p>\n\n<p>This function and its credential type is provided for completeness and wraps <code>libssh2_userauth_publickey()</code>, which is undocumented.</p>\n\n<p>The supplied credential parameter will be internally duplicated.</p>\n",
       "group": "cred"
     },
     "git_cred_default_new": {
@@ -25959,7 +23355,7 @@
         "comment": null
       },
       "description": "<p>Create a credential to specify a username.</p>\n",
-      "comments": "<p>This is used with ssh authentication to query for the username if\n none is specified in the url.</p>\n",
+      "comments": "<p>This is used with ssh authentication to query for the username if none is specified in the url.</p>\n",
       "group": "cred"
     },
     "git_cred_ssh_key_memory_new": {
@@ -26023,7 +23419,7 @@
         "comment": null
       },
       "description": "<p>Free a credential.</p>\n",
-      "comments": "<p>This is only necessary if you own the object; that is, if you are a\n transport.</p>\n",
+      "comments": "<p>This is only necessary if you own the object; that is, if you are a transport.</p>\n",
       "group": "cred"
     },
     "git_tree_lookup": {
@@ -26059,14 +23455,14 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_lookup-90",
-          "ex/v0.28.0/general.html#git_tree_lookup-91"
+          "ex/HEAD/general.html#git_tree_lookup-90",
+          "ex/HEAD/general.html#git_tree_lookup-91"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_tree_lookup-14"
+          "ex/HEAD/init.html#git_tree_lookup-12"
         ],
         "merge.c": [
-          "ex/v0.28.0/merge.html#git_tree_lookup-41"
+          "ex/HEAD/merge.html#git_tree_lookup-37"
         ]
       }
     },
@@ -26126,26 +23522,26 @@
         "comment": null
       },
       "description": "<p>Close an open tree</p>\n",
-      "comments": "<p>You can no longer use the git_tree pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you stop using a tree to\n release memory. Failure to do so will cause a memory leak.</p>\n",
+      "comments": "<p>You can no longer use the git_tree pointer after this call.</p>\n\n<p>IMPORTANT: You MUST call this method when you stop using a tree to release memory. Failure to do so will cause a memory leak.</p>\n",
       "group": "tree",
       "examples": {
         "diff.c": [
-          "ex/v0.28.0/diff.html#git_tree_free-17",
-          "ex/v0.28.0/diff.html#git_tree_free-18"
+          "ex/HEAD/diff.html#git_tree_free-13",
+          "ex/HEAD/diff.html#git_tree_free-14"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_free-92",
-          "ex/v0.28.0/general.html#git_tree_free-93"
+          "ex/HEAD/general.html#git_tree_free-92",
+          "ex/HEAD/general.html#git_tree_free-93"
         ],
         "init.c": [
-          "ex/v0.28.0/init.html#git_tree_free-15"
+          "ex/HEAD/init.html#git_tree_free-13"
         ],
         "log.c": [
-          "ex/v0.28.0/log.html#git_tree_free-59",
-          "ex/v0.28.0/log.html#git_tree_free-60",
-          "ex/v0.28.0/log.html#git_tree_free-61",
-          "ex/v0.28.0/log.html#git_tree_free-62",
-          "ex/v0.28.0/log.html#git_tree_free-63"
+          "ex/HEAD/log.html#git_tree_free-55",
+          "ex/HEAD/log.html#git_tree_free-56",
+          "ex/HEAD/log.html#git_tree_free-57",
+          "ex/HEAD/log.html#git_tree_free-58",
+          "ex/HEAD/log.html#git_tree_free-59"
         ]
       }
     },
@@ -26216,10 +23612,10 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entrycount-41"
+          "ex/HEAD/cat-file.html#git_tree_entrycount-37"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_entrycount-94"
+          "ex/HEAD/general.html#git_tree_entrycount-94"
         ]
       }
     },
@@ -26247,11 +23643,11 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by its filename</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n",
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_entry_byname-95"
+          "ex/HEAD/general.html#git_tree_entry_byname-95"
         ]
       }
     },
@@ -26279,14 +23675,14 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by its position in the tree</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n",
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entry_byindex-42"
+          "ex/HEAD/cat-file.html#git_tree_entry_byindex-38"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_entry_byindex-96"
+          "ex/HEAD/general.html#git_tree_entry_byindex-96"
         ]
       }
     },
@@ -26314,7 +23710,7 @@
         "comment": " the tree entry; NULL if not found"
       },
       "description": "<p>Lookup a tree entry by SHA value.</p>\n",
-      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t\n have to free it, but you must not use it after the git_tree is released.</p>\n\n<p>Warning: this must examine every entry in the tree, so it is not fast.</p>\n",
+      "comments": "<p>This returns a git_tree_entry that is owned by the git_tree.  You don&#39;t have to free it, but you must not use it after the git_tree is released.</p>\n\n<p>Warning: this must examine every entry in the tree, so it is not fast.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_bypath": {
@@ -26346,7 +23742,7 @@
         "comment": " 0 on success; GIT_ENOTFOUND if the path does not exist"
       },
       "description": "<p>Retrieve a tree entry contained in a tree or in any of its subtrees,\n given its relative path.</p>\n",
-      "comments": "<p>Unlike the other lookup functions, the returned tree entry is owned by\n the user and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
+      "comments": "<p>Unlike the other lookup functions, the returned tree entry is owned by the user and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_dup": {
@@ -26373,7 +23769,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Duplicate a tree entry</p>\n",
-      "comments": "<p>Create a copy of a tree entry. The returned copy is owned by the user,\n and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
+      "comments": "<p>Create a copy of a tree entry. The returned copy is owned by the user, and must be freed explicitly with <code>git_tree_entry_free()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_free": {
@@ -26395,7 +23791,7 @@
         "comment": null
       },
       "description": "<p>Free a user-owned tree entry</p>\n",
-      "comments": "<p>IMPORTANT: This function is only needed for tree entries owned by the\n user, such as the ones returned by <code>git_tree_entry_dup()</code> or\n <code>git_tree_entry_bypath()</code>.</p>\n",
+      "comments": "<p>IMPORTANT: This function is only needed for tree entries owned by the user, such as the ones returned by <code>git_tree_entry_dup()</code> or <code>git_tree_entry_bypath()</code>.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_name": {
@@ -26421,11 +23817,11 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entry_name-43"
+          "ex/HEAD/cat-file.html#git_tree_entry_name-39"
         ],
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_entry_name-97",
-          "ex/v0.28.0/general.html#git_tree_entry_name-98"
+          "ex/HEAD/general.html#git_tree_entry_name-97",
+          "ex/HEAD/general.html#git_tree_entry_name-98"
         ]
       }
     },
@@ -26452,7 +23848,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entry_id-44"
+          "ex/HEAD/cat-file.html#git_tree_entry_id-40"
         ]
       }
     },
@@ -26479,7 +23875,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entry_type-45"
+          "ex/HEAD/cat-file.html#git_tree_entry_type-41"
         ]
       }
     },
@@ -26506,7 +23902,7 @@
       "group": "tree",
       "examples": {
         "cat-file.c": [
-          "ex/v0.28.0/cat-file.html#git_tree_entry_filemode-46"
+          "ex/HEAD/cat-file.html#git_tree_entry_filemode-42"
         ]
       }
     },
@@ -26529,7 +23925,7 @@
         "comment": " filemode as an integer"
       },
       "description": "<p>Get the raw UNIX file attributes of a tree entry</p>\n",
-      "comments": "<p>This function does not perform any normalization and is only useful\n if you need to be able to recreate the original tree object.</p>\n",
+      "comments": "<p>This function does not perform any normalization and is only useful if you need to be able to recreate the original tree object.</p>\n",
       "group": "tree"
     },
     "git_tree_entry_cmp": {
@@ -26592,7 +23988,7 @@
       "group": "tree",
       "examples": {
         "general.c": [
-          "ex/v0.28.0/general.html#git_tree_entry_to_object-99"
+          "ex/HEAD/general.html#git_tree_entry_to_object-99"
         ]
       }
     },
@@ -26625,7 +24021,7 @@
         "comment": " 0 on success; error code otherwise"
       },
       "description": "<p>Create a new tree builder.</p>\n",
-      "comments": "<p>The tree builder can be used to create or modify trees in memory and\n write them as tree objects to the database.</p>\n\n<p>If the <code>source</code> parameter is not NULL, the tree builder will be\n initialized with the entries of the given tree.</p>\n\n<p>If the <code>source</code> parameter is NULL, the tree builder will start with no\n entries and will have to be filled manually.</p>\n",
+      "comments": "<p>The tree builder can be used to create or modify trees in memory and write them as tree objects to the database.</p>\n\n<p>If the <code>source</code> parameter is not NULL, the tree builder will be initialized with the entries of the given tree.</p>\n\n<p>If the <code>source</code> parameter is NULL, the tree builder will start with no entries and will have to be filled manually.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_clear": {
@@ -26691,7 +24087,7 @@
         "comment": null
       },
       "description": "<p>Free a tree builder</p>\n",
-      "comments": "<p>This will clear all the entries and free to builder.\n Failing to free the builder after you&#39;re done using it\n will result in a memory leak</p>\n",
+      "comments": "<p>This will clear all the entries and free to builder. Failing to free the builder after you&#39;re done using it will result in a memory leak</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_get": {
@@ -26718,7 +24114,7 @@
         "comment": " pointer to the entry; NULL if not found"
       },
       "description": "<p>Get an entry from the builder from its filename</p>\n",
-      "comments": "<p>The returned entry is owned by the builder and should\n not be freed manually.</p>\n",
+      "comments": "<p>The returned entry is owned by the builder and should not be freed manually.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_insert": {
@@ -26760,7 +24156,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add or update an entry to the builder</p>\n",
-      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the\n given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes\n will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the\n newly created/updated entry.  Pass NULL if you do not need it. The\n pointer may not be valid past the next operation in this\n builder. Duplicate the entry if you want to keep it.</p>\n\n<p>By default the entry that you are inserting will be checked for\n validity; that it exists in the object database and is of the\n correct type.  If you do not want this behavior, set the\n <code>GIT_OPT_ENABLE_STRICT_OBJECT_CREATION</code> library option to false.</p>\n",
+      "comments": "<p>Insert a new entry for <code>filename</code> in the builder with the given attributes.</p>\n\n<p>If an entry named <code>filename</code> already exists, its attributes will be updated with the given ones.</p>\n\n<p>The optional pointer <code>out</code> can be used to retrieve a pointer to the newly created/updated entry.  Pass NULL if you do not need it. The pointer may not be valid past the next operation in this builder. Duplicate the entry if you want to keep it.</p>\n\n<p>By default the entry that you are inserting will be checked for validity; that it exists in the object database and is of the correct type.  If you do not want this behavior, set the <code>GIT_OPT_ENABLE_STRICT_OBJECT_CREATION</code> library option to false.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_remove": {
@@ -26819,7 +24215,7 @@
         "comment": null
       },
       "description": "<p>Selectively remove entries in the tree</p>\n",
-      "comments": "<p>The <code>filter</code> callback will be called for each entry in the tree with a\n pointer to the entry and the provided <code>payload</code>; if the callback returns\n non-zero, the entry will be filtered (removed from the builder).</p>\n",
+      "comments": "<p>The <code>filter</code> callback will be called for each entry in the tree with a pointer to the entry and the provided <code>payload</code>; if the callback returns non-zero, the entry will be filtered (removed from the builder).</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_write": {
@@ -26846,7 +24242,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Write the contents of the tree builder as a tree object</p>\n",
-      "comments": "<p>The tree builder will be written to the given <code>repo</code>, and its\n identifying SHA1 hash will be stored in the <code>id</code> pointer.</p>\n",
+      "comments": "<p>The tree builder will be written to the given <code>repo</code>, and its identifying SHA1 hash will be stored in the <code>id</code> pointer.</p>\n",
       "group": "treebuilder"
     },
     "git_treebuilder_write_with_buffer": {
@@ -26915,7 +24311,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Traverse the entries in a tree and its subtrees in post or pre order.</p>\n",
-      "comments": "<p>The entries will be traversed in the specified order, children subtrees\n will be automatically loaded as required, and the <code>callback</code> will be\n called once per entry with the current (relative) root for the entry and\n the entry data itself.</p>\n\n<p>If the callback returns a positive value, the passed entry will be\n skipped on the traversal (in pre mode). A negative value stops the walk.</p>\n",
+      "comments": "<p>The entries will be traversed in the specified order, children subtrees will be automatically loaded as required, and the <code>callback</code> will be called once per entry with the current (relative) root for the entry and the entry data itself.</p>\n\n<p>If the callback returns a positive value, the passed entry will be skipped on the traversal (in pre mode). A negative value stops the walk.</p>\n",
       "group": "tree"
     },
     "git_tree_dup": {
@@ -26984,7 +24380,7 @@
         "comment": null
       },
       "description": "<p>Create a tree based on another one with the specified modifications</p>\n",
-      "comments": "<p>Given the <code>baseline</code> perform the changes described in the list of\n <code>updates</code> and create a new tree.</p>\n\n<p>This function is optimized for common file/directory addition, removal and\n replacement in trees. It is much more efficient than reading the tree into a\n <code>git_index</code> and modifying that, but in exchange it is not as flexible.</p>\n\n<p>Deleting and adding the same entry is undefined behaviour, changing\n a tree to a blob or viceversa is not supported.</p>\n",
+      "comments": "<p>Given the <code>baseline</code> perform the changes described in the list of <code>updates</code> and create a new tree.</p>\n\n<p>This function is optimized for common file/directory addition, removal and replacement in trees. It is much more efficient than reading the tree into a <code>git_index</code> and modifying that, but in exchange it is not as flexible.</p>\n\n<p>Deleting and adding the same entry is undefined behaviour, changing a tree to a blob or viceversa is not supported.</p>\n",
       "group": "tree"
     },
     "git_worktree_list": {
@@ -27011,7 +24407,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>List names of linked working trees</p>\n",
-      "comments": "<p>The returned list should be released with <code>git_strarray_free</code>\n when no longer needed.</p>\n",
+      "comments": "<p>The returned list should be released with <code>git_strarray_free</code> when no longer needed.</p>\n",
       "group": "worktree"
     },
     "git_worktree_lookup": {
@@ -27070,7 +24466,7 @@
         "comment": null
       },
       "description": "<p>Open a worktree of a given repository</p>\n",
-      "comments": "<p>If a repository is not the main tree but a worktree, this\n function will look up the worktree inside the parent\n repository and create a new <code>git_worktree</code> structure.</p>\n",
+      "comments": "<p>If a repository is not the main tree but a worktree, this function will look up the worktree inside the parent repository and create a new <code>git_worktree</code> structure.</p>\n",
       "group": "worktree"
     },
     "git_worktree_free": {
@@ -27114,10 +24510,10 @@
         "comment": " 0 when worktree is valid, error-code otherwise"
       },
       "description": "<p>Check if worktree is valid</p>\n",
-      "comments": "<p>A valid worktree requires both the git data structures inside\n the linked parent repository and the linked working copy to be\n present.</p>\n",
+      "comments": "<p>A valid worktree requires both the git data structures inside the linked parent repository and the linked working copy to be present.</p>\n",
       "group": "worktree"
     },
-    "git_worktree_add_init_options": {
+    "git_worktree_add_options_init": {
       "type": "function",
       "file": "git2/worktree.h",
       "line": 104,
@@ -27141,7 +24537,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_worktree_add_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_worktree_add_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_worktree_add_options</code> with default values. Equivalent to creating an instance with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>.</p>\n",
       "group": "worktree"
     },
     "git_worktree_add": {
@@ -27183,7 +24579,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Add a new working tree</p>\n",
-      "comments": "<p>Add a new working tree for the repository, that is create the\n required data structures inside the repository and check out\n the current HEAD at <code>path</code></p>\n",
+      "comments": "<p>Add a new working tree for the repository, that is create the required data structures inside the repository and check out the current HEAD at <code>path</code></p>\n",
       "group": "worktree"
     },
     "git_worktree_lock": {
@@ -27210,7 +24606,7 @@
         "comment": " 0 on success, non-zero otherwise"
       },
       "description": "<p>Lock worktree if not already locked</p>\n",
-      "comments": "<p>Lock a worktree, optionally specifying a reason why the linked\n working tree is being locked.</p>\n",
+      "comments": "<p>Lock a worktree, optionally specifying a reason why the linked working tree is being locked.</p>\n",
       "group": "worktree"
     },
     "git_worktree_unlock": {
@@ -27259,7 +24655,7 @@
         "comment": " 0 when the working tree not locked, a value greater\n  than zero if it is locked, less than zero if there was an\n  error"
       },
       "description": "<p>Check if worktree is locked</p>\n",
-      "comments": "<p>A worktree may be locked if the linked working tree is stored\n on a portable device which is not available.</p>\n",
+      "comments": "<p>A worktree may be locked if the linked working tree is stored on a portable device which is not available.</p>\n",
       "group": "worktree"
     },
     "git_worktree_name": {
@@ -27306,7 +24702,7 @@
       "comments": "",
       "group": "worktree"
     },
-    "git_worktree_prune_init_options": {
+    "git_worktree_prune_options_init": {
       "type": "function",
       "file": "git2/worktree.h",
       "line": 217,
@@ -27330,7 +24726,7 @@
         "comment": " Zero on success; -1 on failure."
       },
       "description": "<p>Initialize git_worktree_prune_options structure</p>\n",
-      "comments": "<p>Initializes a <code>git_worktree_prune_options</code> with default values. Equivalent to\n creating an instance with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>.</p>\n",
+      "comments": "<p>Initializes a <code>git_worktree_prune_options</code> with default values. Equivalent to creating an instance with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>.</p>\n",
       "group": "worktree"
     },
     "git_worktree_is_prunable": {
@@ -27357,7 +24753,7 @@
         "comment": null
       },
       "description": "<p>Is the worktree prunable with the given options?</p>\n",
-      "comments": "<p>A worktree is not prunable in the following scenarios:</p>\n\n<ul>\n<li>the worktree is linking to a valid on-disk worktree. The\n<code>valid</code> member will cause this check to be ignored.</li>\n<li>the worktree is locked. The <code>locked</code> flag will cause this\ncheck to be ignored.</li>\n</ul>\n\n<p>If the worktree is not valid and not locked or if the above\n flags have been passed in, this function will return a\n positive value.</p>\n",
+      "comments": "<p>A worktree is not prunable in the following scenarios:</p>\n\n<ul>\n<li>the worktree is linking to a valid on-disk worktree. The   <code>valid</code> member will cause this check to be ignored. - the worktree is locked. The <code>locked</code> flag will cause this   check to be ignored.</li>\n</ul>\n\n<p>If the worktree is not valid and not locked or if the above flags have been passed in, this function will return a positive value.</p>\n",
       "group": "worktree"
     },
     "git_worktree_prune": {
@@ -27384,7 +24780,7 @@
         "comment": " 0 or an error code"
       },
       "description": "<p>Prune working tree</p>\n",
-      "comments": "<p>Prune the working tree, that is remove the git data\n structures on disk. The repository will only be pruned of\n <code>git_worktree_is_prunable</code> succeeds.</p>\n",
+      "comments": "<p>Prune the working tree, that is remove the git data structures on disk. The repository will only be pruned of <code>git_worktree_is_prunable</code> succeeds.</p>\n",
       "group": "worktree"
     }
   },
@@ -27413,7 +24809,7 @@
         "comment": null
       },
       "description": "<p>When applying a patch, callback that will be made per delta (file).</p>\n",
-      "comments": "<p>When the callback:\n - returns \n&lt;\n 0, the apply process will be aborted.\n - returns &gt; 0, the delta will not be applied, but the apply process\n      continues\n - returns 0, the delta is applied, and the apply process continues.</p>\n"
+      "comments": "<p>When the callback: - returns &lt; 0, the apply process will be aborted. - returns &gt; 0, the delta will not be applied, but the apply process      continues - returns 0, the delta is applied, and the apply process continues.</p>\n"
     },
     "git_apply_hunk_cb": {
       "type": "callback",
@@ -27439,7 +24835,7 @@
         "comment": null
       },
       "description": "<p>When applying a patch, callback that will be made per hunk.</p>\n",
-      "comments": "<p>When the callback:\n - returns \n&lt;\n 0, the apply process will be aborted.\n - returns &gt; 0, the hunk will not be applied, but the apply process\n      continues\n - returns 0, the hunk is applied, and the apply process continues.</p>\n"
+      "comments": "<p>When the callback: - returns &lt; 0, the apply process will be aborted. - returns &gt; 0, the hunk will not be applied, but the apply process      continues - returns 0, the hunk is applied, and the apply process continues.</p>\n"
     },
     "git_attr_foreach_cb": {
       "type": "callback",
@@ -27470,13 +24866,13 @@
         "comment": " 0 to continue looping, non-zero to stop. This value will be returned\n         from git_attr_foreach."
       },
       "description": "<p>The callback used with git_attr_foreach.</p>\n",
-      "comments": "<p>This callback will be invoked only once per attribute name, even if there\n are multiple rules for a given file. The highest priority rule will be\n used.</p>\n"
+      "comments": "<p>This callback will be invoked only once per attribute name, even if there are multiple rules for a given file. The highest priority rule will be used.</p>\n"
     },
     "git_checkout_notify_cb": {
       "type": "callback",
       "file": "git2/checkout.h",
-      "line": 223,
-      "lineto": 229,
+      "line": 236,
+      "lineto": 242,
       "args": [
         {
           "name": "why",
@@ -27521,8 +24917,8 @@
     "git_checkout_progress_cb": {
       "type": "callback",
       "file": "git2/checkout.h",
-      "line": 232,
-      "lineto": 236,
+      "line": 245,
+      "lineto": 249,
       "args": [
         {
           "name": "path",
@@ -27557,8 +24953,8 @@
     "git_checkout_perfdata_cb": {
       "type": "callback",
       "file": "git2/checkout.h",
-      "line": 239,
-      "lineto": 241,
+      "line": 252,
+      "lineto": 254,
       "args": [
         {
           "name": "perfdata",
@@ -27619,7 +25015,7 @@
         "comment": " 0, GIT_EINVALIDSPEC, GIT_EEXISTS or an error code"
       },
       "description": "<p>The signature of a function matching git_remote_create, with an additional\n void* as a callback payload.</p>\n",
-      "comments": "<p>Callers of git_clone may provide a function matching this signature to override\n the remote creation and customization process during a clone operation.</p>\n"
+      "comments": "<p>Callers of git_clone may provide a function matching this signature to override the remote creation and customization process during a clone operation.</p>\n"
     },
     "git_repository_create_cb": {
       "type": "callback",
@@ -27655,7 +25051,7 @@
         "comment": " 0, or a negative value to indicate error"
       },
       "description": "<p>The signature of a function matchin git_repository_init, with an\n aditional void * as callback payload.</p>\n",
-      "comments": "<p>Callers of git_clone my provide a function matching this signature\n to override the repository creation and customization process\n during a clone operation.</p>\n"
+      "comments": "<p>Callers of git_clone my provide a function matching this signature to override the repository creation and customization process during a clone operation.</p>\n"
     },
     "git_config_foreach_cb": {
       "type": "callback",
@@ -27681,6 +25077,32 @@
         "comment": null
       },
       "description": "<p>A config enumeration callback</p>\n",
+      "comments": ""
+    },
+    "git_headlist_cb": {
+      "type": "callback",
+      "file": "git2/deprecated.h",
+      "line": 409,
+      "lineto": 409,
+      "args": [
+        {
+          "name": "rhead",
+          "type": "git_remote_head *",
+          "comment": null
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": null
+        }
+      ],
+      "argline": "git_remote_head *rhead, void *payload",
+      "sig": "git_remote_head *::void *",
+      "return": {
+        "type": "int",
+        "comment": null
+      },
+      "description": "<p>Callback for listing the remote heads</p>\n",
       "comments": ""
     },
     "git_diff_notify_cb": {
@@ -27717,7 +25139,7 @@
         "comment": null
       },
       "description": "<p>Diff notification callback function.</p>\n",
-      "comments": "<p>The callback will be called for each file, just before the <code>git_diff_delta</code>\n gets inserted into the diff.</p>\n\n<p>When the callback:\n - returns \n&lt;\n 0, the diff process will be aborted.\n - returns &gt; 0, the delta will not be inserted into the diff, but the\n        diff process continues.\n - returns 0, the delta is inserted into the diff, and the diff process\n        continues.</p>\n"
+      "comments": "<p>The callback will be called for each file, just before the <code>git_diff_delta</code> gets inserted into the diff.</p>\n\n<p>When the callback: - returns &lt; 0, the diff process will be aborted. - returns &gt; 0, the delta will not be inserted into the diff, but the       diff process continues. - returns 0, the delta is inserted into the diff, and the diff process      continues.</p>\n"
     },
     "git_diff_progress_cb": {
       "type": "callback",
@@ -27882,7 +25304,7 @@
         "comment": null
       },
       "description": "<p>When iterating over a diff, callback that will be made per text diff\n line. In this context, the provided range will be NULL.</p>\n",
-      "comments": "<p>When printing a diff, callback that will be made to output each line\n of text.  This uses some extra GIT_DIFF_LINE_... constants for output\n of lines of file and hunk headers.</p>\n"
+      "comments": "<p>When printing a diff, callback that will be made to output each line of text.  This uses some extra GIT_DIFF_LINE_... constants for output of lines of file and hunk headers.</p>\n"
     },
     "git_index_matched_path_cb": {
       "type": "callback",
@@ -27915,30 +25337,30 @@
       "description": "<p>Callback for APIs that add/remove/update files matching pathspec </p>\n",
       "comments": ""
     },
-    "git_headlist_cb": {
+    "git_indexer_progress_cb": {
       "type": "callback",
-      "file": "git2/net.h",
-      "line": 55,
-      "lineto": 55,
+      "file": "git2/indexer.h",
+      "line": 57,
+      "lineto": 57,
       "args": [
         {
-          "name": "rhead",
-          "type": "git_remote_head *",
-          "comment": null
+          "name": "stats",
+          "type": "const git_indexer_progress *",
+          "comment": "Structure containing information about the state of the tran    sfer"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload provided by caller"
         }
       ],
-      "argline": "git_remote_head *rhead, void *payload",
-      "sig": "git_remote_head *::void *",
+      "argline": "const git_indexer_progress *stats, void *payload",
+      "sig": "const git_indexer_progress *::void *",
       "return": {
         "type": "int",
         "comment": null
       },
-      "description": "<p>Callback for listing the remote heads</p>\n",
+      "description": "<p>Type for progress callbacks during indexing.  Return a value less\n than zero to cancel the indexing or download.</p>\n",
       "comments": ""
     },
     "git_note_foreach_cb": {
@@ -27970,13 +25392,13 @@
         "comment": null
       },
       "description": "<p>Callback for git_note_foreach.</p>\n",
-      "comments": "<p>Receives:\n - blob_id: Oid of the blob containing the message\n - annotated_object_id: Oid of the git object being annotated\n - payload: Payload data passed to <code>git_note_foreach</code></p>\n"
+      "comments": "<p>Receives: - blob_id: Oid of the blob containing the message - annotated_object_id: Oid of the git object being annotated - payload: Payload data passed to <code>git_note_foreach</code></p>\n"
     },
     "git_odb_foreach_cb": {
       "type": "callback",
       "file": "git2/odb.h",
-      "line": 27,
-      "lineto": 27,
+      "line": 28,
+      "lineto": 28,
       "args": [
         {
           "name": "id",
@@ -28001,39 +25423,39 @@
     "git_packbuilder_foreach_cb": {
       "type": "callback",
       "file": "git2/pack.h",
-      "line": 181,
-      "lineto": 181,
+      "line": 192,
+      "lineto": 192,
       "args": [
         {
           "name": "buf",
           "type": "void *",
-          "comment": null
+          "comment": "A pointer to the object's data"
         },
         {
           "name": "size",
           "type": "size_t",
-          "comment": null
+          "comment": "The size of the underlying object"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload passed to git_packbuilder_foreach"
         }
       ],
       "argline": "void *buf, size_t size, void *payload",
       "sig": "void *::size_t::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over packed objects</p>\n",
       "comments": ""
     },
     "git_packbuilder_progress": {
       "type": "callback",
       "file": "git2/pack.h",
-      "line": 210,
-      "lineto": 214,
+      "line": 221,
+      "lineto": 225,
       "args": [
         {
           "name": "stage",
@@ -28042,12 +25464,12 @@
         },
         {
           "name": "current",
-          "type": "int",
+          "type": "uint32_t",
           "comment": null
         },
         {
           "name": "total",
-          "type": "int",
+          "type": "uint32_t",
           "comment": null
         },
         {
@@ -28056,8 +25478,8 @@
           "comment": null
         }
       ],
-      "argline": "int stage, int current, int total, void *payload",
-      "sig": "int::int::int::void *",
+      "argline": "int stage, uint32_t current, uint32_t total, void *payload",
+      "sig": "int::uint32_t::uint32_t::void *",
       "return": {
         "type": "int",
         "comment": null
@@ -28068,56 +25490,56 @@
     "git_reference_foreach_cb": {
       "type": "callback",
       "file": "git2/refs.h",
-      "line": 425,
-      "lineto": 425,
+      "line": 434,
+      "lineto": 434,
       "args": [
         {
           "name": "reference",
           "type": "git_reference *",
-          "comment": null
+          "comment": "The reference object"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload passed to git_reference_foreach"
         }
       ],
       "argline": "git_reference *reference, void *payload",
       "sig": "git_reference *::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over references</p>\n",
       "comments": ""
     },
     "git_reference_foreach_name_cb": {
       "type": "callback",
       "file": "git2/refs.h",
-      "line": 426,
-      "lineto": 426,
+      "line": 445,
+      "lineto": 445,
       "args": [
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "The reference name"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload passed to git_reference_foreach_name"
         }
       ],
       "argline": "const char *name, void *payload",
       "sig": "const char *::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over reference names</p>\n",
       "comments": ""
     },
-    "git_push_transfer_progress": {
+    "git_push_transfer_progress_cb": {
       "type": "callback",
       "file": "git2/remote.h",
       "line": 425,
@@ -28156,8 +25578,8 @@
     "git_push_negotiation": {
       "type": "callback",
       "file": "git2/remote.h",
-      "line": 460,
-      "lineto": 460,
+      "line": 461,
+      "lineto": 461,
       "args": [
         {
           "name": "updates",
@@ -28187,8 +25609,8 @@
     "git_push_update_reference_cb": {
       "type": "callback",
       "file": "git2/remote.h",
-      "line": 474,
-      "lineto": 474,
+      "line": 475,
+      "lineto": 475,
       "args": [
         {
           "name": "refname",
@@ -28213,73 +25635,109 @@
         "comment": " 0 on success, otherwise an error"
       },
       "description": "<p>Callback used to inform of the update status from the remote.</p>\n",
-      "comments": "<p>Called for each updated reference on push. If <code>status</code> is\n not <code>NULL</code>, the update was rejected by the remote server\n and <code>status</code> contains the reason given.</p>\n"
+      "comments": "<p>Called for each updated reference on push. If <code>status</code> is not <code>NULL</code>, the update was rejected by the remote server and <code>status</code> contains the reason given.</p>\n"
     },
-    "git_repository_fetchhead_foreach_cb": {
+    "git_url_resolve_cb": {
       "type": "callback",
-      "file": "git2/repository.h",
-      "line": 643,
-      "lineto": 647,
+      "file": "git2/remote.h",
+      "line": 489,
+      "lineto": 489,
       "args": [
         {
-          "name": "ref_name",
+          "name": "url_resolved",
+          "type": "git_buf *",
+          "comment": "The buffer to write the resolved URL to"
+        },
+        {
+          "name": "url",
           "type": "const char *",
-          "comment": null
+          "comment": "The URL to resolve"
         },
         {
-          "name": "remote_url",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "oid",
-          "type": "const git_oid *",
-          "comment": null
-        },
-        {
-          "name": "is_merge",
-          "type": "unsigned int",
-          "comment": null
+          "name": "direction",
+          "type": "int",
+          "comment": "GIT_DIRECTION_FETCH or GIT_DIRECTION_PUSH"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload provided by the caller"
+        }
+      ],
+      "argline": "git_buf *url_resolved, const char *url, int direction, void *payload",
+      "sig": "git_buf *::const char *::int::void *",
+      "return": {
+        "type": "int",
+        "comment": " 0 on success, GIT_PASSTHROUGH or an error"
+      },
+      "description": "<p>Callback to resolve URLs before connecting to remote</p>\n",
+      "comments": "<p>If you return GIT_PASSTHROUGH, you don&#39;t need to write anything to url_resolved.</p>\n"
+    },
+    "git_repository_fetchhead_foreach_cb": {
+      "type": "callback",
+      "file": "git2/repository.h",
+      "line": 655,
+      "lineto": 659,
+      "args": [
+        {
+          "name": "ref_name",
+          "type": "const char *",
+          "comment": "The reference name"
+        },
+        {
+          "name": "remote_url",
+          "type": "const char *",
+          "comment": "The remote URL"
+        },
+        {
+          "name": "oid",
+          "type": "const git_oid *",
+          "comment": "The reference target OID"
+        },
+        {
+          "name": "is_merge",
+          "type": "unsigned int",
+          "comment": "Was the reference the result of a merge"
+        },
+        {
+          "name": "payload",
+          "type": "void *",
+          "comment": "Payload passed to git_repository_fetchhead_foreach"
         }
       ],
       "argline": "const char *ref_name, const char *remote_url, const git_oid *oid, unsigned int is_merge, void *payload",
       "sig": "const char *::const char *::const git_oid *::unsigned int::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over each FETCH_HEAD entry</p>\n",
       "comments": ""
     },
     "git_repository_mergehead_foreach_cb": {
       "type": "callback",
       "file": "git2/repository.h",
-      "line": 665,
-      "lineto": 666,
+      "line": 686,
+      "lineto": 687,
       "args": [
         {
           "name": "oid",
           "type": "const git_oid *",
-          "comment": null
+          "comment": "The merge OID"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload passed to git_repository_mergehead_foreach"
         }
       ],
       "argline": "const git_oid *oid, void *payload",
       "sig": "const git_oid *::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over each MERGE_HEAD entry</p>\n",
       "comments": ""
     },
     "git_revwalk_hide_cb": {
@@ -28432,374 +25890,38 @@
       "description": "<p>Function pointer to receive each submodule</p>\n",
       "comments": ""
     },
-    "git_filter_init_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 141,
-      "lineto": 141,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter *self",
-      "sig": "git_filter *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Initialize callback on filter</p>\n",
-      "comments": "<p>Specified as <code>filter.initialize</code>, this is an optional callback invoked\n before a filter is first used.  It will be called once at most.</p>\n\n<p>If non-NULL, the filter&#39;s <code>initialize</code> callback will be invoked right\n before the first use of the filter, so you can defer expensive\n initialization operations (in case libgit2 is being used in a way that\n doesn&#39;t need the filter).</p>\n"
-    },
-    "git_filter_shutdown_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 153,
-      "lineto": 153,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter *self",
-      "sig": "git_filter *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Shutdown callback on filter</p>\n",
-      "comments": "<p>Specified as <code>filter.shutdown</code>, this is an optional callback invoked\n when the filter is unregistered or when libgit2 is shutting down.  It\n will be called once at most and should release resources as needed.\n This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_filter</code> object itself.</p>\n"
-    },
-    "git_filter_check_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 175,
-      "lineto": 179,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void **",
-          "comment": null
-        },
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        },
-        {
-          "name": "attr_values",
-          "type": "const char **",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter *self, void **payload, const git_filter_source *src, const char **attr_values",
-      "sig": "git_filter *::void **::const git_filter_source *::const char **",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Callback to decide if a given source needs this filter</p>\n",
-      "comments": "<p>Specified as <code>filter.check</code>, this is an optional callback that checks\n if filtering is needed for a given source.</p>\n\n<p>It should return 0 if the filter should be applied (i.e. success),\n GIT_PASSTHROUGH if the filter should not be applied, or an error code\n to fail out of the filter processing pipeline and return to the caller.</p>\n\n<p>The <code>attr_values</code> will be set to the values of any attributes given in\n the filter definition.  See <code>git_filter</code> below for more detail.</p>\n\n<p>The <code>payload</code> will be a pointer to a reference payload for the filter.\n This will start as NULL, but <code>check</code> can assign to this pointer for\n later use by the <code>apply</code> callback.  Note that the value should be heap\n allocated (not stack), so that it doesn&#39;t go away before the <code>apply</code>\n callback can use it.  If a filter allocates and assigns a value to the\n <code>payload</code>, it will need a <code>cleanup</code> callback to free the payload.</p>\n"
-    },
-    "git_filter_apply_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 193,
-      "lineto": 198,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void **",
-          "comment": null
-        },
-        {
-          "name": "to",
-          "type": "git_buf *",
-          "comment": null
-        },
-        {
-          "name": "from",
-          "type": "const git_buf *",
-          "comment": null
-        },
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter *self, void **payload, git_buf *to, const git_buf *from, const git_filter_source *src",
-      "sig": "git_filter *::void **::git_buf *::const git_buf *::const git_filter_source *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Callback to actually perform the data filtering</p>\n",
-      "comments": "<p>Specified as <code>filter.apply</code>, this is the callback that actually filters\n data.  If it successfully writes the output, it should return 0.  Like\n <code>check</code>, it can return GIT_PASSTHROUGH to indicate that the filter\n doesn&#39;t want to run.  Other error codes will stop filter processing and\n return to the caller.</p>\n\n<p>The <code>payload</code> value will refer to any payload that was set by the\n <code>check</code> callback.  It may be read from or written to as needed.</p>\n"
-    },
-    "git_filter_stream_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 200,
-      "lineto": 205,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_writestream **",
-          "comment": null
-        },
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void **",
-          "comment": null
-        },
-        {
-          "name": "src",
-          "type": "const git_filter_source *",
-          "comment": null
-        },
-        {
-          "name": "next",
-          "type": "git_writestream *",
-          "comment": null
-        }
-      ],
-      "argline": "git_writestream **out, git_filter *self, void **payload, const git_filter_source *src, git_writestream *next",
-      "sig": "git_writestream **::git_filter *::void **::const git_filter_source *::git_writestream *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": ""
-    },
-    "git_filter_cleanup_fn": {
-      "type": "callback",
-      "file": "git2/sys/filter.h",
-      "line": 215,
-      "lineto": 217,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_filter *",
-          "comment": null
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_filter *self, void *payload",
-      "sig": "git_filter *::void *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Callback to clean up after filtering has been applied</p>\n",
-      "comments": "<p>Specified as <code>filter.cleanup</code>, this is an optional callback invoked\n after the filter has been applied.  If the <code>check</code> or <code>apply</code> callbacks\n allocated a <code>payload</code> to keep per-source filter state, use this\n callback to free that payload and release resources as required.</p>\n"
-    },
-    "git_merge_driver_init_fn": {
-      "type": "callback",
-      "file": "git2/sys/merge.h",
-      "line": 76,
-      "lineto": 76,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_merge_driver *",
-          "comment": null
-        }
-      ],
-      "argline": "git_merge_driver *self",
-      "sig": "git_merge_driver *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Initialize callback on merge driver</p>\n",
-      "comments": "<p>Specified as <code>driver.initialize</code>, this is an optional callback invoked\n before a merge driver is first used.  It will be called once at most\n per library lifetime.</p>\n\n<p>If non-NULL, the merge driver&#39;s <code>initialize</code> callback will be invoked\n right before the first use of the driver, so you can defer expensive\n initialization operations (in case libgit2 is being used in a way that\n doesn&#39;t need the merge driver).</p>\n"
-    },
-    "git_merge_driver_shutdown_fn": {
-      "type": "callback",
-      "file": "git2/sys/merge.h",
-      "line": 88,
-      "lineto": 88,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_merge_driver *",
-          "comment": null
-        }
-      ],
-      "argline": "git_merge_driver *self",
-      "sig": "git_merge_driver *",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "<p>Shutdown callback on merge driver</p>\n",
-      "comments": "<p>Specified as <code>driver.shutdown</code>, this is an optional callback invoked\n when the merge driver is unregistered or when libgit2 is shutting down.\n It will be called once at most and should release resources as needed.\n This may be called even if the <code>initialize</code> callback was not made.</p>\n\n<p>Typically this function will free the <code>git_merge_driver</code> object itself.</p>\n"
-    },
-    "git_merge_driver_apply_fn": {
-      "type": "callback",
-      "file": "git2/sys/merge.h",
-      "line": 108,
-      "lineto": 114,
-      "args": [
-        {
-          "name": "self",
-          "type": "git_merge_driver *",
-          "comment": null
-        },
-        {
-          "name": "path_out",
-          "type": "const char **",
-          "comment": null
-        },
-        {
-          "name": "mode_out",
-          "type": "int *",
-          "comment": null
-        },
-        {
-          "name": "merged_out",
-          "type": "git_buf *",
-          "comment": null
-        },
-        {
-          "name": "filter_name",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "src",
-          "type": "const git_merge_driver_source *",
-          "comment": null
-        }
-      ],
-      "argline": "git_merge_driver *self, const char **path_out, int *mode_out, git_buf *merged_out, const char *filter_name, const git_merge_driver_source *src",
-      "sig": "git_merge_driver *::const char **::int *::git_buf *::const char *::const git_merge_driver_source *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Callback to perform the merge.</p>\n",
-      "comments": "<p>Specified as <code>driver.apply</code>, this is the callback that actually does the\n merge.  If it can successfully perform a merge, it should populate\n <code>path_out</code> with a pointer to the filename to accept, <code>mode_out</code> with\n the resultant mode, and <code>merged_out</code> with the buffer of the merged file\n and then return 0.  If the driver returns <code>GIT_PASSTHROUGH</code>, then the\n default merge driver should instead be run.  It can also return\n <code>GIT_EMERGECONFLICT</code> if the driver is not able to produce a merge result,\n and the file will remain conflicted.  Any other errors will fail and\n return to the caller.</p>\n\n<p>The <code>filter_name</code> contains the name of the filter that was invoked, as\n specified by the file&#39;s attributes.</p>\n\n<p>The <code>src</code> contains the data about the file to be merged.</p>\n"
-    },
-    "git_stream_cb": {
-      "type": "callback",
-      "file": "git2/sys/stream.h",
-      "line": 117,
-      "lineto": 117,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_stream **",
-          "comment": null
-        },
-        {
-          "name": "host",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "port",
-          "type": "const char *",
-          "comment": null
-        }
-      ],
-      "argline": "git_stream **out, const char *host, const char *port",
-      "sig": "git_stream **::const char *::const char *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": ""
-    },
-    "git_smart_subtransport_cb": {
-      "type": "callback",
-      "file": "git2/sys/transport.h",
-      "line": 364,
-      "lineto": 367,
-      "args": [
-        {
-          "name": "out",
-          "type": "git_smart_subtransport **",
-          "comment": null
-        },
-        {
-          "name": "owner",
-          "type": "git_transport *",
-          "comment": null
-        },
-        {
-          "name": "param",
-          "type": "void *",
-          "comment": null
-        }
-      ],
-      "argline": "git_smart_subtransport **out, git_transport *owner, void *param",
-      "sig": "git_smart_subtransport **::git_transport *::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>A function which creates a new subtransport for the smart transport </p>\n",
-      "comments": ""
-    },
     "git_tag_foreach_cb": {
       "type": "callback",
       "file": "git2/tag.h",
-      "line": 321,
-      "lineto": 321,
+      "line": 330,
+      "lineto": 330,
       "args": [
         {
           "name": "name",
           "type": "const char *",
-          "comment": null
+          "comment": "The tag name"
         },
         {
           "name": "oid",
           "type": "git_oid *",
-          "comment": null
+          "comment": "The tag's OID"
         },
         {
           "name": "payload",
           "type": "void *",
-          "comment": null
+          "comment": "Payload passed to git_tag_foreach"
         }
       ],
       "argline": "const char *name, git_oid *oid, void *payload",
       "sig": "const char *::git_oid *::void *",
       "return": {
         "type": "int",
-        "comment": null
+        "comment": " non-zero to terminate the iteration"
       },
-      "description": "",
+      "description": "<p>Callback used to iterate over tag names</p>\n",
       "comments": ""
     },
-    "git_trace_callback": {
+    "git_trace_cb": {
       "type": "callback",
       "file": "git2/trace.h",
       "line": 52,
@@ -28854,108 +25976,6 @@
         "comment": null
       },
       "description": "<p>Signature of a function which creates a transport </p>\n",
-      "comments": ""
-    },
-    "git_cred_sign_callback": {
-      "type": "callback",
-      "file": "git2/transport.h",
-      "line": 168,
-      "lineto": 168,
-      "args": [
-        {
-          "name": "session",
-          "type": "LIBSSH2_SESSION *",
-          "comment": null
-        },
-        {
-          "name": "sig",
-          "type": "unsigned char **",
-          "comment": null
-        },
-        {
-          "name": "sig_len",
-          "type": "size_t *",
-          "comment": null
-        },
-        {
-          "name": "data",
-          "type": "const unsigned char *",
-          "comment": null
-        },
-        {
-          "name": "data_len",
-          "type": "size_t",
-          "comment": null
-        },
-        {
-          "name": "abstract",
-          "type": "void **",
-          "comment": null
-        }
-      ],
-      "argline": "LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len, const unsigned char *data, size_t data_len, void **abstract",
-      "sig": "LIBSSH2_SESSION *::unsigned char **::size_t *::const unsigned char *::size_t::void **",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "",
-      "comments": ""
-    },
-    "git_cred_ssh_interactive_callback": {
-      "type": "callback",
-      "file": "git2/transport.h",
-      "line": 169,
-      "lineto": 169,
-      "args": [
-        {
-          "name": "name",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "name_len",
-          "type": "int",
-          "comment": null
-        },
-        {
-          "name": "instruction",
-          "type": "const char *",
-          "comment": null
-        },
-        {
-          "name": "instruction_len",
-          "type": "int",
-          "comment": null
-        },
-        {
-          "name": "num_prompts",
-          "type": "int",
-          "comment": null
-        },
-        {
-          "name": "prompts",
-          "type": "const LIBSSH2_USERAUTH_KBDINT_PROMPT *",
-          "comment": null
-        },
-        {
-          "name": "responses",
-          "type": "LIBSSH2_USERAUTH_KBDINT_RESPONSE *",
-          "comment": null
-        },
-        {
-          "name": "abstract",
-          "type": "void **",
-          "comment": null
-        }
-      ],
-      "argline": "const char *name, int name_len, const char *instruction, int instruction_len, int num_prompts, const LIBSSH2_USERAUTH_KBDINT_PROMPT *prompts, LIBSSH2_USERAUTH_KBDINT_RESPONSE *responses, void **abstract",
-      "sig": "const char *::int::const char *::int::int::const LIBSSH2_USERAUTH_KBDINT_PROMPT *::LIBSSH2_USERAUTH_KBDINT_RESPONSE *::void **",
-      "return": {
-        "type": "void",
-        "comment": null
-      },
-      "description": "",
       "comments": ""
     },
     "git_cred_acquire_cb": {
@@ -29023,7 +26043,7 @@
         "comment": null
       },
       "description": "<p>Callback for git_treebuilder_filter</p>\n",
-      "comments": "<p>The return value is treated as a boolean, with zero indicating that the\n entry should be left alone and any non-zero value meaning that the\n entry should be removed from the treebuilder list (i.e. filtered out).</p>\n"
+      "comments": "<p>The return value is treated as a boolean, with zero indicating that the entry should be left alone and any non-zero value meaning that the entry should be removed from the treebuilder list (i.e. filtered out).</p>\n"
     },
     "git_treewalk_cb": {
       "type": "callback",
@@ -29056,37 +26076,11 @@
       "description": "<p>Callback for the tree traversal method </p>\n",
       "comments": ""
     },
-    "git_transfer_progress_cb": {
-      "type": "callback",
-      "file": "git2/types.h",
-      "line": 275,
-      "lineto": 275,
-      "args": [
-        {
-          "name": "stats",
-          "type": "const git_transfer_progress *",
-          "comment": "Structure containing information about the state of the transfer"
-        },
-        {
-          "name": "payload",
-          "type": "void *",
-          "comment": "Payload provided by caller"
-        }
-      ],
-      "argline": "const git_transfer_progress *stats, void *payload",
-      "sig": "const git_transfer_progress *::void *",
-      "return": {
-        "type": "int",
-        "comment": null
-      },
-      "description": "<p>Type for progress callbacks during indexing.  Return a value less than zero\n to cancel the transfer.</p>\n",
-      "comments": ""
-    },
     "git_transport_message_cb": {
       "type": "callback",
       "file": "git2/types.h",
-      "line": 285,
-      "lineto": 285,
+      "line": 255,
+      "lineto": 255,
       "args": [
         {
           "name": "str",
@@ -29116,8 +26110,8 @@
     "git_transport_certificate_check_cb": {
       "type": "callback",
       "file": "git2/types.h",
-      "line": 338,
-      "lineto": 338,
+      "line": 308,
+      "lineto": 308,
       "args": [
         {
           "name": "cert",
@@ -29153,202 +26147,6 @@
   "globals": {},
   "types": [
     [
-      "LIBSSH2_SESSION",
-      {
-        "decl": "LIBSSH2_SESSION",
-        "type": "struct",
-        "value": "LIBSSH2_SESSION",
-        "file": "git2/transport.h",
-        "line": 163,
-        "lineto": 163,
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_cred_sign_callback"
-          ]
-        }
-      }
-    ],
-    [
-      "LIBSSH2_USERAUTH_KBDINT_PROMPT",
-      {
-        "decl": "LIBSSH2_USERAUTH_KBDINT_PROMPT",
-        "type": "struct",
-        "value": "LIBSSH2_USERAUTH_KBDINT_PROMPT",
-        "file": "git2/transport.h",
-        "line": 164,
-        "lineto": 164,
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_cred_ssh_interactive_callback"
-          ]
-        }
-      }
-    ],
-    [
-      "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
-      {
-        "decl": "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
-        "type": "struct",
-        "value": "LIBSSH2_USERAUTH_KBDINT_RESPONSE",
-        "file": "git2/transport.h",
-        "line": 165,
-        "lineto": 165,
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_cred_ssh_interactive_callback"
-          ]
-        }
-      }
-    ],
-    [
-      "_LIBSSH2_SESSION",
-      {
-        "decl": [],
-        "type": "struct",
-        "value": "_LIBSSH2_SESSION",
-        "file": "git2/transport.h",
-        "line": 163,
-        "lineto": 163,
-        "tdef": null,
-        "description": "",
-        "comments": "",
-        "fields": [],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "_LIBSSH2_USERAUTH_KBDINT_PROMPT",
-      {
-        "decl": [],
-        "type": "struct",
-        "value": "_LIBSSH2_USERAUTH_KBDINT_PROMPT",
-        "file": "git2/transport.h",
-        "line": 164,
-        "lineto": 164,
-        "tdef": null,
-        "description": "",
-        "comments": "",
-        "fields": [],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "_LIBSSH2_USERAUTH_KBDINT_RESPONSE",
-      {
-        "decl": [],
-        "type": "struct",
-        "value": "_LIBSSH2_USERAUTH_KBDINT_RESPONSE",
-        "file": "git2/transport.h",
-        "line": 165,
-        "lineto": 165,
-        "tdef": null,
-        "description": "",
-        "comments": "",
-        "fields": [],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "git_allocator",
-      {
-        "decl": [
-          "void *(*)(size_t, const char *, int) gmalloc",
-          "void *(*)(size_t, size_t, const char *, int) gcalloc",
-          "char *(*)(const char *, const char *, int) gstrdup",
-          "char *(*)(const char *, size_t, const char *, int) gstrndup",
-          "char *(*)(const char *, size_t, const char *, int) gsubstrdup",
-          "void *(*)(void *, size_t, const char *, int) grealloc",
-          "void *(*)(void *, size_t, size_t, const char *, int) greallocarray",
-          "void *(*)(size_t, size_t, const char *, int) gmallocarray",
-          "void (*)(void *) gfree"
-        ],
-        "type": "struct",
-        "value": "git_allocator",
-        "file": "git2/sys/alloc.h",
-        "line": 23,
-        "lineto": 73,
-        "block": "void *(*)(size_t, const char *, int) gmalloc\nvoid *(*)(size_t, size_t, const char *, int) gcalloc\nchar *(*)(const char *, const char *, int) gstrdup\nchar *(*)(const char *, size_t, const char *, int) gstrndup\nchar *(*)(const char *, size_t, const char *, int) gsubstrdup\nvoid *(*)(void *, size_t, const char *, int) grealloc\nvoid *(*)(void *, size_t, size_t, const char *, int) greallocarray\nvoid *(*)(size_t, size_t, const char *, int) gmallocarray\nvoid (*)(void *) gfree",
-        "tdef": "typedef",
-        "description": " An instance for a custom memory allocator",
-        "comments": "<p>Setting the pointers of this structure allows the developer to implement\n custom memory allocators. The global memory allocator can be set by using\n &quot;GIT_OPT_SET_ALLOCATOR&quot; with the <code>git_libgit2_opts</code> function. Keep in mind\n that all fields need to be set to a proper function.</p>\n",
-        "fields": [
-          {
-            "type": "void *(*)(size_t, const char *, int)",
-            "name": "gmalloc",
-            "comments": ""
-          },
-          {
-            "type": "void *(*)(size_t, size_t, const char *, int)",
-            "name": "gcalloc",
-            "comments": ""
-          },
-          {
-            "type": "char *(*)(const char *, const char *, int)",
-            "name": "gstrdup",
-            "comments": ""
-          },
-          {
-            "type": "char *(*)(const char *, size_t, const char *, int)",
-            "name": "gstrndup",
-            "comments": ""
-          },
-          {
-            "type": "char *(*)(const char *, size_t, const char *, int)",
-            "name": "gsubstrdup",
-            "comments": ""
-          },
-          {
-            "type": "void *(*)(void *, size_t, const char *, int)",
-            "name": "grealloc",
-            "comments": ""
-          },
-          {
-            "type": "void *(*)(void *, size_t, size_t, const char *, int)",
-            "name": "greallocarray",
-            "comments": ""
-          },
-          {
-            "type": "void *(*)(size_t, size_t, const char *, int)",
-            "name": "gmallocarray",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(void *)",
-            "name": "gfree",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_stdalloc_init_allocator",
-            "git_win32_crtdbg_init_allocator"
-          ]
-        }
-      }
-    ],
-    [
       "git_annotated_commit",
       {
         "decl": "git_annotated_commit",
@@ -29360,7 +26158,6 @@
         "tdef": "typedef",
         "description": " Annotated commits, the input to merge and rebase. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -29392,11 +26189,11 @@
         ],
         "type": "enum",
         "file": "git2/apply.h",
-        "line": 92,
-        "lineto": 110,
+        "line": 95,
+        "lineto": 113,
         "block": "GIT_APPLY_LOCATION_WORKDIR\nGIT_APPLY_LOCATION_INDEX\nGIT_APPLY_LOCATION_BOTH",
         "tdef": "typedef",
-        "description": "",
+        "description": " Possible application locations for git_apply ",
         "comments": "",
         "fields": [
           {
@@ -29443,7 +26240,7 @@
         "block": "unsigned int version\ngit_apply_delta_cb delta_cb\ngit_apply_hunk_cb hunk_cb\nvoid * payload",
         "tdef": "typedef",
         "description": " Apply options structure",
-        "comments": "<p>Initialize with <code>GIT_APPLY_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_apply_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_APPLY_OPTIONS_INIT</code>. Alternatively, you can use <code>git_apply_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -29476,44 +26273,44 @@
       }
     ],
     [
-      "git_attr_t",
+      "git_attr_value_t",
       {
         "decl": [
-          "GIT_ATTR_UNSPECIFIED_T",
-          "GIT_ATTR_TRUE_T",
-          "GIT_ATTR_FALSE_T",
-          "GIT_ATTR_VALUE_T"
+          "GIT_ATTR_VALUE_UNSPECIFIED",
+          "GIT_ATTR_VALUE_TRUE",
+          "GIT_ATTR_VALUE_FALSE",
+          "GIT_ATTR_VALUE_STRING"
         ],
         "type": "enum",
         "file": "git2/attr.h",
         "line": 82,
         "lineto": 87,
-        "block": "GIT_ATTR_UNSPECIFIED_T\nGIT_ATTR_TRUE_T\nGIT_ATTR_FALSE_T\nGIT_ATTR_VALUE_T",
+        "block": "GIT_ATTR_VALUE_UNSPECIFIED\nGIT_ATTR_VALUE_TRUE\nGIT_ATTR_VALUE_FALSE\nGIT_ATTR_VALUE_STRING",
         "tdef": "typedef",
         "description": " Possible states for an attribute",
         "comments": "",
         "fields": [
           {
             "type": "int",
-            "name": "GIT_ATTR_UNSPECIFIED_T",
+            "name": "GIT_ATTR_VALUE_UNSPECIFIED",
             "comments": "<p>The attribute has been left unspecified </p>\n",
             "value": 0
           },
           {
             "type": "int",
-            "name": "GIT_ATTR_TRUE_T",
+            "name": "GIT_ATTR_VALUE_TRUE",
             "comments": "<p>The attribute has been set </p>\n",
             "value": 1
           },
           {
             "type": "int",
-            "name": "GIT_ATTR_FALSE_T",
+            "name": "GIT_ATTR_VALUE_FALSE",
             "comments": "<p>The attribute has been unset </p>\n",
             "value": 2
           },
           {
             "type": "int",
-            "name": "GIT_ATTR_VALUE_T",
+            "name": "GIT_ATTR_VALUE_STRING",
             "comments": "<p>This attribute has a value </p>\n",
             "value": 3
           }
@@ -29538,7 +26335,6 @@
         "tdef": "typedef",
         "description": " Opaque structure to hold blame results ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_blame_get_hunk_byindex",
@@ -29550,7 +26346,9 @@
             "git_blame_free",
             "git_blame_get_hunk_byindex",
             "git_blame_get_hunk_byline",
-            "git_blame_init_options"
+            "git_blame_get_hunk_count",
+            "git_blame_init_options",
+            "git_blame_options_init"
           ]
         }
       }
@@ -29647,7 +26445,7 @@
         "block": "size_t lines_in_hunk\ngit_oid final_commit_id\nsize_t final_start_line_number\ngit_signature * final_signature\ngit_oid orig_commit_id\nconst char * orig_path\nsize_t orig_start_line_number\ngit_signature * orig_signature\nchar boundary",
         "tdef": "typedef",
         "description": " Structure that represents a blame hunk.",
-        "comments": "<ul>\n<li><code>lines_in_hunk</code> is the number of lines in this hunk</li>\n<li><code>final_commit_id</code> is the OID of the commit where this line was last\nchanged.</li>\n<li><code>final_start_line_number</code> is the 1-based line number where this hunk\nbegins, in the final version of the file</li>\n<li><code>final_signature</code> is the author of <code>final_commit_id</code>. If\n<code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical\nreal name and email address.</li>\n<li><code>orig_commit_id</code> is the OID of the commit where this hunk was found.  This\nwill usually be the same as <code>final_commit_id</code>, except when\n<code>GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES</code> has been specified.</li>\n<li><code>orig_path</code> is the path to the file where this hunk originated, as of the\ncommit specified by <code>orig_commit_id</code>.</li>\n<li><code>orig_start_line_number</code> is the 1-based line number where this hunk begins\nin the file named by <code>orig_path</code> in the commit specified by\n<code>orig_commit_id</code>.</li>\n<li><code>orig_signature</code> is the author of <code>orig_commit_id</code>. If\n<code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical\nreal name and email address.</li>\n<li><code>boundary</code> is 1 iff the hunk has been tracked to a boundary commit (the\nroot, or the commit specified in git_blame_options.oldest_commit)</li>\n</ul>\n",
+        "comments": "<ul>\n<li><code>lines_in_hunk</code> is the number of lines in this hunk - <code>final_commit_id</code> is the OID of the commit where this line was last   changed. - <code>final_start_line_number</code> is the 1-based line number where this hunk   begins, in the final version of the file - <code>final_signature</code> is the author of <code>final_commit_id</code>. If   <code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical    real name and email address. - <code>orig_commit_id</code> is the OID of the commit where this hunk was found.  This   will usually be the same as <code>final_commit_id</code>, except when   <code>GIT_BLAME_TRACK_COPIES_ANY_COMMIT_COPIES</code> has been specified. - <code>orig_path</code> is the path to the file where this hunk originated, as of the   commit specified by <code>orig_commit_id</code>. - <code>orig_start_line_number</code> is the 1-based line number where this hunk begins   in the file named by <code>orig_path</code> in the commit specified by   <code>orig_commit_id</code>. - <code>orig_signature</code> is the author of <code>orig_commit_id</code>. If   <code>GIT_BLAME_USE_MAILMAP</code> has been specified, it will contain the canonical    real name and email address. - <code>boundary</code> is 1 iff the hunk has been tracked to a boundary commit (the   root, or the commit specified in git_blame_options.oldest_commit)</li>\n</ul>\n",
         "fields": [
           {
             "type": "size_t",
@@ -29709,8 +26507,8 @@
       {
         "decl": [
           "unsigned int version",
-          "int flags",
-          "int min_match_characters",
+          "uint32_t flags",
+          "uint16_t min_match_characters",
           "git_oid newest_commit",
           "git_oid oldest_commit",
           "size_t min_line",
@@ -29721,10 +26519,10 @@
         "file": "git2/blame.h",
         "line": 59,
         "lineto": 88,
-        "block": "unsigned int version\nint flags\nint min_match_characters\ngit_oid newest_commit\ngit_oid oldest_commit\nsize_t min_line\nsize_t max_line",
+        "block": "unsigned int version\nuint32_t flags\nuint16_t min_match_characters\ngit_oid newest_commit\ngit_oid oldest_commit\nsize_t min_line\nsize_t max_line",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Blame options structure",
+        "comments": "<p>Initialize with <code>GIT_BLAME_OPTIONS_INIT</code>. Alternatively, you can use <code>git_blame_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -29732,14 +26530,14 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
-            "comments": ""
+            "comments": " A combination of `git_blame_flag_t` "
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "min_match_characters",
-            "comments": ""
+            "comments": " The lower bound on the number of alphanumeric\n   characters that must be detected as moving/copying within a file for it to\n   associate those lines with the parent commit. The default value is 20.\n   This value only takes effect if any of the `GIT_BLAME_TRACK_COPIES_*`\n   flags are specified."
           },
           {
             "type": "git_oid",
@@ -29766,7 +26564,8 @@
           "returns": [],
           "needs": [
             "git_blame_file",
-            "git_blame_init_options"
+            "git_blame_init_options",
+            "git_blame_options_init"
           ]
         }
       }
@@ -29783,7 +26582,6 @@
         "tdef": "typedef",
         "description": " In-memory representation of a blob object. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -29820,7 +26618,6 @@
         "tdef": "typedef",
         "description": " Iterator type for branches ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -29893,7 +26690,7 @@
         "block": "char * ptr\nsize_t asize\nsize_t size",
         "tdef": "typedef",
         "description": " A data buffer for exporting data from libgit2",
-        "comments": "<p>Sometimes libgit2 wants to return an allocated data buffer to the\n caller and have the caller take responsibility for freeing that memory.\n This can be awkward if the caller does not have easy access to the same\n allocation functions that libgit2 is using.  In those cases, libgit2\n will fill in a <code>git_buf</code> and the caller can use <code>git_buf_dispose()</code> to\n release it when they are done.</p>\n\n<p>A <code>git_buf</code> may also be used for the caller to pass in a reference to\n a block of memory they hold.  In this case, libgit2 will not resize or\n free the memory, but will read from it as needed.</p>\n\n<p>A <code>git_buf</code> is a public structure with three fields:</p>\n\n<ul>\n<li><p><code>ptr</code> points to the start of the allocated memory.  If it is NULL,\nthen the <code>git_buf</code> is considered empty and libgit2 will feel free\nto overwrite it with new data.</p></li>\n<li><p><code>size</code> holds the size (in bytes) of the data that is actually used.</p></li>\n<li><p><code>asize</code> holds the known total amount of allocated memory if the <code>ptr</code>\nwas allocated by libgit2.  It may be larger than <code>size</code>.  If <code>ptr</code>\nwas not allocated by libgit2 and should not be resized and/or freed,\nthen <code>asize</code> will be set to zero.</p></li>\n</ul>\n\n<p>Some APIs may occasionally do something slightly unusual with a buffer,\n such as setting <code>ptr</code> to a value that was passed in by the user.  In\n those cases, the behavior will be clearly documented by the API.</p>\n",
+        "comments": "<p>Sometimes libgit2 wants to return an allocated data buffer to the caller and have the caller take responsibility for freeing that memory. This can be awkward if the caller does not have easy access to the same allocation functions that libgit2 is using.  In those cases, libgit2 will fill in a <code>git_buf</code> and the caller can use <code>git_buf_dispose()</code> to release it when they are done.</p>\n\n<p>A <code>git_buf</code> may also be used for the caller to pass in a reference to a block of memory they hold.  In this case, libgit2 will not resize or free the memory, but will read from it as needed.</p>\n\n<p>A <code>git_buf</code> is a public structure with three fields:</p>\n\n<ul>\n<li><p><code>ptr</code> points to the start of the allocated memory.  If it is NULL,   then the <code>git_buf</code> is considered empty and libgit2 will feel free   to overwrite it with new data.</p></li>\n<li><p><code>size</code> holds the size (in bytes) of the data that is actually used.</p></li>\n<li><p><code>asize</code> holds the known total amount of allocated memory if the <code>ptr</code>    was allocated by libgit2.  It may be larger than <code>size</code>.  If <code>ptr</code>    was not allocated by libgit2 and should not be resized and/or freed,    then <code>asize</code> will be set to zero.</p></li>\n</ul>\n\n<p>Some APIs may occasionally do something slightly unusual with a buffer, such as setting <code>ptr</code> to a value that was passed in by the user.  In those cases, the behavior will be clearly documented by the API.</p>\n",
         "fields": [
           {
             "type": "char *",
@@ -29939,13 +26736,10 @@
             "git_diff_format_email",
             "git_diff_stats_to_buf",
             "git_diff_to_buf",
-            "git_filter_apply_fn",
             "git_filter_list_apply_to_blob",
             "git_filter_list_apply_to_data",
             "git_filter_list_apply_to_file",
             "git_filter_list_stream_data",
-            "git_mempack_dump",
-            "git_merge_driver_apply_fn",
             "git_message_prettify",
             "git_note_default_ref",
             "git_object_short_id",
@@ -29959,6 +26753,7 @@
             "git_repository_message",
             "git_submodule_resolve_url",
             "git_treebuilder_write_with_buffer",
+            "git_url_resolve_cb",
             "git_worktree_is_locked"
           ]
         }
@@ -29973,8 +26768,8 @@
         "type": "struct",
         "value": "git_cert",
         "file": "git2/types.h",
-        "line": 319,
-        "lineto": 324,
+        "line": 289,
+        "lineto": 294,
         "block": "git_cert_t cert_type",
         "tdef": "typedef",
         "description": " Parent type for `git_cert_hostkey` and `git_cert_x509`.",
@@ -29989,8 +26784,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_transport_certificate_check_cb",
-            "git_transport_smart_certificate_check"
+            "git_transport_certificate_check_cb"
           ]
         }
       }
@@ -30087,8 +26881,8 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 291,
-        "lineto": 314,
+        "line": 261,
+        "lineto": 284,
         "block": "GIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY\nGIT_CERT_NONE\nGIT_CERT_X509\nGIT_CERT_HOSTKEY_LIBSSH2\nGIT_CERT_STRARRAY",
         "tdef": "typedef",
         "description": " Type of host certificate structure that is passed to the check callback",
@@ -30179,12 +26973,12 @@
         ],
         "type": "enum",
         "file": "git2/checkout.h",
-        "line": 205,
-        "lineto": 214,
+        "line": 217,
+        "lineto": 226,
         "block": "GIT_CHECKOUT_NOTIFY_NONE\nGIT_CHECKOUT_NOTIFY_CONFLICT\nGIT_CHECKOUT_NOTIFY_DIRTY\nGIT_CHECKOUT_NOTIFY_UPDATED\nGIT_CHECKOUT_NOTIFY_UNTRACKED\nGIT_CHECKOUT_NOTIFY_IGNORED\nGIT_CHECKOUT_NOTIFY_ALL",
         "tdef": "typedef",
         "description": " Checkout notification flags",
-        "comments": "<p>Checkout will invoke an options notification callback (<code>notify_cb</code>) for\n certain cases - you pick which ones via <code>notify_flags</code>:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_NOTIFY_CONFLICT invokes checkout on conflicting paths.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_DIRTY notifies about &quot;dirty&quot; files, i.e. those that\ndo not need an update but no longer match the baseline.  Core git\ndisplays these files when checkout runs, but won&#39;t stop the checkout.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UPDATED sends notification for any file changed.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UNTRACKED notifies about untracked files.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_IGNORED notifies about ignored files.</p></li>\n</ul>\n\n<p>Returning a non-zero value from this callback will cancel the checkout.\n The non-zero return value will be propagated back and returned by the\n git_checkout_... call.</p>\n\n<p>Notification callbacks are made prior to modifying any files on disk,\n so canceling on any notification will still happen prior to any files\n being modified.</p>\n",
+        "comments": "<p>Checkout will invoke an options notification callback (<code>notify_cb</code>) for certain cases - you pick which ones via <code>notify_flags</code>:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_NOTIFY_CONFLICT invokes checkout on conflicting paths.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_DIRTY notifies about &quot;dirty&quot; files, i.e. those that   do not need an update but no longer match the baseline.  Core git   displays these files when checkout runs, but won&#39;t stop the checkout.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UPDATED sends notification for any file changed.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_UNTRACKED notifies about untracked files.</p></li>\n<li><p>GIT_CHECKOUT_NOTIFY_IGNORED notifies about ignored files.</p></li>\n</ul>\n\n<p>Returning a non-zero value from this callback will cancel the checkout. The non-zero return value will be propagated back and returned by the git_checkout_... call.</p>\n\n<p>Notification callbacks are made prior to modifying any files on disk, so canceling on any notification will still happen prior to any files being modified.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -30265,12 +27059,12 @@
         "type": "struct",
         "value": "git_checkout_options",
         "file": "git2/checkout.h",
-        "line": 250,
-        "lineto": 294,
+        "line": 263,
+        "lineto": 307,
         "block": "unsigned int version\nunsigned int checkout_strategy\nint disable_filters\nunsigned int dir_mode\nunsigned int file_mode\nint file_open_flags\nunsigned int notify_flags\ngit_checkout_notify_cb notify_cb\nvoid * notify_payload\ngit_checkout_progress_cb progress_cb\nvoid * progress_payload\ngit_strarray paths\ngit_tree * baseline\ngit_index * baseline_index\nconst char * target_directory\nconst char * ancestor_label\nconst char * our_label\nconst char * their_label\ngit_checkout_perfdata_cb perfdata_cb\nvoid * perfdata_payload",
         "tdef": "typedef",
         "description": " Checkout options structure",
-        "comments": "<p>Initialize with <code>GIT_CHECKOUT_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_checkout_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_CHECKOUT_OPTIONS_INIT</code>. Alternatively, you can use <code>git_checkout_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -30378,7 +27172,7 @@
           "needs": [
             "git_checkout_head",
             "git_checkout_index",
-            "git_checkout_init_options",
+            "git_checkout_options_init",
             "git_checkout_tree",
             "git_merge",
             "git_reset",
@@ -30398,11 +27192,11 @@
         "type": "struct",
         "value": "git_checkout_perfdata",
         "file": "git2/checkout.h",
-        "line": 216,
-        "lineto": 220,
+        "line": 229,
+        "lineto": 233,
         "block": "size_t mkdir_calls\nsize_t stat_calls\nsize_t chmod_calls",
         "tdef": "typedef",
-        "description": "",
+        "description": " Checkout performance-reporting structure ",
         "comments": "",
         "fields": [
           {
@@ -30459,11 +27253,11 @@
         "type": "enum",
         "file": "git2/checkout.h",
         "line": 106,
-        "lineto": 177,
+        "lineto": 189,
         "block": "GIT_CHECKOUT_NONE\nGIT_CHECKOUT_SAFE\nGIT_CHECKOUT_FORCE\nGIT_CHECKOUT_RECREATE_MISSING\nGIT_CHECKOUT_ALLOW_CONFLICTS\nGIT_CHECKOUT_REMOVE_UNTRACKED\nGIT_CHECKOUT_REMOVE_IGNORED\nGIT_CHECKOUT_UPDATE_ONLY\nGIT_CHECKOUT_DONT_UPDATE_INDEX\nGIT_CHECKOUT_NO_REFRESH\nGIT_CHECKOUT_SKIP_UNMERGED\nGIT_CHECKOUT_USE_OURS\nGIT_CHECKOUT_USE_THEIRS\nGIT_CHECKOUT_DISABLE_PATHSPEC_MATCH\nGIT_CHECKOUT_SKIP_LOCKED_DIRECTORIES\nGIT_CHECKOUT_DONT_OVERWRITE_IGNORED\nGIT_CHECKOUT_CONFLICT_STYLE_MERGE\nGIT_CHECKOUT_CONFLICT_STYLE_DIFF3\nGIT_CHECKOUT_DONT_REMOVE_EXISTING\nGIT_CHECKOUT_DONT_WRITE_INDEX\nGIT_CHECKOUT_UPDATE_SUBMODULES\nGIT_CHECKOUT_UPDATE_SUBMODULES_IF_CHANGED",
         "tdef": "typedef",
         "description": " Checkout behavior flags",
-        "comments": "<p>In libgit2, checkout is used to update the working directory and index\n to match a target tree.  Unlike git checkout, it does not move the HEAD\n commit for you - use <code>git_repository_set_head</code> or the like to do that.</p>\n\n<p>Checkout looks at (up to) four things: the &quot;target&quot; tree you want to\n check out, the &quot;baseline&quot; tree of what was checked out previously, the\n working directory for actual files, and the index for staged changes.</p>\n\n<p>You give checkout one of three strategies for update:</p>\n\n<ul>\n<li><p><code>GIT_CHECKOUT_NONE</code> is a dry-run strategy that checks for conflicts,\netc., but doesn&#39;t make any actual changes.</p></li>\n<li><p><code>GIT_CHECKOUT_FORCE</code> is at the opposite extreme, taking any action to\nmake the working directory match the target (including potentially\ndiscarding modified files).</p></li>\n<li><p><code>GIT_CHECKOUT_SAFE</code> is between these two options, it will only make\nmodifications that will not lose changes.</p>\n\n<pre><code>                 |  target == baseline   |  target != baseline  |\n</code></pre>\n\n<p>---------------------|-----------------------|----------------------|\n workdir == baseline |       no action       |  create, update, or  |\n                     |                       |     delete file      |\n---------------------|-----------------------|----------------------|\n workdir exists and  |       no action       |   conflict (notify   |\n   is != baseline    | notify dirty MODIFIED | and cancel checkout) |\n---------------------|-----------------------|----------------------|\n  workdir missing,   | notify dirty DELETED  |     create file      |\n  baseline present   |                       |                      |\n---------------------|-----------------------|----------------------|</p></li>\n</ul>\n\n<p>To emulate <code>git checkout</code>, use <code>GIT_CHECKOUT_SAFE</code> with a checkout\n notification callback (see below) that displays information about dirty\n files.  The default behavior will cancel checkout on conflicts.</p>\n\n<p>To emulate <code>git checkout-index</code>, use <code>GIT_CHECKOUT_SAFE</code> with a\n notification callback that cancels the operation if a dirty-but-existing\n file is found in the working directory.  This core git command isn&#39;t\n quite &quot;force&quot; but is sensitive about some types of changes.</p>\n\n<p>To emulate <code>git checkout -f</code>, use <code>GIT_CHECKOUT_FORCE</code>.</p>\n\n<p>There are some additional flags to modify the behavior of checkout:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_ALLOW_CONFLICTS makes SAFE mode apply safe file updates\neven if there are conflicts (instead of cancelling the checkout).</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_UNTRACKED means remove untracked files (i.e. not\nin target, baseline, or index, and not ignored) from the working dir.</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_IGNORED means remove ignored files (that are also\nuntracked) from the working directory as well.</p></li>\n<li><p>GIT_CHECKOUT_UPDATE_ONLY means to only update the content of files that\nalready exist.  Files will not be created nor deleted.  This just skips\napplying adds, deletes, and typechanges.</p></li>\n<li><p>GIT_CHECKOUT_DONT_UPDATE_INDEX prevents checkout from writing the\nupdated files&#39; information to the index.</p></li>\n<li><p>Normally, checkout will reload the index and git attributes from disk\nbefore any operations.  GIT_CHECKOUT_NO_REFRESH prevents this reload.</p></li>\n<li><p>Unmerged index entries are conflicts.  GIT_CHECKOUT_SKIP_UNMERGED skips\nfiles with unmerged index entries instead.  GIT_CHECKOUT_USE_OURS and\nGIT_CHECKOUT_USE_THEIRS to proceed with the checkout using either the\nstage 2 (&quot;ours&quot;) or stage 3 (&quot;theirs&quot;) version of files in the index.</p></li>\n<li><p>GIT_CHECKOUT_DONT_OVERWRITE_IGNORED prevents ignored files from being\noverwritten.  Normally, files that are ignored in the working directory\nare not considered &quot;precious&quot; and may be overwritten if the checkout\ntarget contains that file.</p></li>\n<li><p>GIT_CHECKOUT_DONT_REMOVE_EXISTING prevents checkout from removing\nfiles or folders that fold to the same name on case insensitive\nfilesystems.  This can cause files to retain their existing names\nand write through existing symbolic links.</p></li>\n</ul>\n",
+        "comments": "<p>In libgit2, checkout is used to update the working directory and index to match a target tree.  Unlike git checkout, it does not move the HEAD commit for you - use <code>git_repository_set_head</code> or the like to do that.</p>\n\n<p>Checkout looks at (up to) four things: the &quot;target&quot; tree you want to check out, the &quot;baseline&quot; tree of what was checked out previously, the working directory for actual files, and the index for staged changes.</p>\n\n<p>You give checkout one of three strategies for update:</p>\n\n<ul>\n<li><p><code>GIT_CHECKOUT_NONE</code> is a dry-run strategy that checks for conflicts,   etc., but doesn&#39;t make any actual changes.</p></li>\n<li><p><code>GIT_CHECKOUT_FORCE</code> is at the opposite extreme, taking any action to   make the working directory match the target (including potentially   discarding modified files).</p></li>\n<li><p><code>GIT_CHECKOUT_SAFE</code> is between these two options, it will only make   modifications that will not lose changes.</p>\n\n<pre><code>                 |  target == baseline   |  target != baseline  |    ---------------------|-----------------------|----------------------|     workdir == baseline |       no action       |  create, update, or  |                         |                       |     delete file      |    ---------------------|-----------------------|----------------------|     workdir exists and  |       no action       |   conflict (notify   |       is != baseline    | notify dirty MODIFIED | and cancel checkout) |    ---------------------|-----------------------|----------------------|      workdir missing,   | notify dirty DELETED  |     create file      |      baseline present   |                       |                      |    ---------------------|-----------------------|----------------------|\n</code></pre></li>\n</ul>\n\n<p>To emulate <code>git checkout</code>, use <code>GIT_CHECKOUT_SAFE</code> with a checkout notification callback (see below) that displays information about dirty files.  The default behavior will cancel checkout on conflicts.</p>\n\n<p>To emulate <code>git checkout-index</code>, use <code>GIT_CHECKOUT_SAFE</code> with a notification callback that cancels the operation if a dirty-but-existing file is found in the working directory.  This core git command isn&#39;t quite &quot;force&quot; but is sensitive about some types of changes.</p>\n\n<p>To emulate <code>git checkout -f</code>, use <code>GIT_CHECKOUT_FORCE</code>.</p>\n\n<p>There are some additional flags to modify the behavior of checkout:</p>\n\n<ul>\n<li><p>GIT_CHECKOUT_ALLOW_CONFLICTS makes SAFE mode apply safe file updates   even if there are conflicts (instead of cancelling the checkout).</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_UNTRACKED means remove untracked files (i.e. not   in target, baseline, or index, and not ignored) from the working dir.</p></li>\n<li><p>GIT_CHECKOUT_REMOVE_IGNORED means remove ignored files (that are also   untracked) from the working directory as well.</p></li>\n<li><p>GIT_CHECKOUT_UPDATE_ONLY means to only update the content of files that   already exist.  Files will not be created nor deleted.  This just skips   applying adds, deletes, and typechanges.</p></li>\n<li><p>GIT_CHECKOUT_DONT_UPDATE_INDEX prevents checkout from writing the   updated files&#39; information to the index.</p></li>\n<li><p>Normally, checkout will reload the index and git attributes from disk   before any operations.  GIT_CHECKOUT_NO_REFRESH prevents this reload.</p></li>\n<li><p>Unmerged index entries are conflicts.  GIT_CHECKOUT_SKIP_UNMERGED skips   files with unmerged index entries instead.  GIT_CHECKOUT_USE_OURS and   GIT_CHECKOUT_USE_THEIRS to proceed with the checkout using either the   stage 2 (&quot;ours&quot;) or stage 3 (&quot;theirs&quot;) version of files in the index.</p></li>\n<li><p>GIT_CHECKOUT_DONT_OVERWRITE_IGNORED prevents ignored files from being   overwritten.  Normally, files that are ignored in the working directory   are not considered &quot;precious&quot; and may be overwritten if the checkout   target contains that file.</p></li>\n<li><p>GIT_CHECKOUT_DONT_REMOVE_EXISTING prevents checkout from removing   files or folders that fold to the same name on case insensitive   filesystems.  This can cause files to retain their existing names   and write through existing symbolic links.</p></li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -30474,13 +27268,13 @@
           {
             "type": "int",
             "name": "GIT_CHECKOUT_SAFE",
-            "comments": "<p>Allow safe updates that cannot overwrite uncommitted data </p>\n",
+            "comments": "<p>Allow safe updates that cannot overwrite uncommitted data.\n If the uncommitted changes don&#39;t conflict with the checked out files,\n the checkout will still proceed, leaving the changes intact.</p>\n\n<p>Mutually exclusive with GIT_CHECKOUT_FORCE.\n GIT_CHECKOUT_FORCE takes precedence over GIT_CHECKOUT_SAFE.</p>\n",
             "value": 1
           },
           {
             "type": "int",
             "name": "GIT_CHECKOUT_FORCE",
-            "comments": "<p>Allow all updates to force working directory to look like index </p>\n",
+            "comments": "<p>Allow all updates to force working directory to look like index.</p>\n\n<p>Mutually exclusive with GIT_CHECKOUT_SAFE.\n GIT_CHECKOUT_FORCE takes precedence over GIT_CHECKOUT_SAFE.</p>\n",
             "value": 2
           },
           {
@@ -30648,7 +27442,7 @@
           "returns": [],
           "needs": [
             "git_cherrypick",
-            "git_cherrypick_init_options"
+            "git_cherrypick_options_init"
           ]
         }
       }
@@ -30725,7 +27519,7 @@
         "block": "unsigned int version\ngit_checkout_options checkout_opts\ngit_fetch_options fetch_opts\nint bare\ngit_clone_local_t local\nconst char * checkout_branch\ngit_repository_create_cb repository_cb\nvoid * repository_cb_payload\ngit_remote_create_cb remote_cb\nvoid * remote_cb_payload",
         "tdef": "typedef",
         "description": " Clone options structure",
-        "comments": "<p>Initialize with <code>GIT_CLONE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_clone_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_CLONE_OPTIONS_INIT</code>. Alternatively, you can use <code>git_clone_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -30782,7 +27576,7 @@
           "returns": [],
           "needs": [
             "git_clone",
-            "git_clone_init_options"
+            "git_clone_options_init"
           ]
         }
       }
@@ -30799,7 +27593,6 @@
         "tdef": "typedef",
         "description": " Parsed representation of a commit object. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -30814,7 +27607,6 @@
             "git_commit_committer_with_mailmap",
             "git_commit_create",
             "git_commit_create_buffer",
-            "git_commit_create_from_callback",
             "git_commit_dup",
             "git_commit_free",
             "git_commit_header_field",
@@ -30859,11 +27651,9 @@
         "tdef": "typedef",
         "description": " Memory representation of a set of config files ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
-            "git_config_add_backend",
             "git_config_add_file_ondisk",
             "git_config_backend_foreach_match",
             "git_config_delete_entry",
@@ -30882,7 +27672,6 @@
             "git_config_get_path",
             "git_config_get_string",
             "git_config_get_string_buf",
-            "git_config_init_backend",
             "git_config_iterator_free",
             "git_config_iterator_glob_new",
             "git_config_iterator_new",
@@ -30901,8 +27690,7 @@
             "git_config_set_string",
             "git_config_snapshot",
             "git_repository_config",
-            "git_repository_config_snapshot",
-            "git_repository_set_config"
+            "git_repository_config_snapshot"
           ]
         }
       }
@@ -30916,88 +27704,13 @@
         "file": "git2/types.h",
         "line": 148,
         "lineto": 148,
-        "block": "unsigned int version\nint readonly\nstruct git_config * cfg\nint (*)(struct git_config_backend *, git_config_level_t, const git_repository *) open\nint (*)(struct git_config_backend *, const char *, git_config_entry **) get\nint (*)(struct git_config_backend *, const char *, const char *) set\nint (*)(git_config_backend *, const char *, const char *, const char *) set_multivar\nint (*)(struct git_config_backend *, const char *) del\nint (*)(struct git_config_backend *, const char *, const char *) del_multivar\nint (*)(git_config_iterator **, struct git_config_backend *) iterator\nint (*)(struct git_config_backend **, struct git_config_backend *) snapshot\nint (*)(struct git_config_backend *) lock\nint (*)(struct git_config_backend *, int) unlock\nvoid (*)(struct git_config_backend *) free",
         "tdef": "typedef",
         "description": " Interface to access a configuration file ",
         "comments": "",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": ""
-          },
-          {
-            "type": "int",
-            "name": "readonly",
-            "comments": " True if this backend is for a snapshot "
-          },
-          {
-            "type": "struct git_config *",
-            "name": "cfg",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, git_config_level_t, const git_repository *)",
-            "name": "open",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, const char *, git_config_entry **)",
-            "name": "get",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, const char *, const char *)",
-            "name": "set",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_config_backend *, const char *, const char *, const char *)",
-            "name": "set_multivar",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, const char *)",
-            "name": "del",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, const char *, const char *)",
-            "name": "del_multivar",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_config_iterator **, struct git_config_backend *)",
-            "name": "iterator",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend **, struct git_config_backend *)",
-            "name": "snapshot",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *)",
-            "name": "lock",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_config_backend *, int)",
-            "name": "unlock",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(struct git_config_backend *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
           "needs": [
-            "git_config_add_backend",
-            "git_config_backend_foreach_match",
-            "git_config_init_backend"
+            "git_config_backend_foreach_match"
           ]
         }
       }
@@ -31077,28 +27790,6 @@
         "tdef": "typedef",
         "description": " An opaque structure for a configuration iterator",
         "comments": "",
-        "fields": [
-          {
-            "type": "git_config_backend *",
-            "name": "backend",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "flags",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_config_entry **, git_config_iterator *)",
-            "name": "next",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_config_iterator *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
           "needs": [
@@ -31130,7 +27821,7 @@
         "block": "GIT_CONFIG_LEVEL_PROGRAMDATA\nGIT_CONFIG_LEVEL_SYSTEM\nGIT_CONFIG_LEVEL_XDG\nGIT_CONFIG_LEVEL_GLOBAL\nGIT_CONFIG_LEVEL_LOCAL\nGIT_CONFIG_LEVEL_APP\nGIT_CONFIG_HIGHEST_LEVEL",
         "tdef": "typedef",
         "description": " Priority level of a config file.\n These priority levels correspond to the natural escalation logic\n (from higher to lower) when searching for config entries in git.git.",
-        "comments": "<p>git_config_open_default() and git_repository_config() honor those\n priority levels as well.</p>\n",
+        "comments": "<p>git_config_open_default() and git_repository_config() honor those priority levels as well.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31178,7 +27869,6 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_config_add_backend",
             "git_config_add_file_ondisk",
             "git_config_open_level"
           ]
@@ -31188,13 +27878,16 @@
     [
       "git_cred",
       {
-        "decl": "git_cred",
+        "decl": [
+          "git_credtype_t credtype",
+          "void (*)(git_cred *) free"
+        ],
         "type": "struct",
         "value": "git_cred",
         "file": "git2/transport.h",
-        "line": 140,
-        "lineto": 140,
-        "tdef": "typedef",
+        "line": 145,
+        "lineto": 148,
+        "tdef": null,
         "description": " The base structure for all credential types",
         "comments": "",
         "fields": [
@@ -31209,6 +27902,7 @@
             "comments": ""
           }
         ],
+        "block": "git_credtype_t credtype\nvoid (*)(git_cred *) free",
         "used": {
           "returns": [],
           "needs": [
@@ -31223,8 +27917,7 @@
             "git_cred_ssh_key_new",
             "git_cred_username_new",
             "git_cred_userpass",
-            "git_cred_userpass_plaintext_new",
-            "git_transport_smart_credentials"
+            "git_cred_userpass_plaintext_new"
           ]
         }
       }
@@ -31255,7 +27948,7 @@
           "char * username",
           "char * publickey",
           "size_t publickey_len",
-          "git_cred_sign_callback sign_callback",
+          "git_cred_sign_cb sign_callback",
           "void * payload"
         ],
         "type": "struct",
@@ -31263,7 +27956,7 @@
         "file": "git2/transport.h",
         "line": 195,
         "lineto": 202,
-        "block": "git_cred parent\nchar * username\nchar * publickey\nsize_t publickey_len\ngit_cred_sign_callback sign_callback\nvoid * payload",
+        "block": "git_cred parent\nchar * username\nchar * publickey\nsize_t publickey_len\ngit_cred_sign_cb sign_callback\nvoid * payload",
         "tdef": "typedef",
         "description": " A key with a custom signature function",
         "comments": "",
@@ -31289,7 +27982,7 @@
             "comments": ""
           },
           {
-            "type": "git_cred_sign_callback",
+            "type": "git_cred_sign_cb",
             "name": "sign_callback",
             "comments": ""
           },
@@ -31311,7 +28004,7 @@
         "decl": [
           "git_cred parent",
           "char * username",
-          "git_cred_ssh_interactive_callback prompt_callback",
+          "git_cred_ssh_interactive_cb prompt_callback",
           "void * payload"
         ],
         "type": "struct",
@@ -31319,7 +28012,7 @@
         "file": "git2/transport.h",
         "line": 185,
         "lineto": 190,
-        "block": "git_cred parent\nchar * username\ngit_cred_ssh_interactive_callback prompt_callback\nvoid * payload",
+        "block": "git_cred parent\nchar * username\ngit_cred_ssh_interactive_cb prompt_callback\nvoid * payload",
         "tdef": "typedef",
         "description": " Keyboard-interactive based ssh authentication",
         "comments": "",
@@ -31335,7 +28028,7 @@
             "comments": ""
           },
           {
-            "type": "git_cred_ssh_interactive_callback",
+            "type": "git_cred_ssh_interactive_cb",
             "name": "prompt_callback",
             "comments": ""
           },
@@ -31532,7 +28225,7 @@
         "block": "GIT_CREDTYPE_USERPASS_PLAINTEXT\nGIT_CREDTYPE_SSH_KEY\nGIT_CREDTYPE_SSH_CUSTOM\nGIT_CREDTYPE_DEFAULT\nGIT_CREDTYPE_SSH_INTERACTIVE\nGIT_CREDTYPE_USERNAME\nGIT_CREDTYPE_SSH_MEMORY",
         "tdef": "typedef",
         "description": " Supported credential types",
-        "comments": "<p>This represents the various types of authentication methods supported by\n the library.</p>\n",
+        "comments": "<p>This represents the various types of authentication methods supported by the library.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31698,7 +28391,7 @@
         "block": "GIT_DELTA_UNMODIFIED\nGIT_DELTA_ADDED\nGIT_DELTA_DELETED\nGIT_DELTA_MODIFIED\nGIT_DELTA_RENAMED\nGIT_DELTA_COPIED\nGIT_DELTA_IGNORED\nGIT_DELTA_UNTRACKED\nGIT_DELTA_TYPECHANGE\nGIT_DELTA_UNREADABLE\nGIT_DELTA_CONFLICTED",
         "tdef": "typedef",
         "description": " What type of change is described by a git_diff_delta?",
-        "comments": "<p><code>GIT_DELTA_RENAMED</code> and <code>GIT_DELTA_COPIED</code> will only show up if you run\n <code>git_diff_find_similar()</code> on the diff object.</p>\n\n<p><code>GIT_DELTA_TYPECHANGE</code> only shows up given <code>GIT_DIFF_INCLUDE_TYPECHANGE</code>\n in the option flags (otherwise type changes will be split into ADDED /\n DELETED pairs).</p>\n",
+        "comments": "<p><code>GIT_DELTA_RENAMED</code> and <code>GIT_DELTA_COPIED</code> will only show up if you run <code>git_diff_find_similar()</code> on the diff object.</p>\n\n<p><code>GIT_DELTA_TYPECHANGE</code> only shows up given <code>GIT_DIFF_INCLUDE_TYPECHANGE</code> in the option flags (otherwise type changes will be split into ADDED / DELETED pairs).</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31793,7 +28486,7 @@
         "block": "unsigned int version\nunsigned int abbreviated_size\nint always_use_long_format\nconst char * dirty_suffix",
         "tdef": "typedef",
         "description": " Describe format options structure",
-        "comments": "<p>Initialize with <code>GIT_DESCRIBE_FORMAT_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_describe_format_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_DESCRIBE_FORMAT_OPTIONS_INIT</code>. Alternatively, you can use <code>git_describe_format_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -31820,7 +28513,7 @@
           "returns": [],
           "needs": [
             "git_describe_format",
-            "git_describe_init_format_options"
+            "git_describe_format_options_init"
           ]
         }
       }
@@ -31844,7 +28537,7 @@
         "block": "unsigned int version\nunsigned int max_candidates_tags\nunsigned int describe_strategy\nconst char * pattern\nint only_follow_first_parent\nint show_commit_oid_as_fallback",
         "tdef": "typedef",
         "description": " Describe options structure",
-        "comments": "<p>Initialize with <code>GIT_DESCRIBE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_describe_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_DESCRIBE_OPTIONS_INIT</code>. Alternatively, you can use <code>git_describe_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -31881,7 +28574,7 @@
           "returns": [],
           "needs": [
             "git_describe_commit",
-            "git_describe_init_options",
+            "git_describe_options_init",
             "git_describe_workdir"
           ]
         }
@@ -31899,7 +28592,6 @@
         "tdef": "typedef",
         "description": " A struct that stores the result of a describe operation.",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -31926,7 +28618,7 @@
         "block": "GIT_DESCRIBE_DEFAULT\nGIT_DESCRIBE_TAGS\nGIT_DESCRIBE_ALL",
         "tdef": "typedef",
         "description": " Reference lookup strategy",
-        "comments": "<p>These behave like the --tags and --all options to git-describe,\n namely they say to look for any reference in either refs/tags/ or\n refs/ respectively.</p>\n",
+        "comments": "<p>These behave like the --tags and --all options to git-describe, namely they say to look for any reference in either refs/tags/ or refs/ respectively.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -31964,8 +28656,7 @@
         "lineto": 193,
         "tdef": "typedef",
         "description": " The diff object that contains all individual file deltas.",
-        "comments": "<p>A <code>diff</code> represents the cumulative list of differences between two\n snapshots of a repository (possibly filtered by a set of file name\n patterns).</p>\n\n<p>Calculating diffs is generally done in two phases: building a list of\n diffs then traversing it. This makes is easier to share logic across\n the various types of diffs (tree vs tree, workdir vs index, etc.), and\n also allows you to insert optional diff post-processing phases,\n such as rename detection, in between the steps. When you are done with\n a diff object, it must be freed.</p>\n\n<p>This is an opaque structure which will be allocated by one of the diff\n generator functions below (such as <code>git_diff_tree_to_tree</code>). You are\n responsible for releasing the object memory when done, using the\n <code>git_diff_free()</code> function.</p>\n",
-        "fields": [],
+        "comments": "<p>A <code>diff</code> represents the cumulative list of differences between two snapshots of a repository (possibly filtered by a set of file name patterns).</p>\n\n<p>Calculating diffs is generally done in two phases: building a list of diffs then traversing it. This makes is easier to share logic across the various types of diffs (tree vs tree, workdir vs index, etc.), and also allows you to insert optional diff post-processing phases, such as rename detection, in between the steps. When you are done with a diff object, it must be freed.</p>\n\n<p>This is an opaque structure which will be allocated by one of the diff generator functions below (such as <code>git_diff_tree_to_tree</code>). You are responsible for releasing the object memory when done, using the <code>git_diff_free()</code> function.</p>\n",
         "used": {
           "returns": [
             "git_diff_get_delta",
@@ -31984,31 +28675,28 @@
             "git_diff_buffers",
             "git_diff_commit_as_email",
             "git_diff_file_cb",
-            "git_diff_find_init_options",
+            "git_diff_find_options_init",
             "git_diff_find_similar",
             "git_diff_foreach",
             "git_diff_format_email",
-            "git_diff_format_email_init_options",
+            "git_diff_format_email_options_init",
             "git_diff_free",
             "git_diff_from_buffer",
             "git_diff_get_delta",
-            "git_diff_get_perfdata",
             "git_diff_get_stats",
             "git_diff_hunk_cb",
             "git_diff_index_to_index",
             "git_diff_index_to_workdir",
-            "git_diff_init_options",
             "git_diff_is_sorted_icase",
             "git_diff_line_cb",
             "git_diff_merge",
             "git_diff_notify_cb",
             "git_diff_num_deltas",
             "git_diff_num_deltas_of_type",
+            "git_diff_options_init",
             "git_diff_patchid",
-            "git_diff_patchid_init_options",
+            "git_diff_patchid_options_init",
             "git_diff_print",
-            "git_diff_print_callback__to_buf",
-            "git_diff_print_callback__to_file_handle",
             "git_diff_progress_cb",
             "git_diff_stats_deletions",
             "git_diff_stats_files_changed",
@@ -32027,8 +28715,7 @@
             "git_patch_get_hunk",
             "git_patch_get_line_in_hunk",
             "git_patch_print",
-            "git_pathspec_match_diff",
-            "git_status_list_get_perfdata"
+            "git_pathspec_match_diff"
           ]
         }
       }
@@ -32049,7 +28736,7 @@
         "block": "unsigned int contains_data\ngit_diff_binary_file old_file\ngit_diff_binary_file new_file",
         "tdef": "typedef",
         "description": " Structure describing the binary contents of a diff.",
-        "comments": "<p>A <code>binary</code> file / delta is a file (or pair) for which no text diffs\n should be generated. A diff can contain delta entries that are\n binary, but no diff content will be output for those files. There is\n a base heuristic for binary detection and you can further tune the\n behavior with git attributes or diff flags and option settings.</p>\n",
+        "comments": "<p>A <code>binary</code> file / delta is a file (or pair) for which no text diffs should be generated. A diff can contain delta entries that are binary, but no diff content will be output for those files. There is a base heuristic for binary detection and you can further tune the behavior with git attributes or diff flags and option settings.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -32172,9 +28859,9 @@
       {
         "decl": [
           "git_delta_t status",
-          "int flags",
-          "int similarity",
-          "int nfiles",
+          "uint32_t flags",
+          "uint16_t similarity",
+          "uint16_t nfiles",
           "git_diff_file old_file",
           "git_diff_file new_file"
         ],
@@ -32183,10 +28870,10 @@
         "file": "git2/diff.h",
         "line": 309,
         "lineto": 316,
-        "block": "git_delta_t status\nint flags\nint similarity\nint nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
+        "block": "git_delta_t status\nuint32_t flags\nuint16_t similarity\nuint16_t nfiles\ngit_diff_file old_file\ngit_diff_file new_file",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Description of changes to one entry.",
+        "comments": "<p>A <code>delta</code> is a file pair with an old and new revision.  The old version may be absent if the file was just created and the new version may be absent if the file was deleted.  A diff is mostly just a list of deltas.</p>\n\n<p>When iterating over a diff, this will be passed to most callbacks and you can use the contents to understand exactly what has changed.</p>\n\n<p>The <code>old_file</code> represents the &quot;from&quot; side of the diff and the <code>new_file</code> represents to &quot;to&quot; side of the diff.  What those means depend on the function that was used to generate the diff and will be documented below. You can also use the <code>GIT_DIFF_REVERSE</code> flag to flip it around.</p>\n\n<p>Although the two sides of the delta are named &quot;old_file&quot; and &quot;new_file&quot;, they actually may correspond to entries that represent a file, a symbolic link, a submodule commit id, or even a tree (if you are tracking type changes or ignored/untracked directories).</p>\n\n<p>Under some circumstances, in the name of efficiency, not all fields will be filled in, but we generally try to fill in as much as possible.  One example is that the &quot;flags&quot; field may not have either the <code>BINARY</code> or the <code>NOT_BINARY</code> flag set to avoid examining file contents if you do not pass in hunk and/or line callbacks to the diff foreach iteration function.  It will just use the git attributes for those files.</p>\n\n<p>The similarity score is zero unless you call <code>git_diff_find_similar()</code> which does a similarity analysis of files in the diff.  Use that function to do rename and copy detection, and to split heavily modified files in add/delete pairs.  After that call, deltas with a status of GIT_DELTA_RENAMED or GIT_DELTA_COPIED will have a similarity score between 0 and 100 indicating how similar the old and new sides are.</p>\n\n<p>If you ask <code>git_diff_find_similar</code> to find heavily modified files to break, but to not <em>actually</em> break the records, then GIT_DELTA_MODIFIED records may have a non-zero similarity score if the self-similarity is below the split threshold.  To display this value like core Git, invert the score (a la <code>printf(&quot;M%03d&quot;, 100 - delta-&gt;similarity)</code>).</p>\n",
         "fields": [
           {
             "type": "git_delta_t",
@@ -32194,19 +28881,19 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
-            "comments": ""
+            "comments": " git_diff_flag_t values "
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "similarity",
-            "comments": ""
+            "comments": " for RENAMED and COPIED, value 0-100 "
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "nfiles",
-            "comments": ""
+            "comments": " number of files in this delta "
           },
           {
             "type": "git_diff_file",
@@ -32231,9 +28918,7 @@
             "git_diff_file_cb",
             "git_diff_hunk_cb",
             "git_diff_line_cb",
-            "git_diff_notify_cb",
-            "git_diff_print_callback__to_buf",
-            "git_diff_print_callback__to_file_handle"
+            "git_diff_notify_cb"
           ]
         }
       }
@@ -32245,19 +28930,19 @@
           "git_oid id",
           "const char * path",
           "git_off_t size",
-          "int flags",
-          "int mode",
-          "int id_abbrev"
+          "uint32_t flags",
+          "uint16_t mode",
+          "uint16_t id_abbrev"
         ],
         "type": "struct",
         "value": "git_diff_file",
         "file": "git2/diff.h",
         "line": 260,
         "lineto": 267,
-        "block": "git_oid id\nconst char * path\ngit_off_t size\nint flags\nint mode\nint id_abbrev",
+        "block": "git_oid id\nconst char * path\ngit_off_t size\nuint32_t flags\nuint16_t mode\nuint16_t id_abbrev",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Description of one side of a delta.",
+        "comments": "<p>Although this is called a &quot;file&quot;, it could represent a file, a symbolic link, a submodule commit id, or even a tree (although that only if you are tracking type changes or ignored/untracked directories).</p>\n\n<p>The <code>id</code> is the <code>git_oid</code> of the item.  If the entry represents an absent side of a diff (e.g. the <code>old_file</code> of a <code>GIT_DELTA_ADDED</code> delta), then the oid will be zeroes.</p>\n\n<p><code>path</code> is the NUL-terminated path to the entry relative to the working directory of the repository.</p>\n\n<p><code>size</code> is the size of the entry in bytes.</p>\n\n<p><code>flags</code> is a combination of the <code>git_diff_flag_t</code> types</p>\n\n<p><code>mode</code> is, roughly, the stat() <code>st_mode</code> value for the item.  This will be restricted to one of the <code>git_filemode_t</code> values.</p>\n\n<p>The <code>id_abbrev</code> represents the known length of the <code>id</code> field, when converted to a hex string.  It is generally <code>GIT_OID_HEXSZ</code>, unless this delta was created from reading a patch file, in which case it may be abbreviated to something reasonable, like 7 characters.</p>\n",
         "fields": [
           {
             "type": "git_oid",
@@ -32275,17 +28960,17 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "mode",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "id_abbrev",
             "comments": ""
           }
@@ -32307,11 +28992,11 @@
       {
         "decl": [
           "unsigned int version",
-          "int flags",
-          "int rename_threshold",
-          "int rename_from_rewrite_threshold",
-          "int copy_threshold",
-          "int break_rewrite_threshold",
+          "uint32_t flags",
+          "uint16_t rename_threshold",
+          "uint16_t rename_from_rewrite_threshold",
+          "uint16_t copy_threshold",
+          "uint16_t break_rewrite_threshold",
           "size_t rename_limit",
           "git_diff_similarity_metric * metric"
         ],
@@ -32320,10 +29005,10 @@
         "file": "git2/diff.h",
         "line": 718,
         "lineto": 772,
-        "block": "unsigned int version\nint flags\nint rename_threshold\nint rename_from_rewrite_threshold\nint copy_threshold\nint break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
+        "block": "unsigned int version\nuint32_t flags\nuint16_t rename_threshold\nuint16_t rename_from_rewrite_threshold\nuint16_t copy_threshold\nuint16_t break_rewrite_threshold\nsize_t rename_limit\ngit_diff_similarity_metric * metric",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Control behavior of rename and copy detection",
+        "comments": "<p>These options mostly mimic parameters that can be passed to git-diff.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -32331,29 +29016,29 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
-            "comments": ""
+            "comments": " Combination of git_diff_find_t values (default GIT_DIFF_FIND_BY_CONFIG).\n NOTE: if you don't explicitly set this, `diff.renames` could be set\n to false, resulting in `git_diff_find_similar` doing nothing."
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "rename_threshold",
-            "comments": ""
+            "comments": " Threshold above which similar files will be considered renames.\n This is equivalent to the -M option. Defaults to 50."
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "rename_from_rewrite_threshold",
-            "comments": ""
+            "comments": " Threshold below which similar files will be eligible to be a rename source.\n This is equivalent to the first part of the -B option. Defaults to 50."
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "copy_threshold",
-            "comments": ""
+            "comments": " Threshold above which similar files will be considered copies.\n This is equivalent to the -C option. Defaults to 50."
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "break_rewrite_threshold",
-            "comments": ""
+            "comments": " Treshold below which similar files will be split into a delete/add pair.\n This is equivalent to the last part of the -B option. Defaults to 60."
           },
           {
             "type": "size_t",
@@ -32369,7 +29054,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_diff_find_init_options",
+            "git_diff_find_options_init",
             "git_diff_find_similar"
           ]
         }
@@ -32524,7 +29209,7 @@
         "block": "GIT_DIFF_FLAG_BINARY\nGIT_DIFF_FLAG_NOT_BINARY\nGIT_DIFF_FLAG_VALID_ID\nGIT_DIFF_FLAG_EXISTS",
         "tdef": "typedef",
         "description": " Flags for the delta object and the file objects on each side.",
-        "comments": "<p>These flags are used for both the <code>flags</code> value of the <code>git_diff_delta</code>\n and the flags for the <code>git_diff_file</code> objects representing the old and\n new sides of the delta.  Values outside of this public range should be\n considered reserved for internal or future use.</p>\n",
+        "comments": "<p>These flags are used for both the <code>flags</code> value of the <code>git_diff_delta</code> and the flags for the <code>git_diff_file</code> objects representing the old and new sides of the delta.  Values outside of this public range should be considered reserved for internal or future use.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -32662,7 +29347,7 @@
           "returns": [],
           "needs": [
             "git_diff_format_email",
-            "git_diff_format_email_init_options"
+            "git_diff_format_email_options_init"
           ]
         }
       }
@@ -32745,7 +29430,7 @@
         "block": "int old_start\nint old_lines\nint new_start\nint new_lines\nsize_t header_len\nchar [128] header",
         "tdef": "typedef",
         "description": " Structure describing a hunk of a diff.",
-        "comments": "<p>A <code>hunk</code> is a span of modified lines in a delta along with some stable\n surrounding context. You can configure the amount of context and other\n properties of how hunks are generated. Each hunk also comes with a\n header that described where it starts and ends in both the old and new\n versions in the delta.</p>\n",
+        "comments": "<p>A <code>hunk</code> is a span of modified lines in a delta along with some stable surrounding context. You can configure the amount of context and other properties of how hunks are generated. Each hunk also comes with a header that described where it starts and ends in both the old and new versions in the delta.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -32788,8 +29473,6 @@
             "git_diff_foreach",
             "git_diff_hunk_cb",
             "git_diff_line_cb",
-            "git_diff_print_callback__to_buf",
-            "git_diff_print_callback__to_file_handle",
             "git_patch_get_hunk"
           ]
         }
@@ -32815,7 +29498,7 @@
         "block": "char origin\nint old_lineno\nint new_lineno\nint num_lines\nsize_t content_len\ngit_off_t content_offset\nconst char * content",
         "tdef": "typedef",
         "description": " Structure describing a line (or data span) of a diff.",
-        "comments": "<p>A <code>line</code> is a range of characters inside a hunk.  It could be a context\n line (i.e. in both old and new versions), an added line (i.e. only in\n the new version), or a removed line (i.e. only in the old version).\n Unfortunately, we don&#39;t know anything about the encoding of data in the\n file being diffed, so we cannot tell you much about the line content.\n Line data will not be NUL-byte terminated, however, because it will be\n just a span of bytes inside the larger file.</p>\n",
+        "comments": "<p>A <code>line</code> is a range of characters inside a hunk.  It could be a context line (i.e. in both old and new versions), an added line (i.e. only in the new version), or a removed line (i.e. only in the old version). Unfortunately, we don&#39;t know anything about the encoding of data in the file being diffed, so we cannot tell you much about the line content. Line data will not be NUL-byte terminated, however, because it will be just a span of bytes inside the larger file.</p>\n",
         "fields": [
           {
             "type": "char",
@@ -32862,8 +29545,6 @@
             "git_diff_foreach",
             "git_diff_line_cb",
             "git_diff_print",
-            "git_diff_print_callback__to_buf",
-            "git_diff_print_callback__to_file_handle",
             "git_patch_get_line_in_hunk",
             "git_patch_print"
           ]
@@ -32891,7 +29572,7 @@
         "block": "GIT_DIFF_LINE_CONTEXT\nGIT_DIFF_LINE_ADDITION\nGIT_DIFF_LINE_DELETION\nGIT_DIFF_LINE_CONTEXT_EOFNL\nGIT_DIFF_LINE_ADD_EOFNL\nGIT_DIFF_LINE_DEL_EOFNL\nGIT_DIFF_LINE_FILE_HDR\nGIT_DIFF_LINE_HUNK_HDR\nGIT_DIFF_LINE_BINARY",
         "tdef": "typedef",
         "description": " Line origin constants.",
-        "comments": "<p>These values describe where a line came from and will be passed to\n the git_diff_line_cb when iterating over a diff.  There are some\n special origin constants at the end that are used for the text\n output callbacks to demarcate lines that are actually part of\n the file or hunk headers.</p>\n",
+        "comments": "<p>These values describe where a line came from and will be passed to the git_diff_line_cb when iterating over a diff.  There are some special origin constants at the end that are used for the text output callbacks to demarcate lines that are actually part of the file or hunk headers.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -33190,15 +29871,15 @@
       {
         "decl": [
           "unsigned int version",
-          "int flags",
+          "uint32_t flags",
           "git_submodule_ignore_t ignore_submodules",
           "git_strarray pathspec",
           "git_diff_notify_cb notify_cb",
           "git_diff_progress_cb progress_cb",
           "void * payload",
-          "int context_lines",
-          "int interhunk_lines",
-          "int id_abbrev",
+          "uint32_t context_lines",
+          "uint32_t interhunk_lines",
+          "uint16_t id_abbrev",
           "git_off_t max_size",
           "const char * old_prefix",
           "const char * new_prefix"
@@ -33208,10 +29889,10 @@
         "file": "git2/diff.h",
         "line": 361,
         "lineto": 433,
-        "block": "unsigned int version\nint flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nint context_lines\nint interhunk_lines\nint id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
+        "block": "unsigned int version\nuint32_t flags\ngit_submodule_ignore_t ignore_submodules\ngit_strarray pathspec\ngit_diff_notify_cb notify_cb\ngit_diff_progress_cb progress_cb\nvoid * payload\nuint32_t context_lines\nuint32_t interhunk_lines\nuint16_t id_abbrev\ngit_off_t max_size\nconst char * old_prefix\nconst char * new_prefix",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Structure describing options about how the diff should be executed.",
+        "comments": "<p>Setting all values of the structure to zero will yield the default values.  Similarly, passing NULL for the options structure will give the defaults.  The default values are marked below.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -33219,9 +29900,9 @@
             "comments": " version for the struct "
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
-            "comments": ""
+            "comments": " A combination of `git_diff_option_t` values above.\n Defaults to GIT_DIFF_NORMAL"
           },
           {
             "type": "git_submodule_ignore_t",
@@ -33249,19 +29930,19 @@
             "comments": " The payload to pass to the callback functions. "
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "context_lines",
-            "comments": ""
+            "comments": " The number of unchanged lines that define the boundary of a hunk\n (and to display before and after). Defaults to 3."
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "interhunk_lines",
-            "comments": ""
+            "comments": " The maximum number of unchanged lines between hunk boundaries before\n the hunks will be merged into one. Defaults to 0."
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "id_abbrev",
-            "comments": ""
+            "comments": " The abbreviation length to use when formatting object ids.\n Defaults to the value of 'core.abbrev' from the config, or 7 if unset."
           },
           {
             "type": "git_off_t",
@@ -33288,7 +29969,7 @@
             "git_diff_commit_as_email",
             "git_diff_index_to_index",
             "git_diff_index_to_workdir",
-            "git_diff_init_options",
+            "git_diff_options_init",
             "git_diff_tree_to_index",
             "git_diff_tree_to_tree",
             "git_diff_tree_to_workdir",
@@ -33314,7 +29995,7 @@
         "block": "unsigned int version",
         "tdef": "typedef",
         "description": " Patch ID options structure",
-        "comments": "<p>Initialize with <code>GIT_PATCHID_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_patchid_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_PATCHID_OPTIONS_INIT</code>. Alternatively, you can use <code>git_diff_patchid_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -33326,50 +30007,7 @@
           "returns": [],
           "needs": [
             "git_diff_patchid",
-            "git_diff_patchid_init_options"
-          ]
-        }
-      }
-    ],
-    [
-      "git_diff_perfdata",
-      {
-        "decl": [
-          "unsigned int version",
-          "size_t stat_calls",
-          "size_t oid_calculations"
-        ],
-        "type": "struct",
-        "value": "git_diff_perfdata",
-        "file": "git2/sys/diff.h",
-        "line": 67,
-        "lineto": 71,
-        "block": "unsigned int version\nsize_t stat_calls\nsize_t oid_calculations",
-        "tdef": "typedef",
-        "description": " Performance data from diffing",
-        "comments": "",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": ""
-          },
-          {
-            "type": "size_t",
-            "name": "stat_calls",
-            "comments": " Number of stat() calls performed "
-          },
-          {
-            "type": "size_t",
-            "name": "oid_calculations",
-            "comments": " Number of ID calculations "
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_diff_get_perfdata",
-            "git_status_list_get_perfdata"
+            "git_diff_patchid_options_init"
           ]
         }
       }
@@ -33438,7 +30076,6 @@
         "tdef": "typedef",
         "description": " This is an opaque structure which is allocated by `git_diff_get_stats`.\n You are responsible for releasing the object memory when done, using the\n `git_diff_stats_free()` function.",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -33524,7 +30161,7 @@
         "block": "GIT_DIRECTION_FETCH\nGIT_DIRECTION_PUSH",
         "tdef": "typedef",
         "description": " Direction of the connection.",
-        "comments": "<p>We need this because we need to know whether we should call\n git-upload-pack or git-receive-pack on the remote end when get_refs\n gets called.</p>\n",
+        "comments": "<p>We need this because we need to know whether we should call git-upload-pack or git-receive-pack on the remote end when get_refs gets called.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -33564,7 +30201,7 @@
         "block": "char * message\nint klass",
         "tdef": "typedef",
         "description": " Structure to store extra details of the last error that occurred.",
-        "comments": "<p>This is kept on a per-thread basis if GIT_THREADS was defined when the\n library was build, otherwise one is kept globally for the library</p>\n",
+        "comments": "<p>This is kept on a per-thread basis if GIT_THREADS was defined when the library was build, otherwise one is kept globally for the library</p>\n",
         "fields": [
           {
             "type": "char *",
@@ -34087,8 +30724,8 @@
         ],
         "type": "enum",
         "file": "git2/common.h",
-        "line": 130,
-        "lineto": 153,
+        "line": 127,
+        "lineto": 150,
         "block": "GIT_FEATURE_THREADS\nGIT_FEATURE_HTTPS\nGIT_FEATURE_SSH\nGIT_FEATURE_NSEC",
         "tdef": "typedef",
         "description": " Combinations of these values describe the features with which libgit2\n was compiled",
@@ -34140,12 +30777,12 @@
         "type": "struct",
         "value": "git_fetch_options",
         "file": "git2/remote.h",
-        "line": 629,
-        "lineto": 666,
+        "line": 651,
+        "lineto": 688,
         "block": "int version\ngit_remote_callbacks callbacks\ngit_fetch_prune_t prune\nint update_fetchhead\ngit_remote_autotag_option_t download_tags\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Fetch options structure.",
-        "comments": "<p>Zero out for defaults.  Initialize with <code>GIT_FETCH_OPTIONS_INIT</code> macro to\n correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;\n</code></pre>\n",
+        "comments": "<p>Zero out for defaults.  Initialize with <code>GIT_FETCH_OPTIONS_INIT</code> macro to correctly set the <code>version</code> field.  E.g.</p>\n\n<pre><code>    git_fetch_options opts = GIT_FETCH_OPTIONS_INIT;\n</code></pre>\n",
         "fields": [
           {
             "type": "int",
@@ -34186,7 +30823,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_fetch_init_options",
+            "git_fetch_options_init",
             "git_remote_download",
             "git_remote_fetch"
           ]
@@ -34203,11 +30840,11 @@
         ],
         "type": "enum",
         "file": "git2/remote.h",
-        "line": 581,
-        "lineto": 594,
+        "line": 603,
+        "lineto": 616,
         "block": "GIT_FETCH_PRUNE_UNSPECIFIED\nGIT_FETCH_PRUNE\nGIT_FETCH_NO_PRUNE",
         "tdef": "typedef",
-        "description": "",
+        "description": " Acceptable prune settings when fetching ",
         "comments": "",
         "fields": [
           {
@@ -34314,79 +30951,19 @@
         "lineto": 61,
         "tdef": "typedef",
         "description": " A filter that can transform file data",
-        "comments": "<p>This represents a filter that can be used to transform or even replace\n file data.  Libgit2 includes one built in filter and it is possible to\n write your own (see git2/sys/filter.h for information on that).</p>\n\n<p>The two builtin filters are:</p>\n\n<ul>\n<li>&quot;crlf&quot; which uses the complex rules with the &quot;text&quot;, &quot;eol&quot;, and\n&quot;crlf&quot; file attributes to decide how to convert between LF and CRLF\nline endings</li>\n<li>&quot;ident&quot; which replaces &quot;$Id$&quot; in a blob with &quot;$Id: \n<blob\nOID>$&quot; upon\ncheckout and replaced &quot;$Id: \n<anything\n>$&quot; with &quot;$Id$&quot; on checkin.</li>\n</ul>\n",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": " The `version` field should be set to `GIT_FILTER_VERSION`. "
-          },
-          {
-            "type": "const char *",
-            "name": "attributes",
-            "comments": " A whitespace-separated list of attribute names to check for this\n filter (e.g. \"eol crlf text\").  If the attribute name is bare, it\n will be simply loaded and passed to the `check` callback.  If it\n has a value (i.e. \"name=value\"), the attribute must match that\n value for the filter to be applied.  The value may be a wildcard\n (eg, \"name=*\"), in which case the filter will be invoked for any\n value for the given attribute name.  See the attribute parameter\n of the `check` callback for the attribute value that was specified."
-          },
-          {
-            "type": "git_filter_init_fn",
-            "name": "initialize",
-            "comments": " Called when the filter is first used for any file. "
-          },
-          {
-            "type": "git_filter_shutdown_fn",
-            "name": "shutdown",
-            "comments": " Called when the filter is removed or unregistered from the system. "
-          },
-          {
-            "type": "git_filter_check_fn",
-            "name": "check",
-            "comments": " Called to determine whether the filter should be invoked for a\n given file.  If this function returns `GIT_PASSTHROUGH` then the\n `apply` function will not be invoked and the contents will be passed\n through unmodified."
-          },
-          {
-            "type": "git_filter_apply_fn",
-            "name": "apply",
-            "comments": " Called to actually apply the filter to file contents.  If this\n function returns `GIT_PASSTHROUGH` then the contents will be passed\n through unmodified."
-          },
-          {
-            "type": "git_filter_stream_fn",
-            "name": "stream",
-            "comments": " Called to apply the filter in a streaming manner.  If this is not\n specified then the system will call `apply` with the whole buffer."
-          },
-          {
-            "type": "git_filter_cleanup_fn",
-            "name": "cleanup",
-            "comments": " Called when the system is done filtering for a file. "
-          }
-        ],
+        "comments": "<p>This represents a filter that can be used to transform or even replace file data.  Libgit2 includes one built in filter and it is possible to write your own (see git2/sys/filter.h for information on that).</p>\n\n<p>The two builtin filters are:</p>\n\n<ul>\n<li>&quot;crlf&quot; which uses the complex rules with the &quot;text&quot;, &quot;eol&quot;, and   &quot;crlf&quot; file attributes to decide how to convert between LF and CRLF   line endings * &quot;ident&quot; which replaces &quot;$Id$&quot; in a blob with &quot;$Id: <blob OID>$&quot; upon   checkout and replaced &quot;$Id: <anything>$&quot; with &quot;$Id$&quot; on checkin.</li>\n</ul>\n",
         "used": {
-          "returns": [
-            "git_filter_lookup",
-            "git_filter_source_mode"
-          ],
+          "returns": [],
           "needs": [
-            "git_filter_apply_fn",
-            "git_filter_check_fn",
-            "git_filter_cleanup_fn",
-            "git_filter_init",
-            "git_filter_init_fn",
             "git_filter_list_apply_to_blob",
             "git_filter_list_apply_to_data",
             "git_filter_list_apply_to_file",
             "git_filter_list_contains",
             "git_filter_list_free",
-            "git_filter_list_length",
             "git_filter_list_load",
-            "git_filter_list_new",
-            "git_filter_list_push",
             "git_filter_list_stream_blob",
             "git_filter_list_stream_data",
-            "git_filter_list_stream_file",
-            "git_filter_register",
-            "git_filter_shutdown_fn",
-            "git_filter_source_id",
-            "git_filter_source_mode",
-            "git_filter_source_path",
-            "git_filter_source_repo",
-            "git_filter_stream_fn"
+            "git_filter_list_stream_file"
           ]
         }
       }
@@ -34437,8 +31014,7 @@
         "lineto": 73,
         "tdef": "typedef",
         "description": " List of filters to be applied",
-        "comments": "<p>This represents a list of filters to be applied to a file / blob.  You\n can build the list with one call, apply it with another, and dispose it\n with a third.  In typical usage, there are not many occasions where a\n git_filter_list is needed directly since the library will generally\n handle conversions for you, but it can be convenient to be able to\n build and apply the list sometimes.</p>\n",
-        "fields": [],
+        "comments": "<p>This represents a list of filters to be applied to a file / blob.  You can build the list with one call, apply it with another, and dispose it with a third.  In typical usage, there are not many occasions where a git_filter_list is needed directly since the library will generally handle conversions for you, but it can be convenient to be able to build and apply the list sometimes.</p>\n",
         "used": {
           "returns": [],
           "needs": [
@@ -34447,10 +31023,7 @@
             "git_filter_list_apply_to_file",
             "git_filter_list_contains",
             "git_filter_list_free",
-            "git_filter_list_length",
             "git_filter_list_load",
-            "git_filter_list_new",
-            "git_filter_list_push",
             "git_filter_list_stream_blob",
             "git_filter_list_stream_data",
             "git_filter_list_stream_file"
@@ -34502,12 +31075,9 @@
           }
         ],
         "used": {
-          "returns": [
-            "git_filter_source_mode"
-          ],
+          "returns": [],
           "needs": [
-            "git_filter_list_load",
-            "git_filter_list_new"
+            "git_filter_list_load"
           ]
         }
       }
@@ -34524,42 +31094,9 @@
         "tdef": "typedef",
         "description": " A filter source represents a file/blob to be processed",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
-          "needs": [
-            "git_filter_apply_fn",
-            "git_filter_check_fn",
-            "git_filter_source_id",
-            "git_filter_source_mode",
-            "git_filter_source_path",
-            "git_filter_source_repo",
-            "git_filter_stream_fn"
-          ]
-        }
-      }
-    ],
-    [
-      "git_hashsig",
-      {
-        "decl": "git_hashsig",
-        "type": "struct",
-        "value": "git_hashsig",
-        "file": "git2/sys/hashsig.h",
-        "line": 17,
-        "lineto": 17,
-        "tdef": "typedef",
-        "description": " Similarity signature of arbitrary text content based on line hashes",
-        "comments": "",
-        "fields": [],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_hashsig_compare",
-            "git_hashsig_create",
-            "git_hashsig_create_fromfile",
-            "git_hashsig_free"
-          ]
+          "needs": []
         }
       }
     ],
@@ -34579,7 +31116,7 @@
         "block": "GIT_HASHSIG_NORMAL\nGIT_HASHSIG_IGNORE_WHITESPACE\nGIT_HASHSIG_SMART_WHITESPACE\nGIT_HASHSIG_ALLOW_SMALL_FILES",
         "tdef": "typedef",
         "description": " Options for hashsig computation",
-        "comments": "<p>The options GIT_HASHSIG_NORMAL, GIT_HASHSIG_IGNORE_WHITESPACE,\n GIT_HASHSIG_SMART_WHITESPACE are exclusive and should not be combined.</p>\n",
+        "comments": "<p>The options GIT_HASHSIG_NORMAL, GIT_HASHSIG_IGNORE_WHITESPACE, GIT_HASHSIG_SMART_WHITESPACE are exclusive and should not be combined.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -34608,10 +31145,7 @@
         ],
         "used": {
           "returns": [],
-          "needs": [
-            "git_hashsig_create",
-            "git_hashsig_create_fromfile"
-          ]
+          "needs": []
         }
       }
     ],
@@ -34627,17 +31161,11 @@
         "tdef": "typedef",
         "description": " Memory representation of an index file. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_index_get_byindex",
             "git_index_get_bypath",
-            "git_index_name_get_byindex",
-            "git_index_reuc_get_byindex",
-            "git_index_reuc_get_bypath",
-            "git_merge_driver_source_ancestor",
-            "git_merge_driver_source_ours",
-            "git_merge_driver_source_theirs"
+            "git_remote_stats"
           ],
           "needs": [
             "git_apply_to_tree",
@@ -34649,7 +31177,7 @@
             "git_index_add",
             "git_index_add_all",
             "git_index_add_bypath",
-            "git_index_add_frombuffer",
+            "git_index_add_from_buffer",
             "git_index_caps",
             "git_index_checksum",
             "git_index_clear",
@@ -34672,10 +31200,6 @@
             "git_index_iterator_free",
             "git_index_iterator_new",
             "git_index_iterator_next",
-            "git_index_name_add",
-            "git_index_name_clear",
-            "git_index_name_entrycount",
-            "git_index_name_get_byindex",
             "git_index_new",
             "git_index_open",
             "git_index_owner",
@@ -34686,13 +31210,6 @@
             "git_index_remove_all",
             "git_index_remove_bypath",
             "git_index_remove_directory",
-            "git_index_reuc_add",
-            "git_index_reuc_clear",
-            "git_index_reuc_entrycount",
-            "git_index_reuc_find",
-            "git_index_reuc_get_byindex",
-            "git_index_reuc_get_bypath",
-            "git_index_reuc_remove",
             "git_index_set_caps",
             "git_index_set_version",
             "git_index_update_all",
@@ -34704,15 +31221,17 @@
             "git_indexer_commit",
             "git_indexer_free",
             "git_indexer_hash",
-            "git_indexer_init_options",
             "git_indexer_new",
+            "git_indexer_options_init",
+            "git_indexer_progress_cb",
             "git_merge_commits",
             "git_merge_file_from_index",
             "git_merge_trees",
+            "git_odb_write_pack",
+            "git_packbuilder_write",
             "git_pathspec_match_index",
             "git_rebase_inmemory_index",
             "git_repository_index",
-            "git_repository_set_index",
             "git_revert_commit"
           ]
         }
@@ -34828,7 +31347,6 @@
         "tdef": "typedef",
         "description": " An iterator for conflicts in the index. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -34845,15 +31363,15 @@
         "decl": [
           "git_index_time ctime",
           "git_index_time mtime",
-          "int dev",
-          "int ino",
-          "int mode",
-          "int uid",
-          "int gid",
-          "int file_size",
+          "uint32_t dev",
+          "uint32_t ino",
+          "uint32_t mode",
+          "uint32_t uid",
+          "uint32_t gid",
+          "uint32_t file_size",
           "git_oid id",
-          "int flags",
-          "int flags_extended",
+          "uint16_t flags",
+          "uint16_t flags_extended",
           "const char * path"
         ],
         "type": "struct",
@@ -34861,10 +31379,10 @@
         "file": "git2/index.h",
         "line": 53,
         "lineto": 70,
-        "block": "git_index_time ctime\ngit_index_time mtime\nint dev\nint ino\nint mode\nint uid\nint gid\nint file_size\ngit_oid id\nint flags\nint flags_extended\nconst char * path",
+        "block": "git_index_time ctime\ngit_index_time mtime\nuint32_t dev\nuint32_t ino\nuint32_t mode\nuint32_t uid\nuint32_t gid\nuint32_t file_size\ngit_oid id\nuint16_t flags\nuint16_t flags_extended\nconst char * path",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " In-memory representation of a file entry in the index.",
+        "comments": "<p>This is a public structure that represents a file entry in the index. The meaning of the fields corresponds to core Git&#39;s documentation (in &quot;Documentation/technical/index-format.txt&quot;).</p>\n\n<p>The <code>flags</code> field consists of a number of bit fields which can be accessed via the first set of <code>GIT_INDEX_ENTRY_...</code> bitmasks below. These flags are all read from and persisted to disk.</p>\n\n<p>The <code>flags_extended</code> field also has a number of bit fields which can be accessed via the later <code>GIT_INDEX_ENTRY_...</code> bitmasks below.  Some of these flags are read from and written to disk, but some are set aside for in-memory only reference.</p>\n\n<p>Note that the time and size fields are truncated to 32 bits. This is enough to detect changes, which is enough for the index to function as a cache, but it should not be taken as an authoritative source for that data.</p>\n",
         "fields": [
           {
             "type": "git_index_time",
@@ -34877,32 +31395,32 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "dev",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "ino",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "mode",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "uid",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "gid",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "file_size",
             "comments": ""
           },
@@ -34912,12 +31430,12 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint16_t",
             "name": "flags_extended",
             "comments": ""
           },
@@ -34930,14 +31448,11 @@
         "used": {
           "returns": [
             "git_index_get_byindex",
-            "git_index_get_bypath",
-            "git_merge_driver_source_ancestor",
-            "git_merge_driver_source_ours",
-            "git_merge_driver_source_theirs"
+            "git_index_get_bypath"
           ],
           "needs": [
             "git_index_add",
-            "git_index_add_frombuffer",
+            "git_index_add_from_buffer",
             "git_index_conflict_add",
             "git_index_conflict_get",
             "git_index_conflict_next",
@@ -34965,7 +31480,7 @@
         "block": "GIT_INDEX_ENTRY_INTENT_TO_ADD\nGIT_INDEX_ENTRY_SKIP_WORKTREE\nGIT_INDEX_ENTRY_EXTENDED_FLAGS\nGIT_INDEX_ENTRY_UPTODATE",
         "tdef": "typedef",
         "description": " Bitmasks for on-disk fields of `git_index_entry`'s `flags_extended`",
-        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the\n fields that are read from and written to disk, and other fields that\n in-memory only and used by libgit2.  Only the flags in\n <code>GIT_INDEX_ENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the\n <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You\n can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code>\n <code>flags_extended</code> value that are only used in-memory by libgit2.\n You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
+        "comments": "<p>In memory, the <code>flags_extended</code> fields are divided into two parts: the fields that are read from and written to disk, and other fields that in-memory only and used by libgit2.  Only the flags in <code>GIT_INDEX_ENTRY_EXTENDED_FLAGS</code> will get saved on-disk.</p>\n\n<p>Thee first three bitmasks match the three fields in the <code>git_index_entry</code> <code>flags_extended</code> value that belong on disk.  You can use them to interpret the data in the <code>flags_extended</code>.</p>\n\n<p>The rest of the bitmasks match the other fields in the <code>git_index_entry</code> <code>flags_extended</code> value that are only used in-memory by libgit2. You can use them to interpret the data in the <code>flags_extended</code>.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -35045,7 +31560,6 @@
         "tdef": "typedef",
         "description": " An iterator for entries in the index. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -35053,91 +31567,6 @@
             "git_index_iterator_new",
             "git_index_iterator_next"
           ]
-        }
-      }
-    ],
-    [
-      "git_index_name_entry",
-      {
-        "decl": [
-          "char * ancestor",
-          "char * ours",
-          "char * theirs"
-        ],
-        "type": "struct",
-        "value": "git_index_name_entry",
-        "file": "git2/sys/index.h",
-        "line": 23,
-        "lineto": 27,
-        "block": "char * ancestor\nchar * ours\nchar * theirs",
-        "tdef": "typedef",
-        "description": " Representation of a rename conflict entry in the index. ",
-        "comments": "",
-        "fields": [
-          {
-            "type": "char *",
-            "name": "ancestor",
-            "comments": ""
-          },
-          {
-            "type": "char *",
-            "name": "ours",
-            "comments": ""
-          },
-          {
-            "type": "char *",
-            "name": "theirs",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_index_name_get_byindex"
-          ],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "git_index_reuc_entry",
-      {
-        "decl": [
-          "int [3] mode",
-          "git_oid [3] oid",
-          "char * path"
-        ],
-        "type": "struct",
-        "value": "git_index_reuc_entry",
-        "file": "git2/sys/index.h",
-        "line": 30,
-        "lineto": 34,
-        "block": "int [3] mode\ngit_oid [3] oid\nchar * path",
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int [3]",
-            "name": "mode",
-            "comments": ""
-          },
-          {
-            "type": "git_oid [3]",
-            "name": "oid",
-            "comments": ""
-          },
-          {
-            "type": "char *",
-            "name": "path",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_index_reuc_get_byindex",
-            "git_index_reuc_get_bypath"
-          ],
-          "needs": []
         }
       }
     ],
@@ -35153,11 +31582,11 @@
         ],
         "type": "enum",
         "file": "git2/index.h",
-        "line": 146,
-        "lineto": 166,
+        "line": 147,
+        "lineto": 167,
         "block": "GIT_INDEX_STAGE_ANY\nGIT_INDEX_STAGE_NORMAL\nGIT_INDEX_STAGE_ANCESTOR\nGIT_INDEX_STAGE_OURS\nGIT_INDEX_STAGE_THEIRS",
         "tdef": "typedef",
-        "description": "",
+        "description": " Git index stage states ",
         "comments": "",
         "fields": [
           {
@@ -35201,26 +31630,26 @@
       "git_index_time",
       {
         "decl": [
-          "int seconds",
-          "int nanoseconds"
+          "int32_t seconds",
+          "uint32_t nanoseconds"
         ],
         "type": "struct",
         "value": "git_index_time",
         "file": "git2/index.h",
         "line": 26,
         "lineto": 30,
-        "block": "int seconds\nint nanoseconds",
+        "block": "int32_t seconds\nuint32_t nanoseconds",
         "tdef": "typedef",
-        "description": "",
+        "description": " Time structure used in a git index entry ",
         "comments": "",
         "fields": [
           {
-            "type": "int",
+            "type": "int32_t",
             "name": "seconds",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "nanoseconds",
             "comments": ""
           }
@@ -35238,21 +31667,25 @@
         "type": "struct",
         "value": "git_indexer",
         "file": "git2/indexer.h",
-        "line": 16,
-        "lineto": 16,
+        "line": 17,
+        "lineto": 17,
         "tdef": "typedef",
-        "description": "",
+        "description": " A git indexer object ",
         "comments": "",
-        "fields": [],
         "used": {
-          "returns": [],
+          "returns": [
+            "git_remote_stats"
+          ],
           "needs": [
             "git_indexer_append",
             "git_indexer_commit",
             "git_indexer_free",
             "git_indexer_hash",
-            "git_indexer_init_options",
-            "git_indexer_new"
+            "git_indexer_new",
+            "git_indexer_options_init",
+            "git_indexer_progress_cb",
+            "git_odb_write_pack",
+            "git_packbuilder_write"
           ]
         }
       }
@@ -35262,18 +31695,18 @@
       {
         "decl": [
           "unsigned int version",
-          "git_transfer_progress_cb progress_cb",
+          "git_indexer_progress_cb progress_cb",
           "void * progress_cb_payload",
           "unsigned char verify"
         ],
         "type": "struct",
         "value": "git_indexer_options",
         "file": "git2/indexer.h",
-        "line": 18,
-        "lineto": 28,
-        "block": "unsigned int version\ngit_transfer_progress_cb progress_cb\nvoid * progress_cb_payload\nunsigned char verify",
+        "line": 62,
+        "lineto": 72,
+        "block": "unsigned int version\ngit_indexer_progress_cb progress_cb\nvoid * progress_cb_payload\nunsigned char verify",
         "tdef": "typedef",
-        "description": "",
+        "description": " Options for indexer configuration",
         "comments": "",
         "fields": [
           {
@@ -35282,7 +31715,7 @@
             "comments": ""
           },
           {
-            "type": "git_transfer_progress_cb",
+            "type": "git_indexer_progress_cb",
             "name": "progress_cb",
             "comments": " progress_cb function to call with progress information "
           },
@@ -35300,28 +31733,81 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_indexer_init_options",
-            "git_indexer_new"
+            "git_indexer_new",
+            "git_indexer_options_init"
           ]
         }
       }
     ],
     [
-      "git_iterator",
+      "git_indexer_progress",
       {
-        "decl": [],
+        "decl": [
+          "unsigned int total_objects",
+          "unsigned int indexed_objects",
+          "unsigned int received_objects",
+          "unsigned int local_objects",
+          "unsigned int total_deltas",
+          "unsigned int indexed_deltas",
+          "size_t received_bytes"
+        ],
         "type": "struct",
-        "value": "git_iterator",
-        "file": "git2/notes.h",
-        "line": 35,
-        "lineto": 35,
-        "tdef": null,
-        "description": "",
+        "value": "git_indexer_progress",
+        "file": "git2/indexer.h",
+        "line": 24,
+        "lineto": 48,
+        "block": "unsigned int total_objects\nunsigned int indexed_objects\nunsigned int received_objects\nunsigned int local_objects\nunsigned int total_deltas\nunsigned int indexed_deltas\nsize_t received_bytes",
+        "tdef": "typedef",
+        "description": " This structure is used to provide callers information about the\n progress of indexing a packfile, either directly or part of a\n fetch or clone that downloads a packfile.",
         "comments": "",
-        "fields": [],
+        "fields": [
+          {
+            "type": "unsigned int",
+            "name": "total_objects",
+            "comments": " number of objects in the packfile being indexed "
+          },
+          {
+            "type": "unsigned int",
+            "name": "indexed_objects",
+            "comments": " received objects that have been hashed "
+          },
+          {
+            "type": "unsigned int",
+            "name": "received_objects",
+            "comments": " received_objects: objects which have been downloaded "
+          },
+          {
+            "type": "unsigned int",
+            "name": "local_objects",
+            "comments": " locally-available objects that have been injected in order\n to fix a thin pack"
+          },
+          {
+            "type": "unsigned int",
+            "name": "total_deltas",
+            "comments": " number of deltas in the packfile being indexed "
+          },
+          {
+            "type": "unsigned int",
+            "name": "indexed_deltas",
+            "comments": " received deltas that have been indexed "
+          },
+          {
+            "type": "size_t",
+            "name": "received_bytes",
+            "comments": " size of the packfile received up to now "
+          }
+        ],
         "used": {
-          "returns": [],
-          "needs": []
+          "returns": [
+            "git_remote_stats"
+          ],
+          "needs": [
+            "git_indexer_append",
+            "git_indexer_commit",
+            "git_indexer_progress_cb",
+            "git_odb_write_pack",
+            "git_packbuilder_write"
+          ]
         }
       }
     ],
@@ -35355,16 +31841,17 @@
           "GIT_OPT_SET_ALLOCATOR",
           "GIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY",
           "GIT_OPT_GET_PACK_MAX_OBJECTS",
-          "GIT_OPT_SET_PACK_MAX_OBJECTS"
+          "GIT_OPT_SET_PACK_MAX_OBJECTS",
+          "GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS"
         ],
         "type": "enum",
         "file": "git2/common.h",
-        "line": 181,
-        "lineto": 209,
-        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION\nGIT_OPT_SET_ALLOCATOR\nGIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY\nGIT_OPT_GET_PACK_MAX_OBJECTS\nGIT_OPT_SET_PACK_MAX_OBJECTS",
+        "line": 178,
+        "lineto": 207,
+        "block": "GIT_OPT_GET_MWINDOW_SIZE\nGIT_OPT_SET_MWINDOW_SIZE\nGIT_OPT_GET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_SET_MWINDOW_MAPPED_LIMIT\nGIT_OPT_GET_SEARCH_PATH\nGIT_OPT_SET_SEARCH_PATH\nGIT_OPT_SET_CACHE_OBJECT_LIMIT\nGIT_OPT_SET_CACHE_MAX_SIZE\nGIT_OPT_ENABLE_CACHING\nGIT_OPT_GET_CACHED_MEMORY\nGIT_OPT_GET_TEMPLATE_PATH\nGIT_OPT_SET_TEMPLATE_PATH\nGIT_OPT_SET_SSL_CERT_LOCATIONS\nGIT_OPT_SET_USER_AGENT\nGIT_OPT_ENABLE_STRICT_OBJECT_CREATION\nGIT_OPT_ENABLE_STRICT_SYMBOLIC_REF_CREATION\nGIT_OPT_SET_SSL_CIPHERS\nGIT_OPT_GET_USER_AGENT\nGIT_OPT_ENABLE_OFS_DELTA\nGIT_OPT_ENABLE_FSYNC_GITDIR\nGIT_OPT_GET_WINDOWS_SHAREMODE\nGIT_OPT_SET_WINDOWS_SHAREMODE\nGIT_OPT_ENABLE_STRICT_HASH_VERIFICATION\nGIT_OPT_SET_ALLOCATOR\nGIT_OPT_ENABLE_UNSAVED_INDEX_SAFETY\nGIT_OPT_GET_PACK_MAX_OBJECTS\nGIT_OPT_SET_PACK_MAX_OBJECTS\nGIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS",
         "tdef": "typedef",
         "description": " Global library options",
-        "comments": "<p>These are used to select which global option to set or get and are\n used in <code>git_libgit2_opts()</code>.</p>\n",
+        "comments": "<p>These are used to select which global option to set or get and are used in <code>git_libgit2_opts()</code>.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -35527,6 +32014,12 @@
             "name": "GIT_OPT_SET_PACK_MAX_OBJECTS",
             "comments": "",
             "value": 26
+          },
+          {
+            "type": "int",
+            "name": "GIT_OPT_DISABLE_PACK_KEEP_FILE_CHECKS",
+            "comments": "",
+            "value": 27
           }
         ],
         "used": {
@@ -35542,12 +32035,11 @@
         "type": "struct",
         "value": "git_mailmap",
         "file": "git2/types.h",
-        "line": 442,
-        "lineto": 442,
+        "line": 412,
+        "lineto": 412,
         "tdef": "typedef",
         "description": " Representation of .mailmap file state. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -35576,8 +32068,8 @@
         ],
         "type": "enum",
         "file": "git2/merge.h",
-        "line": 320,
-        "lineto": 349,
+        "line": 316,
+        "lineto": 345,
         "block": "GIT_MERGE_ANALYSIS_NONE\nGIT_MERGE_ANALYSIS_NORMAL\nGIT_MERGE_ANALYSIS_UP_TO_DATE\nGIT_MERGE_ANALYSIS_FASTFORWARD\nGIT_MERGE_ANALYSIS_UNBORN",
         "tdef": "typedef",
         "description": " The results of `git_merge_analysis` indicate the merge opportunities.",
@@ -35624,58 +32116,6 @@
       }
     ],
     [
-      "git_merge_driver",
-      {
-        "decl": "git_merge_driver",
-        "type": "struct",
-        "value": "git_merge_driver",
-        "file": "git2/sys/merge.h",
-        "line": 24,
-        "lineto": 24,
-        "tdef": "typedef",
-        "description": " \n\n git2/sys/merge.h\n ",
-        "comments": "<p>@\n{</p>\n",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": " The `version` should be set to `GIT_MERGE_DRIVER_VERSION`. "
-          },
-          {
-            "type": "git_merge_driver_init_fn",
-            "name": "initialize",
-            "comments": " Called when the merge driver is first used for any file. "
-          },
-          {
-            "type": "git_merge_driver_shutdown_fn",
-            "name": "shutdown",
-            "comments": " Called when the merge driver is unregistered from the system. "
-          },
-          {
-            "type": "git_merge_driver_apply_fn",
-            "name": "apply",
-            "comments": " Called to merge the contents of a conflict.  If this function\n returns `GIT_PASSTHROUGH` then the default (`text`) merge driver\n will instead be invoked.  If this function returns\n `GIT_EMERGECONFLICT` then the file will remain conflicted."
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_merge_driver_lookup"
-          ],
-          "needs": [
-            "git_merge_driver_apply_fn",
-            "git_merge_driver_init_fn",
-            "git_merge_driver_register",
-            "git_merge_driver_shutdown_fn",
-            "git_merge_driver_source_ancestor",
-            "git_merge_driver_source_file_options",
-            "git_merge_driver_source_ours",
-            "git_merge_driver_source_repo",
-            "git_merge_driver_source_theirs"
-          ]
-        }
-      }
-    ],
-    [
       "git_merge_driver_source",
       {
         "decl": "git_merge_driver_source",
@@ -35687,17 +32127,9 @@
         "tdef": "typedef",
         "description": " A merge driver source represents the file to be merged",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
-          "needs": [
-            "git_merge_driver_apply_fn",
-            "git_merge_driver_source_ancestor",
-            "git_merge_driver_source_file_options",
-            "git_merge_driver_source_ours",
-            "git_merge_driver_source_repo",
-            "git_merge_driver_source_theirs"
-          ]
+          "needs": []
         }
       }
     ],
@@ -35884,7 +32316,7 @@
           "returns": [],
           "needs": [
             "git_merge_file",
-            "git_merge_file_init_input"
+            "git_merge_file_input_init"
           ]
         }
       }
@@ -35948,13 +32380,11 @@
           }
         ],
         "used": {
-          "returns": [
-            "git_merge_driver_source_file_options"
-          ],
+          "returns": [],
           "needs": [
             "git_merge_file",
             "git_merge_file_from_index",
-            "git_merge_file_init_options"
+            "git_merge_file_options_init"
           ]
         }
       }
@@ -35972,8 +32402,8 @@
         "type": "struct",
         "value": "git_merge_file_result",
         "file": "git2/merge.h",
-        "line": 222,
-        "lineto": 243,
+        "line": 220,
+        "lineto": 241,
         "block": "unsigned int automergeable\nconst char * path\nunsigned int mode\nconst char * ptr\nsize_t len",
         "tdef": "typedef",
         "description": " Information about file-level merging",
@@ -36081,8 +32511,8 @@
         "type": "struct",
         "value": "git_merge_options",
         "file": "git2/merge.h",
-        "line": 248,
-        "lineto": 297,
+        "line": 246,
+        "lineto": 295,
         "block": "unsigned int version\ngit_merge_flag_t flags\nunsigned int rename_threshold\nunsigned int target_limit\ngit_diff_similarity_metric * metric\nunsigned int recursion_limit\nconst char * default_driver\ngit_merge_file_favor_t file_favor\ngit_merge_file_flag_t file_flags",
         "tdef": "typedef",
         "description": " Merging options",
@@ -36140,7 +32570,7 @@
             "git_cherrypick_commit",
             "git_merge",
             "git_merge_commits",
-            "git_merge_init_options",
+            "git_merge_options_init",
             "git_merge_trees",
             "git_revert_commit"
           ]
@@ -36157,8 +32587,8 @@
         ],
         "type": "enum",
         "file": "git2/merge.h",
-        "line": 354,
-        "lineto": 372,
+        "line": 350,
+        "lineto": 368,
         "block": "GIT_MERGE_PREFERENCE_NONE\nGIT_MERGE_PREFERENCE_NO_FASTFORWARD\nGIT_MERGE_PREFERENCE_FASTFORWARD_ONLY",
         "tdef": "typedef",
         "description": " The user's stated preference for merges.",
@@ -36245,7 +32675,7 @@
         "block": "git_message_trailer * trailers\nsize_t count\nchar * _trailer_block",
         "tdef": "typedef",
         "description": " Represents an array of git message trailers.",
-        "comments": "<p>Struct members under the private comment are private, subject to change\n and should not be used by callers.</p>\n",
+        "comments": "<p>Struct members under the private comment are private, subject to change and should not be used by callers.</p>\n",
         "fields": [
           {
             "type": "git_message_trailer *",
@@ -36284,7 +32714,6 @@
         "tdef": "typedef",
         "description": " Representation of a git note ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -36339,7 +32768,6 @@
         "tdef": "typedef",
         "description": " Representation of a generic object in a repository ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_object_string2type",
@@ -36351,7 +32779,6 @@
           "needs": [
             "git_checkout_tree",
             "git_describe_commit",
-            "git_object__size",
             "git_object_dup",
             "git_object_free",
             "git_object_id",
@@ -36361,6 +32788,7 @@
             "git_object_owner",
             "git_object_peel",
             "git_object_short_id",
+            "git_object_size",
             "git_object_type",
             "git_object_type2string",
             "git_object_typeisloose",
@@ -36466,11 +32894,11 @@
             "git_tree_entry_type"
           ],
           "needs": [
-            "git_object__size",
             "git_object_lookup",
             "git_object_lookup_bypath",
             "git_object_lookup_prefix",
             "git_object_peel",
+            "git_object_size",
             "git_object_type2string",
             "git_object_typeisloose",
             "git_odb_hash",
@@ -36497,19 +32925,14 @@
         "tdef": "typedef",
         "description": " An open object database handle. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
             "git_indexer_new",
-            "git_mempack_dump",
-            "git_mempack_new",
-            "git_mempack_reset",
             "git_odb_add_alternate",
             "git_odb_add_backend",
             "git_odb_add_disk_alternate",
             "git_odb_backend_loose",
-            "git_odb_backend_malloc",
             "git_odb_backend_one_pack",
             "git_odb_backend_pack",
             "git_odb_exists",
@@ -36518,7 +32941,6 @@
             "git_odb_foreach",
             "git_odb_free",
             "git_odb_get_backend",
-            "git_odb_init_backend",
             "git_odb_new",
             "git_odb_num_backends",
             "git_odb_object_data",
@@ -36541,7 +32963,6 @@
             "git_odb_write",
             "git_odb_write_pack",
             "git_repository_odb",
-            "git_repository_set_odb",
             "git_repository_wrap_odb"
           ]
         }
@@ -36556,101 +32977,18 @@
         "file": "git2/types.h",
         "line": 85,
         "lineto": 85,
-        "block": "unsigned int version\ngit_odb * odb\nint (*)(void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *) read\nint (*)(git_oid *, void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *, size_t) read_prefix\nint (*)(size_t *, git_object_t *, git_odb_backend *, const git_oid *) read_header\nint (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_object_t) write\nint (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_object_t) writestream\nint (*)(git_odb_stream **, size_t *, git_object_t *, git_odb_backend *, const git_oid *) readstream\nint (*)(git_odb_backend *, const git_oid *) exists\nint (*)(git_oid *, git_odb_backend *, const git_oid *, size_t) exists_prefix\nint (*)(git_odb_backend *) refresh\nint (*)(git_odb_backend *, git_odb_foreach_cb, void *) foreach\nint (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *) writepack\nint (*)(git_odb_backend *, const git_oid *) freshen\nvoid (*)(git_odb_backend *) free",
         "tdef": "typedef",
         "description": " A custom backend in an ODB ",
         "comments": "",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": ""
-          },
-          {
-            "type": "git_odb *",
-            "name": "odb",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
-            "name": "read",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_oid *, void **, size_t *, git_object_t *, git_odb_backend *, const git_oid *, size_t)",
-            "name": "read_prefix",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
-            "name": "read_header",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_backend *, const git_oid *, const void *, size_t, git_object_t)",
-            "name": "write",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_stream **, git_odb_backend *, git_off_t, git_object_t)",
-            "name": "writestream",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_stream **, size_t *, git_object_t *, git_odb_backend *, const git_oid *)",
-            "name": "readstream",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_backend *, const git_oid *)",
-            "name": "exists",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_oid *, git_odb_backend *, const git_oid *, size_t)",
-            "name": "exists_prefix",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_backend *)",
-            "name": "refresh",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_backend *, git_odb_foreach_cb, void *)",
-            "name": "foreach",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_writepack **, git_odb_backend *, git_odb *, git_transfer_progress_cb, void *)",
-            "name": "writepack",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_odb_backend *, const git_oid *)",
-            "name": "freshen",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_odb_backend *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
           "needs": [
-            "git_mempack_dump",
-            "git_mempack_new",
-            "git_mempack_reset",
             "git_odb_add_alternate",
             "git_odb_add_backend",
             "git_odb_backend_loose",
-            "git_odb_backend_malloc",
             "git_odb_backend_one_pack",
             "git_odb_backend_pack",
-            "git_odb_get_backend",
-            "git_odb_init_backend"
+            "git_odb_get_backend"
           ]
         }
       }
@@ -36666,8 +33004,8 @@
         "type": "struct",
         "value": "git_odb_expand_id",
         "file": "git2/odb.h",
-        "line": 180,
-        "lineto": 195,
+        "line": 181,
+        "lineto": 196,
         "block": "git_oid id\nunsigned short length\ngit_object_t type",
         "tdef": "typedef",
         "description": " The information about object IDs to query in `git_odb_expand_ids`,\n which will be populated upon return.",
@@ -36709,7 +33047,6 @@
         "tdef": "typedef",
         "description": " An object read from the ODB ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -36808,8 +33145,8 @@
         ],
         "type": "enum",
         "file": "git2/odb_backend.h",
-        "line": 70,
-        "lineto": 74,
+        "line": 71,
+        "lineto": 75,
         "block": "GIT_STREAM_RDONLY\nGIT_STREAM_WRONLY\nGIT_STREAM_RW",
         "tdef": "typedef",
         "description": " Streaming mode ",
@@ -36849,7 +33186,7 @@
         "file": "git2/types.h",
         "line": 94,
         "lineto": 94,
-        "block": "git_odb_backend * backend\nint (*)(git_odb_writepack *, const void *, size_t, git_transfer_progress *) append\nint (*)(git_odb_writepack *, git_transfer_progress *) commit\nvoid (*)(git_odb_writepack *) free",
+        "block": "git_odb_backend * backend\nint (*)(git_odb_writepack *, const void *, size_t, git_indexer_progress *) append\nint (*)(git_odb_writepack *, git_indexer_progress *) commit\nvoid (*)(git_odb_writepack *) free",
         "tdef": "typedef",
         "description": " A stream to write a packfile to the ODB ",
         "comments": "",
@@ -36860,12 +33197,12 @@
             "comments": ""
           },
           {
-            "type": "int (*)(git_odb_writepack *, const void *, size_t, git_transfer_progress *)",
+            "type": "int (*)(git_odb_writepack *, const void *, size_t, git_indexer_progress *)",
             "name": "append",
             "comments": ""
           },
           {
-            "type": "int (*)(git_odb_writepack *, git_transfer_progress *)",
+            "type": "int (*)(git_odb_writepack *, git_indexer_progress *)",
             "name": "commit",
             "comments": ""
           },
@@ -36912,7 +33249,6 @@
             "git_commit_id",
             "git_commit_parent_id",
             "git_commit_tree_id",
-            "git_filter_source_id",
             "git_index_checksum",
             "git_indexer_hash",
             "git_note_id",
@@ -36920,6 +33256,8 @@
             "git_odb_object_id",
             "git_oid_shorten_new",
             "git_packbuilder_hash",
+            "git_rebase_onto_id",
+            "git_rebase_orig_head_id",
             "git_reference_target",
             "git_reference_target_peel",
             "git_reflog_entry_id_new",
@@ -36935,16 +33273,15 @@
           "needs": [
             "git_annotated_commit_from_fetchhead",
             "git_annotated_commit_lookup",
-            "git_blob_create_frombuffer",
-            "git_blob_create_fromdisk",
-            "git_blob_create_fromstream_commit",
+            "git_blob_create_from_buffer",
+            "git_blob_create_from_disk",
+            "git_blob_create_from_stream_commit",
+            "git_blob_create_from_workdir",
             "git_blob_create_fromworkdir",
             "git_blob_lookup",
             "git_blob_lookup_prefix",
             "git_commit_amend",
             "git_commit_create",
-            "git_commit_create_from_callback",
-            "git_commit_create_from_ids",
             "git_commit_create_v",
             "git_commit_create_with_signature",
             "git_commit_extract_signature",
@@ -36953,7 +33290,6 @@
             "git_diff_patchid",
             "git_graph_ahead_behind",
             "git_graph_descendant_of",
-            "git_index_reuc_add",
             "git_index_write_tree",
             "git_index_write_tree_to",
             "git_merge_base",
@@ -36990,6 +33326,7 @@
             "git_oid_fromstr",
             "git_oid_fromstrn",
             "git_oid_fromstrp",
+            "git_oid_is_zero",
             "git_oid_iszero",
             "git_oid_ncmp",
             "git_oid_nfmt",
@@ -37006,7 +33343,6 @@
             "git_packbuilder_insert_recur",
             "git_packbuilder_insert_tree",
             "git_rebase_commit",
-            "git_reference__alloc",
             "git_reference_create",
             "git_reference_create_matching",
             "git_reference_name_to_id",
@@ -37024,7 +33360,7 @@
             "git_stash_save",
             "git_tag_annotation_create",
             "git_tag_create",
-            "git_tag_create_frombuffer",
+            "git_tag_create_from_buffer",
             "git_tag_create_lightweight",
             "git_tag_foreach_cb",
             "git_tag_lookup",
@@ -37053,7 +33389,6 @@
         "tdef": "typedef",
         "description": " OID Shortener object",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_oid_shorten_new"
@@ -37115,7 +33450,6 @@
         "tdef": "typedef",
         "description": " Representation of a git packbuilder ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37147,8 +33481,8 @@
         ],
         "type": "enum",
         "file": "git2/pack.h",
-        "line": 51,
-        "lineto": 54,
+        "line": 52,
+        "lineto": 55,
         "block": "GIT_PACKBUILDER_ADDING_OBJECTS\nGIT_PACKBUILDER_DELTAFICATION",
         "tdef": "typedef",
         "description": " Stages that are reported by the packbuilder progress callback.",
@@ -37184,8 +33518,7 @@
         "lineto": 29,
         "tdef": "typedef",
         "description": " The diff patch is used to store all the text diffs for a delta.",
-        "comments": "<p>You can easily loop over the content of patches and get information about\n them.</p>\n",
-        "fields": [],
+        "comments": "<p>You can easily loop over the content of patches and get information about them.</p>\n",
         "used": {
           "returns": [],
           "needs": [
@@ -37245,53 +33578,7 @@
         ],
         "used": {
           "returns": [],
-          "needs": [
-            "git_path_is_gitfile"
-          ]
-        }
-      }
-    ],
-    [
-      "git_path_gitfile",
-      {
-        "decl": [
-          "GIT_PATH_GITFILE_GITIGNORE",
-          "GIT_PATH_GITFILE_GITMODULES",
-          "GIT_PATH_GITFILE_GITATTRIBUTES"
-        ],
-        "type": "enum",
-        "file": "git2/sys/path.h",
-        "line": 21,
-        "lineto": 28,
-        "block": "GIT_PATH_GITFILE_GITIGNORE\nGIT_PATH_GITFILE_GITMODULES\nGIT_PATH_GITFILE_GITATTRIBUTES",
-        "tdef": "typedef",
-        "description": " The kinds of git-specific files we know about.",
-        "comments": "<p>The order needs to stay the same to not break the <code>gitfiles</code>\n array in path.c</p>\n",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_PATH_GITFILE_GITIGNORE",
-            "comments": "<p>Check for the .gitignore file </p>\n",
-            "value": 0
-          },
-          {
-            "type": "int",
-            "name": "GIT_PATH_GITFILE_GITMODULES",
-            "comments": "<p>Check for the .gitmodules file </p>\n",
-            "value": 1
-          },
-          {
-            "type": "int",
-            "name": "GIT_PATH_GITFILE_GITATTRIBUTES",
-            "comments": "<p>Check for the .gitattributes file </p>\n",
-            "value": 2
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_path_is_gitfile"
-          ]
+          "needs": []
         }
       }
     ],
@@ -37307,7 +33594,6 @@
         "tdef": "typedef",
         "description": " Compiled pathspec",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37410,7 +33696,6 @@
         "tdef": "typedef",
         "description": " List of filenames matching a pathspec",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -37447,7 +33732,7 @@
         "block": "unsigned int version\ngit_proxy_t type\nconst char * url\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\nvoid * payload",
         "tdef": "typedef",
         "description": " Options for connecting through a proxy",
-        "comments": "<p>Note that not all types may be supported, depending on the platform\n and compilation options.</p>\n",
+        "comments": "<p>Note that not all types may be supported, depending on the platform and compilation options.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -37483,9 +33768,8 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_proxy_init_options",
-            "git_remote_connect",
-            "git_transport_smart_proxy_options"
+            "git_proxy_options_init",
+            "git_remote_connect"
           ]
         }
       }
@@ -37544,12 +33828,11 @@
         "tdef": "typedef",
         "description": " Preparation for a push operation. Can be used to configure what to\n push and the level of parallelism of the packfile builder.",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
-            "git_push_init_options",
             "git_push_negotiation",
+            "git_push_options_init",
             "git_remote_push",
             "git_remote_upload"
           ]
@@ -37569,8 +33852,8 @@
         "type": "struct",
         "value": "git_push_options",
         "file": "git2/remote.h",
-        "line": 690,
-        "lineto": 717,
+        "line": 712,
+        "lineto": 739,
         "block": "unsigned int version\nunsigned int pb_parallelism\ngit_remote_callbacks callbacks\ngit_proxy_options proxy_opts\ngit_strarray custom_headers",
         "tdef": "typedef",
         "description": " Controls the behavior of a git_push object.",
@@ -37605,7 +33888,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_push_init_options",
+            "git_push_options_init",
             "git_remote_push",
             "git_remote_upload"
           ]
@@ -37624,8 +33907,8 @@
         "type": "struct",
         "value": "git_push_update",
         "file": "git2/remote.h",
-        "line": 433,
-        "lineto": 450,
+        "line": 434,
+        "lineto": 451,
         "block": "char * src_refname\nchar * dst_refname\ngit_oid src\ngit_oid dst",
         "tdef": "typedef",
         "description": " Represents an update which will be performed on the remote during push",
@@ -37672,7 +33955,6 @@
         "tdef": "typedef",
         "description": " Representation of a rebase ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_rebase_operation_byindex"
@@ -37683,13 +33965,17 @@
             "git_rebase_finish",
             "git_rebase_free",
             "git_rebase_init",
-            "git_rebase_init_options",
             "git_rebase_inmemory_index",
             "git_rebase_next",
+            "git_rebase_onto_id",
+            "git_rebase_onto_name",
             "git_rebase_open",
             "git_rebase_operation_byindex",
             "git_rebase_operation_current",
-            "git_rebase_operation_entrycount"
+            "git_rebase_operation_entrycount",
+            "git_rebase_options_init",
+            "git_rebase_orig_head_id",
+            "git_rebase_orig_head_name"
           ]
         }
       }
@@ -37710,7 +33996,7 @@
         "block": "git_rebase_operation_t type\nconst git_oid id\nconst char * exec",
         "tdef": "typedef",
         "description": " A rebase operation",
-        "comments": "<p>Describes a single instruction/operation to be performed during the\n rebase.</p>\n",
+        "comments": "<p>Describes a single instruction/operation to be performed during the rebase.</p>\n",
         "fields": [
           {
             "type": "git_rebase_operation_t",
@@ -37857,8 +34143,8 @@
           "returns": [],
           "needs": [
             "git_rebase_init",
-            "git_rebase_init_options",
-            "git_rebase_open"
+            "git_rebase_open",
+            "git_rebase_options_init"
           ]
         }
       }
@@ -37875,19 +34161,14 @@
         "tdef": "typedef",
         "description": " An open refs database handle. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
-            "git_refdb_backend_fs",
             "git_refdb_compress",
             "git_refdb_free",
-            "git_refdb_init_backend",
             "git_refdb_new",
             "git_refdb_open",
-            "git_refdb_set_backend",
-            "git_repository_refdb",
-            "git_repository_set_refdb"
+            "git_repository_refdb"
           ]
         }
       }
@@ -37901,104 +34182,12 @@
         "file": "git2/types.h",
         "line": 100,
         "lineto": 100,
-        "block": "unsigned int version\nint (*)(int *, git_refdb_backend *, const char *) exists\nint (*)(git_reference **, git_refdb_backend *, const char *) lookup\nint (*)(git_reference_iterator **, struct git_refdb_backend *, const char *) iterator\nint (*)(git_refdb_backend *, const git_reference *, int, const git_signature *, const char *, const git_oid *, const char *) write\nint (*)(git_reference **, git_refdb_backend *, const char *, const char *, int, const git_signature *, const char *) rename\nint (*)(git_refdb_backend *, const char *, const git_oid *, const char *) del\nint (*)(git_refdb_backend *) compress\nint (*)(git_refdb_backend *, const char *) has_log\nint (*)(git_refdb_backend *, const char *) ensure_log\nvoid (*)(git_refdb_backend *) free\nint (*)(git_reflog **, git_refdb_backend *, const char *) reflog_read\nint (*)(git_refdb_backend *, git_reflog *) reflog_write\nint (*)(git_refdb_backend *, const char *, const char *) reflog_rename\nint (*)(git_refdb_backend *, const char *) reflog_delete\nint (*)(void **, git_refdb_backend *, const char *) lock\nint (*)(git_refdb_backend *, void *, int, int, const git_reference *, const git_signature *, const char *) unlock",
         "tdef": "typedef",
         "description": " A custom backend for refs ",
         "comments": "",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(int *, git_refdb_backend *, const char *)",
-            "name": "exists",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_reference **, git_refdb_backend *, const char *)",
-            "name": "lookup",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_reference_iterator **, struct git_refdb_backend *, const char *)",
-            "name": "iterator",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const git_reference *, int, const git_signature *, const char *, const git_oid *, const char *)",
-            "name": "write",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_reference **, git_refdb_backend *, const char *, const char *, int, const git_signature *, const char *)",
-            "name": "rename",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const char *, const git_oid *, const char *)",
-            "name": "del",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *)",
-            "name": "compress",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const char *)",
-            "name": "has_log",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const char *)",
-            "name": "ensure_log",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_refdb_backend *)",
-            "name": "free",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_reflog **, git_refdb_backend *, const char *)",
-            "name": "reflog_read",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, git_reflog *)",
-            "name": "reflog_write",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const char *, const char *)",
-            "name": "reflog_rename",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, const char *)",
-            "name": "reflog_delete",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(void **, git_refdb_backend *, const char *)",
-            "name": "lock",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_refdb_backend *, void *, int, int, const git_reference *, const git_signature *, const char *)",
-            "name": "unlock",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
-          "needs": [
-            "git_refdb_backend_fs",
-            "git_refdb_init_backend",
-            "git_refdb_set_backend"
-          ]
+          "needs": []
         }
       }
     ],
@@ -38014,11 +34203,8 @@
         "tdef": "typedef",
         "description": " In-memory representation of a reference. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
-            "git_reference__alloc",
-            "git_reference__alloc_symbolic",
             "git_reference_type"
           ],
           "needs": [
@@ -38088,8 +34274,8 @@
         ],
         "type": "enum",
         "file": "git2/refs.h",
-        "line": 639,
-        "lineto": 668,
+        "line": 658,
+        "lineto": 687,
         "block": "GIT_REFERENCE_FORMAT_NORMAL\nGIT_REFERENCE_FORMAT_ALLOW_ONELEVEL\nGIT_REFERENCE_FORMAT_REFSPEC_PATTERN\nGIT_REFERENCE_FORMAT_REFSPEC_SHORTHAND",
         "tdef": "typedef",
         "description": " Normalization options for reference lookup",
@@ -38135,32 +34321,9 @@
         "file": "git2/types.h",
         "line": 180,
         "lineto": 180,
-        "block": "git_refdb * db\nint (*)(git_reference **, git_reference_iterator *) next\nint (*)(const char **, git_reference_iterator *) next_name\nvoid (*)(git_reference_iterator *) free",
         "tdef": "typedef",
         "description": " Iterator for references ",
         "comments": "",
-        "fields": [
-          {
-            "type": "git_refdb *",
-            "name": "db",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_reference **, git_reference_iterator *)",
-            "name": "next",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(const char **, git_reference_iterator *)",
-            "name": "next_name",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_reference_iterator *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
           "needs": [
@@ -38236,16 +34399,13 @@
         "tdef": "typedef",
         "description": " Representation of a reference log ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
-            "git_reflog_entry__alloc",
             "git_reflog_entry_byindex"
           ],
           "needs": [
             "git_reflog_append",
             "git_reflog_drop",
-            "git_reflog_entry__free",
             "git_reflog_entry_byindex",
             "git_reflog_entry_committer",
             "git_reflog_entry_id_new",
@@ -38272,14 +34432,11 @@
         "tdef": "typedef",
         "description": " Representation of a reference log entry ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
-            "git_reflog_entry__alloc",
             "git_reflog_entry_byindex"
           ],
           "needs": [
-            "git_reflog_entry__free",
             "git_reflog_entry_committer",
             "git_reflog_entry_id_new",
             "git_reflog_entry_id_old",
@@ -38300,7 +34457,6 @@
         "tdef": "typedef",
         "description": " A refspec specifies the mapping between remote and local reference\n names when fetch or pushing.",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_remote_get_refspec"
@@ -38333,7 +34489,6 @@
         "tdef": "typedef",
         "description": " Git's idea of a remote repository. A remote can be anonymous (in\n which case it does not have backing configuration entires).",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_remote_autotag"
@@ -38347,7 +34502,7 @@
             "git_remote_create_anonymous",
             "git_remote_create_cb",
             "git_remote_create_detached",
-            "git_remote_create_init_options",
+            "git_remote_create_options_init",
             "git_remote_create_with_fetchspec",
             "git_remote_create_with_opts",
             "git_remote_default_branch",
@@ -38375,12 +34530,7 @@
             "git_remote_update_tips",
             "git_remote_upload",
             "git_remote_url",
-            "git_transport_cb",
-            "git_transport_dummy",
-            "git_transport_local",
-            "git_transport_new",
-            "git_transport_smart",
-            "git_transport_ssh_with_paths"
+            "git_transport_cb"
           ]
         }
       }
@@ -38396,8 +34546,8 @@
         ],
         "type": "enum",
         "file": "git2/remote.h",
-        "line": 601,
-        "lineto": 619,
+        "line": 623,
+        "lineto": 641,
         "block": "GIT_REMOTE_DOWNLOAD_TAGS_UNSPECIFIED\nGIT_REMOTE_DOWNLOAD_TAGS_AUTO\nGIT_REMOTE_DOWNLOAD_TAGS_NONE\nGIT_REMOTE_DOWNLOAD_TAGS_ALL",
         "tdef": "typedef",
         "description": " Automatic tag following option",
@@ -38442,16 +34592,31 @@
     [
       "git_remote_callbacks",
       {
-        "decl": "git_remote_callbacks",
+        "decl": [
+          "unsigned int version",
+          "git_transport_message_cb sideband_progress",
+          "int (*)(git_remote_completion_t, void *) completion",
+          "git_cred_acquire_cb credentials",
+          "git_transport_certificate_check_cb certificate_check",
+          "git_indexer_progress_cb transfer_progress",
+          "int (*)(const char *, const git_oid *, const git_oid *, void *) update_tips",
+          "git_packbuilder_progress pack_progress",
+          "git_push_transfer_progress_cb push_transfer_progress",
+          "git_push_update_reference_cb push_update_reference",
+          "git_push_negotiation push_negotiation",
+          "git_transport_cb transport",
+          "void * payload",
+          "git_url_resolve_cb resolve_url"
+        ],
         "type": "struct",
         "value": "git_remote_callbacks",
-        "file": "git2/types.h",
-        "line": 245,
-        "lineto": 245,
-        "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_type, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_transfer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress push_transfer_progress\ngit_push_update_reference_cb push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload",
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "file": "git2/remote.h",
+        "line": 497,
+        "lineto": 585,
+        "block": "unsigned int version\ngit_transport_message_cb sideband_progress\nint (*)(git_remote_completion_t, void *) completion\ngit_cred_acquire_cb credentials\ngit_transport_certificate_check_cb certificate_check\ngit_indexer_progress_cb transfer_progress\nint (*)(const char *, const git_oid *, const git_oid *, void *) update_tips\ngit_packbuilder_progress pack_progress\ngit_push_transfer_progress_cb push_transfer_progress\ngit_push_update_reference_cb push_update_reference\ngit_push_negotiation push_negotiation\ngit_transport_cb transport\nvoid * payload\ngit_url_resolve_cb resolve_url",
+        "tdef": null,
+        "description": " The callback settings structure",
+        "comments": "<p>Set the callbacks to be called by the remote when informing the user about the progress of the network operations.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -38464,7 +34629,7 @@
             "comments": " Textual progress from the remote. Text send over the\n progress side-band will be passed to this function (this is\n the 'counting objects' output)."
           },
           {
-            "type": "int (*)(git_remote_completion_type, void *)",
+            "type": "int (*)(git_remote_completion_t, void *)",
             "name": "completion",
             "comments": ""
           },
@@ -38479,7 +34644,7 @@
             "comments": " If cert verification fails, this will be called to let the\n user make the final decision of whether to allow the\n connection to proceed. Returns 0 to allow the connection\n or a negative value to indicate an error."
           },
           {
-            "type": "git_transfer_progress_cb",
+            "type": "git_indexer_progress_cb",
             "name": "transfer_progress",
             "comments": " During the download of new data, this will be regularly\n called with the current count of progress done by the\n indexer."
           },
@@ -38494,7 +34659,7 @@
             "comments": " Function to call with progress information during pack\n building. Be aware that this is called inline with pack\n building operations, so performance may be affected."
           },
           {
-            "type": "git_push_transfer_progress",
+            "type": "git_push_transfer_progress_cb",
             "name": "push_transfer_progress",
             "comments": " Function to call with progress information during the\n upload portion of a push. Be aware that this is called\n inline with pack building operations, so performance may be\n affected."
           },
@@ -38517,6 +34682,11 @@
             "type": "void *",
             "name": "payload",
             "comments": " This will be passed to each of the callbacks in this struct\n as the last parameter."
+          },
+          {
+            "type": "git_url_resolve_cb",
+            "name": "resolve_url",
+            "comments": " Resolve URL before connecting to remote.\n The returned URL will be used to connect to the remote instead."
           }
         ],
         "used": {
@@ -38531,7 +34701,7 @@
       }
     ],
     [
-      "git_remote_completion_type",
+      "git_remote_completion_t",
       {
         "decl": [
           "GIT_REMOTE_COMPLETION_DOWNLOAD",
@@ -38625,7 +34795,7 @@
         "block": "unsigned int version\ngit_repository * repository\nconst char * name\nconst char * fetchspec\nunsigned int flags",
         "tdef": "typedef",
         "description": " Remote creation options structure",
-        "comments": "<p>Initialize with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_remote_create_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_REMOTE_CREATE_OPTIONS_INIT</code>. Alternatively, you can use <code>git_remote_create_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -38656,7 +34826,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_remote_create_init_options",
+            "git_remote_create_options_init",
             "git_remote_create_with_opts"
           ]
         }
@@ -38665,15 +34835,21 @@
     [
       "git_remote_head",
       {
-        "decl": "git_remote_head",
+        "decl": [
+          "int local",
+          "git_oid oid",
+          "git_oid loid",
+          "char * name",
+          "char * symref_target"
+        ],
         "type": "struct",
         "value": "git_remote_head",
-        "file": "git2/types.h",
-        "line": 244,
-        "lineto": 244,
+        "file": "git2/net.h",
+        "line": 40,
+        "lineto": 50,
         "block": "int local\ngit_oid oid\ngit_oid loid\nchar * name\nchar * symref_target",
-        "tdef": "typedef",
-        "description": "",
+        "tdef": null,
+        "description": " Description of a reference advertised by a remote server, given out\n on `ls` calls.",
         "comments": "",
         "fields": [
           {
@@ -38723,14 +34899,11 @@
         "tdef": "typedef",
         "description": " Representation of an existing git repository,\n including all its object contents",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_blob_owner",
             "git_commit_owner",
-            "git_filter_source_repo",
             "git_index_owner",
-            "git_merge_driver_source_repo",
             "git_object_owner",
             "git_reference_owner",
             "git_remote_owner",
@@ -38752,9 +34925,10 @@
             "git_attr_get",
             "git_attr_get_many",
             "git_blame_file",
-            "git_blob_create_frombuffer",
-            "git_blob_create_fromdisk",
-            "git_blob_create_fromstream",
+            "git_blob_create_from_buffer",
+            "git_blob_create_from_disk",
+            "git_blob_create_from_stream",
+            "git_blob_create_from_workdir",
             "git_blob_create_fromworkdir",
             "git_blob_lookup",
             "git_blob_lookup_prefix",
@@ -38773,14 +34947,11 @@
             "git_clone",
             "git_commit_create",
             "git_commit_create_buffer",
-            "git_commit_create_from_callback",
-            "git_commit_create_from_ids",
             "git_commit_create_v",
             "git_commit_create_with_signature",
             "git_commit_extract_signature",
             "git_commit_lookup",
             "git_commit_lookup_prefix",
-            "git_config_add_backend",
             "git_config_add_file_ondisk",
             "git_describe_workdir",
             "git_diff_commit_as_email",
@@ -38792,7 +34963,6 @@
             "git_diff_tree_to_workdir_with_index",
             "git_filter_list_apply_to_file",
             "git_filter_list_load",
-            "git_filter_list_new",
             "git_filter_list_stream_file",
             "git_graph_ahead_behind",
             "git_graph_descendant_of",
@@ -38801,7 +34971,6 @@
             "git_ignore_path_is_ignored",
             "git_index_write_tree_to",
             "git_mailmap_from_repository",
-            "git_mempack_dump",
             "git_merge",
             "git_merge_analysis",
             "git_merge_analysis_for_ref",
@@ -38828,7 +34997,6 @@
             "git_pathspec_match_workdir",
             "git_rebase_init",
             "git_rebase_open",
-            "git_refdb_backend_fs",
             "git_refdb_new",
             "git_refdb_open",
             "git_reference_create",
@@ -38863,7 +35031,6 @@
             "git_remote_set_autotag",
             "git_remote_set_pushurl",
             "git_remote_set_url",
-            "git_repository__cleanup",
             "git_repository_commondir",
             "git_repository_config",
             "git_repository_config_snapshot",
@@ -38882,7 +35049,7 @@
             "git_repository_index",
             "git_repository_init",
             "git_repository_init_ext",
-            "git_repository_init_init_options",
+            "git_repository_init_options_init",
             "git_repository_is_bare",
             "git_repository_is_empty",
             "git_repository_is_shallow",
@@ -38891,7 +35058,6 @@
             "git_repository_mergehead_foreach",
             "git_repository_message",
             "git_repository_message_remove",
-            "git_repository_new",
             "git_repository_odb",
             "git_repository_open",
             "git_repository_open_bare",
@@ -38899,22 +35065,14 @@
             "git_repository_open_from_worktree",
             "git_repository_path",
             "git_repository_refdb",
-            "git_repository_reinit_filesystem",
-            "git_repository_set_bare",
-            "git_repository_set_config",
             "git_repository_set_head",
             "git_repository_set_head_detached",
             "git_repository_set_head_detached_from_annotated",
             "git_repository_set_ident",
-            "git_repository_set_index",
             "git_repository_set_namespace",
-            "git_repository_set_odb",
-            "git_repository_set_refdb",
             "git_repository_set_workdir",
             "git_repository_state",
             "git_repository_state_cleanup",
-            "git_repository_submodule_cache_all",
-            "git_repository_submodule_cache_clear",
             "git_repository_workdir",
             "git_repository_wrap_odb",
             "git_reset",
@@ -38951,7 +35109,7 @@
             "git_submodule_status",
             "git_tag_annotation_create",
             "git_tag_create",
-            "git_tag_create_frombuffer",
+            "git_tag_create_from_buffer",
             "git_tag_create_lightweight",
             "git_tag_delete",
             "git_tag_foreach",
@@ -38992,7 +35150,7 @@
         "block": "GIT_REPOSITORY_INIT_BARE\nGIT_REPOSITORY_INIT_NO_REINIT\nGIT_REPOSITORY_INIT_NO_DOTGIT_DIR\nGIT_REPOSITORY_INIT_MKDIR\nGIT_REPOSITORY_INIT_MKPATH\nGIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE\nGIT_REPOSITORY_INIT_RELATIVE_GITLINK",
         "tdef": "typedef",
         "description": " Option flags for `git_repository_init_ext`.",
-        "comments": "<p>These flags configure extra behaviors to <code>git_repository_init_ext</code>.\n In every case, the default behavior is the zero value (i.e. flag is\n not set).  Just OR the flag values together for the <code>flags</code> parameter\n when initializing a new repo.  Details of individual values are:</p>\n\n<ul>\n<li>BARE   - Create a bare repository with no working directory.</li>\n<li>NO_REINIT - Return an GIT_EEXISTS error if the repo_path appears to\n    already be an git repository.</li>\n<li>NO_DOTGIT_DIR - Normally a &quot;/.git/&quot; will be appended to the repo\n    path for non-bare repos (if it is not already there), but\n    passing this flag prevents that behavior.</li>\n<li>MKDIR  - Make the repo_path (and workdir_path) as needed.  Init is\n    always willing to create the &quot;.git&quot; directory even without this\n    flag.  This flag tells init to create the trailing component of\n    the repo and workdir paths as needed.</li>\n<li>MKPATH - Recursively make all components of the repo and workdir\n    paths as necessary.</li>\n<li>EXTERNAL_TEMPLATE - libgit2 normally uses internal templates to\n    initialize a new repo.  This flags enables external templates,\n    looking the &quot;template_path&quot; from the options if set, or the\n    <code>init.templatedir</code> global config if not, or falling back on\n    &quot;/usr/share/git-core/templates&quot; if it exists.</li>\n<li>GIT_REPOSITORY_INIT_RELATIVE_GITLINK - If an alternate workdir is\n    specified, use relative paths for the gitdir and core.worktree.</li>\n</ul>\n",
+        "comments": "<p>These flags configure extra behaviors to <code>git_repository_init_ext</code>. In every case, the default behavior is the zero value (i.e. flag is not set).  Just OR the flag values together for the <code>flags</code> parameter when initializing a new repo.  Details of individual values are:</p>\n\n<ul>\n<li>BARE   - Create a bare repository with no working directory. * NO_REINIT - Return an GIT_EEXISTS error if the repo_path appears to        already be an git repository. * NO_DOTGIT_DIR - Normally a &quot;/.git/&quot; will be appended to the repo        path for non-bare repos (if it is not already there), but        passing this flag prevents that behavior. * MKDIR  - Make the repo_path (and workdir_path) as needed.  Init is        always willing to create the &quot;.git&quot; directory even without this        flag.  This flag tells init to create the trailing component of        the repo and workdir paths as needed. * MKPATH - Recursively make all components of the repo and workdir        paths as necessary. * EXTERNAL_TEMPLATE - libgit2 normally uses internal templates to        initialize a new repo.  This flags enables external templates,        looking the &quot;template_path&quot; from the options if set, or the        <code>init.templatedir</code> global config if not, or falling back on        &quot;/usr/share/git-core/templates&quot; if it exists. * GIT_REPOSITORY_INIT_RELATIVE_GITLINK - If an alternate workdir is        specified, use relative paths for the gitdir and core.worktree.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -39058,7 +35216,7 @@
         "block": "GIT_REPOSITORY_INIT_SHARED_UMASK\nGIT_REPOSITORY_INIT_SHARED_GROUP\nGIT_REPOSITORY_INIT_SHARED_ALL",
         "tdef": "typedef",
         "description": " Mode options for `git_repository_init_ext`.",
-        "comments": "<p>Set the mode field of the <code>git_repository_init_options</code> structure\n either to the custom mode that you would like, or to one of the\n following modes:</p>\n\n<ul>\n<li>SHARED_UMASK - Use permissions configured by umask - the default.</li>\n<li>SHARED_GROUP - Use &quot;--shared=group&quot; behavior, chmod&#39;ing the new repo\n    to be group writable and &quot;g+sx&quot; for sticky group assignment.</li>\n<li>SHARED_ALL - Use &quot;--shared=all&quot; behavior, adding world readability.</li>\n<li>Anything else - Set to custom value.</li>\n</ul>\n",
+        "comments": "<p>Set the mode field of the <code>git_repository_init_options</code> structure either to the custom mode that you would like, or to one of the following modes:</p>\n\n<ul>\n<li>SHARED_UMASK - Use permissions configured by umask - the default. * SHARED_GROUP - Use &quot;--shared=group&quot; behavior, chmod&#39;ing the new repo        to be group writable and &quot;g+sx&quot; for sticky group assignment. * SHARED_ALL - Use &quot;--shared=all&quot; behavior, adding world readability. * Anything else - Set to custom value.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -39090,8 +35248,8 @@
       {
         "decl": [
           "unsigned int version",
-          "int flags",
-          "int mode",
+          "uint32_t flags",
+          "uint32_t mode",
           "const char * workdir_path",
           "const char * description",
           "const char * template_path",
@@ -39103,10 +35261,10 @@
         "file": "git2/repository.h",
         "line": 302,
         "lineto": 311,
-        "block": "unsigned int version\nint flags\nint mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
+        "block": "unsigned int version\nuint32_t flags\nuint32_t mode\nconst char * workdir_path\nconst char * description\nconst char * template_path\nconst char * initial_head\nconst char * origin_url",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Extended options structure for `git_repository_init_ext`.",
+        "comments": "<p>This contains extra options for <code>git_repository_init_ext</code> that enable additional initialization features.  The fields are:</p>\n\n<ul>\n<li>flags - Combination of GIT_REPOSITORY_INIT flags above. * mode  - Set to one of the standard GIT_REPOSITORY_INIT_SHARED_...        constants above, or to a custom value that you would like. * workdir_path - The path to the working dir or NULL for default (i.e.        repo_path parent on non-bare repos).  IF THIS IS RELATIVE PATH,        IT WILL BE EVALUATED RELATIVE TO THE REPO_PATH.  If this is not        the &quot;natural&quot; working directory, a .git gitlink file will be        created here linking to the repo_path. * description - If set, this will be used to initialize the &quot;description&quot;        file in the repository, instead of using the template content. * template_path - When GIT_REPOSITORY_INIT_EXTERNAL_TEMPLATE is set,        this contains the path to use for the template directory.  If        this is NULL, the config or default directory options will be        used instead. * initial_head - The name of the head to point HEAD at.  If NULL, then        this will be treated as &quot;master&quot; and the HEAD ref will be set        to &quot;refs/heads/master&quot;.  If this begins with &quot;refs/&quot; it will be        used verbatim; otherwise &quot;refs/heads/&quot; will be prefixed. * origin_url - If this is non-NULL, then after the rest of the        repository initialization is completed, an &quot;origin&quot; remote        will be added pointing to this URL.</li>\n</ul>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -39114,12 +35272,12 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "mode",
             "comments": ""
           },
@@ -39153,7 +35311,7 @@
           "returns": [],
           "needs": [
             "git_repository_init_ext",
-            "git_repository_init_init_options"
+            "git_repository_init_options_init"
           ]
         }
       }
@@ -39354,12 +35512,12 @@
         ],
         "type": "enum",
         "file": "git2/repository.h",
-        "line": 799,
-        "lineto": 812,
+        "line": 820,
+        "lineto": 833,
         "block": "GIT_REPOSITORY_STATE_NONE\nGIT_REPOSITORY_STATE_MERGE\nGIT_REPOSITORY_STATE_REVERT\nGIT_REPOSITORY_STATE_REVERT_SEQUENCE\nGIT_REPOSITORY_STATE_CHERRYPICK\nGIT_REPOSITORY_STATE_CHERRYPICK_SEQUENCE\nGIT_REPOSITORY_STATE_BISECT\nGIT_REPOSITORY_STATE_REBASE\nGIT_REPOSITORY_STATE_REBASE_INTERACTIVE\nGIT_REPOSITORY_STATE_REBASE_MERGE\nGIT_REPOSITORY_STATE_APPLY_MAILBOX\nGIT_REPOSITORY_STATE_APPLY_MAILBOX_OR_REBASE",
         "tdef": "typedef",
         "description": " Repository state",
-        "comments": "<p>These values represent possible states for the repository to be in,\n based on the current operation which is ongoing.</p>\n",
+        "comments": "<p>These values represent possible states for the repository to be in, based on the current operation which is ongoing.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -39529,7 +35687,7 @@
           "returns": [],
           "needs": [
             "git_revert",
-            "git_revert_init_options"
+            "git_revert_options_init"
           ]
         }
       }
@@ -39630,7 +35788,6 @@
         "tdef": "typedef",
         "description": " Representation of an in-progress walk through the commits in a repo ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -39705,8 +35862,6 @@
             "git_commit_committer_with_mailmap",
             "git_commit_create",
             "git_commit_create_buffer",
-            "git_commit_create_from_callback",
-            "git_commit_create_from_ids",
             "git_commit_create_v",
             "git_mailmap_resolve_signature",
             "git_note_commit_create",
@@ -39772,126 +35927,6 @@
             "name": "GIT_SERVICE_RECEIVEPACK",
             "comments": "",
             "value": 4
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "git_smart_subtransport",
-      {
-        "decl": "git_smart_subtransport",
-        "type": "struct",
-        "value": "git_smart_subtransport",
-        "file": "git2/sys/transport.h",
-        "line": 294,
-        "lineto": 294,
-        "tdef": "typedef",
-        "description": " An implementation of a subtransport which carries data for the\n smart transport",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int (*)(git_smart_subtransport_stream **, git_smart_subtransport *, const char *, git_smart_service_t)",
-            "name": "action",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_smart_subtransport *)",
-            "name": "close",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_smart_subtransport *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_smart_subtransport_cb",
-            "git_smart_subtransport_git",
-            "git_smart_subtransport_http",
-            "git_smart_subtransport_ssh"
-          ]
-        }
-      }
-    ],
-    [
-      "git_smart_subtransport_definition",
-      {
-        "decl": [
-          "git_smart_subtransport_cb callback",
-          "unsigned int rpc",
-          "void * param"
-        ],
-        "type": "struct",
-        "value": "git_smart_subtransport_definition",
-        "file": "git2/sys/transport.h",
-        "line": 383,
-        "lineto": 395,
-        "block": "git_smart_subtransport_cb callback\nunsigned int rpc\nvoid * param",
-        "tdef": "typedef",
-        "description": " Definition for a \"subtransport\"",
-        "comments": "<p>The smart transport knows how to speak the git protocol, but it has no\n knowledge of how to establish a connection between it and another endpoint,\n or how to move data back and forth. For this, a subtransport interface is\n declared, and the smart transport delegates this work to the subtransports.</p>\n\n<p>Three subtransports are provided by libgit2: ssh, git, http(s).</p>\n\n<p>Subtransports can either be RPC = 0 (persistent connection) or RPC = 1\n (request/response). The smart transport handles the differences in its own\n logic. The git subtransport is RPC = 0, while http is RPC = 1.</p>\n",
-        "fields": [
-          {
-            "type": "git_smart_subtransport_cb",
-            "name": "callback",
-            "comments": " The function to use to create the git_smart_subtransport "
-          },
-          {
-            "type": "unsigned int",
-            "name": "rpc",
-            "comments": " True if the protocol is stateless; false otherwise. For example,\n http:// is stateless, but git:// is not."
-          },
-          {
-            "type": "void *",
-            "name": "param",
-            "comments": " User-specified parameter passed to the callback "
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
-        }
-      }
-    ],
-    [
-      "git_smart_subtransport_stream",
-      {
-        "decl": "git_smart_subtransport_stream",
-        "type": "struct",
-        "value": "git_smart_subtransport_stream",
-        "file": "git2/sys/transport.h",
-        "line": 295,
-        "lineto": 295,
-        "tdef": "typedef",
-        "description": " A stream used by the smart transport to read and write data\n from a subtransport.",
-        "comments": "<p>This provides a customization point in case you need to\n support some other communication method.</p>\n",
-        "fields": [
-          {
-            "type": "git_smart_subtransport *",
-            "name": "subtransport",
-            "comments": " The owning subtransport "
-          },
-          {
-            "type": "int (*)(git_smart_subtransport_stream *, char *, size_t, size_t *)",
-            "name": "read",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_smart_subtransport_stream *, const char *, size_t)",
-            "name": "write",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_smart_subtransport_stream *)",
-            "name": "free",
-            "comments": ""
           }
         ],
         "used": {
@@ -40002,7 +36037,7 @@
         "block": "unsigned int version\ngit_stash_apply_flags flags\ngit_checkout_options checkout_options\ngit_stash_apply_progress_cb progress_cb\nvoid * progress_payload",
         "tdef": "typedef",
         "description": " Stash application options structure",
-        "comments": "<p>Initialize with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_stash_apply_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_STASH_APPLY_OPTIONS_INIT</code>. Alternatively, you can use <code>git_stash_apply_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -40034,7 +36069,7 @@
           "returns": [],
           "needs": [
             "git_stash_apply",
-            "git_stash_apply_init_options",
+            "git_stash_apply_options_init",
             "git_stash_pop"
           ]
         }
@@ -40184,7 +36219,7 @@
         "block": "git_status_t status\ngit_diff_delta * head_to_index\ngit_diff_delta * index_to_workdir",
         "tdef": "typedef",
         "description": " A status entry, providing the differences between the file as it exists\n in HEAD and the index, and providing the differences between the index\n and the working directory.",
-        "comments": "<p>The <code>status</code> value provides the status flags for this file.</p>\n\n<p>The <code>head_to_index</code> value provides detailed information about the\n differences between the file in HEAD and the file in the index.</p>\n\n<p>The <code>index_to_workdir</code> value provides detailed information about the\n differences between the file in the index and the file in the\n working directory.</p>\n",
+        "comments": "<p>The <code>status</code> value provides the status flags for this file.</p>\n\n<p>The <code>head_to_index</code> value provides detailed information about the differences between the file in HEAD and the file in the index.</p>\n\n<p>The <code>index_to_workdir</code> value provides detailed information about the differences between the file in the index and the file in the working directory.</p>\n",
         "fields": [
           {
             "type": "git_status_t",
@@ -40222,14 +36257,12 @@
         "tdef": "typedef",
         "description": " Representation of a status collection ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
             "git_status_byindex",
             "git_status_list_entrycount",
             "git_status_list_free",
-            "git_status_list_get_perfdata",
             "git_status_list_new"
           ]
         }
@@ -40263,7 +36296,7 @@
         "block": "GIT_STATUS_OPT_INCLUDE_UNTRACKED\nGIT_STATUS_OPT_INCLUDE_IGNORED\nGIT_STATUS_OPT_INCLUDE_UNMODIFIED\nGIT_STATUS_OPT_EXCLUDE_SUBMODULES\nGIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS\nGIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH\nGIT_STATUS_OPT_RECURSE_IGNORED_DIRS\nGIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX\nGIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR\nGIT_STATUS_OPT_SORT_CASE_SENSITIVELY\nGIT_STATUS_OPT_SORT_CASE_INSENSITIVELY\nGIT_STATUS_OPT_RENAMES_FROM_REWRITES\nGIT_STATUS_OPT_NO_REFRESH\nGIT_STATUS_OPT_UPDATE_INDEX\nGIT_STATUS_OPT_INCLUDE_UNREADABLE\nGIT_STATUS_OPT_INCLUDE_UNREADABLE_AS_UNTRACKED",
         "tdef": "typedef",
         "description": " Flags to control status callbacks",
-        "comments": "<ul>\n<li>GIT_STATUS_OPT_INCLUDE_UNTRACKED says that callbacks should be made\non untracked files.  These will only be made if the workdir files are\nincluded in the status &quot;show&quot; option.</li>\n<li>GIT_STATUS_OPT_INCLUDE_IGNORED says that ignored files get callbacks.\nAgain, these callbacks will only be made if the workdir files are\nincluded in the status &quot;show&quot; option.</li>\n<li>GIT_STATUS_OPT_INCLUDE_UNMODIFIED indicates that callback should be\nmade even on unmodified files.</li>\n<li>GIT_STATUS_OPT_EXCLUDE_SUBMODULES indicates that submodules should be\nskipped.  This only applies if there are no pending typechanges to\nthe submodule (either from or to another type).</li>\n<li>GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS indicates that all files in\nuntracked directories should be included.  Normally if an entire\ndirectory is new, then just the top-level directory is included (with\na trailing slash on the entry name).  This flag says to include all\nof the individual files in the directory instead.</li>\n<li>GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH indicates that the given path\nshould be treated as a literal path, and not as a pathspec pattern.</li>\n<li>GIT_STATUS_OPT_RECURSE_IGNORED_DIRS indicates that the contents of\nignored directories should be included in the status.  This is like\ndoing <code>git ls-files -o -i --exclude-standard</code> with core git.</li>\n<li>GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX indicates that rename detection\nshould be processed between the head and the index and enables\nthe GIT_STATUS_INDEX_RENAMED as a possible status flag.</li>\n<li>GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates that rename\ndetection should be run between the index and the working directory\nand enabled GIT_STATUS_WT_RENAMED as a possible status flag.</li>\n<li>GIT_STATUS_OPT_SORT_CASE_SENSITIVELY overrides the native case\nsensitivity for the file system and forces the output to be in\ncase-sensitive order</li>\n<li>GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY overrides the native case\nsensitivity for the file system and forces the output to be in\ncase-insensitive order</li>\n<li>GIT_STATUS_OPT_RENAMES_FROM_REWRITES indicates that rename detection\nshould include rewritten files</li>\n<li>GIT_STATUS_OPT_NO_REFRESH bypasses the default status behavior of\ndoing a &quot;soft&quot; index reload (i.e. reloading the index data if the\nfile on disk has been modified outside libgit2).</li>\n<li>GIT_STATUS_OPT_UPDATE_INDEX tells libgit2 to refresh the stat cache\nin the index for files that are unchanged but have out of date stat\ninformation in the index.  It will result in less work being done on\nsubsequent calls to get status.  This is mutually exclusive with the\nNO_REFRESH option.</li>\n</ul>\n\n<p>Calling <code>git_status_foreach()</code> is like calling the extended version\n with: GIT_STATUS_OPT_INCLUDE_IGNORED, GIT_STATUS_OPT_INCLUDE_UNTRACKED,\n and GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS.  Those options are bundled\n together as <code>GIT_STATUS_OPT_DEFAULTS</code> if you want them as a baseline.</p>\n",
+        "comments": "<ul>\n<li>GIT_STATUS_OPT_INCLUDE_UNTRACKED says that callbacks should be made   on untracked files.  These will only be made if the workdir files are   included in the status &quot;show&quot; option. - GIT_STATUS_OPT_INCLUDE_IGNORED says that ignored files get callbacks.   Again, these callbacks will only be made if the workdir files are   included in the status &quot;show&quot; option. - GIT_STATUS_OPT_INCLUDE_UNMODIFIED indicates that callback should be   made even on unmodified files. - GIT_STATUS_OPT_EXCLUDE_SUBMODULES indicates that submodules should be   skipped.  This only applies if there are no pending typechanges to   the submodule (either from or to another type). - GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS indicates that all files in   untracked directories should be included.  Normally if an entire   directory is new, then just the top-level directory is included (with   a trailing slash on the entry name).  This flag says to include all   of the individual files in the directory instead. - GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH indicates that the given path   should be treated as a literal path, and not as a pathspec pattern. - GIT_STATUS_OPT_RECURSE_IGNORED_DIRS indicates that the contents of   ignored directories should be included in the status.  This is like   doing <code>git ls-files -o -i --exclude-standard</code> with core git. - GIT_STATUS_OPT_RENAMES_HEAD_TO_INDEX indicates that rename detection   should be processed between the head and the index and enables   the GIT_STATUS_INDEX_RENAMED as a possible status flag. - GIT_STATUS_OPT_RENAMES_INDEX_TO_WORKDIR indicates that rename   detection should be run between the index and the working directory   and enabled GIT_STATUS_WT_RENAMED as a possible status flag. - GIT_STATUS_OPT_SORT_CASE_SENSITIVELY overrides the native case   sensitivity for the file system and forces the output to be in   case-sensitive order - GIT_STATUS_OPT_SORT_CASE_INSENSITIVELY overrides the native case   sensitivity for the file system and forces the output to be in   case-insensitive order - GIT_STATUS_OPT_RENAMES_FROM_REWRITES indicates that rename detection   should include rewritten files - GIT_STATUS_OPT_NO_REFRESH bypasses the default status behavior of   doing a &quot;soft&quot; index reload (i.e. reloading the index data if the   file on disk has been modified outside libgit2). - GIT_STATUS_OPT_UPDATE_INDEX tells libgit2 to refresh the stat cache   in the index for files that are unchanged but have out of date stat   information in the index.  It will result in less work being done on   subsequent calls to get status.  This is mutually exclusive with the   NO_REFRESH option.</li>\n</ul>\n\n<p>Calling <code>git_status_foreach()</code> is like calling the extended version with: GIT_STATUS_OPT_INCLUDE_IGNORED, GIT_STATUS_OPT_INCLUDE_UNTRACKED, and GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS.  Those options are bundled together as <code>GIT_STATUS_OPT_DEFAULTS</code> if you want them as a baseline.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -40386,7 +36419,7 @@
         "block": "unsigned int version\ngit_status_show_t show\nunsigned int flags\ngit_strarray pathspec\ngit_tree * baseline",
         "tdef": "typedef",
         "description": " Options to control how `git_status_foreach_ext()` will issue callbacks.",
-        "comments": "<p>This structure is set so that zeroing it out will give you relatively\n sane defaults.</p>\n\n<p>The <code>show</code> value is one of the <code>git_status_show_t</code> constants that\n control which files to scan and in what order.</p>\n\n<p>The <code>flags</code> value is an OR&#39;ed combination of the <code>git_status_opt_t</code>\n values above.</p>\n\n<p>The <code>pathspec</code> is an array of path patterns to match (using\n fnmatch-style matching), or just an array of paths to match exactly if\n <code>GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH</code> is specified in the flags.</p>\n\n<p>The <code>baseline</code> is the tree to be used for comparison to the working directory\n and index; defaults to HEAD.</p>\n",
+        "comments": "<p>This structure is set so that zeroing it out will give you relatively sane defaults.</p>\n\n<p>The <code>show</code> value is one of the <code>git_status_show_t</code> constants that control which files to scan and in what order.</p>\n\n<p>The <code>flags</code> value is an OR&#39;ed combination of the <code>git_status_opt_t</code> values above.</p>\n\n<p>The <code>pathspec</code> is an array of path patterns to match (using fnmatch-style matching), or just an array of paths to match exactly if <code>GIT_STATUS_OPT_DISABLE_PATHSPEC_MATCH</code> is specified in the flags.</p>\n\n<p>The <code>baseline</code> is the tree to be used for comparison to the working directory and index; defaults to HEAD.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -40418,8 +36451,8 @@
           "returns": [],
           "needs": [
             "git_status_foreach_ext",
-            "git_status_init_options",
-            "git_status_list_new"
+            "git_status_list_new",
+            "git_status_options_init"
           ]
         }
       }
@@ -40439,7 +36472,7 @@
         "block": "GIT_STATUS_SHOW_INDEX_AND_WORKDIR\nGIT_STATUS_SHOW_INDEX_ONLY\nGIT_STATUS_SHOW_WORKDIR_ONLY",
         "tdef": "typedef",
         "description": " Select the files on which to report status.",
-        "comments": "<p>With <code>git_status_foreach_ext</code>, this will control which changes get\n callbacks.  With <code>git_status_list_new</code>, these will control which\n changes are included in the list.</p>\n\n<ul>\n<li>GIT_STATUS_SHOW_INDEX_AND_WORKDIR is the default.  This roughly\nmatches <code>git status --porcelain</code> regarding which files are\nincluded and in what order.</li>\n<li>GIT_STATUS_SHOW_INDEX_ONLY only gives status based on HEAD to index\ncomparison, not looking at working directory changes.</li>\n<li>GIT_STATUS_SHOW_WORKDIR_ONLY only gives status based on index to\nworking directory comparison, not comparing the index to the HEAD.</li>\n</ul>\n",
+        "comments": "<p>With <code>git_status_foreach_ext</code>, this will control which changes get callbacks.  With <code>git_status_list_new</code>, these will control which changes are included in the list.</p>\n\n<ul>\n<li>GIT_STATUS_SHOW_INDEX_AND_WORKDIR is the default.  This roughly   matches <code>git status --porcelain</code> regarding which files are   included and in what order. - GIT_STATUS_SHOW_INDEX_ONLY only gives status based on HEAD to index   comparison, not looking at working directory changes. - GIT_STATUS_SHOW_WORKDIR_ONLY only gives status based on index to   working directory comparison, not comparing the index to the HEAD.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -40492,7 +36525,7 @@
         "block": "GIT_STATUS_CURRENT\nGIT_STATUS_INDEX_NEW\nGIT_STATUS_INDEX_MODIFIED\nGIT_STATUS_INDEX_DELETED\nGIT_STATUS_INDEX_RENAMED\nGIT_STATUS_INDEX_TYPECHANGE\nGIT_STATUS_WT_NEW\nGIT_STATUS_WT_MODIFIED\nGIT_STATUS_WT_DELETED\nGIT_STATUS_WT_TYPECHANGE\nGIT_STATUS_WT_RENAMED\nGIT_STATUS_WT_UNREADABLE\nGIT_STATUS_IGNORED\nGIT_STATUS_CONFLICTED",
         "tdef": "typedef",
         "description": " Status flags for a single file.",
-        "comments": "<p>A combination of these values will be returned to indicate the status of\n a file.  Status compares the working directory, the index, and the\n current HEAD of the repository.  The <code>GIT_STATUS_INDEX</code> set of flags\n represents the status of file in the index relative to the HEAD, and the\n <code>GIT_STATUS_WT</code> set of flags represent the status of the file in the\n working directory relative to the index.</p>\n",
+        "comments": "<p>A combination of these values will be returned to indicate the status of a file.  Status compares the working directory, the index, and the current HEAD of the repository.  The <code>GIT_STATUS_INDEX</code> set of flags represents the status of file in the index relative to the HEAD, and the <code>GIT_STATUS_WT</code> set of flags represent the status of the file in the working directory relative to the index.</p>\n",
         "fields": [
           {
             "type": "int",
@@ -40641,128 +36674,6 @@
       }
     ],
     [
-      "git_stream",
-      {
-        "decl": [
-          "int version",
-          "int encrypted",
-          "int proxy_support",
-          "int (*)(struct git_stream *) connect",
-          "int (*)(git_cert **, struct git_stream *) certificate",
-          "int (*)(struct git_stream *, const git_proxy_options *) set_proxy",
-          "int ((int *))(struct git_stream *, void *, size_t) ssize_t",
-          "int (*)(struct git_stream *) close",
-          "void (*)(struct git_stream *) free"
-        ],
-        "type": "struct",
-        "value": "git_stream",
-        "file": "git2/sys/stream.h",
-        "line": 29,
-        "lineto": 41,
-        "block": "int version\nint encrypted\nint proxy_support\nint (*)(struct git_stream *) connect\nint (*)(git_cert **, struct git_stream *) certificate\nint (*)(struct git_stream *, const git_proxy_options *) set_proxy\nint ((int *))(struct git_stream *, void *, size_t) ssize_t\nint (*)(struct git_stream *) close\nvoid (*)(struct git_stream *) free",
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "version",
-            "comments": ""
-          },
-          {
-            "type": "int",
-            "name": "encrypted",
-            "comments": ""
-          },
-          {
-            "type": "int",
-            "name": "proxy_support",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_stream *)",
-            "name": "connect",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_cert **, struct git_stream *)",
-            "name": "certificate",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_stream *, const git_proxy_options *)",
-            "name": "set_proxy",
-            "comments": ""
-          },
-          {
-            "type": "int ((int *))(struct git_stream *, void *, size_t)",
-            "name": "ssize_t",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(struct git_stream *)",
-            "name": "close",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(struct git_stream *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_stream_cb",
-            "git_stream_register",
-            "git_stream_register_tls"
-          ]
-        }
-      }
-    ],
-    [
-      "git_stream_registration",
-      {
-        "decl": [
-          "int version",
-          "int (*)(git_stream **, const char *, const char *) init",
-          "int (*)(git_stream **, git_stream *, const char *) wrap"
-        ],
-        "type": "struct",
-        "value": "git_stream_registration",
-        "file": "git2/sys/stream.h",
-        "line": 43,
-        "lineto": 72,
-        "block": "int version\nint (*)(git_stream **, const char *, const char *) init\nint (*)(git_stream **, git_stream *, const char *) wrap",
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "fields": [
-          {
-            "type": "int",
-            "name": "version",
-            "comments": " The `version` field should be set to `GIT_STREAM_VERSION`. "
-          },
-          {
-            "type": "int (*)(git_stream **, const char *, const char *)",
-            "name": "init",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_stream **, git_stream *, const char *)",
-            "name": "wrap",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": [
-            "git_stream_register"
-          ]
-        }
-      }
-    ],
-    [
       "git_stream_t",
       {
         "decl": [
@@ -40793,9 +36704,7 @@
         ],
         "used": {
           "returns": [],
-          "needs": [
-            "git_stream_register"
-          ]
+          "needs": []
         }
       }
     ],
@@ -40806,12 +36715,11 @@
         "type": "struct",
         "value": "git_submodule",
         "file": "git2/types.h",
-        "line": 343,
-        "lineto": 343,
+        "line": 313,
+        "lineto": 313,
         "tdef": "typedef",
         "description": " Opaque structure representing a submodule.",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_submodule_fetch_recurse_submodules",
@@ -40845,7 +36753,7 @@
             "git_submodule_status",
             "git_submodule_sync",
             "git_submodule_update",
-            "git_submodule_update_init_options",
+            "git_submodule_update_options_init",
             "git_submodule_update_strategy",
             "git_submodule_url",
             "git_submodule_wd_id"
@@ -40865,12 +36773,12 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 407,
-        "lineto": 414,
+        "line": 377,
+        "lineto": 384,
         "block": "GIT_SUBMODULE_IGNORE_UNSPECIFIED\nGIT_SUBMODULE_IGNORE_NONE\nGIT_SUBMODULE_IGNORE_UNTRACKED\nGIT_SUBMODULE_IGNORE_DIRTY\nGIT_SUBMODULE_IGNORE_ALL",
         "tdef": "typedef",
         "description": " Submodule ignore values",
-        "comments": "<p>These values represent settings for the <code>submodule.$name.ignore</code>\n configuration value which says how deeply to look at the working\n directory when getting submodule status.</p>\n\n<p>You can override this value in memory on a per-submodule basis with\n <code>git_submodule_set_ignore()</code> and can write the changed value to disk\n with <code>git_submodule_save()</code>.  If you have overwritten the value, you\n can revert to the on disk value by using <code>GIT_SUBMODULE_IGNORE_RESET</code>.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_IGNORE_UNSPECIFIED: use the submodule&#39;s configuration</li>\n<li>GIT_SUBMODULE_IGNORE_NONE: don&#39;t ignore any change - i.e. even an\nuntracked file, will mark the submodule as dirty.  Ignored files are\nstill ignored, of course.</li>\n<li>GIT_SUBMODULE_IGNORE_UNTRACKED: ignore untracked files; only changes\nto tracked files, or the index or the HEAD commit will matter.</li>\n<li>GIT_SUBMODULE_IGNORE_DIRTY: ignore changes in the working directory,\nonly considering changes if the HEAD of submodule has moved from the\nvalue in the superproject.</li>\n<li>GIT_SUBMODULE_IGNORE_ALL: never check if the submodule is dirty</li>\n<li>GIT_SUBMODULE_IGNORE_DEFAULT: not used except as static initializer\nwhen we don&#39;t want any particular ignore rule to be specified.</li>\n</ul>\n",
+        "comments": "<p>These values represent settings for the <code>submodule.$name.ignore</code> configuration value which says how deeply to look at the working directory when getting submodule status.</p>\n\n<p>You can override this value in memory on a per-submodule basis with <code>git_submodule_set_ignore()</code> and can write the changed value to disk with <code>git_submodule_save()</code>.  If you have overwritten the value, you can revert to the on disk value by using <code>GIT_SUBMODULE_IGNORE_RESET</code>.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_IGNORE_UNSPECIFIED: use the submodule&#39;s configuration - GIT_SUBMODULE_IGNORE_NONE: don&#39;t ignore any change - i.e. even an   untracked file, will mark the submodule as dirty.  Ignored files are   still ignored, of course. - GIT_SUBMODULE_IGNORE_UNTRACKED: ignore untracked files; only changes   to tracked files, or the index or the HEAD commit will matter. - GIT_SUBMODULE_IGNORE_DIRTY: ignore changes in the working directory,   only considering changes if the HEAD of submodule has moved from the   value in the superproject. - GIT_SUBMODULE_IGNORE_ALL: never check if the submodule is dirty - GIT_SUBMODULE_IGNORE_DEFAULT: not used except as static initializer   when we don&#39;t want any particular ignore rule to be specified.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -40924,12 +36832,12 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 426,
-        "lineto": 430,
+        "line": 396,
+        "lineto": 400,
         "block": "GIT_SUBMODULE_RECURSE_NO\nGIT_SUBMODULE_RECURSE_YES\nGIT_SUBMODULE_RECURSE_ONDEMAND",
         "tdef": "typedef",
         "description": " Options for submodule recurse.",
-        "comments": "<p>Represent the value of <code>submodule.$name.fetchRecurseSubmodules</code></p>\n\n<ul>\n<li>GIT_SUBMODULE_RECURSE_NO    - do no recurse into submodules</li>\n<li>GIT_SUBMODULE_RECURSE_YES   - recurse into submodules</li>\n<li>GIT_SUBMODULE_RECURSE_ONDEMAND - recurse into submodules only when\n                                commit not already in local clone</li>\n</ul>\n",
+        "comments": "<p>Represent the value of <code>submodule.$name.fetchRecurseSubmodules</code></p>\n\n<ul>\n<li>GIT_SUBMODULE_RECURSE_NO    - do no recurse into submodules * GIT_SUBMODULE_RECURSE_YES   - recurse into submodules * GIT_SUBMODULE_RECURSE_ONDEMAND - recurse into submodules only when                                    commit not already in local clone</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -40986,7 +36894,7 @@
         "block": "GIT_SUBMODULE_STATUS_IN_HEAD\nGIT_SUBMODULE_STATUS_IN_INDEX\nGIT_SUBMODULE_STATUS_IN_CONFIG\nGIT_SUBMODULE_STATUS_IN_WD\nGIT_SUBMODULE_STATUS_INDEX_ADDED\nGIT_SUBMODULE_STATUS_INDEX_DELETED\nGIT_SUBMODULE_STATUS_INDEX_MODIFIED\nGIT_SUBMODULE_STATUS_WD_UNINITIALIZED\nGIT_SUBMODULE_STATUS_WD_ADDED\nGIT_SUBMODULE_STATUS_WD_DELETED\nGIT_SUBMODULE_STATUS_WD_MODIFIED\nGIT_SUBMODULE_STATUS_WD_INDEX_MODIFIED\nGIT_SUBMODULE_STATUS_WD_WD_MODIFIED\nGIT_SUBMODULE_STATUS_WD_UNTRACKED",
         "tdef": "typedef",
         "description": " Return codes for submodule status.",
-        "comments": "<p>A combination of these flags will be returned to describe the status of a\n submodule.  Depending on the &quot;ignore&quot; property of the submodule, some of\n the flags may never be returned because they indicate changes that are\n supposed to be ignored.</p>\n\n<p>Submodule info is contained in 4 places: the HEAD tree, the index, config\n files (both .git/config and .gitmodules), and the working directory.  Any\n or all of those places might be missing information about the submodule\n depending on what state the repo is in.  We consider all four places to\n build the combination of status flags.</p>\n\n<p>There are four values that are not really status, but give basic info\n about what sources of submodule data are available.  These will be\n returned even if ignore is set to &quot;ALL&quot;.</p>\n\n<ul>\n<li>IN_HEAD   - superproject head contains submodule</li>\n<li>IN_INDEX  - superproject index contains submodule</li>\n<li>IN_CONFIG - superproject gitmodules has submodule</li>\n<li>IN_WD     - superproject workdir has submodule</li>\n</ul>\n\n<p>The following values will be returned so long as ignore is not &quot;ALL&quot;.</p>\n\n<ul>\n<li>INDEX_ADDED       - in index, not in head</li>\n<li>INDEX_DELETED     - in head, not in index</li>\n<li>INDEX_MODIFIED    - index and head don&#39;t match</li>\n<li>WD_UNINITIALIZED  - workdir contains empty directory</li>\n<li>WD_ADDED          - in workdir, not index</li>\n<li>WD_DELETED        - in index, not workdir</li>\n<li>WD_MODIFIED       - index and workdir head don&#39;t match</li>\n</ul>\n\n<p>The following can only be returned if ignore is &quot;NONE&quot; or &quot;UNTRACKED&quot;.</p>\n\n<ul>\n<li>WD_INDEX_MODIFIED - submodule workdir index is dirty</li>\n<li>WD_WD_MODIFIED    - submodule workdir has modified files</li>\n</ul>\n\n<p>Lastly, the following will only be returned for ignore &quot;NONE&quot;.</p>\n\n<ul>\n<li>WD_UNTRACKED      - wd contains untracked files</li>\n</ul>\n",
+        "comments": "<p>A combination of these flags will be returned to describe the status of a submodule.  Depending on the &quot;ignore&quot; property of the submodule, some of the flags may never be returned because they indicate changes that are supposed to be ignored.</p>\n\n<p>Submodule info is contained in 4 places: the HEAD tree, the index, config files (both .git/config and .gitmodules), and the working directory.  Any or all of those places might be missing information about the submodule depending on what state the repo is in.  We consider all four places to build the combination of status flags.</p>\n\n<p>There are four values that are not really status, but give basic info about what sources of submodule data are available.  These will be returned even if ignore is set to &quot;ALL&quot;.</p>\n\n<ul>\n<li>IN_HEAD   - superproject head contains submodule * IN_INDEX  - superproject index contains submodule * IN_CONFIG - superproject gitmodules has submodule * IN_WD     - superproject workdir has submodule</li>\n</ul>\n\n<p>The following values will be returned so long as ignore is not &quot;ALL&quot;.</p>\n\n<ul>\n<li>INDEX_ADDED       - in index, not in head * INDEX_DELETED     - in head, not in index * INDEX_MODIFIED    - index and head don&#39;t match * WD_UNINITIALIZED  - workdir contains empty directory * WD_ADDED          - in workdir, not index * WD_DELETED        - in index, not workdir * WD_MODIFIED       - index and workdir head don&#39;t match</li>\n</ul>\n\n<p>The following can only be returned if ignore is &quot;NONE&quot; or &quot;UNTRACKED&quot;.</p>\n\n<ul>\n<li>WD_INDEX_MODIFIED - submodule workdir index is dirty * WD_WD_MODIFIED    - submodule workdir has modified files</li>\n</ul>\n\n<p>Lastly, the following will only be returned for ignore &quot;NONE&quot;.</p>\n\n<ul>\n<li>WD_UNTRACKED      - wd contains untracked files</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -41096,7 +37004,7 @@
         "block": "unsigned int version\ngit_checkout_options checkout_opts\ngit_fetch_options fetch_opts\nint allow_fetch",
         "tdef": "typedef",
         "description": " Submodule update options structure",
-        "comments": "<p>Initialize with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_submodule_update_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_SUBMODULE_UPDATE_OPTIONS_INIT</code>. Alternatively, you can use <code>git_submodule_update_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -41123,7 +37031,7 @@
           "returns": [],
           "needs": [
             "git_submodule_update",
-            "git_submodule_update_init_options"
+            "git_submodule_update_options_init"
           ]
         }
       }
@@ -41140,12 +37048,12 @@
         ],
         "type": "enum",
         "file": "git2/types.h",
-        "line": 371,
-        "lineto": 378,
+        "line": 341,
+        "lineto": 348,
         "block": "GIT_SUBMODULE_UPDATE_CHECKOUT\nGIT_SUBMODULE_UPDATE_REBASE\nGIT_SUBMODULE_UPDATE_MERGE\nGIT_SUBMODULE_UPDATE_NONE\nGIT_SUBMODULE_UPDATE_DEFAULT",
         "tdef": "typedef",
         "description": " Submodule update values",
-        "comments": "<p>These values represent settings for the <code>submodule.$name.update</code>\n configuration value which says how to handle <code>git submodule update</code> for\n this submodule.  The value is usually set in the &quot;.gitmodules&quot; file and\n copied to &quot;.git/config&quot; when the submodule is initialized.</p>\n\n<p>You can override this setting on a per-submodule basis with\n <code>git_submodule_set_update()</code> and write the changed value to disk using\n <code>git_submodule_save()</code>.  If you have overwritten the value, you can\n revert it by passing <code>GIT_SUBMODULE_UPDATE_RESET</code> to the set function.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_UPDATE_CHECKOUT: the default; when a submodule is\nupdated, checkout the new detached HEAD to the submodule directory.</li>\n<li>GIT_SUBMODULE_UPDATE_REBASE: update by rebasing the current checked\nout branch onto the commit from the superproject.</li>\n<li>GIT_SUBMODULE_UPDATE_MERGE: update by merging the commit in the\nsuperproject into the current checkout out branch of the submodule.</li>\n<li>GIT_SUBMODULE_UPDATE_NONE: do not update this submodule even when\nthe commit in the superproject is updated.</li>\n<li>GIT_SUBMODULE_UPDATE_DEFAULT: not used except as static initializer\nwhen we don&#39;t want any particular update rule to be specified.</li>\n</ul>\n",
+        "comments": "<p>These values represent settings for the <code>submodule.$name.update</code> configuration value which says how to handle <code>git submodule update</code> for this submodule.  The value is usually set in the &quot;.gitmodules&quot; file and copied to &quot;.git/config&quot; when the submodule is initialized.</p>\n\n<p>You can override this setting on a per-submodule basis with <code>git_submodule_set_update()</code> and write the changed value to disk using <code>git_submodule_save()</code>.  If you have overwritten the value, you can revert it by passing <code>GIT_SUBMODULE_UPDATE_RESET</code> to the set function.</p>\n\n<p>The values are:</p>\n\n<ul>\n<li>GIT_SUBMODULE_UPDATE_CHECKOUT: the default; when a submodule is   updated, checkout the new detached HEAD to the submodule directory. - GIT_SUBMODULE_UPDATE_REBASE: update by rebasing the current checked   out branch onto the commit from the superproject. - GIT_SUBMODULE_UPDATE_MERGE: update by merging the commit in the   superproject into the current checkout out branch of the submodule. - GIT_SUBMODULE_UPDATE_NONE: do not update this submodule even when   the commit in the superproject is updated. - GIT_SUBMODULE_UPDATE_DEFAULT: not used except as static initializer   when we don&#39;t want any particular update rule to be specified.</li>\n</ul>\n",
         "fields": [
           {
             "type": "int",
@@ -41200,7 +37108,6 @@
         "tdef": "typedef",
         "description": " Parsed representation of a tag object. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -41333,7 +37240,7 @@
         "used": {
           "returns": [],
           "needs": [
-            "git_trace_callback",
+            "git_trace_cb",
             "git_trace_set"
           ]
         }
@@ -41351,7 +37258,6 @@
         "tdef": "typedef",
         "description": " Transactional interface to references ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -41369,78 +37275,6 @@
       }
     ],
     [
-      "git_transfer_progress",
-      {
-        "decl": [
-          "unsigned int total_objects",
-          "unsigned int indexed_objects",
-          "unsigned int received_objects",
-          "unsigned int local_objects",
-          "unsigned int total_deltas",
-          "unsigned int indexed_deltas",
-          "size_t received_bytes"
-        ],
-        "type": "struct",
-        "value": "git_transfer_progress",
-        "file": "git2/types.h",
-        "line": 258,
-        "lineto": 266,
-        "block": "unsigned int total_objects\nunsigned int indexed_objects\nunsigned int received_objects\nunsigned int local_objects\nunsigned int total_deltas\nunsigned int indexed_deltas\nsize_t received_bytes",
-        "tdef": "typedef",
-        "description": " This is passed as the first argument to the callback to allow the\n user to see the progress.",
-        "comments": "<ul>\n<li>total_objects: number of objects in the packfile being downloaded</li>\n<li>indexed_objects: received objects that have been hashed</li>\n<li>received_objects: objects which have been downloaded</li>\n<li>local_objects: locally-available objects that have been injected\nin order to fix a thin pack.</li>\n<li>received-bytes: size of the packfile received up to now</li>\n</ul>\n",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "total_objects",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "indexed_objects",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "received_objects",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "local_objects",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "total_deltas",
-            "comments": ""
-          },
-          {
-            "type": "unsigned int",
-            "name": "indexed_deltas",
-            "comments": ""
-          },
-          {
-            "type": "size_t",
-            "name": "received_bytes",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [
-            "git_remote_stats"
-          ],
-          "needs": [
-            "git_indexer_append",
-            "git_indexer_commit",
-            "git_odb_write_pack",
-            "git_packbuilder_write",
-            "git_transfer_progress_cb"
-          ]
-        }
-      }
-    ],
-    [
       "git_transport",
       {
         "decl": "git_transport",
@@ -41449,124 +37283,14 @@
         "file": "git2/types.h",
         "line": 235,
         "lineto": 235,
-        "block": "unsigned int version\nint (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *) set_callbacks\nint (*)(git_transport *, const git_strarray *) set_custom_headers\nint (*)(git_transport *, const char *, git_cred_acquire_cb, void *, const git_proxy_options *, int, int) connect\nint (*)(const git_remote_head ***, size_t *, git_transport *) ls\nint (*)(git_transport *, git_push *, const git_remote_callbacks *) push\nint (*)(git_transport *, git_repository *, const git_remote_head *const *, size_t) negotiate_fetch\nint (*)(git_transport *, git_repository *, git_transfer_progress *, git_transfer_progress_cb, void *) download_pack\nint (*)(git_transport *) is_connected\nint (*)(git_transport *, int *) read_flags\nvoid (*)(git_transport *) cancel\nint (*)(git_transport *) close\nvoid (*)(git_transport *) free",
         "tdef": "typedef",
         "description": " Interface which represents a transport to communicate with a\n remote.",
         "comments": "",
-        "fields": [
-          {
-            "type": "unsigned int",
-            "name": "version",
-            "comments": " The struct version "
-          },
-          {
-            "type": "int (*)(git_transport *, git_transport_message_cb, git_transport_message_cb, git_transport_certificate_check_cb, void *)",
-            "name": "set_callbacks",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, const git_strarray *)",
-            "name": "set_custom_headers",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, const char *, git_cred_acquire_cb, void *, const git_proxy_options *, int, int)",
-            "name": "connect",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(const git_remote_head ***, size_t *, git_transport *)",
-            "name": "ls",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, git_push *, const git_remote_callbacks *)",
-            "name": "push",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, git_repository *, const git_remote_head *const *, size_t)",
-            "name": "negotiate_fetch",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, git_repository *, git_transfer_progress *, git_transfer_progress_cb, void *)",
-            "name": "download_pack",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *)",
-            "name": "is_connected",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *, int *)",
-            "name": "read_flags",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_transport *)",
-            "name": "cancel",
-            "comments": ""
-          },
-          {
-            "type": "int (*)(git_transport *)",
-            "name": "close",
-            "comments": ""
-          },
-          {
-            "type": "void (*)(git_transport *)",
-            "name": "free",
-            "comments": ""
-          }
-        ],
         "used": {
           "returns": [],
           "needs": [
-            "git_smart_subtransport_cb",
-            "git_smart_subtransport_git",
-            "git_smart_subtransport_http",
-            "git_smart_subtransport_ssh",
-            "git_transport_cb",
-            "git_transport_dummy",
-            "git_transport_init",
-            "git_transport_local",
-            "git_transport_new",
-            "git_transport_register",
-            "git_transport_smart",
-            "git_transport_smart_certificate_check",
-            "git_transport_smart_credentials",
-            "git_transport_smart_proxy_options",
-            "git_transport_ssh_with_paths"
+            "git_transport_cb"
           ]
-        }
-      }
-    ],
-    [
-      "git_transport_flags_t",
-      {
-        "decl": [
-          "GIT_TRANSPORTFLAGS_NONE"
-        ],
-        "type": "enum",
-        "file": "git2/sys/transport.h",
-        "line": 31,
-        "lineto": 33,
-        "block": "GIT_TRANSPORTFLAGS_NONE",
-        "tdef": "typedef",
-        "description": " Flags to pass to transport",
-        "comments": "<p>Currently unused.</p>\n",
-        "fields": [
-          {
-            "type": "int",
-            "name": "GIT_TRANSPORTFLAGS_NONE",
-            "comments": "",
-            "value": 0
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
         }
       }
     ],
@@ -41582,7 +37306,6 @@
         "tdef": "typedef",
         "description": " Representation of a tree object. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_tree_entry_byid",
@@ -41654,7 +37377,6 @@
         "tdef": "typedef",
         "description": " Representation of each one of the entries in a tree object. ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [
             "git_tree_entry_byid",
@@ -41775,7 +37497,6 @@
         "tdef": "typedef",
         "description": " Constructor for in-memory trees ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
@@ -41842,13 +37563,12 @@
         "tdef": "typedef",
         "description": " Representation of a working tree ",
         "comments": "",
-        "fields": [],
         "used": {
           "returns": [],
           "needs": [
             "git_repository_open_from_worktree",
             "git_worktree_add",
-            "git_worktree_add_init_options",
+            "git_worktree_add_options_init",
             "git_worktree_free",
             "git_worktree_is_locked",
             "git_worktree_is_prunable",
@@ -41858,7 +37578,7 @@
             "git_worktree_open_from_repository",
             "git_worktree_path",
             "git_worktree_prune",
-            "git_worktree_prune_init_options",
+            "git_worktree_prune_options_init",
             "git_worktree_unlock",
             "git_worktree_validate"
           ]
@@ -41881,7 +37601,7 @@
         "block": "unsigned int version\nint lock\ngit_reference * ref",
         "tdef": "typedef",
         "description": " Worktree add options structure",
-        "comments": "<p>Initialize with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>. Alternatively, you can\n use <code>git_worktree_add_init_options</code>.</p>\n",
+        "comments": "<p>Initialize with <code>GIT_WORKTREE_ADD_OPTIONS_INIT</code>. Alternatively, you can use <code>git_worktree_add_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -41903,7 +37623,7 @@
           "returns": [],
           "needs": [
             "git_worktree_add",
-            "git_worktree_add_init_options"
+            "git_worktree_add_options_init"
           ]
         }
       }
@@ -41913,17 +37633,17 @@
       {
         "decl": [
           "unsigned int version",
-          "int flags"
+          "uint32_t flags"
         ],
         "type": "struct",
         "value": "git_worktree_prune_options",
         "file": "git2/worktree.h",
         "line": 198,
         "lineto": 202,
-        "block": "unsigned int version\nint flags",
+        "block": "unsigned int version\nuint32_t flags",
         "tdef": "typedef",
-        "description": "",
-        "comments": "",
+        "description": " Worktree prune options structure",
+        "comments": "<p>Initialize with <code>GIT_WORKTREE_PRUNE_OPTIONS_INIT</code>. Alternatively, you can use <code>git_worktree_prune_options_init</code>.</p>\n",
         "fields": [
           {
             "type": "unsigned int",
@@ -41931,7 +37651,7 @@
             "comments": ""
           },
           {
-            "type": "int",
+            "type": "uint32_t",
             "name": "flags",
             "comments": ""
           }
@@ -41941,7 +37661,7 @@
           "needs": [
             "git_worktree_is_prunable",
             "git_worktree_prune",
-            "git_worktree_prune_init_options"
+            "git_worktree_prune_options_init"
           ]
         }
       }
@@ -41991,13 +37711,17 @@
     [
       "git_writestream",
       {
-        "decl": "git_writestream",
+        "decl": [
+          "int (*)(git_writestream *, const char *, size_t) write",
+          "int (*)(git_writestream *) close",
+          "void (*)(git_writestream *) free"
+        ],
         "type": "struct",
         "value": "git_writestream",
         "file": "git2/types.h",
-        "line": 432,
-        "lineto": 432,
-        "tdef": "typedef",
+        "line": 405,
+        "lineto": 409,
+        "tdef": null,
         "description": " A type to write in a streaming fashion, for example, for filters. ",
         "comments": "",
         "fields": [
@@ -42017,50 +37741,16 @@
             "comments": ""
           }
         ],
+        "block": "int (*)(git_writestream *, const char *, size_t) write\nint (*)(git_writestream *) close\nvoid (*)(git_writestream *) free",
         "used": {
           "returns": [],
           "needs": [
-            "git_blob_create_fromstream",
-            "git_blob_create_fromstream_commit",
+            "git_blob_create_from_stream",
+            "git_blob_create_from_stream_commit",
             "git_filter_list_stream_blob",
             "git_filter_list_stream_data",
-            "git_filter_list_stream_file",
-            "git_filter_stream_fn"
+            "git_filter_list_stream_file"
           ]
-        }
-      }
-    ],
-    [
-      "imaxdiv_t",
-      {
-        "decl": [
-          "intmax_t quot",
-          "intmax_t rem"
-        ],
-        "type": "struct",
-        "value": "imaxdiv_t",
-        "file": "git2/inttypes.h",
-        "line": 51,
-        "lineto": 54,
-        "block": "intmax_t quot\nintmax_t rem",
-        "tdef": "typedef",
-        "description": "",
-        "comments": "",
-        "fields": [
-          {
-            "type": "intmax_t",
-            "name": "quot",
-            "comments": ""
-          },
-          {
-            "type": "intmax_t",
-            "name": "rem",
-            "comments": ""
-          }
-        ],
-        "used": {
-          "returns": [],
-          "needs": []
         }
       }
     ]
@@ -42106,16 +37796,18 @@
         "git_blame_get_hunk_byindex",
         "git_blame_get_hunk_byline",
         "git_blame_get_hunk_count",
-        "git_blame_init_options"
+        "git_blame_init_options",
+        "git_blame_options_init"
       ]
     ],
     [
       "blob",
       [
-        "git_blob_create_frombuffer",
-        "git_blob_create_fromdisk",
-        "git_blob_create_fromstream",
-        "git_blob_create_fromstream_commit",
+        "git_blob_create_from_buffer",
+        "git_blob_create_from_disk",
+        "git_blob_create_from_stream",
+        "git_blob_create_from_stream_commit",
+        "git_blob_create_from_workdir",
         "git_blob_create_fromworkdir",
         "git_blob_dup",
         "git_blob_filtered_content",
@@ -42166,7 +37858,7 @@
       [
         "git_checkout_head",
         "git_checkout_index",
-        "git_checkout_init_options",
+        "git_checkout_options_init",
         "git_checkout_tree"
       ]
     ],
@@ -42175,14 +37867,14 @@
       [
         "git_cherrypick",
         "git_cherrypick_commit",
-        "git_cherrypick_init_options"
+        "git_cherrypick_options_init"
       ]
     ],
     [
       "clone",
       [
         "git_clone",
-        "git_clone_init_options"
+        "git_clone_options_init"
       ]
     ],
     [
@@ -42196,8 +37888,6 @@
         "git_commit_committer_with_mailmap",
         "git_commit_create",
         "git_commit_create_buffer",
-        "git_commit_create_from_callback",
-        "git_commit_create_from_ids",
         "git_commit_create_v",
         "git_commit_create_with_signature",
         "git_commit_dup",
@@ -42226,7 +37916,6 @@
     [
       "config",
       [
-        "git_config_add_backend",
         "git_config_add_file_ondisk",
         "git_config_backend_foreach_match",
         "git_config_delete_entry",
@@ -42248,7 +37937,6 @@
         "git_config_get_path",
         "git_config_get_string",
         "git_config_get_string_buf",
-        "git_config_init_backend",
         "git_config_iterator_free",
         "git_config_iterator_glob_new",
         "git_config_iterator_new",
@@ -42294,8 +37982,8 @@
       [
         "git_describe_commit",
         "git_describe_format",
-        "git_describe_init_format_options",
-        "git_describe_init_options",
+        "git_describe_format_options_init",
+        "git_describe_options_init",
         "git_describe_result_free",
         "git_describe_workdir"
       ]
@@ -42307,28 +37995,25 @@
         "git_diff_blobs",
         "git_diff_buffers",
         "git_diff_commit_as_email",
-        "git_diff_find_init_options",
+        "git_diff_find_options_init",
         "git_diff_find_similar",
         "git_diff_foreach",
         "git_diff_format_email",
-        "git_diff_format_email_init_options",
+        "git_diff_format_email_options_init",
         "git_diff_free",
         "git_diff_from_buffer",
         "git_diff_get_delta",
-        "git_diff_get_perfdata",
         "git_diff_get_stats",
         "git_diff_index_to_index",
         "git_diff_index_to_workdir",
-        "git_diff_init_options",
         "git_diff_is_sorted_icase",
         "git_diff_merge",
         "git_diff_num_deltas",
         "git_diff_num_deltas_of_type",
+        "git_diff_options_init",
         "git_diff_patchid",
-        "git_diff_patchid_init_options",
+        "git_diff_patchid_options_init",
         "git_diff_print",
-        "git_diff_print_callback__to_buf",
-        "git_diff_print_callback__to_file_handle",
         "git_diff_stats_deletions",
         "git_diff_stats_files_changed",
         "git_diff_stats_free",
@@ -42354,34 +38039,21 @@
     [
       "fetch",
       [
-        "git_fetch_init_options"
+        "git_fetch_options_init"
       ]
     ],
     [
       "filter",
       [
-        "git_filter_init",
         "git_filter_list_apply_to_blob",
         "git_filter_list_apply_to_data",
         "git_filter_list_apply_to_file",
         "git_filter_list_contains",
         "git_filter_list_free",
-        "git_filter_list_length",
         "git_filter_list_load",
-        "git_filter_list_new",
-        "git_filter_list_push",
         "git_filter_list_stream_blob",
         "git_filter_list_stream_data",
-        "git_filter_list_stream_file",
-        "git_filter_lookup",
-        "git_filter_register",
-        "git_filter_source_filemode",
-        "git_filter_source_flags",
-        "git_filter_source_id",
-        "git_filter_source_mode",
-        "git_filter_source_path",
-        "git_filter_source_repo",
-        "git_filter_unregister"
+        "git_filter_list_stream_file"
       ]
     ],
     [
@@ -42401,15 +38073,6 @@
       ]
     ],
     [
-      "hashsig",
-      [
-        "git_hashsig_compare",
-        "git_hashsig_create",
-        "git_hashsig_create_fromfile",
-        "git_hashsig_free"
-      ]
-    ],
-    [
       "ignore",
       [
         "git_ignore_add_rule",
@@ -42418,18 +38081,12 @@
       ]
     ],
     [
-      "imaxdiv",
-      [
-        "imaxdiv"
-      ]
-    ],
-    [
       "index",
       [
         "git_index_add",
         "git_index_add_all",
         "git_index_add_bypath",
-        "git_index_add_frombuffer",
+        "git_index_add_from_buffer",
         "git_index_caps",
         "git_index_checksum",
         "git_index_clear",
@@ -42452,10 +38109,6 @@
         "git_index_iterator_free",
         "git_index_iterator_new",
         "git_index_iterator_next",
-        "git_index_name_add",
-        "git_index_name_clear",
-        "git_index_name_entrycount",
-        "git_index_name_get_byindex",
         "git_index_new",
         "git_index_open",
         "git_index_owner",
@@ -42466,13 +38119,6 @@
         "git_index_remove_all",
         "git_index_remove_bypath",
         "git_index_remove_directory",
-        "git_index_reuc_add",
-        "git_index_reuc_clear",
-        "git_index_reuc_entrycount",
-        "git_index_reuc_find",
-        "git_index_reuc_get_byindex",
-        "git_index_reuc_get_bypath",
-        "git_index_reuc_remove",
         "git_index_set_caps",
         "git_index_set_version",
         "git_index_update_all",
@@ -42489,8 +38135,8 @@
         "git_indexer_commit",
         "git_indexer_free",
         "git_indexer_hash",
-        "git_indexer_init_options",
-        "git_indexer_new"
+        "git_indexer_new",
+        "git_indexer_options_init"
       ]
     ],
     [
@@ -42516,14 +38162,6 @@
       ]
     ],
     [
-      "mempack",
-      [
-        "git_mempack_dump",
-        "git_mempack_new",
-        "git_mempack_reset"
-      ]
-    ],
-    [
       "merge",
       [
         "git_merge",
@@ -42535,20 +38173,12 @@
         "git_merge_bases",
         "git_merge_bases_many",
         "git_merge_commits",
-        "git_merge_driver_lookup",
-        "git_merge_driver_register",
-        "git_merge_driver_source_ancestor",
-        "git_merge_driver_source_file_options",
-        "git_merge_driver_source_ours",
-        "git_merge_driver_source_repo",
-        "git_merge_driver_source_theirs",
-        "git_merge_driver_unregister",
         "git_merge_file",
         "git_merge_file_from_index",
-        "git_merge_file_init_input",
-        "git_merge_file_init_options",
+        "git_merge_file_input_init",
+        "git_merge_file_options_init",
         "git_merge_file_result_free",
-        "git_merge_init_options",
+        "git_merge_options_init",
         "git_merge_trees"
       ]
     ],
@@ -42585,7 +38215,6 @@
     [
       "object",
       [
-        "git_object__size",
         "git_object_dup",
         "git_object_free",
         "git_object_id",
@@ -42595,6 +38224,7 @@
         "git_object_owner",
         "git_object_peel",
         "git_object_short_id",
+        "git_object_size",
         "git_object_string2type",
         "git_object_type",
         "git_object_type2string",
@@ -42608,7 +38238,6 @@
         "git_odb_add_backend",
         "git_odb_add_disk_alternate",
         "git_odb_backend_loose",
-        "git_odb_backend_malloc",
         "git_odb_backend_one_pack",
         "git_odb_backend_pack",
         "git_odb_exists",
@@ -42619,7 +38248,6 @@
         "git_odb_get_backend",
         "git_odb_hash",
         "git_odb_hashfile",
-        "git_odb_init_backend",
         "git_odb_new",
         "git_odb_num_backends",
         "git_odb_object_data",
@@ -42654,6 +38282,7 @@
         "git_oid_fromstr",
         "git_oid_fromstrn",
         "git_oid_fromstrp",
+        "git_oid_is_zero",
         "git_oid_iszero",
         "git_oid_ncmp",
         "git_oid_nfmt",
@@ -42671,12 +38300,6 @@
       "oidarray",
       [
         "git_oidarray_free"
-      ]
-    ],
-    [
-      "openssl",
-      [
-        "git_openssl_set_locking"
       ]
     ],
     [
@@ -42719,12 +38342,6 @@
       ]
     ],
     [
-      "path",
-      [
-        "git_path_is_gitfile"
-      ]
-    ],
-    [
       "pathspec",
       [
         "git_pathspec_free",
@@ -42745,13 +38362,13 @@
     [
       "proxy",
       [
-        "git_proxy_init_options"
+        "git_proxy_options_init"
       ]
     ],
     [
       "push",
       [
-        "git_push_init_options"
+        "git_push_options_init"
       ]
     ],
     [
@@ -42762,32 +38379,31 @@
         "git_rebase_finish",
         "git_rebase_free",
         "git_rebase_init",
-        "git_rebase_init_options",
         "git_rebase_inmemory_index",
         "git_rebase_next",
+        "git_rebase_onto_id",
+        "git_rebase_onto_name",
         "git_rebase_open",
         "git_rebase_operation_byindex",
         "git_rebase_operation_current",
-        "git_rebase_operation_entrycount"
+        "git_rebase_operation_entrycount",
+        "git_rebase_options_init",
+        "git_rebase_orig_head_id",
+        "git_rebase_orig_head_name"
       ]
     ],
     [
       "refdb",
       [
-        "git_refdb_backend_fs",
         "git_refdb_compress",
         "git_refdb_free",
-        "git_refdb_init_backend",
         "git_refdb_new",
-        "git_refdb_open",
-        "git_refdb_set_backend"
+        "git_refdb_open"
       ]
     ],
     [
       "reference",
       [
-        "git_reference__alloc",
-        "git_reference__alloc_symbolic",
         "git_reference_cmp",
         "git_reference_create",
         "git_reference_create_matching",
@@ -42837,8 +38453,6 @@
         "git_reflog_append",
         "git_reflog_delete",
         "git_reflog_drop",
-        "git_reflog_entry__alloc",
-        "git_reflog_entry__free",
         "git_reflog_entry_byindex",
         "git_reflog_entry_committer",
         "git_reflog_entry_id_new",
@@ -42878,7 +38492,7 @@
         "git_remote_create",
         "git_remote_create_anonymous",
         "git_remote_create_detached",
-        "git_remote_create_init_options",
+        "git_remote_create_options_init",
         "git_remote_create_with_fetchspec",
         "git_remote_create_with_opts",
         "git_remote_default_branch",
@@ -42917,7 +38531,6 @@
     [
       "repository",
       [
-        "git_repository__cleanup",
         "git_repository_commondir",
         "git_repository_config",
         "git_repository_config_snapshot",
@@ -42936,7 +38549,7 @@
         "git_repository_index",
         "git_repository_init",
         "git_repository_init_ext",
-        "git_repository_init_init_options",
+        "git_repository_init_options_init",
         "git_repository_is_bare",
         "git_repository_is_empty",
         "git_repository_is_shallow",
@@ -42945,7 +38558,6 @@
         "git_repository_mergehead_foreach",
         "git_repository_message",
         "git_repository_message_remove",
-        "git_repository_new",
         "git_repository_odb",
         "git_repository_open",
         "git_repository_open_bare",
@@ -42953,22 +38565,14 @@
         "git_repository_open_from_worktree",
         "git_repository_path",
         "git_repository_refdb",
-        "git_repository_reinit_filesystem",
-        "git_repository_set_bare",
-        "git_repository_set_config",
         "git_repository_set_head",
         "git_repository_set_head_detached",
         "git_repository_set_head_detached_from_annotated",
         "git_repository_set_ident",
-        "git_repository_set_index",
         "git_repository_set_namespace",
-        "git_repository_set_odb",
-        "git_repository_set_refdb",
         "git_repository_set_workdir",
         "git_repository_state",
         "git_repository_state_cleanup",
-        "git_repository_submodule_cache_all",
-        "git_repository_submodule_cache_clear",
         "git_repository_workdir",
         "git_repository_wrap_odb"
       ]
@@ -42986,7 +38590,7 @@
       [
         "git_revert",
         "git_revert_commit",
-        "git_revert_init_options"
+        "git_revert_options_init"
       ]
     ],
     [
@@ -43031,18 +38635,10 @@
       ]
     ],
     [
-      "smart",
-      [
-        "git_smart_subtransport_git",
-        "git_smart_subtransport_http",
-        "git_smart_subtransport_ssh"
-      ]
-    ],
-    [
       "stash",
       [
         "git_stash_apply",
-        "git_stash_apply_init_options",
+        "git_stash_apply_options_init",
         "git_stash_drop",
         "git_stash_foreach",
         "git_stash_pop",
@@ -43056,18 +38652,11 @@
         "git_status_file",
         "git_status_foreach",
         "git_status_foreach_ext",
-        "git_status_init_options",
         "git_status_list_entrycount",
         "git_status_list_free",
-        "git_status_list_get_perfdata",
         "git_status_list_new",
+        "git_status_options_init",
         "git_status_should_ignore"
-      ]
-    ],
-    [
-      "stdalloc",
-      [
-        "git_stdalloc_init_allocator"
       ]
     ],
     [
@@ -43075,13 +38664,6 @@
       [
         "git_strarray_copy",
         "git_strarray_free"
-      ]
-    ],
-    [
-      "stream",
-      [
-        "git_stream_register",
-        "git_stream_register_tls"
       ]
     ],
     [
@@ -43115,7 +38697,7 @@
         "git_submodule_status",
         "git_submodule_sync",
         "git_submodule_update",
-        "git_submodule_update_init_options",
+        "git_submodule_update_options_init",
         "git_submodule_update_strategy",
         "git_submodule_url",
         "git_submodule_wd_id"
@@ -43126,7 +38708,7 @@
       [
         "git_tag_annotation_create",
         "git_tag_create",
-        "git_tag_create_frombuffer",
+        "git_tag_create_from_buffer",
         "git_tag_create_lightweight",
         "git_tag_delete",
         "git_tag_dup",
@@ -43148,12 +38730,6 @@
       ]
     ],
     [
-      "time",
-      [
-        "git_time_monotonic"
-      ]
-    ],
-    [
       "trace",
       [
         "git_trace_set"
@@ -43170,22 +38746,6 @@
         "git_transaction_set_reflog",
         "git_transaction_set_symbolic_target",
         "git_transaction_set_target"
-      ]
-    ],
-    [
-      "transport",
-      [
-        "git_transport_dummy",
-        "git_transport_init",
-        "git_transport_local",
-        "git_transport_new",
-        "git_transport_register",
-        "git_transport_smart",
-        "git_transport_smart_certificate_check",
-        "git_transport_smart_credentials",
-        "git_transport_smart_proxy_options",
-        "git_transport_ssh_with_paths",
-        "git_transport_unregister"
       ]
     ],
     [
@@ -43231,16 +38791,10 @@
       ]
     ],
     [
-      "win32",
-      [
-        "git_win32_crtdbg_init_allocator"
-      ]
-    ],
-    [
       "worktree",
       [
         "git_worktree_add",
-        "git_worktree_add_init_options",
+        "git_worktree_add_options_init",
         "git_worktree_free",
         "git_worktree_is_locked",
         "git_worktree_is_prunable",
@@ -43251,7 +38805,7 @@
         "git_worktree_open_from_repository",
         "git_worktree_path",
         "git_worktree_prune",
-        "git_worktree_prune_init_options",
+        "git_worktree_prune_options_init",
         "git_worktree_unlock",
         "git_worktree_validate"
       ]
@@ -43260,103 +38814,99 @@
   "examples": [
     [
       "add.c",
-      "ex/v0.28.0/add.html"
+      "ex/HEAD/add.html"
     ],
     [
       "blame.c",
-      "ex/v0.28.0/blame.html"
+      "ex/HEAD/blame.html"
     ],
     [
       "cat-file.c",
-      "ex/v0.28.0/cat-file.html"
+      "ex/HEAD/cat-file.html"
     ],
     [
       "checkout.c",
-      "ex/v0.28.0/checkout.html"
+      "ex/HEAD/checkout.html"
+    ],
+    [
+      "clone.c",
+      "ex/HEAD/clone.html"
     ],
     [
       "common.c",
-      "ex/v0.28.0/common.html"
+      "ex/HEAD/common.html"
     ],
     [
       "describe.c",
-      "ex/v0.28.0/describe.html"
+      "ex/HEAD/describe.html"
     ],
     [
       "diff.c",
-      "ex/v0.28.0/diff.html"
+      "ex/HEAD/diff.html"
+    ],
+    [
+      "fetch.c",
+      "ex/HEAD/fetch.html"
     ],
     [
       "for-each-ref.c",
-      "ex/v0.28.0/for-each-ref.html"
+      "ex/HEAD/for-each-ref.html"
     ],
     [
       "general.c",
-      "ex/v0.28.0/general.html"
+      "ex/HEAD/general.html"
+    ],
+    [
+      "index-pack.c",
+      "ex/HEAD/index-pack.html"
     ],
     [
       "init.c",
-      "ex/v0.28.0/init.html"
+      "ex/HEAD/init.html"
+    ],
+    [
+      "lg2.c",
+      "ex/HEAD/lg2.html"
     ],
     [
       "log.c",
-      "ex/v0.28.0/log.html"
+      "ex/HEAD/log.html"
     ],
     [
       "ls-files.c",
-      "ex/v0.28.0/ls-files.html"
+      "ex/HEAD/ls-files.html"
+    ],
+    [
+      "ls-remote.c",
+      "ex/HEAD/ls-remote.html"
     ],
     [
       "merge.c",
-      "ex/v0.28.0/merge.html"
-    ],
-    [
-      "network/clone.c",
-      "ex/v0.28.0/network/clone.html"
-    ],
-    [
-      "network/common.c",
-      "ex/v0.28.0/network/common.html"
-    ],
-    [
-      "network/fetch.c",
-      "ex/v0.28.0/network/fetch.html"
-    ],
-    [
-      "network/git2.c",
-      "ex/v0.28.0/network/git2.html"
-    ],
-    [
-      "network/index-pack.c",
-      "ex/v0.28.0/network/index-pack.html"
-    ],
-    [
-      "network/ls-remote.c",
-      "ex/v0.28.0/network/ls-remote.html"
+      "ex/HEAD/merge.html"
     ],
     [
       "remote.c",
-      "ex/v0.28.0/remote.html"
+      "ex/HEAD/remote.html"
     ],
     [
       "rev-list.c",
-      "ex/v0.28.0/rev-list.html"
+      "ex/HEAD/rev-list.html"
     ],
     [
       "rev-parse.c",
-      "ex/v0.28.0/rev-parse.html"
+      "ex/HEAD/rev-parse.html"
     ],
     [
-      "showindex.c",
-      "ex/v0.28.0/showindex.html"
+      "show-index.c",
+      "ex/HEAD/show-index.html"
     ],
     [
       "status.c",
-      "ex/v0.28.0/status.html"
+      "ex/HEAD/status.html"
     ],
     [
       "tag.c",
-      "ex/v0.28.0/tag.html"
+      "ex/HEAD/tag.html"
     ]
   ]
 }

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -141,6 +141,23 @@
           "isErrorCode": true
         }
       },
+      "git_diff_get_perfdata": {
+        "file": "sys/diff.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_diff_perfdata *"
+          },
+          {
+            "name": "diff",
+            "type": "const git_diff *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "diff"
+      },
       "git_filter_list_load": {
         "isManual": true,
         "cFile": "generate/templates/manual/filter_list/load.cc",
@@ -150,7 +167,7 @@
       },
       "git_filter_source_filemode": {
         "type": "function",
-        "file": "filter.h",
+        "file": "sys/filter.h",
         "args": [
           {
             "name": "src",
@@ -164,7 +181,7 @@
       },
       "git_filter_source_flags": {
         "type": "function",
-        "file": "filter.h",
+        "file": "sys/filter.h",
         "args": [
           {
             "name": "src",
@@ -173,6 +190,48 @@
         ],
         "return": {
           "type": "uint32_t"
+        },
+        "group": "filter_source"
+      },
+      "git_filter_source_id": {
+        "type": "function",
+        "file": "sys/filter.h",
+        "args": [
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "return": {
+          "type": "const git_oid *"
+        },
+        "group": "filter_source"
+      },
+      "git_filter_source_mode": {
+        "type": "function",
+        "file": "sys/filter.h",
+        "args": [
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "return": {
+          "type": "git_filter_mode_t"
+        },
+        "group": "filter_source"
+      },
+      "git_filter_source_path": {
+        "type": "function",
+        "file": "sys/filter.h",
+        "args": [
+          {
+            "name": "src",
+            "type": "const git_filter_source *"
+          }
+        ],
+        "return": {
+          "type": "const char *"
         },
         "group": "filter_source"
       },
@@ -198,6 +257,290 @@
           "isErrorCode": true
         }
       },
+      "git_hashsig_compare": {
+        "type": "function",
+        "file": "sys/hashsig.h",
+        "args": [
+          {
+            "name": "a",
+            "type": "const git_hashsig *"
+          },
+          {
+            "name": "b",
+            "type": "const git_hashsig *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "hashsig"
+      },
+      "git_hashsig_create": {
+        "type": "function",
+        "file": "sys/hashsig.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_hashsig **"
+          },
+          {
+            "name": "buf",
+            "type": "const char *"
+          },
+          {
+            "name": "buflen",
+            "type": "size_t"
+          },
+          {
+            "name": "opts",
+            "type": "git_hashsig_option_t"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "hashsig"
+      },
+      "git_hashsig_create_fromfile": {
+        "type": "function",
+        "file": "sys/hashsig.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_hashsig **"
+          },
+          {
+            "name": "path",
+            "type": "const char *"
+          },
+          {
+            "name": "opts",
+            "type": "git_hashsig_option_t"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "hashsig"
+      },
+      "git_index_name_add": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "ancestor",
+            "type": "const char *"
+          },
+          {
+            "name": "ours",
+            "type": "const char *"
+          },
+          {
+            "name": "theirs",
+            "type": "const char *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "index_name_entry"
+      },
+      "git_index_name_clear": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "group": "index_name_entry"
+      },
+      "git_index_name_entrycount": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          }
+        ],
+        "return": {
+          "type": "size_t"
+        },
+        "group": "index_name_entry"
+      },
+      "git_index_name_get_byindex": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "n",
+            "type": "size_t"
+          }
+        ],
+        "return": {
+          "type": "const git_index_name_entry *"
+        },
+        "group": "index_name_entry"
+      },
+      "git_index_reuc_add": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "path",
+            "type": "const char *"
+          },
+          {
+            "name": "ancestor_mode",
+            "type": "int"
+          },
+          {
+            "name": "ancestor_id",
+            "type": "const git_oid *"
+          },
+          {
+            "name": "our_mode",
+            "type": "int"
+          },
+          {
+            "name": "our_id",
+            "type": "const git_oid *"
+          },
+          {
+            "name": "their_mode",
+            "type": "int"
+          },
+          {
+            "name": "their_id",
+            "type": "const git_oid *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_clear": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          }
+        ],
+        "return": {
+          "type": "const git_index_reuc_entry *"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_entrycount": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          }
+        ],
+        "return": {
+          "type": "size_t"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_find": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "at_pos",
+            "type": "size_t *"
+          },
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "path",
+            "type": "const char *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_get_byindex": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "n",
+            "type": "size_t"
+          }
+        ],
+        "return": {
+          "type": "const git_index_reuc_entry *"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_get_bypath": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "path",
+            "type": "const char *"
+          }
+        ],
+        "return": {
+          "type": "const git_index_reuc_entry *"
+        },
+        "group": "index_reuc_entry"
+      },
+      "git_index_reuc_remove": {
+        "type": "function",
+        "file": "sys/index.h",
+        "args": [
+          {
+            "name": "index",
+            "type": "git_index *"
+          },
+          {
+            "name": "n",
+            "type": "size_t"
+          }
+        ],
+        "return": {
+          "type": "const git_index_reuc_entry *"
+        },
+        "group": "index_reuc_entry"
+      },
       "git_patch_convenient_from_diff": {
         "args": [
           {
@@ -219,6 +562,32 @@
           "type": "int",
           "isErrorCode": true
         }
+      },
+      "git_path_is_gitfile": {
+        "type": "function",
+        "file": "sys/path.h",
+        "args": [
+          {
+            "name": "path",
+            "type": "const char *"
+          },
+          {
+            "name": "pathlen",
+            "type": "size_t"
+          },
+          {
+            "name": "gitfile",
+            "type": "git_path_gitfile"
+          },
+          {
+            "name": "fs",
+            "type": "git_path_fs"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "path"
       },
       "git_rebase_next": {
         "type": "function",
@@ -259,6 +628,20 @@
           "type": "int",
           "isErrorCode": true
         }
+      },
+      "git_repository__cleanup": {
+        "type": "function",
+        "file": "sys/repository.h",
+        "args": [
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "group": "repository"
       },
       "git_repository_get_references": {
         "args": [
@@ -347,6 +730,52 @@
           "type": "int",
           "isErrorCode": true
         }
+      },
+      "git_repository_set_index": {
+        "type": "function",
+        "file": "sys/repository.h",
+        "args": [
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          },
+          {
+            "name": "index",
+            "type": "git_index *"
+          }
+        ],
+        "return": {
+          "type": "void"
+        },
+        "group": "repository"
+      },
+      "git_repository_submodule_cache_all": {
+        "type": "function",
+        "file": "sys/repository.h",
+        "args": [
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "repository"
+      },
+      "git_repository_submodule_cache_clear": {
+        "type": "function",
+        "file": "sys/repository.h",
+        "args": [
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "repository"
       },
       "git_reset": {
         "type": "function",
@@ -485,6 +914,23 @@
           "type": "int"
         },
         "group": "stash"
+      },
+      "git_status_list_get_perfdata": {
+        "file": "sys/diff.h",
+        "args": [
+          {
+            "name": "out",
+            "type": "git_diff_perfdata *"
+          },
+          {
+            "name": "status",
+            "type": "const git_status_list *"
+          }
+        ],
+        "return": {
+          "type": "int"
+        },
+        "group": "status_list"
       }
     },
     "groups": [
@@ -804,6 +1250,27 @@
         }
       ],
       [
+        "git_diff_perfdata",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version",
+              "ignore": true
+            },
+            {
+              "type": "size_t",
+              "name": "stat_calls"
+            },
+            {
+              "type": "size_t",
+              "name": "oid_calculations"
+            }
+          ]
+        }
+      ],
+      [
         "git_filter",
         {
           "type": "struct",
@@ -835,45 +1302,6 @@
             {
               "type": "git_filter_cleanup_fn",
               "name": "cleanup"
-            }
-          ]
-        }
-      ],
-      [
-        "git_status_entry",
-        {
-          "fields": [
-            {
-              "type": "git_status_t",
-              "name": "status"
-            },
-            {
-              "type": "git_diff_delta *",
-              "name": "head_to_index"
-            },
-            {
-              "type": "git_diff_delta *",
-              "name": "index_to_workdir"
-            }
-          ]
-        }
-      ],
-      [
-        "git_diff_perfdata",
-        {
-          "type": "struct",
-          "fields": [
-            {
-              "type": "unsigned int",
-              "name": "version"
-            },
-            {
-              "type": "size_t",
-              "name": "stat_calls"
-            },
-            {
-              "type": "size_t",
-              "name": "oid_calculations"
             }
           ]
         }
@@ -939,6 +1367,46 @@
               "type": "int",
               "name": "git_fetch_no_prune",
               "value": 2
+            }
+          ]
+        }
+      ],
+      [
+        "git_index_name_entry",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "char *",
+              "name": "ancestor"
+            },
+            {
+              "type": "char *",
+              "name": "ours"
+            },
+            {
+              "type": "char *",
+              "name": "theirs"
+            }
+          ]
+        }
+      ],
+      [
+        "git_index_reuc_entry",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "uint32_t [3]",
+              "name": "mode"
+            },
+            {
+              "type": "git_oid [3]",
+              "name": "oid"
+            },
+            {
+              "type": "char *",
+              "name": "path"
             }
           ]
         }
@@ -1116,6 +1584,29 @@
         }
       ],
       [
+        "git_path_gitfile",
+        {
+          "type": "enum",
+          "fields": [
+            {
+              "type": "int",
+              "name": "GIT_PATH_GITFILE_GITIGNORE",
+              "value": 0
+            },
+            {
+              "type": "int",
+              "name": "GIT_PATH_GITFILE_GITMODULES",
+              "value": 1
+            },
+            {
+              "type": "int",
+              "name": "GIT_PATH_GITFILE_GITATTRIBUTES",
+              "value": 1
+            }
+          ]
+        }
+      ],
+      [
         "git_stash_apply_progress_t",
         {
           "type": "enum",
@@ -1164,37 +1655,6 @@
         }
       ],
       [
-        "git_status_options",
-        {
-          "type": "struct",
-          "fields": [
-            {
-              "type": "unsigned int",
-              "name": "version"
-            },
-            {
-              "type": "git_status_show_t",
-              "name": "show"
-            },
-            {
-              "type": "git_status_opt_t",
-              "name": "flags"
-            },
-            {
-              "type": "git_strarray",
-              "name": "pathspec"
-            }
-          ],
-          "used": {
-            "needs": [
-              "git_status_init_options",
-              "git_status_foreach_ext",
-              "git_status_list_new"
-            ]
-          }
-        }
-      ],
-      [
         "git_stash_apply_options",
         {
           "type": "struct",
@@ -1229,6 +1689,37 @@
         }
       ],
       [
+        "git_status_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "git_status_show_t",
+              "name": "show"
+            },
+            {
+              "type": "git_status_opt_t",
+              "name": "flags"
+            },
+            {
+              "type": "git_strarray",
+              "name": "pathspec"
+            }
+          ],
+          "used": {
+            "needs": [
+              "git_status_init_options",
+              "git_status_foreach_ext",
+              "git_status_list_new"
+            ]
+          }
+        }
+      ],
+      [
         "git_time_t",
         {
           "type": "enum"
@@ -1257,6 +1748,22 @@
         }
       ],
       [
+        "git_worktree_prune_options",
+        {
+          "type": "struct",
+          "fields": [
+            {
+              "type": "unsigned int",
+              "name": "version"
+            },
+            {
+              "type": "uint32_t",
+              "name": "flags"
+            }
+          ]
+        }
+      ],
+      [
         "git_worktree_prune_t",
         {
           "type": "enum",
@@ -1275,22 +1782,6 @@
               "type": "unsigned int",
               "name": "git_worktree_prune_working_tree",
               "value": 4
-            }
-          ]
-        }
-      ],
-      [
-        "git_worktree_prune_options",
-        {
-          "type": "struct",
-          "fields": [
-            {
-              "type": "unsigned int",
-              "name": "version"
-            },
-            {
-              "type": "uint32_t",
-              "name": "flags"
             }
           ]
         }

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -86,20 +86,6 @@
   },
   "new" : {
     "functions": {
-      "git_blame_get_hunk_count": {
-        "type": "function",
-        "file": "blame.h",
-        "args": [
-          {
-            "name": "blame",
-            "type": "git_blame *"
-          }
-        ],
-        "return": {
-          "type": "int"
-        },
-        "group": "blame"
-      },
       "git_clone": {
         "isManual": true,
         "cFile": "generate/templates/manual/clone/clone.cc",
@@ -589,24 +575,6 @@
         },
         "group": "path"
       },
-      "git_rebase_next": {
-        "type": "function",
-        "file": "rebase.h",
-        "args": [
-          {
-            "name": "out",
-            "type": "git_rebase_operation **"
-          },
-          {
-            "name": "rebase",
-            "type": "git_rebase *"
-          }
-        ],
-        "return": {
-          "type": "int"
-        },
-        "group": "rebase"
-      },
       "git_remote_reference_list": {
         "args": [
           {
@@ -777,32 +745,6 @@
         },
         "group": "repository"
       },
-      "git_reset": {
-        "type": "function",
-        "file": "reset.h",
-        "args": [
-          {
-            "name": "repo",
-            "type": "git_repository *"
-          },
-          {
-            "name": "target",
-            "type": "git_object *"
-          },
-          {
-            "name": "reset_type",
-            "type": "git_reset_t"
-          },
-          {
-            "name": "checkout_opts",
-            "type": "git_checkout_options *"
-          }
-        ],
-        "return": {
-          "type": "int"
-        },
-        "group": "reset"
-      },
       "git_revwalk_commit_walk": {
         "args": [
           {
@@ -884,36 +826,6 @@
           "type": "int",
           "isErrorCode": true
         }
-      },
-      "git_stash_save": {
-        "type": "function",
-        "file": "stash.h",
-        "args": [
-          {
-            "name": "out",
-            "type": "git_oid *"
-          },
-          {
-            "name": "repo",
-            "type": "git_repository *"
-          },
-          {
-            "name": "stasher",
-            "type": "const git_signature *"
-          },
-          {
-            "name": "message",
-            "type": "const char *"
-          },
-          {
-            "name": "flags",
-            "type": "unsigned int"
-          }
-        ],
-        "return": {
-          "type": "int"
-        },
-        "group": "stash"
       },
       "git_status_list_get_perfdata": {
         "file": "sys/diff.h",

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -433,7 +433,7 @@
           }
         ],
         "return": {
-          "type": "const git_index_reuc_entry *"
+          "type": "void"
         },
         "group": "index_reuc_entry"
       },
@@ -523,7 +523,7 @@
           }
         ],
         "return": {
-          "type": "const git_index_reuc_entry *"
+          "type": "int"
         },
         "group": "index_reuc_entry"
       },
@@ -869,6 +869,12 @@
         ]
       ],
       [
+        "diff",
+        [
+          "git_diff_get_perfdata"
+        ]
+      ],
+      [
         "diff_stats",
         [
           "git_diff_stats_files_changed",
@@ -897,6 +903,14 @@
           "git_filter_source_id",
           "git_filter_source_mode",
           "git_filter_source_flags"
+        ]
+      ],
+      [
+        "hashsig",
+        [
+          "git_hashsig_compare",
+          "git_hashsig_create",
+          "git_hashsig_create_fromfile"
         ]
       ],
       [
@@ -977,6 +991,12 @@
         ]
       ],
       [
+        "path",
+        [
+          "git_path_is_gitfile"
+        ]
+      ],
+      [
         "pathspec_match_list",
         [
           "git_pathspec_match_list_diff_entry",
@@ -1005,10 +1025,14 @@
       [
         "repository",
         [
+          "git_repository__cleanup",
           "git_repository_get_references",
           "git_repository_get_submodules",
           "git_repository_get_remotes",
-          "git_repository_refresh_references"
+          "git_repository_refresh_references",
+          "git_repository_set_index",
+          "git_repository_submodule_cache_all",
+          "git_repository_submodule_cache_clear"
         ]
       ],
       [
@@ -1284,6 +1308,13 @@
         }
       ],
       [
+        "git_hashsig",
+        {
+          "type": "struct",
+          "fields": []
+        }
+      ],
+      [
         "git_index_name_entry",
         {
           "type": "struct",
@@ -1400,11 +1431,11 @@
               "name": "certificate_check"
             },
             {
-              "type": "git_transfer_progress_cb",
+              "type": "git_indexer_progress_cb",
               "name": "transfer_progress"
             },
             {
-              "type": "git_push_transfer_progress",
+              "type": "git_push_transfer_progress_cb",
               "name": "push_transfer_progress",
               "isCallback": true
             },
@@ -1420,6 +1451,10 @@
             {
               "type": "void *",
               "name": "payload"
+            },
+            {
+              "type": "git_url_resolve_cb",
+              "name": "resolve_url"
             }
           ],
           "used": {

--- a/generate/scripts/helpers.js
+++ b/generate/scripts/helpers.js
@@ -69,12 +69,13 @@ var Helpers = {
   },
 
   isConstructorFunction: function(cType, fnName) {
-    var initFnName = cType.split('_');
+    var deprecatedInitFnName = cType.split("_");
+    deprecatedInitFnName.splice(-1, 0, "init");
+    deprecatedInitFnName = deprecatedInitFnName.join("_");
 
-    initFnName.splice(-1, 0, "init");
-    initFnName = initFnName.join('_');
+    var initFnName = cType + "_init";
 
-    return initFnName === fnName;
+    return initFnName === fnName || deprecatedInitFnName === fnName;
   },
 
   hasConstructor: function(type, normalizedType) {

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -94,6 +94,9 @@
         ],
         [
           "OS=='mac'", {
+            "libraries": [
+              "-liconv",
+            ],
             "conditions": [
               ["<(is_electron) == 1", {
                 "include_dirs": [
@@ -153,8 +156,16 @@
             ]
           }
         ],
+        ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+          "libraries": [
+            "<!(krb5-config gssapi --libs)"
+          ]
+        }],
         [
           "OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+            "libraries": [
+              "<!(pcre-config --libs-posix)"
+            ],
             "cflags": [
               "-std=c++11"
             ]

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -348,7 +348,6 @@
           ],
           "include_dirs": ["libgit2/deps/ntlmclient"],
           "defines": [
-            "GIT_USE_FUTIMENS",
             "GIT_NTLM",
             "GIT_GSSAPI"
           ],
@@ -380,8 +379,9 @@
           ],
           "defines": [
             "GIT_OPENSSL",
-            "GIT_USE_STAT_MTIM",
-            "GIT_REGEX_PCRE"
+            "GIT_REGEX_PCRE",
+            "GIT_USE_FUTIMENS",
+            "GIT_USE_STAT_MTIM"
           ]
         }],
         ["<(is_IBMi) == 1", {

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -178,6 +178,8 @@
         "libgit2/src/oidmap.h",
         "libgit2/src/streams/mbedtls.c",
         "libgit2/src/streams/mbedtls.h",
+        "libgit2/src/streams/openssl.c",
+        "libgit2/src/streams/openssl.h",
         "libgit2/src/streams/registry.c",
         "libgit2/src/streams/registry.h",
         "libgit2/src/pack-objects.c",
@@ -380,10 +382,6 @@
             "GIT_OPENSSL",
             "GIT_USE_STAT_MTIM",
             "GIT_REGEX_PCRE"
-          ],
-          "sources": [
-            "libgit2/src/streams/openssl.c",
-            "libgit2/src/streams/openssl.h"
           ]
         }],
         ["<(is_IBMi) == 1", {

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -20,9 +20,12 @@
         "GIT_SSH",
         "GIT_SSH_MEMORY_CREDENTIALS",
         "LIBGIT2_NO_FEATURES_H",
+        "GIT_SHA1_COLLISIONDETECT",
+        "GIT_USE_NSEC",
+        "GIT_HTTPS",
         # Node's util.h may be accidentally included so use this to guard
         # against compilation error.
-        "SRC_UTIL_H_",
+        "SRC_UTIL_H_"
       ],
       "dependencies": [
         "zlib",
@@ -32,8 +35,11 @@
       "sources": [
         "libgit2/include/git2/sys/hashsig.h",
         "libgit2/include/git2/sys/merge.h",
-        "libgit2/include/git2/sys/time.h",
         "libgit2/include/git2/worktree.h",
+        "libgit2/src/allocators/stdalloc.c",
+        "libgit2/src/allocators/stdalloc.h",
+        "libgit2/src/commit.c",
+        "libgit2/src/commit.h",
         "libgit2/src/alloc.c",
         "libgit2/src/alloc.h",
         "libgit2/src/annotated_commit.c",
@@ -71,8 +77,6 @@
         "libgit2/src/clone.h",
         "libgit2/src/commit_list.c",
         "libgit2/src/commit_list.h",
-        "libgit2/src/commit.c",
-        "libgit2/src/commit.h",
         "libgit2/src/common.h",
         "libgit2/src/config_backend.h",
         "libgit2/src/config_cache.c",
@@ -105,6 +109,7 @@
         "libgit2/src/diff.c",
         "libgit2/src/diff.h",
         "libgit2/src/errors.c",
+        "libgit2/src/errors.h",
         "libgit2/src/fetch.c",
         "libgit2/src/fetch.h",
         "libgit2/src/fetchhead.c",
@@ -115,8 +120,6 @@
         "libgit2/src/fileops.h",
         "libgit2/src/filter.c",
         "libgit2/src/filter.h",
-        "libgit2/src/fnmatch.c",
-        "libgit2/src/fnmatch.h",
         "libgit2/src/global.c",
         "libgit2/src/global.h",
         "libgit2/src/graph.c",
@@ -126,6 +129,7 @@
         "libgit2/src/hash/sha1dc/sha1.h",
         "libgit2/src/hash/sha1dc/ubc_check.c",
         "libgit2/src/hash/sha1dc/ubc_check.h",
+        "libgit2/src/hash/hash_collisiondetect.h",
         "libgit2/src/hashsig.c",
         "libgit2/src/ident.c",
         "libgit2/src/idxmap.c",
@@ -150,6 +154,8 @@
         "libgit2/src/message.h",
         "libgit2/src/mwindow.c",
         "libgit2/src/mwindow.h",
+        "libgit2/src/net.c",
+        "libgit2/src/net.h",
         "libgit2/src/netops.c",
         "libgit2/src/netops.h",
         "libgit2/src/notes.c",
@@ -172,8 +178,6 @@
         "libgit2/src/oidmap.h",
         "libgit2/src/streams/mbedtls.c",
         "libgit2/src/streams/mbedtls.h",
-        "libgit2/src/streams/openssl.c",
-        "libgit2/src/streams/openssl.h",
         "libgit2/src/streams/registry.c",
         "libgit2/src/streams/registry.h",
         "libgit2/src/pack-objects.c",
@@ -196,6 +200,7 @@
         "libgit2/src/pool.h",
         "libgit2/src/posix.c",
         "libgit2/src/posix.h",
+        "libgit2/src/posix_regex.h",
         "libgit2/src/pqueue.c",
         "libgit2/src/pqueue.h",
         "libgit2/src/proxy.c",
@@ -236,8 +241,6 @@
         "libgit2/src/stash.c",
         "libgit2/src/status.c",
         "libgit2/src/status.h",
-        "libgit2/src/stdalloc.c",
-        "libgit2/src/stdalloc.h",
         "libgit2/src/strmap.c",
         "libgit2/src/strmap.h",
         "libgit2/src/strnlen.h",
@@ -254,12 +257,9 @@
         "libgit2/src/trailer.c",
         "libgit2/src/transaction.c",
         "libgit2/src/transport.c",
-        "libgit2/src/transports/auth.c",
-        "libgit2/src/transports/auth.h",
         "libgit2/src/transports/cred_helpers.c",
         "libgit2/src/transports/cred.c",
         "libgit2/src/transports/git.c",
-        "libgit2/src/transports/http.c",
         "libgit2/src/transports/local.c",
         "libgit2/src/transports/smart_pkt.c",
         "libgit2/src/transports/smart_protocol.c",
@@ -278,6 +278,8 @@
         "libgit2/src/varint.h",
         "libgit2/src/vector.c",
         "libgit2/src/vector.h",
+        "libgit2/src/wildmatch.c",
+        "libgit2/src/wildmatch.h",
         "libgit2/src/worktree.c",
         "libgit2/src/worktree.h",
         "libgit2/src/xdiff/xdiff.h",
@@ -299,6 +301,15 @@
         "libgit2/src/zstream.h"
       ],
       "conditions": [
+        ["target_arch=='x64'", {
+          "defines": [
+            "GIT_ARCH_64"
+          ]
+        }, {
+          "defines": [
+            "GIT_ARCH_32"
+          ]
+        }],
         ["OS=='mac'", {
             "conditions": [
               ["<(is_electron) == 1", {
@@ -309,11 +320,16 @@
             ],
             "defines": [
                 "GIT_SECURE_TRANSPORT",
-                "GIT_USE_STAT_MTIMESPEC"
+                "GIT_USE_STAT_MTIMESPEC",
+                "GIT_REGEX_REGCOMP_L",
+                "GIT_USE_ICONV"
             ],
             "sources": [
                 "libgit2/src/streams/stransport.c",
                 "libgit2/src/streams/stransport.h"
+            ],
+            "libraries": [
+              "-liconv",
             ],
             "link_settings": {
                 "xcode_settings": {
@@ -325,24 +341,49 @@
             }
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+          "dependencies": [
+            "ntlmclient"
+          ],
+          "include_dirs": ["libgit2/deps/ntlmclient"],
           "defines": [
-            "GIT_SHA1_OPENSSL"
+            "GIT_USE_FUTIMENS",
+            "GIT_NTLM",
+            "GIT_GSSAPI"
           ],
           "sources": [
-            "libgit2/src/hash/hash_openssl.h",
+            "libgit2/src/transports/http.c",
+            "libgit2/src/transports/http.h",
+            "libgit2/src/transports/auth.h",
+            "libgit2/src/transports/auth.c",
+            "libgit2/src/transports/auth_negotiate.c",
+            "libgit2/src/transports/auth_negotiate.h",
+            "libgit2/src/transports/auth_ntlm.c",
+            "libgit2/src/transports/auth_ntlm.h",
             "libgit2/src/streams/tls.c",
             "libgit2/src/streams/tls.h"
+          ],
+          "cflags": [
+            "<!(krb5-config gssapi --cflags)"
+          ],
+          "libraries": [
+            "<!(krb5-config gssapi --libs)"
           ]
         }],
         ["OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
           "cflags": [
-            "-DGIT_SSH",
-            "-DGIT_SSL",
-            "-w",
+            "<!(pcre-config --cflags-posix)"
+          ],
+          "libraries": [
+            "<!(pcre-config --libs-posix)"
           ],
           "defines": [
             "GIT_OPENSSL",
-            "GIT_USE_STAT_MTIM"
+            "GIT_USE_STAT_MTIM",
+            "GIT_REGEX_PCRE"
+          ],
+          "sources": [
+            "libgit2/src/streams/openssl.c",
+            "libgit2/src/streams/openssl.h"
           ]
         }],
         ["<(is_IBMi) == 1", {
@@ -351,9 +392,13 @@
           ]
         }],
         ["OS=='win'", {
+          "dependencies": [
+            "pcre"
+          ],
+          "include_dirs": ["libgit2/deps/pcre"],
           "defines": [
             "GIT_WINHTTP",
-            "GIT_SHA1_WIN32"
+            "GIT_REGEX_BUILTIN"
           ],
           "msvs_settings": {
             "VCLinkerTool": {
@@ -394,13 +439,7 @@
             # 'InterlockedDecrement' undefined; assuming extern returning int.
             4013,
           ],
-          "include_dirs": [
-            "libgit2/deps/regex"
-          ],
           "sources": [
-            "libgit2/deps/regex/regex.c",
-            "libgit2/src/hash/hash_win32.c",
-            "libgit2/src/hash/hash_win32.h",
             "libgit2/src/transports/winhttp.c",
             "libgit2/src/win32/dir.c",
             "libgit2/src/win32/dir.h",
@@ -426,6 +465,7 @@
             "libgit2/src/win32/version.h",
             "libgit2/src/win32/w32_buffer.c",
             "libgit2/src/win32/w32_buffer.h",
+            "libgit2/src/win32/w32_common.h",
             "libgit2/src/win32/w32_util.c",
             "libgit2/src/win32/w32_util.h",
           ],
@@ -593,6 +633,102 @@
             "/QOpenSys/pkgs/include"
           ]
         }],
+      ]
+    },
+    {
+      "target_name": "ntlmclient",
+      "type": "static_library",
+      "sources": [
+        "libgit2/deps/ntlmclient/compat.h",
+        "libgit2/deps/ntlmclient/crypt.h",
+        "libgit2/deps/ntlmclient/ntlm.c",
+        "libgit2/deps/ntlmclient/ntlm.h",
+        "libgit2/deps/ntlmclient/ntlmclient.h",
+        "libgit2/deps/ntlmclient/unicode.h",
+        "libgit2/deps/ntlmclient/unicode_builtin.c",
+        "libgit2/deps/ntlmclient/utf8.h",
+        "libgit2/deps/ntlmclient/util.c",
+        "libgit2/deps/ntlmclient/util.h"
+      ],
+      "conditions": [
+        ["OS=='mac' and <(is_electron) == 1", {
+          "include_dirs": ["openssl/include"]
+        }],
+        ["OS=='mac'", {
+          "sources": [
+            "libgit2/deps/ntlmclient/crypt_commoncrypto.c",
+            "libgit2/deps/ntlmclient/crypt_commoncrypto.h"
+          ],
+          "defines": [
+            "CRYPT_COMMONCRYPTO"
+          ]
+        }],
+        ["OS=='linux'", {
+          "sources": [
+            "libgit2/deps/ntlmclient/crypt_openssl.c",
+            "libgit2/deps/ntlmclient/crypt_openssl.h"
+          ],
+          "defines": [
+            "CRYPT_OPENSSL"
+          ]
+        }]
+      ]
+    },
+    {
+      "target_name": "pcre",
+      "type": "static_library",
+      "sources": [
+        "libgit2/deps/pcre/pcre_byte_order.c",
+        "libgit2/deps/pcre/pcre_chartables.c",
+        "libgit2/deps/pcre/pcre_compile.c",
+        "libgit2/deps/pcre/pcre_config.c",
+        "libgit2/deps/pcre/pcre_dfa_exec.c",
+        "libgit2/deps/pcre/pcre_exec.c",
+        "libgit2/deps/pcre/pcre_fullinfo.c",
+        "libgit2/deps/pcre/pcre_get.c",
+        "libgit2/deps/pcre/pcre_globals.c",
+        "libgit2/deps/pcre/pcre.h",
+        "libgit2/deps/pcre/pcre_internal.h",
+        "libgit2/deps/pcre/pcre_jit_compile.c",
+        "libgit2/deps/pcre/pcre_maketables.c",
+        "libgit2/deps/pcre/pcre_newline.c",
+        "libgit2/deps/pcre/pcre_ord2utf8.c",
+        "libgit2/deps/pcre/pcreposix.c",
+        "libgit2/deps/pcre/pcreposix.h",
+        "libgit2/deps/pcre/pcre_printint.c",
+        "libgit2/deps/pcre/pcre_refcount.c",
+        "libgit2/deps/pcre/pcre_string_utils.c",
+        "libgit2/deps/pcre/pcre_study.c",
+        "libgit2/deps/pcre/pcre_tables.c",
+        "libgit2/deps/pcre/pcre_ucd.c",
+        "libgit2/deps/pcre/pcre_valid_utf8.c",
+        "libgit2/deps/pcre/pcre_version.c",
+        "libgit2/deps/pcre/pcre_xclass.c",
+        "libgit2/deps/pcre/ucp.h"
+      ],
+      "defines": [
+        "HAVE_SYS_STAT_H",
+        "HAVE_SYS_TYPES_H",
+        "HAVE_WINDOWS_H",
+        "HAVE_STDINT_H",
+        "HAVE_INTTYPES_H",
+        "HAVE_MEMMOVE",
+        "HAVE_STRERROR",
+        "HAVE_STRTOLL",
+        "HAVE__STRTOI64",
+        "SUPPORT_PCRE8",
+        "NO_RECURSE",
+        "HAVE_LONG_LONG",
+        "HAVE_UNSIGNED_LONG_LONG",
+        "NEWLINE=10",
+        "POSIX_MALLOC_THRESHOLD=10",
+        "LINK_SIZE=2",
+        "PARENS_NEST_LIMIT=250",
+        "MATCH_LIMIT=10000000",
+        "MATCH_LIMIT_RECURSION=10000000",
+        "PCREGREP_BUFSIZE",
+        "MAX_NAME_SIZE=32",
+        "MAX_NAME_COUNT=10000"
       ]
     }
   ]


### PR DESCRIPTION
New library requirements:
**OSX**
  - libiconv
  - libgssapi-krb5

**Linux**
  - libgssapi-krb5
  - pcre
  - pcreposix

On unix systems we now compile ntlmclient for ntlm support.
On Windows, we now compile pcre from libgit2 for regex support.

Hopefully this will get the ball rolling with 0.25.0 and get it out the door within a reasonable timeframe.