### PR TITLE
Return/accept boolean for Config#get/setBool

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,29 @@ var NodeGit = require("../");
 
 var Config = NodeGit.Config;
 
+var _getBool = Config.prototype.getBool;
+var _setBool = Config.prototype.setBool;
+
+/**
+ * @async
+ * @param {String} name The variable's name
+ * @return {Boolean} The variable's value
+ */
+Config.prototype.getBool = function(name) {
+  return _getBool.call(this, name)
+    .then(result => Boolean(result));
+};
+
+/**
+ * @async
+ * @param {String} name The variable's name
+ * @param {Boolean} name The variable's value
+ * @return {Number} 0 or an error code
+ */
+Config.prototype.setBool = function(name, value) {
+  return _setBool.call(this, name, value ? 1 : 0);
+};
+
 // Backwards compatibility.
 Config.prototype.getString = function() {
   return this.getStringBuf.apply(this, arguments);


### PR DESCRIPTION
libgit2 expects an `int` as the value for `setBool` and returns an `int` for `getBool`.  We have booleans in JavaScript, so let's use them.