### PR TITLE
returns_info: fix ownedByIndices

### DIFF
--- a/generate/templates/filters/returns_info.js
+++ b/generate/templates/filters/returns_info.js
@@ -52,7 +52,7 @@ module.exports = function(fn, argReturnsOnly, isAsync) {
     // sync functions will need to know this.
     if (!isAsync && return_info.ownedBy) {
       return_info.ownedBy.forEach(function (argName) {
-        return_info.ownedByIndices.push(nameToArgIndex[return_info.ownedBy]);
+        return_info.ownedByIndices.push(nameToArgIndex[argName]);
       })
     }
 


### PR DESCRIPTION
I'm preparing a PR for using eslint and prettier, and eslint pointed out this unused variable.

It looks like this was a mistake?