### PR TITLE
Remove block for sideband_progress in remote_callbacks

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -3418,7 +3418,7 @@
           "ignore": true
         },
         "sideband_progress": {
-          "ignore": true
+          "ignore": false
         },
         "update_tips": {
           "ignore": true


### PR DESCRIPTION
Simple PR. Just removing block for sideband_progress in remote_callbacks from generate/input/descriptor.json.