### PR TITLE
Add missing return type to Blame.file documentation

### DIFF
--- a/lib/blame.js
+++ b/lib/blame.js
@@ -11,6 +11,7 @@ var _file = Blame.file;
  * @param {Repository} repo that contains the file
  * @param {String} path to the file to get the blame of
  * @param {BlameOptions} [options] Options for the blame
+ * @return {Blame} the blame
  */
 Blame.file = function(repo, path, options) {
   options = normalizeOptions(options, NodeGit.BlameOptions);


### PR DESCRIPTION
Please correct me if I'm wrong, but I think the return type for the function `Blame.file` is missing in the documentation.

https://github.com/nodegit/nodegit/blob/af9e53f/lib/blame.js
https://www.nodegit.org/api/blame (25.07.2019)