### PR TITLE
Define optional arguments for Patch.fromBlobs()

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -2743,6 +2743,29 @@
         "git_patch_free": {
           "ignore": true
         },
+        "git_patch_from_blobs": {
+          "isAsync": true,
+          "args": {
+            "out": {
+              "isReturn": true
+            },
+            "old_blob": {
+              "isOptional": true
+            },
+            "old_as_path": {
+              "isOptional": true
+            },
+            "new_blob": {
+              "isOptional": true
+            },
+            "new_as_path": {
+              "isOptional": true
+            },
+            "opts": {
+              "isOptional": true
+            }
+          }
+        },
         "git_patch_from_blob_and_buffer": {
           "ignore": true
         },

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var NodeGit = require("../");
+var Patch = NodeGit.Patch;
+var normalizeOptions = NodeGit.Utils.normalizeOptions;
+
+var _fromBlobs = Patch.fromBlobs;
+
+Patch.fromBlobs = function (
+    old_blob,
+    old_as_path,
+    new_blob,
+    new_as_path,
+    opts
+) {
+    opts = normalizeOptions(opts, NodeGit.DiffOptions);
+    return _fromBlobs.call(
+        this,
+        old_blob,
+        old_as_path,
+        new_blob,
+        new_as_path,
+        opts
+    );
+};

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -61,4 +61,26 @@ describe("Patch", function() {
       });
 
   });
+
+  it("can generate patch from blobs", async function() {
+    // Generates a patch for README.md from commit fce88902e66c72b5b93e75bdb5ae717038b221f6
+    const file = "README.md";
+
+    const blob = await NodeGit.Blob.lookup(this.repository, "b252f396b17661462372f78b7bcfc403b8731aaa");
+    const oldBlob = await NodeGit.Blob.lookup(this.repository, "b8d014998072c3f9e4b7eba8486011e80d8de98a");
+    const patch = await NodeGit.Patch.fromBlobs(oldBlob, file, blob, file);
+
+    assert.strictEqual(patch.size(0, 0, 0), 254);
+  });
+
+  it ("can generate patch from blobs without 'old_blob'", async function() {
+    // Generates a patch for README.md from commit fce88902e66c72b5b93e75bdb5ae717038b221f6
+    // without old_blob. Should show all lines as additions.
+    const file = "README.md";
+
+    const blob = await NodeGit.Blob.lookup(this.repository, "b252f396b17661462372f78b7bcfc403b8731aaa");
+    const patch = await NodeGit.Patch.fromBlobs(null, file, blob, file);
+
+    assert.strictEqual(patch.size(0, 0, 0), 8905);
+  });
 });

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -83,7 +83,7 @@ describe("Patch", function() {
     });
   });
 
-  it ("can generate patch from blobs without 'old_blob'", function() {
+  it("can generate patch from blobs without 'old_blob'", function() {
     // Generates a patch for README.md from commit 
     // fce88902e66c72b5b93e75bdb5ae717038b221f6 without
     // old_blob. Should show all lines as additions.
@@ -98,5 +98,12 @@ describe("Patch", function() {
           assert.strictEqual(patch.size(0, 0, 0), 8905);
         });
     });
+  });
+
+  it("can generate patch from blobs without arguments", function() {
+    NodeGit.Patch.fromBlobs()
+      .then(patch => {
+        assert.strictEqual(patch.size(0, 0, 0), 0);
+      });
   });
 });

--- a/test/tests/patch.js
+++ b/test/tests/patch.js
@@ -62,25 +62,41 @@ describe("Patch", function() {
 
   });
 
-  it("can generate patch from blobs", async function() {
-    // Generates a patch for README.md from commit fce88902e66c72b5b93e75bdb5ae717038b221f6
+  it("can generate patch from blobs", function() {
+    // Generates a patch for README.md from commit
+    // fce88902e66c72b5b93e75bdb5ae717038b221f6
     const file = "README.md";
 
-    const blob = await NodeGit.Blob.lookup(this.repository, "b252f396b17661462372f78b7bcfc403b8731aaa");
-    const oldBlob = await NodeGit.Blob.lookup(this.repository, "b8d014998072c3f9e4b7eba8486011e80d8de98a");
-    const patch = await NodeGit.Patch.fromBlobs(oldBlob, file, blob, file);
-
-    assert.strictEqual(patch.size(0, 0, 0), 254);
+    NodeGit.Blob.lookup(
+      this.repository,
+      "b252f396b17661462372f78b7bcfc403b8731aaa"
+    ).then(blob => {
+      NodeGit.Blob.lookup(
+        this.repository,
+        "b8d014998072c3f9e4b7eba8486011e80d8de98a"
+      ).then(oldBlob => {
+        NodeGit.Patch.fromBlobs(oldBlob, file, blob, file)
+          .then(patch => {
+            assert.strictEqual(patch.size(0, 0, 0), 254);
+          });
+        });
+    });
   });
 
-  it ("can generate patch from blobs without 'old_blob'", async function() {
-    // Generates a patch for README.md from commit fce88902e66c72b5b93e75bdb5ae717038b221f6
-    // without old_blob. Should show all lines as additions.
+  it ("can generate patch from blobs without 'old_blob'", function() {
+    // Generates a patch for README.md from commit 
+    // fce88902e66c72b5b93e75bdb5ae717038b221f6 without
+    // old_blob. Should show all lines as additions.
     const file = "README.md";
 
-    const blob = await NodeGit.Blob.lookup(this.repository, "b252f396b17661462372f78b7bcfc403b8731aaa");
-    const patch = await NodeGit.Patch.fromBlobs(null, file, blob, file);
-
-    assert.strictEqual(patch.size(0, 0, 0), 8905);
+    NodeGit.Blob.lookup(
+      this.repository,
+      "b252f396b17661462372f78b7bcfc403b8731aaa"
+    ).then(blob => {
+      NodeGit.Patch.fromBlobs(null, file, blob, file)
+        .then(patch => {
+          assert.strictEqual(patch.size(0, 0, 0), 8905);
+        });
+    });
   });
 });


### PR DESCRIPTION
According to the libgit2 documentation (https://libgit2.org/libgit2/#HEAD/group/patch/git_patch_from_blobs) all arguments are allowed to be NULL.