### PR TITLE
Reintroduce Odb.prototype.addDiskAlternate

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2373,7 +2373,10 @@
           "ignore": true
         },
         "git_odb_add_disk_alternate": {
-          "ignore": true
+          "isAsync": true,
+          "return": {
+            "isErrorCode": true
+          }
         },
         "git_odb_exists": {
           "ignore": true,


### PR DESCRIPTION
Fixes: https://github.com/nodegit/nodegit/issues/1580

Note, this function should have been async as it reads from the disk. It will be async in the next version of NodeGit.