### PR TITLE
Remote needs to persist the callback/proxyOpts/headers

### DIFF
--- a/lib/remote.js
+++ b/lib/remote.js
@@ -8,6 +8,7 @@ var shallowClone = NodeGit.Utils.shallowClone;
 var Remote = NodeGit.Remote;
 var _connect = Remote.prototype.connect;
 var _createWithOpts = Remote.createWithOpts;
+var _disconnect = Remote.prototype.disconnect;
 var _download = Remote.prototype.download;
 var _fetch = Remote.prototype.fetch;
 var _push = Remote.prototype.push;
@@ -45,12 +46,58 @@ Remote.prototype.connect = function(
   proxyOpts = normalizeOptions(proxyOpts || {}, NodeGit.ProxyOptions);
   customHeaders = customHeaders || [];
 
-  return _connect.call(this, direction, callbacks, proxyOpts, customHeaders);
+  return _connect.call(this, direction, callbacks, proxyOpts, customHeaders)
+    .then(() => {
+      // Save options on the remote object. If we don't do this,
+      // the options may be cleaned up and cause a segfault
+      // when Remote.prototype.connect is called.
+      Object.defineProperties(this, {
+        callbacks: {
+          configurable: true,
+          value: callbacks,
+          writable: false
+        },
+        proxyOpts: {
+          configurable: true,
+          value: proxyOpts,
+          writable: false
+        },
+        customHeaders: {
+          configurable: true,
+          value: customHeaders,
+          writable: false
+        }
+      });
+    });
 };
 
 Remote.createWithOpts = function(url, options) {
   return _createWithOpts(url, normalizeOptions(
     options, NodeGit.RemoteCreateOptions));
+};
+
+Remote.prototype.disconnect = function() {
+  return _disconnect.call(this)
+    .then(() => {
+      // Release the options
+      Object.defineProperties(this, {
+        callbacks: {
+          configurable: true,
+          value: undefined,
+          writable: false
+        },
+        proxyOpts: {
+          configurable: true,
+          value: undefined,
+          writable: false
+        },
+        customHeaders: {
+          configurable: true,
+          value: undefined,
+          writable: false
+        }
+      });
+    });
 };
 
 /**


### PR DESCRIPTION
This was causing a segfault (sometimes) while pushing using connect/upload/disconnect. v8 was releasing the pointers to the options after the call to connect. When upload tries to reuse those pointers, they need to have survived until the remote is disconnected.