### PR TITLE
Check if module is compiled under context aware node version

### DIFF
--- a/generate/templates/manual/include/context.h
+++ b/generate/templates/manual/include/context.h
@@ -8,6 +8,20 @@
 #include <uv.h>
 #include <v8.h>
 
+/*
+ * Determine if node module is compiled under a supported node release.
+ * Currently 12 - 15 (ignoring pre-releases). Will need to be updated
+ * for new major versions.
+ * 
+ * See: https://github.com/nodejs/node/issues/36349
+ * and: https://github.com/nodejs/node/blob/master/doc/abi_version_registry.json
+ */
+#define IS_CONTEXT_AWARE_NODE_MODULE_VERSION \
+  (NODE_MODULE_VERSION == 72 \
+  || NODE_MODULE_VERSION == 79 \
+  || NODE_MODULE_VERSION == 83 \
+  || NODE_MODULE_VERSION == 88)
+
 #include "async_worker.h"
 #include "thread_pool.h"
 

--- a/generate/templates/manual/src/context.cc
+++ b/generate/templates/manual/src/context.cc
@@ -5,7 +5,11 @@ namespace nodegit {
 
   AsyncContextCleanupHandle::AsyncContextCleanupHandle(v8::Isolate *isolate, Context *context)
     : context(context),
+#if IS_CONTEXT_AWARE_NODE_MODULE_VERSION
       handle(node::AddEnvironmentCleanupHook(isolate, AsyncCleanupContext, this))
+#else
+      handle(nullptr)
+#endif
   {}
 
   AsyncContextCleanupHandle::~AsyncContextCleanupHandle() {

--- a/generate/templates/manual/src/thread_pool.cc
+++ b/generate/templates/manual/src/thread_pool.cc
@@ -687,10 +687,19 @@ namespace nodegit {
     asyncCallbackData->cleanupHandle.swap(cleanupHandle);
     asyncCallbackData->pool = nullptr;
 
+#if IS_CONTEXT_AWARE_NODE_MODULE_VERSION
     uv_close(reinterpret_cast<uv_handle_t *>(&jsThreadCallbackAsync), [](uv_handle_t *handle) {
-      auto asyncCallbackData = static_cast<AsyncCallbackData *>(handle->data);
-      delete asyncCallbackData;
+      auto closeAsyncCallbackData = static_cast<AsyncCallbackData *>(handle->data);
+      delete closeAsyncCallbackData;
     });
+#else
+    // NOTE We are deliberately leaking this pointer because `async` cleanup in
+    // node has not completely landed yet. Trying to cleanup this pointer
+    // is probably not worth the fight as it's very little memory lost per context
+    // When all LTS versions of node and Electron support async cleanup, we should
+    // be heading back to cleanup this
+    uv_close(reinterpret_cast<uv_handle_t *>(&jsThreadCallbackAsync), nullptr);
+#endif
   }
 
   ThreadPool::ThreadPool(int numberOfThreads, uv_loop_t *loop, nodegit::Context *context)

--- a/generate/templates/templates/nodegit.cc
+++ b/generate/templates/templates/nodegit.cc
@@ -108,4 +108,8 @@ NAN_MODULE_INIT(init) {
   nodegit::LockMaster::InitializeContext();
 }
 
+#if IS_CONTEXT_AWARE_NODE_MODULE_VERSION
 NAN_MODULE_WORKER_ENABLED(nodegit, init)
+#else
+NODE_MODULE(nodegit, init)
+#endif


### PR DESCRIPTION
If not, leak cleanup pointer like before.

Once the electron patch is in and released we can revert this.

https://github.com/electron/electron/issues/28043