### PR TITLE
Remove pcre-config from binding.gyp

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -163,9 +163,6 @@
         }],
         [
           "OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
-            "libraries": [
-              "<!(pcre-config --libs-posix)"
-            ],
             "cflags": [
               "-std=c++11"
             ]


### PR DESCRIPTION
There's no need to link to this library anymore.