### PR TITLE
Don't strdup nullptr from git_tag_message 

### DIFF
--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -97,7 +97,8 @@ public:
 
     git_tag *referencedTag;
     if (git_tag_lookup(&referencedTag, repo, referencedTargetOid) == GIT_OK) {
-      refModel->message = strdup(git_tag_message(referencedTag));
+      const char *tagMessage = git_tag_message(referencedTag);
+      refModel->message = tagMessage ? strdup(tagMessage) : NULL;
 
       git_odb_object *tagOdbObject;
       if (git_odb_read(&tagOdbObject, odb, git_tag_id(referencedTag)) == GIT_OK) {


### PR DESCRIPTION
git_tag_message can return nullptr. From docs: "message of the tag or NULL when unspecified"

e.g. https://gitlab.freedesktop.org/mesa/mesa/-/tags/R300_DRIVER_0
