### PR TITLE
Fix rebase using in-memory index

### DIFF
--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -1392,6 +1392,10 @@
             {
               "type": "void *",
               "name": "payload"
+            },
+            {
+              "type": "int",
+              "name": "inmemory"
             }
           ],
           "used": {

--- a/test/tests/rebase.js
+++ b/test/tests/rebase.js
@@ -149,7 +149,7 @@ describe("Rebase", function() {
       });
   });
 
-  it("can cleanly rebase a branch onto another branch", function() {
+  it("can cleanly rebase a branch in-memory", function() {
     var baseFileName = "baseNewFile.txt";
     var ourFileName = "ourNewFile.txt";
     var theirFileName = "theirNewFile.txt";
@@ -233,6 +233,187 @@ describe("Rebase", function() {
 
           return repository.createCommit(ourBranch.name(), ourSignature,
             ourSignature, "we made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        return removeFileFromIndex(repository, ourFileName);
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), ourFileName));
+      })
+      .then(function() {
+        return repository.checkoutBranch(ourBranchName);
+      })
+      .then(function() {
+        return Promise.all([
+          repository.getReference(ourBranchName),
+          repository.getReference(theirBranchName)
+        ]);
+      })
+      .then(function(refs) {
+        assert.equal(refs.length, 2);
+
+        return Promise.all([
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[0]),
+          NodeGit.AnnotatedCommit.fromRef(repository, refs[1])
+        ]);
+      })
+      .then(function(annotatedCommits) {
+        assert.equal(annotatedCommits.length, 2);
+
+        var ourAnnotatedCommit = annotatedCommits[0];
+        var theirAnnotatedCommit = annotatedCommits[1];
+
+        assert.equal(ourAnnotatedCommit.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+        assert.equal(theirAnnotatedCommit.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+
+        var rebaseOptions = new NodeGit.RebaseOptions();
+        rebaseOptions.inmemory = 1;
+
+        return NodeGit.Rebase.init(repository, ourAnnotatedCommit,
+          theirAnnotatedCommit, undefined, rebaseOptions);
+      })
+      .then(function(newRebase) {
+        rebase = newRebase;
+
+        // there should only be 1 rebase operation to perform
+        assert.equal(rebase.operationEntrycount(), 1);
+
+        return rebase.next();
+      })
+      .then(function(rebaseOperation) {
+        assert.equal(rebaseOperation.type(),
+          NodeGit.RebaseOperation.REBASE_OPERATION.PICK);
+        assert.equal(rebaseOperation.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        return rebase.commit(null, ourSignature);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "b937100ee0ea17ef20525306763505a7fe2be29e");
+
+        // git_rebase_operation_current returns the index of the rebase
+        // operation that was last applied, so after the first operation, it
+        // should be 0.
+        assert.equal(rebase.operationCurrent(), 0);
+
+        return rebase.finish(ourSignature, {});
+      })
+      .then(function(result) {
+        assert.equal(result, 0);
+
+        return repository.getBranchCommit(ourBranchName);
+      })
+      .then(function(commit) {
+        // verify that the "ours" branch has NOT moved.
+        // In-memory rebase does not touch refs.
+        assert.equal(commit.id().toString(),
+          "e7f37ee070837052937e24ad8ba66f6d83ae7941");
+
+        // Lookup the new commit
+        return NodeGit.Commit.lookup(repository,
+          "b937100ee0ea17ef20525306763505a7fe2be29e");
+      })
+      .then(function(commit) {
+        // Lookup the parent of our new commit
+        return commit.parent(0);
+      })
+      .then(function(commit) {
+        // verify that we are on top of "their commit"
+        assert.equal(commit.id().toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+      });
+  });
+
+  it("can cleanly rebase a branch onto another branch", function() {
+    var baseFileName = "baseNewFile.txt";
+    var ourFileName = "ourNewFile.txt";
+    var theirFileName = "theirNewFile.txt";
+
+    var baseFileContent = "How do you feel about Toll Roads?";
+    var ourFileContent = "I like Toll Roads. I have an EZ-Pass!";
+    var theirFileContent = "I'm skeptical about Toll Roads";
+
+    var ourSignature = NodeGit.Signature.create
+    ("Ron Paul", "RonPaul@TollRoadsRBest.info", 123456789, 60);
+    var theirSignature = NodeGit.Signature.create
+    ("Greg Abbott", "Gregggg@IllTollYourFace.us", 123456789, 60);
+
+    var repository = this.repository;
+    var ourCommit;
+    var ourBranch;
+    var theirBranch;
+    var rebase;
+
+    return fse.writeFile(path.join(repository.workdir(), baseFileName),
+      baseFileContent)
+    // Load up the repository index and make our initial commit to HEAD
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, baseFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "b5cdc109d437c4541a13fb7509116b5f03d5039a");
+
+        return repository.createCommit("HEAD", ourSignature,
+          ourSignature, "initial commit", oid, []);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "be03abdf0353d05924c53bebeb0e5bb129cda44a");
+
+        return repository.getCommit(commitOid).then(function(commit) {
+          ourCommit = commit;
+        }).then(function() {
+          return repository.createBranch(ourBranchName, commitOid)
+            .then(function(branch) {
+              ourBranch = branch;
+              return repository.createBranch(theirBranchName, commitOid);
+            });
+        });
+      })
+      .then(function(branch) {
+        theirBranch = branch;
+        return fse.writeFile(path.join(repository.workdir(), theirFileName),
+          theirFileContent);
+      })
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, theirFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "be5f0fd38a39a67135ad68921c93cd5c17fefb3d");
+
+        return repository.createCommit(theirBranch.name(), theirSignature,
+          theirSignature, "they made a commit", oid, [ourCommit]);
+      })
+      .then(function(commitOid) {
+        assert.equal(commitOid.toString(),
+          "e9ebd92f2f4778baf6fa8e92f0c68642f931a554");
+
+        return removeFileFromIndex(repository, theirFileName);
+      })
+      .then(function() {
+        return fse.remove(path.join(repository.workdir(), theirFileName));
+      })
+      .then(function() {
+        return fse.writeFile(path.join(repository.workdir(), ourFileName),
+          ourFileContent);
+      })
+      .then(function() {
+        return RepoUtils.addFileToIndex(repository, ourFileName);
+      })
+      .then(function(oid) {
+        assert.equal(oid.toString(),
+          "77867fc0bfeb3f80ab18a78c8d53aa3a06207047");
+
+        return repository.createCommit(ourBranch.name(), ourSignature,
+          ourSignature, "we made a commit", oid, [ourCommit]);
       })
       .then(function(commitOid) {
         assert.equal(commitOid.toString(),


### PR DESCRIPTION
In the current master there is missing the `RebaseOptions#inmemory` flag. This is why rebasing is currently not possible at all on bare repos. This fix adds the missing field in supplements config file. Rebasing works fine with `Rebase.init`.