### PR TITLE
Workaround: Prevent objectwrap from being cleaned up during async work

### DIFF
--- a/generate/templates/filters/args_info.js
+++ b/generate/templates/filters/args_info.js
@@ -1,3 +1,11 @@
+var bannedCppClassNames = [
+  "Buffer",
+  "Function",
+  "GitBuf",
+  "GitStrarray",
+  "Wrapper"
+];
+
 module.exports = function(args) {
   var result = [],
       cArg,
@@ -19,6 +27,9 @@ module.exports = function(args) {
     arg.cArg = cArg;
     arg.isCppClassStringOrArray = ~["String", "Array"].indexOf(arg.cppClassName);
     arg.isConst = ~arg.cType.indexOf("const ");
+
+    arg.isUnwrappable = arg.isLibgitType && !arg.isEnum &&
+      !bannedCppClassNames.includes(arg.cppClassName);
 
     // if we have a callback then we also need the corresponding payload for that callback
     if (arg.isCallbackFunction) {

--- a/generate/templates/filters/fields_info.js
+++ b/generate/templates/filters/fields_info.js
@@ -1,15 +1,26 @@
+var bannedCppClassNames = [
+  "Buffer",
+  "Function",
+  "GitBuf",
+  "GitStrarray",
+  "Wrapper"
+];
+
 module.exports = function(fields) {
   var result = [];
 
-  fields.forEach(function (field){
+  fields.forEach(function (field, index){
     var fieldInfo = {};
 
     fieldInfo.__proto__ = field;
 
+    fieldInfo.index = index;
     fieldInfo.parsedName = field.name || "result";
     fieldInfo.isCppClassIntType = ~["Uint32", "Int32"].indexOf(field.cppClassName);
     fieldInfo.parsedClassName = (field.cppClassName || '').toLowerCase() + "_t";
     fieldInfo.hasOwner = !fieldInfo.selfOwned && !!fieldInfo.ownedByThis;
+    fieldInfo.isUnwrappable = fieldInfo.isLibgitType && !fieldInfo.isEnum &&
+      !bannedCppClassNames.includes(fieldInfo.cppClassName);
 
     result.push(fieldInfo);
   });

--- a/generate/templates/manual/clone/clone.cc
+++ b/generate/templates/manual/clone/clone.cc
@@ -79,12 +79,10 @@ NAN_METHOD(GitClone::Clone) {
       new Nan::Callback(v8::Local<Function>::Cast(info[3]));
   CloneWorker *worker = new CloneWorker(baton, callback);
 
-  if (!info[0]->IsUndefined() && !info[0]->IsNull())
-    worker->SaveToPersistent("url", Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  if (!info[1]->IsUndefined() && !info[1]->IsNull())
-    worker->SaveToPersistent("local_path", Nan::To<v8::Object>(info[1]).ToLocalChecked());
-  if (!info[2]->IsUndefined() && !info[2]->IsNull())
-    worker->SaveToPersistent("options", Nan::To<v8::Object>(info[2]).ToLocalChecked());
+  worker->SaveToPersistent("url", info[0]);
+  worker->SaveToPersistent("local_path", info[1]);
+  worker->SaveToPersistent("options", info[2]);
+  worker->Reference<GitCloneOptions>("options", info[2]);
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/clone/clone.cc
+++ b/generate/templates/manual/clone/clone.cc
@@ -79,9 +79,9 @@ NAN_METHOD(GitClone::Clone) {
       new Nan::Callback(v8::Local<Function>::Cast(info[3]));
   CloneWorker *worker = new CloneWorker(baton, callback);
 
-  worker->SaveToPersistent("url", info[0]);
-  worker->SaveToPersistent("local_path", info[1]);
-  worker->SaveToPersistent("options", info[2]);
+  worker->Reference("url", info[0]);
+  worker->Reference("local_path", info[1]);
+  worker->Reference("options", info[2]);
   worker->Reference<GitCloneOptions>("options", info[2]);
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());

--- a/generate/templates/manual/commit/extract_signature.cc
+++ b/generate/templates/manual/commit/extract_signature.cc
@@ -65,8 +65,8 @@ NAN_METHOD(GitCommit::ExtractSignature)
   }
 
   ExtractSignatureWorker *worker = new ExtractSignatureWorker(baton, callback);
-  worker->SaveToPersistent("repo", Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  worker->SaveToPersistent("commit_id", Nan::To<v8::Object>(info[1]).ToLocalChecked());
+  worker->Reference<GitRepository>("repo", info[0]);
+  worker->Reference<GitOid>("commit_id", info[1]);
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/filter_list/load.cc
+++ b/generate/templates/manual/filter_list/load.cc
@@ -92,16 +92,8 @@ NAN_METHOD(GitFilterList::Load) {
       new Nan::Callback(v8::Local<Function>::Cast(info[5]));
   LoadWorker *worker = new LoadWorker(baton, callback);
 
-  if (!info[0]->IsUndefined() && !info[0]->IsNull())
-    worker->SaveToPersistent("repo", Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  if (!info[1]->IsUndefined() && !info[1]->IsNull())
-    worker->SaveToPersistent("blob", Nan::To<v8::Object>(info[1]).ToLocalChecked());
-  if (!info[2]->IsUndefined() && !info[2]->IsNull())
-    worker->SaveToPersistent("path", Nan::To<v8::Object>(info[2]).ToLocalChecked());
-  if (!info[3]->IsUndefined() && !info[3]->IsNull())
-    worker->SaveToPersistent("mode", Nan::To<v8::Object>(info[3]).ToLocalChecked());
-  if (!info[4]->IsUndefined() && !info[4]->IsNull())
-    worker->SaveToPersistent("flags", Nan::To<v8::Object>(info[4]).ToLocalChecked());
+  worker->Reference<GitRepository>("repo", info[0]);
+  worker->Reference<GitBlob>("blob", info[1]);
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/filter_source/repo.cc
+++ b/generate/templates/manual/filter_source/repo.cc
@@ -21,7 +21,7 @@ NAN_METHOD(GitFilterSource::Repo) {
   Nan::Callback *callback = new Nan::Callback(v8::Local<Function>::Cast(info[0]));
   RepoWorker *worker = new RepoWorker(baton, callback);
 
-  worker->SaveToPersistent("src", info.This());
+  worker->Reference<GitFilterSource>("src", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/include/async_worker.h
+++ b/generate/templates/manual/include/async_worker.h
@@ -2,6 +2,7 @@
 #define NODEGIT_ASYNC_WORKER
 
 #include <nan.h>
+#include <functional>
 #include "lock_master.h"
 
 namespace nodegit {
@@ -25,7 +26,12 @@ namespace nodegit {
 
     bool GetIsCancelled() const;
 
+    void Destroy() override;
+
+    void RegisterCleanupCall(std::function<void()> cleanupCall);
+
   private:
+    std::vector<std::function<void()>> cleanupCalls;
     bool isCancelled = false;
   };
 }

--- a/generate/templates/manual/include/async_worker.h
+++ b/generate/templates/manual/include/async_worker.h
@@ -30,6 +30,43 @@ namespace nodegit {
 
     void RegisterCleanupCall(std::function<void()> cleanupCall);
 
+    template<class NodeGitWrapperT>
+    void Reference(v8::Local<v8::Value> item) {
+      if (item->IsString() || item->IsNull() || item->IsUndefined()) {
+        return;
+      }
+
+      auto objectWrapPointer = Nan::ObjectWrap::Unwrap<NodeGitWrapperT>(item.As<v8::Object>());
+      objectWrapPointer->Reference();
+      RegisterCleanupCall([objectWrapPointer]() {
+        objectWrapPointer->Unreference();
+      });
+    }
+
+    template<class NodeGitWrapperT>
+    inline void Reference(const char *label, v8::Local<v8::Value> item) {
+      SaveToPersistent(label, item);
+      Reference<NodeGitWrapperT>(item);
+    }
+
+    template<class NodeGitWrapperT>
+    inline void Reference(const char *label, v8::Local<v8::Object> item) {
+      SaveToPersistent(label, item);
+      Reference<NodeGitWrapperT>(item);
+    }
+
+    template<class NodeGitWrapperT>
+    inline void Reference(const char *label, v8::Local<v8::Array> array) {
+      SaveToPersistent(label, array);
+      for (uint32_t i = 0; i < array->Length(); ++i) {
+        Reference<NodeGitWrapperT>(Nan::Get(array, i).ToLocalChecked());
+      }
+    }
+
+    inline void Reference(const char *label, v8::Local<v8::Value> item) {
+      SaveToPersistent(label, item);
+    }
+
   private:
     std::vector<std::function<void()>> cleanupCalls;
     bool isCancelled = false;

--- a/generate/templates/manual/include/convenient_hunk.h
+++ b/generate/templates/manual/include/convenient_hunk.h
@@ -36,6 +36,9 @@ class ConvenientHunk : public Nan::ObjectWrap {
     char *GetHeader();
     size_t GetSize();
 
+    void Reference();
+    void Unreference();
+
   private:
     ConvenientHunk(HunkData *hunk);
     ~ConvenientHunk();

--- a/generate/templates/manual/include/convenient_patch.h
+++ b/generate/templates/manual/include/convenient_patch.h
@@ -50,6 +50,9 @@ class ConvenientPatch : public Nan::ObjectWrap {
     size_t GetNumHunks();
     PatchData *GetValue();
 
+    void Reference();
+    void Unreference();
+
   private:
     ConvenientPatch(PatchData *raw);
     ~ConvenientPatch();

--- a/generate/templates/manual/include/nodegit_wrapper.h
+++ b/generate/templates/manual/include/nodegit_wrapper.h
@@ -2,6 +2,7 @@
 #define NODEGIT_WRAPPER_H
 
 #include <nan.h>
+#include <algorithm>
 #include <unordered_map>
 
 // the Traits template parameter supplies:
@@ -33,7 +34,7 @@ public:
   // (and through a method) instead of changing selfFreeing, but that's
   // a separate issue.
   bool selfFreeing;
-  
+
   const nodegit::Context *nodegitContext = nullptr;
 
 protected:
@@ -63,8 +64,17 @@ protected:
 public:
   static v8::Local<v8::Value> New(const cType *raw, bool selfFreeing, v8::Local<v8::Object> owner = v8::Local<v8::Object>());
 
+  void Reference();
+  void Unreference();
+
+  void AddReferenceCallbacks(size_t, std::function<void()>, std::function<void()>);
+
   cType *GetValue();
   void ClearValue();
+
+private:
+  std::unordered_map<size_t, std::function<void()>> referenceCallbacks;
+  std::unordered_map<size_t, std::function<void()>> unreferenceCallbacks;
 };
 
 #endif

--- a/generate/templates/manual/patches/convenient_patches.cc
+++ b/generate/templates/manual/patches/convenient_patches.cc
@@ -19,7 +19,7 @@ NAN_METHOD(GitPatch::ConvenientFromDiff) {
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]));
   ConvenientFromDiffWorker *worker = new ConvenientFromDiffWorker(baton, callback);
 
-  worker->SaveToPersistent("diff", info[0]);
+  worker->Reference<GitDiff>("diff", info[0]);
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -13,7 +13,7 @@ NAN_METHOD(GitRemote::ReferenceList)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   ReferenceListWorker *worker = new ReferenceListWorker(baton, callback);
-  worker->SaveToPersistent("remote", info.This());
+  worker->Reference<GitRemote>("remote", info.This());
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/repository/get_references.cc
+++ b/generate/templates/manual/repository/get_references.cc
@@ -13,7 +13,7 @@ NAN_METHOD(GitRepository::GetReferences)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   GetReferencesWorker *worker = new GetReferencesWorker(baton, callback);
-  worker->SaveToPersistent("repo", info.This());
+  worker->Reference<GitRepository>("repo", info.This());
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -13,7 +13,7 @@ NAN_METHOD(GitRepository::GetRemotes)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   GetRemotesWorker *worker = new GetRemotesWorker(baton, callback);
-  worker->SaveToPersistent("repo", info.This());
+  worker->Reference<GitRepository>("repo", info.This());
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/repository/get_submodules.cc
+++ b/generate/templates/manual/repository/get_submodules.cc
@@ -13,7 +13,7 @@ NAN_METHOD(GitRepository::GetSubmodules)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   GetSubmodulesWorker *worker = new GetSubmodulesWorker(baton, callback);
-  worker->SaveToPersistent("repo", info.This());
+  worker->Reference<GitRepository>("repo", info.This());
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -405,7 +405,7 @@ NAN_METHOD(GitRepository::RefreshReferences)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   RefreshReferencesWorker *worker = new RefreshReferencesWorker(baton, callback);
-  worker->SaveToPersistent("repo", info.This());
+  worker->Reference<GitRepository>("repo", info.This());
   worker->SaveToPersistent("signatureType", signatureType);
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/repository/refresh_references.cc
+++ b/generate/templates/manual/repository/refresh_references.cc
@@ -406,7 +406,7 @@ NAN_METHOD(GitRepository::RefreshReferences)
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   RefreshReferencesWorker *worker = new RefreshReferencesWorker(baton, callback);
   worker->Reference<GitRepository>("repo", info.This());
-  worker->SaveToPersistent("signatureType", signatureType);
+  worker->Reference("signatureType", signatureType);
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
   return;

--- a/generate/templates/manual/revwalk/commit_walk.cc
+++ b/generate/templates/manual/revwalk/commit_walk.cc
@@ -143,7 +143,7 @@ NAN_METHOD(GitRevwalk::CommitWalk) {
   baton->walk = Nan::ObjectWrap::Unwrap<GitRevwalk>(info.This())->GetValue();
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]->IsFunction() ? info[1] : info[2]));
   CommitWalkWorker *worker = new CommitWalkWorker(baton, callback);
-  worker->SaveToPersistent("commitWalk", info.This());
+  worker->Reference<GitRevwalk>("commitWalk", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -19,7 +19,7 @@ NAN_METHOD(GitRevwalk::FastWalk)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]));
   FastWalkWorker *worker = new FastWalkWorker(baton, callback);
-  worker->SaveToPersistent("fastWalk", info.This());
+  worker->Reference<GitRevwalk>("fastWalk", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/revwalk/file_history_walk.cc
+++ b/generate/templates/manual/revwalk/file_history_walk.cc
@@ -205,7 +205,7 @@ NAN_METHOD(GitRevwalk::FileHistoryWalk)
 
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[2]));
   FileHistoryWalkWorker *worker = new FileHistoryWalkWorker(baton, callback);
-  worker->SaveToPersistent("fileHistoryWalk", info.This());
+  worker->Reference<GitRevwalk>("fileHistoryWalk", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/src/async_worker.cc
+++ b/generate/templates/manual/src/async_worker.cc
@@ -21,4 +21,15 @@ namespace nodegit {
   bool AsyncWorker::GetIsCancelled() const {
     return isCancelled;
   }
+
+  void AsyncWorker::Destroy() {
+    std::for_each(cleanupCalls.begin(), cleanupCalls.end(), [](std::function<void()> cleanupCall) {
+      cleanupCall();
+    });
+    Nan::AsyncWorker::Destroy();
+  }
+
+  void AsyncWorker::RegisterCleanupCall(std::function<void()> cleanupCall) {
+    cleanupCalls.push_back(cleanupCall);
+  }
 }

--- a/generate/templates/manual/src/convenient_hunk.cc
+++ b/generate/templates/manual/src/convenient_hunk.cc
@@ -105,7 +105,7 @@ NAN_METHOD(ConvenientHunk::Lines) {
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   LinesWorker *worker = new LinesWorker(baton, callback);
 
-  worker->SaveToPersistent("hunk", info.This());
+  worker->Reference<ConvenientHunk>("hunk", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
@@ -200,4 +200,12 @@ NAN_METHOD(ConvenientHunk::Header) {
   }
 
   info.GetReturnValue().Set(to);
+}
+
+void ConvenientHunk::Reference() {
+  Ref();
+}
+
+void ConvenientHunk::Unreference() {
+  Unref();
 }

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -221,7 +221,7 @@ NAN_METHOD(ConvenientPatch::Hunks) {
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[0]));
   HunksWorker *worker = new HunksWorker(baton, callback);
 
-  worker->SaveToPersistent("patch", info.This());
+  worker->Reference<ConvenientPatch>("patch", info.This());
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);
@@ -419,4 +419,12 @@ NAN_METHOD(ConvenientPatch::IsConflicted) {
   Local<v8::Value> to;
   to = Nan::New<Boolean>(Nan::ObjectWrap::Unwrap<ConvenientPatch>(info.This())->GetStatus() == GIT_DELTA_CONFLICTED);
   info.GetReturnValue().Set(to);
+}
+
+void ConvenientPatch::Reference() {
+  Ref();
+}
+
+void ConvenientPatch::Unreference() {
+  Unref();
 }

--- a/generate/templates/manual/src/filter_registry.cc
+++ b/generate/templates/manual/src/filter_registry.cc
@@ -71,8 +71,8 @@ NAN_METHOD(GitFilterRegistry::GitFilterRegister) {
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[3]));
   RegisterWorker *worker = new RegisterWorker(baton, callback);
 
-  worker->SaveToPersistent("filter_name", Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  worker->SaveToPersistent("filter_priority", Nan::To<v8::Object>(info[2]).ToLocalChecked());
+  worker->Reference("filter_name", info[0]);
+  worker->Reference("filter_priority", info[2]);
 
   nodegitContext->QueueWorker(worker);
   return;
@@ -177,7 +177,7 @@ NAN_METHOD(GitFilterRegistry::GitFilterUnregister) {
   Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[1]));
   UnregisterWorker *worker = new UnregisterWorker(baton, callback);
 
-  worker->SaveToPersistent("filter_name", info[0]);
+  worker->Reference("filter_name", info[0]);
 
   nodegit::Context *nodegitContext = reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
   nodegitContext->QueueWorker(worker);

--- a/generate/templates/manual/src/nodegit_wrapper.cc
+++ b/generate/templates/manual/src/nodegit_wrapper.cc
@@ -124,3 +124,25 @@ void NodeGitWrapper<Traits>::InitializeTemplate(v8::Local<v8::FunctionTemplate> 
   Nan::SetMethod(tpl, "getSelfFreeingInstanceCount", GetSelfFreeingInstanceCount);
   Nan::SetMethod(tpl, "getNonSelfFreeingConstructedCount", GetNonSelfFreeingConstructedCount);
 }
+
+template<typename Traits>
+void NodeGitWrapper<Traits>::Reference() {
+  Ref();
+  for (auto &i : referenceCallbacks) {
+    i.second();
+  }
+}
+
+template<typename Traits>
+void NodeGitWrapper<Traits>::Unreference() {
+  Unref();
+  for (auto &i : unreferenceCallbacks) {
+    i.second();
+  }
+}
+
+template<typename Traits>
+void NodeGitWrapper<Traits>::AddReferenceCallbacks(size_t fieldIndex, std::function<void()> refCb, std::function<void()> unrefCb) {
+  referenceCallbacks[fieldIndex] = refCb;
+  unreferenceCallbacks[fieldIndex] = unrefCb;
+}

--- a/test/tests/revwalk.js
+++ b/test/tests/revwalk.js
@@ -345,7 +345,9 @@ describe("Revwalk", function() {
     var test = this;
 
     return leakTest(NodeGit.Revwalk, function() {
-      return Promise.resolve(NodeGit.Revwalk.create(test.repository));
+      const walker = test.repository.createRevWalk();
+      walker.push("115d114e2c4d5028c7a78428f16a4528c51be7dd");
+      return walker.next();
     });
   });
 


### PR DESCRIPTION
We're seeing some super weird behavior where an object that was persisted is being cleaned up during async work. We need to workaround this issue, as we are reasonably certain that our persistent references are well formed. We suspect this is an issue with v8 itself rather than an issue with our code. We are now aggressively preventing GC from calling the objectwrap destructor until the objectwrap is no longer in use.
