### PR TITLE
Remove DiffList

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -34,7 +34,7 @@ Tree.prototype.builder = function() {
  * @async
  * @param {Tree} tree to diff against
  * @param {Function} callback
- * @return {DiffList}
+ * @return {Diff}
  */
 Tree.prototype.diff = function(tree, callback) {
   return this.diffWithOptions(tree, null, callback);
@@ -46,7 +46,7 @@ Tree.prototype.diff = function(tree, callback) {
  * @param {Tree} tree to diff against
  * @param {Object} options
  * @param {Function} callback
- * @return {DiffList}
+ * @return {Diff}
  */
 Tree.prototype.diffWithOptions = function(tree, options, callback) {
   return Diff.treeToTree(this.repo, tree, this, options).then(function(diff) {

--- a/test/tests/diff.js
+++ b/test/tests/diff.js
@@ -112,7 +112,7 @@ describe("Diff", function() {
     });
   });
 
-  it("can walk a DiffList", function() {
+  it("can walk an Array<Diff>", function() {
     return this.diff[0].patches()
       .then(function(patches) {
         var patch = patches[0];


### PR DESCRIPTION
The `DiffList` is a legacy name for a type that doesn't currently exist. In cases where several diffs are returned, `Array<Diff>` is documented.

However, Tree#diff and Tree#diffWithOptions return a single `{Diff}`, which is incorrect in the docs:

- https://www.nodegit.org/api/tree/#diff
- https://www.nodegit.org/api/tree/#diffWithOptions

This PR removes `DiffList` from the repo to avoid confusion and updates to the correct type. Please see this previous issue for more context: https://github.com/nodegit/nodegit/issues/1359

Thanks for the library 👍 