### PR TITLE
Upgrade c++ standard to v14 to ensure compatibility with Electron v11

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -114,7 +114,7 @@
               "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
               "MACOSX_DEPLOYMENT_TARGET": "10.9",
               'CLANG_CXX_LIBRARY': 'libc++',
-              'CLANG_CXX_LANGUAGE_STANDARD':'c++11',
+              'CLANG_CXX_LANGUAGE_STANDARD':'c++14',
 
               "WARNING_CFLAGS": [
                 "-Wno-unused-variable",
@@ -166,7 +166,7 @@
         [
           "OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
             "cflags": [
-              "-std=c++11"
+              "-std=c++14"
             ]
           }
         ],


### PR DESCRIPTION
Fixes #1808

Apparently the C++ standard was dropped to C++11 fairly recently: https://github.com/nodegit/nodegit/commit/69d9d4e03235a52c13a5bd52d7a5f15aa0481655. This makes installation for Nodegit fail on Electron v11 (god knows why 😕).: 
<details>
<summary>NPM install output with Electron v11 on macOS 10.15.7</summary>

```
    In file included from ../src/nodegit.cc:3:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
                !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    In file included from
    ../src/lock_master.cc
    :1:
    In file included from ../../nan/nan.h:
    56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
    In file included from
    ../src/async_baton.cc:1:
    In file included from ../src/../include/async_baton.h:5:
    In file included from ../../nan/nan.h:56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
    !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    CXX(target) Release/obj.target/nodegit/src/convenient_hunk.o
    In file included from ../src/wrapper.cc:4:
    In file included from ../../nan/nan.h:56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67
    :
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
                !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    In file included from ../src/convenient_patch.cc:1:
    In file included from ../../nan/nan.h:56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
                !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    In file included from ../src/promise_completion.cc:2:
    In file included from ../src/../include/promise_completion.h:4:
    In file included from ../../nan/nan.h:56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:
    67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
                !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/wrapper.o] Error 1
    make: *** Waiting for unfinished jobs....
    1
    error generated
    .
    make: *** [Release/obj.target/nodegit/src/async_baton.o] Error 1
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/lock_master.o] Error 1
    In file included from ../src/convenient_hunk.cc:1:
    In file included from ../../nan/nan.h:56:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/node.h:67:
    In file included from /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8.h:30:
    /Users/leinelissen/Library/Caches/node-gyp/11.0.3/include/node/v8-internal.h:418:38: error: no template named 'remove_cv_t' in namespace 'std'; did you mean 'remove_cv'?
                !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                    ~~~~~^~~~~~~~~~~
                                        remove_cv
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/type_traits:697:50: note: 'remove_cv' declared here
    template <class _Tp> struct _LIBCPP_TEMPLATE_VIS remove_cv
                                                    ^
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/promise_completion.o] Error 1
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/convenient_patch.o] Error 1
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/nodegit.o] Error 1
    1 error generated.
    make: *** [Release/obj.target/nodegit/src/convenient_hunk.o] Error 1
    gyp
    ERR! build error
    gyp ERR!
    stack Error: make failed with exit code: 2
    gyp ERR! stack     at ChildProcess.onExit (/usr/local/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
    gyp ERR! stack
    at ChildProcess.emit (events.js:314:20)
    gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:276:12)
    gyp ERR! System Darwin 19.6.0
    gyp ERR! command "/usr/local/Cellar/node/14.13.1_1/bin/node" "/usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "build" "--fallback-to-build" "--module=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release/nodegit.node" "--module_name=nodegit" "--module_path=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release" "--napi_version=7" "--node_abi_napi=napi" "--napi_build_version=0" "--node_napi_label=electron-v11.0"
    gyp ERR! cwd /Users/leinelissen/Documents/Code/aeon/node_modules/nodegit
    gyp ERR! node -v v14.13.1
    gyp ERR! node-gyp -v v5.1.0
    gyp
    ERR! not ok
    node-pre-gyp
    ERR! build error
    node-pre-gyp ERR! stack Error: Failed to execute '/usr/local/Cellar/node/14.13.1_1/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release/nodegit.node --module_name=nodegit --module_path=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release --napi_version=7 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=electron-v11.0' (1)
    node-pre-gyp ERR!
    stack     at ChildProcess.<anonymous> (/Users/leinelissen/Documents/Code/aeon/node_modules/node-pre-gyp/lib/util/compile.js:83:29)
    node-pre-gyp ERR! stack     at ChildProcess.emit (events.js:314:20)
    node-pre-gyp ERR! stack     at maybeClose (internal/child_process.js:1047:16)
    node-pre-gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5)
    node-pre-gyp ERR! System Darwin 19.6.0
    node-pre-gyp ERR! command "/usr/local/Cellar/node/14.13.1_1/bin/node" "/Users/leinelissen/Documents/Code/aeon/node_modules/.bin/node-pre-gyp" "install" "--fallback-to-build"
    node-pre-gyp ERR!
    cwd /Users/leinelissen/Documents/Code/aeon/node_modules/nodegit
    node-pre-gyp ERR! node -v v14.13.1
    node-pre-gyp ERR! node-pre-gyp -v v0.13.0
    node-pre-gyp
    ERR! not ok
    Failed to execute '/usr/local/Cellar/node/14.13.1_1/bin/node /usr/local/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js build --fallback-to-build --module=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release/nodegit.node --module_name=nodegit --module_path=/Users/leinelissen/Documents/Code/aeon/node_modules/nodegit/build/Release --napi_version=7 --node_abi_napi=napi --napi_build_version=0 --node_napi_label=electron-v11.0' (1)
    [nodegit] ERROR - Could not finish install
    [nodegit] ERROR - finished with error code: 1
```
</details>

This is weird considering that V8, NodeJS and Electron have all been on C++14 for years: https://github.com/nodejs/node/issues/17065, https://www.electronjs.org/blog/electron-2-0

This fix ensures that Nodegit can be built on Electron v11+ versions, at the very least on macOS, but possibly on other OS'es as well.