### PR TITLE
Remove NSEC

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -21,7 +21,11 @@
         "GIT_SSH_MEMORY_CREDENTIALS",
         "LIBGIT2_NO_FEATURES_H",
         "GIT_SHA1_COLLISIONDETECT",
-        "GIT_USE_NSEC",
+        # "GIT_USE_NSEC", We've been shipping without NSEC for awhile
+        # Turning NSEC on should be left up to application maintainer
+        # There may be negative performance impacts using nodegit with
+        # NSEC turned on in a repository that was cloned with nodegit
+        # with NSEC turned off
         "GIT_HTTPS",
         # Node's util.h may be accidentally included so use this to guard
         # against compilation error.


### PR DESCRIPTION
It seems that since we've been building without NSEC, if you operate on a repository that had been cloned without NSEC, using NSEC to perform working directory diffs can be incredibly slow. To mitigate massive slow downs, we'll turn this off for now. It can still be enabled and recompiled on a fork of NodeGit fairly easily.
