### PR TITLE
Statistics with same output as "git-sizer -j"

### DIFF
--- a/generate/input/descriptor.json
+++ b/generate/input/descriptor.json
@@ -3699,6 +3699,9 @@
         "git_repository_set_refdb": {
           "ignore": true
         },
+        "git_repository_statistics": {
+          "isAsync": true
+        },
         "git_repository_submodule_cache_all": {
           "return": {
             "isErrorCode": true

--- a/generate/input/libgit2-supplement.json
+++ b/generate/input/libgit2-supplement.json
@@ -725,6 +725,28 @@
         },
         "group": "repository"
       },
+      "git_repository_statistics": {
+        "args": [
+          {
+            "name": "out",
+            "type": "void *"
+          },
+          {
+            "name": "repo",
+            "type": "git_repository *"
+          }
+        ],
+        "type": "function",
+        "isManual": true,
+        "cFile": "generate/templates/manual/repository/statistics.cc",
+        "isAsync": true,
+        "isPrototypeMethod": true,
+        "group": "repository",
+        "return": {
+          "type": "int",
+          "isErrorCode": true
+        }
+      },
       "git_repository_submodule_cache_all": {
         "type": "function",
         "file": "sys/repository.h",
@@ -1043,6 +1065,7 @@
           "git_repository_get_remotes",
           "git_repository_refresh_references",
           "git_repository_set_index",
+          "git_repository_statistics",
           "git_repository_submodule_cache_all",
           "git_repository_submodule_cache_clear"
         ]

--- a/generate/templates/manual/include/worker_pool.h
+++ b/generate/templates/manual/include/worker_pool.h
@@ -1,0 +1,161 @@
+#ifndef WORK_POOL_H
+#define WORK_POOL_H
+
+#include <type_traits>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <vector>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+/**
+ * \class WorkItem
+ * Abstract class for work items in the WorkerPool.
+ */
+class WorkItem
+{
+public:
+  WorkItem() = default;
+  virtual ~WorkItem() = default;
+  WorkItem(const WorkItem &other) = default;
+  WorkItem(WorkItem &&other) = default;
+  WorkItem& operator=(const WorkItem &other) = default;
+  WorkItem& operator=(WorkItem &&other) = default;
+};
+
+/**
+ * \class Worker
+ * Interface for Workers in the WorkerPool.
+ */
+class IWorker
+{
+public:
+  IWorker() = default;
+  virtual ~IWorker() = default;
+  IWorker(const IWorker &other) = delete;
+  IWorker(IWorker &&other) = delete;
+  IWorker& operator=(const IWorker &other) = delete;
+  IWorker& operator=(IWorker &&other) = delete;
+
+  virtual bool Initialize() = 0;
+  virtual bool Execute(std::unique_ptr<WorkItem> &&work) = 0;
+};
+
+/**
+ * \class WorkerPool
+ * To leverage this class, a Worker must inherit from IWorker.
+ * WorkItem is an abstract class from which to inherit too.
+ */
+template<class Worker, class WorkItem>
+class WorkerPool {
+public:
+  WorkerPool();
+  ~WorkerPool() = default;
+  WorkerPool(const WorkerPool &other) = delete;
+  WorkerPool(WorkerPool &&other) = delete;
+  WorkerPool& operator=(const WorkerPool &other) = delete;
+  WorkerPool& operator=(WorkerPool &&other) = delete;
+
+  bool Init(std::vector< std::shared_ptr<Worker> > workers);
+  bool InsertWork(std::unique_ptr<WorkItem> &&work);
+  void Shutdown();
+
+private:
+  void DoWork(std::shared_ptr<Worker> worker);
+  
+  std::mutex m_workQueueMutex {};
+  std::condition_variable m_workQueueCondition {};
+  std::queue< std::unique_ptr<WorkItem> > m_workQueue {};
+  std::vector<std::unique_ptr<std::thread>> m_threads {};
+  bool m_stop {true}; // initially the workpool has no worker threads
+};
+
+
+template<class Worker, class WorkItem>
+WorkerPool<Worker,WorkItem>::WorkerPool() {
+  static_assert(std::is_base_of<IWorker, Worker>::value, "Worker must inherit from IWorker");
+}
+
+// returns true it it wasn't initialized previously; false otherwise
+template<class Worker, class WorkItem>
+bool WorkerPool<Worker,WorkItem>::Init(std::vector< std::shared_ptr<Worker> > workers)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_workQueueMutex);
+    if (!m_stop)
+      return false;
+    m_stop = false;
+  }
+  
+  std::for_each (workers.begin(), workers.end(), [this](std::shared_ptr<Worker> worker) {
+    m_threads.emplace_back(std::make_unique<std::thread>(std::bind(&WorkerPool::DoWork, this, worker)));
+  });
+  
+  return true;
+}
+
+// returns true if successfully inserted work; false otherwise
+template<class Worker, class WorkItem>
+bool WorkerPool<Worker,WorkItem>::InsertWork(std::unique_ptr<WorkItem> &&work)
+{
+  {
+    std::lock_guard<std::mutex> lock(m_workQueueMutex);
+    if (m_stop)
+      return false;
+    m_workQueue.emplace(std::move(work));
+  }
+  m_workQueueCondition.notify_one();
+  
+  return true;
+}
+
+template<class Worker, class WorkItem>
+void WorkerPool<Worker,WorkItem>::Shutdown()
+{
+  {
+    std::lock_guard<std::mutex> lock(m_workQueueMutex);
+    if (m_stop)
+      return;
+    m_stop = true;
+  }
+  m_workQueueCondition.notify_all();
+  
+  std::for_each (m_threads.begin(), m_threads.end(), [](std::unique_ptr<std::thread> &wt) {
+    if (wt->joinable()) {
+      wt->join();
+    }
+  });
+}
+
+template<class Worker, class WorkItem>
+void WorkerPool<Worker,WorkItem>::DoWork(std::shared_ptr<Worker> worker)
+{
+  if (!worker->Initialize()) {
+    return; // signal main that we've exited early
+  }
+  
+  while (true) {
+    std::unique_ptr<WorkItem> work {};
+    {
+      std::unique_lock<std::mutex> lock(m_workQueueMutex);
+      m_workQueueCondition.wait(lock, [this] {
+        return this->m_stop || !this->m_workQueue.empty();
+      });
+      
+      if (m_stop && m_workQueue.empty())
+        return;
+      
+      work = std::move(m_workQueue.front());
+      m_workQueue.pop();
+    }
+    
+    if (!worker->Execute(std::move(work))) {
+      return; // signal main that we've exited early
+    }
+  }
+}
+
+#endif  // WORK_POOL_H
+

--- a/generate/templates/manual/include/worker_pool.h
+++ b/generate/templates/manual/include/worker_pool.h
@@ -9,6 +9,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <thread>
+#include <atomic>
 
 /**
  * \class WorkItem
@@ -43,6 +44,14 @@ public:
   virtual bool Execute(std::unique_ptr<WorkItem> &&work) = 0;
 };
 
+/* Enumeration describing the Worker Pool Status:
+* - kOk: everything ok.
+* - kInitializeFailed: a worker thread failed when calling Initialize().
+* - kExecuteFailed: a worker thread failed when calling Execute().
+* - kShutdownEarly: InsertWork() was called but the worker pool was stopped.
+*/
+enum class WPStatus {kOk, kInitializeFailed, kExecuteFailed, kShutdownEarly};
+
 /**
  * \class WorkerPool
  * To leverage this class, a Worker must inherit from IWorker.
@@ -61,25 +70,17 @@ public:
   void Init(std::vector< std::shared_ptr<Worker> > workers);
   void InsertWork(std::unique_ptr<WorkItem> &&work);
   void Shutdown();
-  bool Status() { return m_status.workersInitialize && m_status.workersExecute && !m_status.shutdownEarly; }
-  bool StatusWorkersInitialize() { return m_status.workersInitialize; }
-  bool StatusWorkersExecute() { return m_status.workersExecute; }
-  bool StatusShutdownEarly() { return !m_status.shutdownEarly; }
+  WPStatus Status() { return m_atomicWPStatus; }
 
 private:
   void DoWork(std::shared_ptr<Worker> worker);
   
-  std::mutex m_workQueueMutex {};
-  std::condition_variable m_workQueueCondition {};
+  std::mutex m_mutex {};            // locks m_workQueue and m_stop
+  std::condition_variable m_condition {};
   std::queue< std::unique_ptr<WorkItem> > m_workQueue {};
-  std::vector<std::unique_ptr<std::thread>> m_threads {};
   bool m_stop {true};               // initially the workpool has no worker threads
-  struct {
-    bool workersInitialize {true};
-    bool workersExecute {true};
-    bool shutdownEarly {false};   // for instance if the workerPool was ShutDown, and InsertWork called after that
-  } m_status;
-  std::mutex m_statusMutex {};
+  std::vector<std::unique_ptr<std::thread>> m_threads {};
+  std::atomic<WPStatus> m_atomicWPStatus {WPStatus::kOk};
 };
 
 
@@ -93,7 +94,7 @@ template<class Worker, class WorkItem>
 void WorkerPool<Worker,WorkItem>::Init(std::vector< std::shared_ptr<Worker> > workers)
 {
   {
-    std::lock_guard<std::mutex> lock(m_workQueueMutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_stop)
       return;
     m_stop = false;
@@ -104,33 +105,32 @@ void WorkerPool<Worker,WorkItem>::Init(std::vector< std::shared_ptr<Worker> > wo
   });
 }
 
-// queues work, or updates shutdownEarly status
+// queues work, or sets WPStatus::kShutdownEarly
 template<class Worker, class WorkItem>
 void WorkerPool<Worker,WorkItem>::InsertWork(std::unique_ptr<WorkItem> &&work)
 {
   {
-    std::lock_guard<std::mutex> lock(m_workQueueMutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (m_stop) {
-      // update shutdownEarly status and return
-      std::lock_guard<std::mutex> lock(m_statusMutex);
-      m_status.shutdownEarly = true;
+      m_atomicWPStatus = WPStatus::kShutdownEarly;
       return;
     }
     m_workQueue.emplace(std::move(work));
   }
-  m_workQueueCondition.notify_one();
+  m_condition.notify_one();
 }
 
 template<class Worker, class WorkItem>
 void WorkerPool<Worker,WorkItem>::Shutdown()
 {
   {
-    std::lock_guard<std::mutex> lock(m_workQueueMutex);
-    if (m_stop)
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_stop) {
       return;
+    }
     m_stop = true;
   }
-  m_workQueueCondition.notify_all();
+  m_condition.notify_all();
   
   std::for_each (m_threads.begin(), m_threads.end(), [](std::unique_ptr<std::thread> &wt) {
     if (wt->joinable()) {
@@ -142,24 +142,22 @@ void WorkerPool<Worker,WorkItem>::Shutdown()
 template<class Worker, class WorkItem>
 void WorkerPool<Worker,WorkItem>::DoWork(std::shared_ptr<Worker> worker)
 {
-  if (!worker->Initialize())
-  { // update initialized status and stop worker
-    std::lock_guard<std::mutex> lock(m_statusMutex);
-    m_status.workersInitialize = false;
+  if (!worker->Initialize()) {
+    m_atomicWPStatus = WPStatus::kInitializeFailed;
     return;
   }
 
   while (true) {
     std::unique_ptr<WorkItem> work {};
     {
-      std::unique_lock<std::mutex> lock(m_workQueueMutex);
-      m_workQueueCondition.wait(lock, [this] {
+      std::unique_lock<std::mutex> lock(m_mutex);
+      m_condition.wait(lock, [this] {
         return this->m_stop || !this->m_workQueue.empty();
       });
 
       // stop all workers if any of them failed on Initialize() or Execute()
       // or the workerPool shutdown early
-      if (!Status()) {
+      if (Status() != WPStatus::kOk) {
         return;
       }
 
@@ -171,10 +169,8 @@ void WorkerPool<Worker,WorkItem>::DoWork(std::shared_ptr<Worker> worker)
       m_workQueue.pop();
     }
     
-    if (!worker->Execute(std::move(work)))
-    { // update execute status
-      std::lock_guard<std::mutex> lock(m_statusMutex);
-      m_status.workersExecute = false;
+    if (!worker->Execute(std::move(work))) {
+      m_atomicWPStatus = WPStatus::kExecuteFailed;
       return;
     }
   }

--- a/generate/templates/manual/repository/statistics.cc
+++ b/generate/templates/manual/repository/statistics.cc
@@ -1,0 +1,1889 @@
+/**
+ * \struct CommitsGraphNode
+ */
+struct CommitsGraphNode
+{
+  CommitsGraphNode(uint32_t aParentsLeft) : parentsLeft(aParentsLeft) {}
+  CommitsGraphNode() = default;
+  ~CommitsGraphNode() = default;
+  CommitsGraphNode(const CommitsGraphNode &other) = delete;
+  CommitsGraphNode(CommitsGraphNode &&other) = delete;
+  CommitsGraphNode& operator=(const CommitsGraphNode &other) = delete;
+  CommitsGraphNode& operator=(CommitsGraphNode &&other) = delete;
+
+  std::vector<CommitsGraphNode *> children {};
+  uint32_t parentsLeft {0}; // used when calculating the maximum history depth
+};
+
+/**
+ * \class CommitsGraph
+ */
+class CommitsGraph
+{
+public:
+  CommitsGraph() = default;
+  ~CommitsGraph() = default;
+  CommitsGraph(const CommitsGraph &other) = delete;
+  CommitsGraph(CommitsGraph &&other) = delete;
+  CommitsGraph& operator=(const CommitsGraph &other) = delete;
+  CommitsGraph& operator=(CommitsGraph &&other) = delete;
+
+  using CommitsGraphMap = std::unordered_map<std::string, std::unique_ptr<CommitsGraphNode>>;
+
+  void AddNode(const std::string &oidStr, const std::vector<std::string> &parents, uint32_t numParents);
+  uint32_t CalculateMaxDepth();
+
+private:
+  void addParentNode(const std::string &oidParentStr, CommitsGraphNode *child);
+
+  CommitsGraphMap m_mapOidNode {};
+  std::vector<CommitsGraphNode *> m_roots {};
+};
+
+/**
+ * CommitsGraph::AddNode
+ * 
+ * \param oidStr oid of the commit object to add.
+ * \param parents oids of the commit's parents.
+ * \param numParents Number of parents of the commit object.
+ */
+void CommitsGraph::AddNode(const std::string &oidStr, const std::vector<std::string> &parents,
+  uint32_t numParents)
+{
+  auto emplacePair = m_mapOidNode.emplace(std::make_pair(
+    oidStr, std::make_unique<CommitsGraphNode>(numParents)));
+
+  CommitsGraphMap::iterator itNode = emplacePair.first;
+
+  // if this node already added by a child, update its parentsLeft
+  if (emplacePair.second == false) {
+    itNode->second.get()->parentsLeft = numParents;
+  }
+
+  // set roots
+  if (numParents == 0) {
+    m_roots.emplace_back(itNode->second.get());
+  }
+
+  // add parents
+  for (unsigned int i = 0; i < numParents; ++i) {
+    addParentNode(parents.at(i), itNode->second.get());
+  }
+}
+
+/**
+ * CommitsGraph::CalculateMaxDepth
+ * \return Calculated maximum depth of the tree.
+ * 
+ * Uses iterative algorithm to count levels.
+ * Considers multiple initial commits.
+ * Considers that children of one level can have multiple parents, hence we insert unique children
+ * at each level.
+ * Considers that same child can be in different levels. Here to prevent counting the same child
+ * multiple times, we only add a child when the last parent (parentsLeft) inserts it. This is
+ * actually what makes the algorithm fast.
+ * Recursive algorithm avoided to prevent stack overflow in case of excessive levels in the tree.
+ */
+uint32_t CommitsGraph::CalculateMaxDepth()
+{
+  uint32_t maxDepth {0};
+  std::set<CommitsGraphNode *> parents {};
+  std::set<CommitsGraphNode *> children {};
+
+  // start from the root commmits
+  for (CommitsGraphNode *root : m_roots) {
+    children.insert(root);
+  }
+
+  while (!children.empty()) {
+    ++maxDepth;
+    parents = std::move(children);
+
+    // add unique children of next level, and only if from the last parent
+    for (CommitsGraphNode *parent : parents) {
+      for (CommitsGraphNode *child : parent->children) {
+        if (--child->parentsLeft == 0) {
+          children.insert(child);
+        }
+      }
+    }
+  }
+
+  return maxDepth;
+}
+
+/**
+ * CommitsGraph::addParentNode
+ * 
+ * \param oidParentStr oid of the parent commit to add.
+ * \param child Child of the parent commit being added.
+ */
+void CommitsGraph::addParentNode(const std::string &oidParentStr, CommitsGraphNode *child)
+{
+  CommitsGraphMap::iterator itParentNode = m_mapOidNode.emplace(std::make_pair(
+    oidParentStr, std::make_unique<CommitsGraphNode>())).first;
+
+  // add child to parent
+  itParentNode->second->children.emplace_back(child);
+}
+
+/**
+ * \struct TreeStatistics
+ *  Structure to store statistics for a git tree object.
+ */
+struct TreeStatistics
+{
+  TreeStatistics() = default;
+  ~TreeStatistics() = default;
+  TreeStatistics(const TreeStatistics &other) = delete;
+  TreeStatistics(TreeStatistics &&other) = default;
+  TreeStatistics& operator=(const TreeStatistics &other) = delete;
+  TreeStatistics& operator=(TreeStatistics &&other) = default;
+
+  size_t numDirectories{0};
+  size_t maxPathDepth {0};
+  size_t maxPathLength {0};
+  size_t numFiles {0};
+  size_t totalFileSize {0};
+  size_t numSymlinks {0};
+  size_t numSubmodules {0};
+};
+
+/**
+ * \struct Statistics
+ * Stores statistics of the analyzed repository.
+ */
+struct Statistics
+{
+  Statistics() = default;
+  ~Statistics() = default;
+  Statistics(const Statistics &other) = delete;
+  Statistics(Statistics &&other) = delete;
+  Statistics& operator=(const Statistics &other) = delete;
+  Statistics& operator=(Statistics &&other) = delete;
+
+  struct {
+    struct { size_t count {0}; size_t size {0}; } commits;
+    struct { size_t count {0}; size_t size {0}; size_t entries {0}; } trees;
+    struct { size_t count {0}; size_t size {0}; } blobs;
+    struct { size_t count {0}; } annotatedTags;
+    struct { size_t count {0}; } references;
+  } repositorySize {};
+
+  struct {
+    struct { size_t maxSize {0}; size_t maxParents {0}; } commits;
+    struct { size_t maxEntries {0}; } trees;
+    struct { size_t maxSize {0}; } blobs;
+  } biggestObjects {};
+
+  struct {
+    uint32_t maxDepth {0};
+    uint32_t maxTagDepth {0};
+  } historyStructure {};
+
+  TreeStatistics biggestCheckouts {};
+};
+
+/**
+ * \struct OdbObjectsData
+ * Structure to store, for each object read from the repository:
+ * - its information (size, parents for a commit, etc.)
+ * - different data needed to obtain the resulting statistics
+ */
+struct OdbObjectsData
+{
+  static constexpr uint32_t kUnreachable = 0;
+
+  struct CommitInfo {
+    CommitInfo() = default;
+    ~CommitInfo() = default;
+    CommitInfo(const CommitInfo &other) = delete;
+    CommitInfo(CommitInfo &&other) = default;
+    CommitInfo& operator=(const CommitInfo &other) = delete;
+    CommitInfo& operator=(CommitInfo &&other) = default;
+
+    std::string oidTree {};
+    size_t size {0};
+    std::vector<std::string> parents {};
+    // number of sources from which a commit can be reached:
+    // a child commit, a tag, or a direct git reference
+    uint32_t reachability {kUnreachable};
+  };
+
+  struct TreeInfoAndStats {
+    TreeInfoAndStats() = default;
+    ~TreeInfoAndStats() = default;
+    TreeInfoAndStats(const TreeInfoAndStats &other) = delete;
+    TreeInfoAndStats(TreeInfoAndStats &&other) = default;
+    TreeInfoAndStats& operator=(const TreeInfoAndStats &other) = delete;
+    TreeInfoAndStats& operator=(TreeInfoAndStats &&other) = default;
+
+    size_t size {0};
+    size_t numEntries {0};
+    std::vector<std::string> entryBlobs {};
+    std::vector< std::pair<std::string, size_t> > entryTreesNameLen {};
+    // number of sources from which a tree can be reached:
+    // a commit, another tree's entry, or a tag
+    uint32_t reachability {kUnreachable};
+    TreeStatistics stats {};
+    bool statsDone {false};
+  };
+
+  struct BlobInfo {
+    BlobInfo() = default;
+    ~BlobInfo() = default;
+    BlobInfo(const BlobInfo &other) = delete;
+    BlobInfo(BlobInfo &&other) = default;
+    BlobInfo& operator=(const BlobInfo &other) = delete;
+    BlobInfo& operator=(BlobInfo &&other) = default;
+
+    size_t size {0};
+    // number of sources from which a blob can be reached:
+    // a tree's entry, or a tag
+    uint32_t reachability {kUnreachable};
+  };
+
+  struct TagInfo {
+    static constexpr uint32_t kUnsetDepth = 0;
+
+    TagInfo() = default;
+    ~TagInfo() = default;
+    TagInfo(const TagInfo &other) = delete;
+    TagInfo(TagInfo &&other) = default;
+    TagInfo& operator=(const TagInfo &other) = delete;
+    TagInfo& operator=(TagInfo &&other) = default;
+
+    std::string oidTarget {};
+    git_object_t typeTarget {GIT_OBJECT_INVALID};
+    uint32_t depth {kUnsetDepth};
+    // number of sources from which a tag can be reached:
+    // a reference, or another tag
+    uint32_t reachability {kUnreachable};
+  };
+
+  OdbObjectsData() = default;
+  ~OdbObjectsData() = default;
+  OdbObjectsData(const OdbObjectsData &other) = delete;
+  OdbObjectsData(OdbObjectsData &&other) = delete;
+  OdbObjectsData& operator=(const OdbObjectsData &other) = delete;
+  OdbObjectsData& operator=(OdbObjectsData &&other) = delete;
+
+  struct {
+    std::unordered_map<std::string, CommitInfo> info {};
+    std::unordered_set<std::string> unreachables {};
+    // tree of commits (graph) to be built while reading the object database,
+    // in order to calculate the maximum history depth
+    CommitsGraph graph {};
+    size_t totalSize {0};
+    size_t maxSize {0};
+    size_t maxParents {0};
+  } commits {};
+
+  struct {
+    std::unordered_map<std::string, TreeInfoAndStats> info;
+    std::unordered_set<std::string> unreachables {};
+    size_t totalSize {0};
+    size_t totalEntries {0};
+    size_t maxEntries {0};
+  } trees {};
+
+  struct {
+    std::unordered_map<std::string, BlobInfo> info {};
+    std::unordered_set<std::string> unreachables {};
+    size_t totalSize {0};
+    size_t maxSize {0};
+  } blobs {};
+
+  struct {
+    std::unordered_map<std::string, TagInfo> info;
+    std::unordered_set<std::string> unreachables {};
+  } tags {};
+
+  struct {
+    std::mutex commits {};
+    std::mutex trees {};
+    std::mutex blobs {};
+    std::mutex tags {};
+  } infoMutex;
+
+  using iterCommitInfo = std::unordered_map<std::string, CommitInfo>::iterator;
+  using iterUnreachable = std::unordered_set<std::string>::iterator;
+  using iterTreeInfo = std::unordered_map<std::string, TreeInfoAndStats>::iterator;
+  using iterBlobInfo = std::unordered_map<std::string, BlobInfo>::iterator;
+  using iterTagInfo = std::unordered_map<std::string, TagInfo>::iterator;
+};
+
+/**
+ * \class WorkItemOid
+ * WorkItem storing odb oids for the WorkPool.
+ */
+class WorkItemOid : public WorkItem{
+public:
+  WorkItemOid(const git_oid &oid)
+    : m_oid(oid) {}
+  ~WorkItemOid() = default;
+  WorkItemOid(const WorkItemOid &other) = delete;
+  WorkItemOid(WorkItemOid &&other) = delete;
+  WorkItemOid& operator=(const WorkItemOid &other) = delete;
+  WorkItemOid& operator=(WorkItemOid &&other) = delete;
+  
+  const git_oid& GetOid() const { return m_oid; }
+
+private:
+  git_oid m_oid {};
+};
+
+/**
+ * \class WorkerStoreOdbData
+ * Worker for the WorkPool to store odb object data.
+ */
+class WorkerStoreOdbData : public IWorker
+{
+public:
+  WorkerStoreOdbData(const std::string &repoPath, OdbObjectsData *odbObjectsData)
+    : m_repoPath(repoPath), m_odbObjectsData(odbObjectsData) {}
+  ~WorkerStoreOdbData();
+  WorkerStoreOdbData(const WorkerStoreOdbData &other) = delete;
+  WorkerStoreOdbData(WorkerStoreOdbData &&other) = delete;
+  WorkerStoreOdbData& operator=(const WorkerStoreOdbData &other) = delete;
+  WorkerStoreOdbData& operator=(WorkerStoreOdbData &&other) = delete;
+
+  bool Initialize();
+  bool Execute(std::unique_ptr<WorkItem> &&work);
+
+private:
+  OdbObjectsData::TreeInfoAndStats thisTreeInfoAndStats(git_tree *tree, size_t size, size_t numEntries);
+
+  std::string m_repoPath {};
+  git_repository *m_repo {nullptr};
+  git_odb *m_odb {nullptr};
+  OdbObjectsData *m_odbObjectsData {nullptr};
+};
+
+/**
+ * WorkerStoreOdbData::~WorkerStoreOdbData
+ */
+WorkerStoreOdbData::~WorkerStoreOdbData() {
+  if (m_odb) {
+    git_odb_free(m_odb);
+  }
+  if (m_repo) {
+    git_repository_free(m_repo);
+  }
+}
+
+/**
+ * WorkerStoreOdbData::Initialize
+ */
+bool WorkerStoreOdbData::Initialize() {
+  if (m_repo != nullptr) { // if already initialized
+    return true;
+  }
+
+  if (m_repoPath.empty()) {
+    return false;
+  }
+  else {
+    if (git_repository_open(&m_repo, m_repoPath.c_str()) != GIT_OK) {
+      return false;
+    }
+    
+    if (git_repository_odb(&m_odb, m_repo) != GIT_OK) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * WorkerStoreOdbData::Execute
+ */
+bool WorkerStoreOdbData::Execute(std::unique_ptr<WorkItem> &&work)
+{
+  std::unique_ptr<WorkItemOid> wi {static_cast<WorkItemOid*>(work.release())};
+  const git_oid &oid = wi->GetOid();
+
+  // NOTE about PERFORMANCE (May 2021):
+  // git_object_lookup() is as expensive as git_odb_read().
+  // They give access to different information from the libgit2 API.
+  // Try to call only one of them if possible.
+
+  git_object *target {nullptr};
+  if (git_object_lookup(&target, m_repo, &oid, GIT_OBJECT_ANY) != GIT_OK) {
+    return false;
+  }
+
+  switch (git_object_type(target))
+  {
+    case GIT_OBJECT_COMMIT:
+    {
+      git_commit *commit = (git_commit*)target;
+      // NOTE about PERFORMANCE (May 2021):
+      // calling git_odb_object_size() was slightly faster than calculating header size + message size + 1 with GK repo
+
+      // obtain size
+      git_odb_object *obj {nullptr};
+      if (git_odb_read(&obj, m_odb, &oid) != GIT_OK) {
+        git_object_free(target);
+        return false;
+      }
+      size_t size = git_odb_object_size(obj);
+      git_odb_object_free(obj);
+
+      // obtain CommitInfo
+      unsigned int numParents = git_commit_parentcount(commit);
+      std::vector<std::string> parents {};
+      for (unsigned int i = 0; i < numParents; ++i) {
+        parents.emplace_back(reinterpret_cast<const char *>(git_commit_parent_id(commit, i)->id),
+          GIT_OID_RAWSZ);
+      }
+
+      OdbObjectsData::CommitInfo commitInfo {
+        std::string(reinterpret_cast<const char *>(git_commit_tree_id(commit)->id), GIT_OID_RAWSZ),
+        size,
+        std::move(parents),
+        OdbObjectsData::kUnreachable};
+
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.commits);
+
+        m_odbObjectsData->commits.info.emplace(std::make_pair(
+          std::string(reinterpret_cast<const char *>(oid.id), GIT_OID_RAWSZ),
+          std::move(commitInfo)));
+      }
+    }
+      break;
+
+    case GIT_OBJECT_TREE:
+    {
+      git_tree *tree = (git_tree*)target;
+
+      // do not count empty trees, like git's empty tree "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+      size_t numEntries = git_tree_entrycount(tree);
+      if (numEntries == 0) {
+        git_object_free(target);
+        return true;
+      }
+
+      // obtain size
+      git_odb_object *obj {nullptr};
+      if (git_odb_read(&obj, m_odb, &oid) != GIT_OK) {
+        git_object_free(target);
+        return false;
+      }
+      size_t size = git_odb_object_size(obj);
+      git_odb_object_free(obj);
+
+      // obtain tree data and calculate statistics for only this tree (not recursively)
+      OdbObjectsData::TreeInfoAndStats treeInfoAndStats = thisTreeInfoAndStats(tree, size, numEntries);
+     
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.trees);
+
+        m_odbObjectsData->trees.info.emplace(std::make_pair(
+          std::string(reinterpret_cast<const char *>(oid.id), GIT_OID_RAWSZ),
+          std::move(treeInfoAndStats)));
+      }
+    }
+      break;
+
+    case GIT_OBJECT_BLOB:
+    {
+      git_blob *blob = (git_blob*)target;
+      size_t size = git_blob_rawsize(blob);
+      OdbObjectsData::BlobInfo blobInfo {size, OdbObjectsData::kUnreachable};
+
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.blobs);
+
+        m_odbObjectsData->blobs.info.emplace(std::make_pair(
+          std::string(reinterpret_cast<const char *>(oid.id), GIT_OID_RAWSZ),
+          std::move(blobInfo)));
+      }
+    }
+      break;
+
+    case GIT_OBJECT_TAG:
+    {
+      // obtain TagInfo
+      git_tag *tag = (git_tag*)target;
+      const git_oid *oid_target = git_tag_target_id(tag);
+      OdbObjectsData::TagInfo tagInfo {
+        std::string(reinterpret_cast<const char *>(oid_target->id), GIT_OID_RAWSZ),
+        git_tag_target_type(tag),
+        OdbObjectsData::TagInfo::kUnsetDepth,
+        OdbObjectsData::kUnreachable};
+
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.tags);
+        m_odbObjectsData->tags.info.emplace(std::make_pair(
+            std::string(reinterpret_cast<const char *>(oid.id), GIT_OID_RAWSZ),
+            std::move(tagInfo)));
+      }
+    }
+      break;
+
+    default:
+      break;
+  }
+
+  git_object_free(target);
+
+  return true;
+}
+
+/**
+ * WorkerStoreOdbData::thisTreeInfoAndStats
+ * 
+ * Obtain tree data and calculate the part of this tree's statistics that each thread can do.
+ * 
+ * \param tree tree to get data from and calculate partial statistics of.
+ * \param size tree size, to be added to the final result.
+ * \param numEntries number of entries of this tree.
+ * \return this tree's data and partial statistics.
+  */
+OdbObjectsData::TreeInfoAndStats WorkerStoreOdbData::thisTreeInfoAndStats(git_tree *tree, size_t size,
+  size_t numEntries)
+{
+  const git_tree_entry *te {nullptr};
+  git_object_t te_type {GIT_OBJECT_INVALID};
+  const char *teName {nullptr};
+  size_t teNameLen {0};
+  const git_oid *te_oid {nullptr};
+
+  OdbObjectsData::TreeInfoAndStats treeInfoAndStats {};
+  treeInfoAndStats.size = size;
+  treeInfoAndStats.numEntries = numEntries;
+
+  for (size_t i = 0; i < numEntries; ++i)
+  {
+    te = git_tree_entry_byindex(tree, i);
+    if (te == nullptr) {
+      continue;
+    }
+
+    te_type = git_tree_entry_type(te);
+
+    switch (te_type)
+    {
+      // count submodules
+      case GIT_OBJECT_COMMIT:
+        if (git_tree_entry_filemode(te) == GIT_FILEMODE_COMMIT) {
+          ++treeInfoAndStats.stats.numSubmodules;
+        }
+        break;
+
+      case GIT_OBJECT_BLOB:
+      {
+        // count symbolic links, but don't add them as blob entries
+        if (git_tree_entry_filemode(te) == GIT_FILEMODE_LINK) {
+          ++treeInfoAndStats.stats.numSymlinks;
+        }
+        else {
+          ++treeInfoAndStats.stats.numFiles;
+          teName = git_tree_entry_name(te);
+          teNameLen = std::char_traits<char>::length(teName);
+          treeInfoAndStats.stats.maxPathLength =
+            std::max<size_t>(treeInfoAndStats.stats.maxPathLength, teNameLen);
+        }
+        // store both types of files (symbolic links and non symbolic links) as entryBlob
+        te_oid = git_tree_entry_id(te);
+        treeInfoAndStats.entryBlobs.emplace_back(
+          reinterpret_cast<const char *>(te_oid->id), GIT_OID_RAWSZ);
+      }
+        break;
+        
+      case GIT_OBJECT_TREE:
+      {
+        // We store tree's name lenght to compare in posterior stage, after threads work
+        teName = git_tree_entry_name(te);
+        teNameLen = std::char_traits<char>::length(teName);
+
+        te_oid = git_tree_entry_id(te);
+        treeInfoAndStats.entryTreesNameLen.emplace_back(std::make_pair(
+          std::string(reinterpret_cast<const char *>(te_oid->id), GIT_OID_RAWSZ),
+          teNameLen));
+      }
+        break;
+        
+      default:
+        break;
+    }
+  }
+
+  return treeInfoAndStats;
+}
+
+/**
+ * \class WorkItemOidStrType
+ * WorkItem storing pointers to object info structs for the WorkPool.
+ */
+class WorkItemOidStrType : public WorkItem{
+public:
+  WorkItemOidStrType(void *objectInfo, git_object_t type)
+    : m_objectInfo(objectInfo), m_oid_type(type) {}
+  ~WorkItemOidStrType() = default;
+  WorkItemOidStrType(const WorkItemOidStrType &other) = delete;
+  WorkItemOidStrType(WorkItemOidStrType &&other) = delete;
+  WorkItemOidStrType& operator=(const WorkItemOidStrType &other) = delete;
+  WorkItemOidStrType& operator=(WorkItemOidStrType &&other) = delete;
+  
+  void* GetObjectInfo() const { return m_objectInfo; }
+  const git_object_t& GetOidType() const { return m_oid_type; }
+
+private:
+  void *m_objectInfo {nullptr};
+  git_object_t m_oid_type {};
+};
+
+/**
+ * \class WorkerReachCounter
+ * Worker for the WorkPool to count reachability of each object.
+ */
+class WorkerReachCounter : public IWorker
+{
+public:
+  WorkerReachCounter(OdbObjectsData *odbObjectsData)
+    : m_odbObjectsData(odbObjectsData) {}
+  ~WorkerReachCounter() = default;
+  WorkerReachCounter(const WorkerReachCounter &other) = delete;
+  WorkerReachCounter(WorkerReachCounter &&other) = delete;
+  WorkerReachCounter& operator=(const WorkerReachCounter &other) = delete;
+  WorkerReachCounter& operator=(WorkerReachCounter &&other) = delete;
+
+  bool Initialize() { return true; }
+  bool Execute(std::unique_ptr<WorkItem> &&work);
+
+private:
+  void setReachabilityFromTags(void *objectInfo);
+  void setReachabilityFromCommits(void *objectInfo);
+  void setReachabilityFromTrees(void *objectInfo);
+
+  OdbObjectsData *m_odbObjectsData {nullptr};
+};
+
+/**
+ * WorkerReachCounter::Execute
+ */
+bool WorkerReachCounter::Execute(std::unique_ptr<WorkItem> &&work)
+{
+  std::unique_ptr<WorkItemOidStrType> wi {static_cast<WorkItemOidStrType*>(work.release())};
+  void *objectInfo = wi->GetObjectInfo();
+  const git_object_t &oid_type = wi->GetOidType();
+
+  switch (oid_type) {
+    case GIT_OBJECT_TAG:
+      setReachabilityFromTags(objectInfo);
+      break;
+    case GIT_OBJECT_COMMIT:
+      setReachabilityFromCommits(objectInfo);
+      break;
+    case GIT_OBJECT_TREE:
+      setReachabilityFromTrees(objectInfo);
+      break;
+    case GIT_OBJECT_BLOB:
+      // do not process blobs in this stage
+      break;
+    default:
+      break;
+  }
+
+  return true;
+}
+
+/**
+ * WorkerReachCounter::setReachabilityFromTags
+ * Adds reachability counter where tags point (any type of object).
+ */
+void WorkerReachCounter::setReachabilityFromTags(void *objectInfo)
+{
+  const OdbObjectsData::TagInfo *tagInfo = static_cast<const OdbObjectsData::TagInfo *>(objectInfo);
+
+  switch (tagInfo->typeTarget) {
+    case GIT_OBJECT_COMMIT:
+    {
+      OdbObjectsData::iterCommitInfo itCommitInfo =
+      m_odbObjectsData->commits.info.find(tagInfo->oidTarget);
+    
+      if (itCommitInfo != m_odbObjectsData->commits.info.end()) {
+        { // lock
+          std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.commits);
+          ++itCommitInfo->second.reachability;
+        }
+      }
+    }
+      break;
+
+    case GIT_OBJECT_TREE:
+    {
+      OdbObjectsData::iterTreeInfo itTreeInfo =
+      m_odbObjectsData->trees.info.find(tagInfo->oidTarget);
+    
+      if (itTreeInfo != m_odbObjectsData->trees.info.end()) {
+        { // lock
+          std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.trees);
+          ++itTreeInfo->second.reachability;
+        }
+      }
+    }
+
+    case GIT_OBJECT_BLOB:
+    {
+      OdbObjectsData::iterBlobInfo itBlobInfo =
+      m_odbObjectsData->blobs.info.find(tagInfo->oidTarget);
+    
+      if (itBlobInfo != m_odbObjectsData->blobs.info.end()) {
+        { // lock
+          std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.blobs);
+          ++itBlobInfo->second.reachability;
+        }
+      }
+    }
+
+    case GIT_OBJECT_TAG:
+    {
+      OdbObjectsData::iterTagInfo itTargetTagInfo =
+      m_odbObjectsData->tags.info.find(tagInfo->oidTarget);
+    
+      if (itTargetTagInfo != m_odbObjectsData->tags.info.end()) {
+        { // lock
+          std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.tags);
+          ++itTargetTagInfo->second.reachability;
+        }
+      }
+    }
+    default:
+      break;
+  }
+}
+
+/**
+ * WorkerReachCounter::setReachabilityFromCommits
+ * Adds reachability counter where commits point (parents and tree).
+ */
+void WorkerReachCounter::setReachabilityFromCommits(void *objectInfo)
+{
+  const OdbObjectsData::CommitInfo *commitInfo =
+    static_cast<const OdbObjectsData::CommitInfo *>(objectInfo);
+  size_t numParents = commitInfo->parents.size();
+
+  // set parents' reachability
+  for (size_t i = 0; i < numParents; ++i) {
+    OdbObjectsData::iterCommitInfo itParentCommitInfo =
+      m_odbObjectsData->commits.info.find(commitInfo->parents.at(i));
+    
+    if (itParentCommitInfo != m_odbObjectsData->commits.info.end()) {
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.commits);
+        ++itParentCommitInfo->second.reachability;
+      }
+    }
+  }
+
+  // add 1 to its tree's reachability
+  OdbObjectsData::iterTreeInfo itCommitTreeInfo =
+    m_odbObjectsData->trees.info.find(commitInfo->oidTree);
+  
+  if (itCommitTreeInfo != m_odbObjectsData->trees.info.end()) {
+    { // lock
+      std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.trees);
+      ++itCommitTreeInfo->second.reachability;
+    }
+  }
+}
+
+/**
+ * WorkerReachCounter::setReachabilityFromTrees
+ * Adds reachability counter where tree entries point (blobs and other trees).
+ */
+void WorkerReachCounter::setReachabilityFromTrees(void *objectInfo)
+{
+  const OdbObjectsData::TreeInfoAndStats *treeInfo =
+    static_cast<const OdbObjectsData::TreeInfoAndStats *>(objectInfo);
+
+  // set entry blobs' reachability
+  for (auto &blob : treeInfo->entryBlobs) {
+    OdbObjectsData::iterBlobInfo itBlobInfo = m_odbObjectsData->blobs.info.find(blob);
+    
+    if (itBlobInfo != m_odbObjectsData->blobs.info.end()) {
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.blobs);
+        ++itBlobInfo->second.reachability;
+      }
+    }
+  }
+
+  // set entry trees' reachability
+  for (auto &treeNameLen : treeInfo->entryTreesNameLen) {
+    OdbObjectsData::iterTreeInfo itTreeInfo = m_odbObjectsData->trees.info.find(treeNameLen.first);
+    
+    if (itTreeInfo != m_odbObjectsData->trees.info.end()) {
+      { // lock
+        std::lock_guard<std::mutex> lock(m_odbObjectsData->infoMutex.trees);
+        ++itTreeInfo->second.reachability;
+      }
+    }
+  }
+}
+
+/**
+ * forEachOdbCb. Callback for git_odb_foreach.
+ * Returns GIT_OK on success; GIT_EUSER otherwise
+ */
+static int forEachOdbCb(const git_oid *oid, void *payloadToCast)
+{
+  WorkerPool<WorkerStoreOdbData,WorkItemOid> *workerPool =
+    static_cast<WorkerPool<WorkerStoreOdbData,WorkItemOid>*>(payloadToCast);
+
+  // Must insert copies of oid, since the pointers might not survive until worker thread picks it up
+  if (!workerPool->InsertWork(std::make_unique<WorkItemOid>(*oid))) {
+    return GIT_EUSER;
+  }
+
+  return GIT_OK;
+}
+
+/**
+ * \class RepoAnalysis
+ * Class to analyse and hold repository statistics
+ */
+class RepoAnalysis
+{
+public:
+  static constexpr unsigned int kMinThreads = 4;
+
+  explicit RepoAnalysis(git_repository *repo)
+    : m_repo(repo) {}
+  ~RepoAnalysis() = default;
+  RepoAnalysis(const RepoAnalysis &other) = delete;
+  RepoAnalysis(RepoAnalysis &&other) = delete;
+  RepoAnalysis& operator=(const RepoAnalysis &other) = delete;
+  RepoAnalysis& operator=(RepoAnalysis &&other) = delete;
+
+  int Analyze();
+  v8::Local<v8::Object> StatisticsToJS() const;
+
+private:
+  // stage 1 methods: store data from repository (with threads)
+  int storeObjectsInfo();
+  int storeAndCountRefs();
+  // stage 2 methods: count reachability of each object (with threads)
+  // NOTE: we need this stage, since so far libgit2 doesn't provide unreachable objects
+  void setObjectsReachability();
+  void setReachabilityFromRefs();
+  void setUnreachables();
+  // stage 3 methods: prune unreachable oids
+  void pruneUnreachables();
+  void pruneUnreachableTags();
+  void pruneUnreachableCommits();
+  void pruneUnreachableTrees();
+  void pruneUnreachableBlobs();
+  // stage 4 methods: repositorySize and biggestObjects
+  void statsCountAndMax();
+  // stage 5 methods: historyStructure and biggestCheckouts
+  bool statsHistoryAndBiggestCheckouts();
+  bool calculateBiggestCheckouts();
+  OdbObjectsData::iterTreeInfo calculateTreeStatistics(const std::string &oidTree);
+  bool calculateMaxTagDepth();
+  OdbObjectsData::iterTagInfo calculateTagDepth(const std::string &oidTag);
+  // methods to return the statistics calculated
+  void fillOutStatistics();
+  v8::Local<v8::Object> repositorySizeToJS() const;
+  v8::Local<v8::Object> biggestObjectsToJS() const;
+  v8::Local<v8::Object> historyStructureToJS() const;
+  v8::Local<v8::Object> biggestCheckoutsToJS() const;
+
+  git_repository *m_repo {nullptr};
+  Statistics m_statistics {};
+  // odb objects info to build while reading the object database by each thread
+  OdbObjectsData m_odbObjectsData {};
+  // oid and type of peeled references
+  std::unordered_map<std::string, git_object_t> m_peeledRefs {};
+};
+
+/**
+ * RepoAnalysis::Analyze
+ */
+int RepoAnalysis::Analyze()
+{
+  int errorCode {GIT_OK};
+
+  if ((errorCode = storeObjectsInfo() != GIT_OK)) {
+    return errorCode;
+  }
+
+  setObjectsReachability();
+  pruneUnreachables();
+
+  statsCountAndMax();
+
+  if (!statsHistoryAndBiggestCheckouts()) {
+    return GIT_EUSER;
+  }
+
+  fillOutStatistics();
+
+  return errorCode;
+}
+
+/**
+ * RepoAnalysis::StatisticsToJS
+ */
+v8::Local<v8::Object> RepoAnalysis::StatisticsToJS() const
+{
+  v8::Local<v8::Object> result = Nan::New<Object>();
+
+  v8::Local<v8::Object> repositorySize = repositorySizeToJS();
+  Nan::Set(result, Nan::New("repositorySize").ToLocalChecked(), repositorySize);
+
+  v8::Local<v8::Object> biggestObjects = biggestObjectsToJS();
+  Nan::Set(result, Nan::New("biggestObjects").ToLocalChecked(), biggestObjects);
+
+  v8::Local<v8::Object> historyStructure = historyStructureToJS();
+  Nan::Set(result, Nan::New("historyStructure").ToLocalChecked(), historyStructure);
+
+  v8::Local<v8::Object> biggestCheckouts = biggestCheckoutsToJS();
+  Nan::Set(result, Nan::New("biggestCheckouts").ToLocalChecked(), biggestCheckouts);
+
+  return result;
+}
+
+/**
+ * RepoAnalysis::storeObjectsInfo
+ * Store information from read odb objects.
+ * Build a container with only reachable objects (avoid dangling objects).
+ */
+int RepoAnalysis::storeObjectsInfo()
+{
+  int errorCode {GIT_OK};
+
+  // get the objects database
+  git_odb *odb {nullptr};
+  if ((errorCode = git_repository_odb(&odb, m_repo)) != GIT_OK) {
+    return errorCode;
+  }
+
+  // initialize workers for the worker pool
+  std::string repoPath = git_repository_path(m_repo);
+  unsigned int numThreads =
+    std::max<unsigned int>(std::thread::hardware_concurrency(), static_cast<unsigned int>(kMinThreads));
+
+  std::vector< std::shared_ptr<WorkerStoreOdbData> > workers {};
+  for (unsigned int i = 0; i < numThreads; ++i) {
+    workers.emplace_back(std::make_shared<WorkerStoreOdbData>(repoPath, &m_odbObjectsData));
+  }
+
+  // initialize worker pool
+  WorkerPool<WorkerStoreOdbData,WorkItemOid> workerPool {};  
+  workerPool.Init(workers);
+
+  if ((errorCode = git_odb_foreach(odb, forEachOdbCb, &workerPool)) != GIT_OK) {
+    git_odb_free(odb);
+    return errorCode;
+  }
+
+  // main thread will work on the refs while waiting for the threads to finish
+  if ((errorCode = storeAndCountRefs() != GIT_OK)) {
+    return errorCode;
+  }
+
+  // wait for the threads to finish and shutdown the work pool
+  workerPool.Shutdown();
+
+  git_odb_free(odb);
+
+  return errorCode;
+}
+
+/**
+ * RepoAnalysis::storeAndCountRefs
+ * Stores the oid and type of peeled references.
+ * Also counts total references.
+ */
+int RepoAnalysis::storeAndCountRefs()
+{
+  int errorCode {GIT_OK};
+  git_strarray ref_list;
+
+  // count refs
+  if ((errorCode = git_reference_list(&ref_list, m_repo)) != GIT_OK) {
+    return errorCode;
+  }
+  m_statistics.repositorySize.references.count = ref_list.count;
+
+  // store refs info
+  for (size_t i = 0; i < ref_list.count; ++i)
+  {
+    // lookup ref
+    git_reference *ref {nullptr};
+    int refLookupError = git_reference_lookup(&ref, m_repo, ref_list.strings[i]);
+    if (refLookupError == GIT_ENOTFOUND || refLookupError == GIT_EINVALIDSPEC) {
+      continue;
+    }
+    else if (refLookupError != GIT_OK) {
+      git_strarray_dispose(&ref_list);
+      return refLookupError;
+    }
+
+    // obtain peeled oid of the reference
+    const git_oid *oid_ref {nullptr};
+    switch (git_reference_type(ref))
+    {
+      case GIT_REFERENCE_DIRECT:
+        oid_ref = git_reference_target(ref);
+        break;
+
+      case GIT_REFERENCE_SYMBOLIC:
+      {
+        git_reference *ref_resolved {nullptr};
+        if ((errorCode = git_reference_resolve(&ref_resolved, ref)) != GIT_OK) {
+          git_reference_free(ref);
+          git_strarray_dispose(&ref_list);
+          return errorCode;
+        }
+        oid_ref = git_reference_target(ref_resolved);
+        git_reference_free(ref_resolved);
+      }
+        break;
+
+      default:
+        break;
+    }
+
+    // store object's oid and type
+    if (oid_ref != nullptr)
+    {
+      git_object *target {nullptr};
+      if (git_object_lookup(&target, m_repo, oid_ref, GIT_OBJECT_ANY) != GIT_OK) {
+        git_reference_free(ref);
+        git_strarray_dispose(&ref_list);
+        return false;
+      }
+
+      m_peeledRefs.emplace(std::make_pair(
+        std::string(reinterpret_cast<const char *>(oid_ref->id), GIT_OID_RAWSZ),
+        git_object_type(target)));
+
+      git_object_free(target);
+    }
+    git_reference_free(ref);
+  }
+  git_strarray_dispose(&ref_list);
+
+  return errorCode;
+}
+
+/**
+ * RepoAnalysis::setObjectsReachability
+ * Leverages threads to set reachability from tags, commits, and trees.
+ * NOTE: performance didn't improve leveraging threads for adding objects to unreachables container.
+ */
+void RepoAnalysis::setObjectsReachability()
+{
+  // references are not objects, hence they won't be sent to the worker threads
+  setReachabilityFromRefs();
+
+  unsigned int numThreads =
+    std::max<unsigned int>(std::thread::hardware_concurrency(), static_cast<unsigned int>(kMinThreads));
+  std::vector< std::shared_ptr<WorkerReachCounter> > workers {};
+  for (unsigned int i = 0; i < numThreads; ++i) {
+    workers.emplace_back(std::make_shared<WorkerReachCounter>(&m_odbObjectsData));
+  }
+
+  // initialize worker pool
+  WorkerPool<WorkerReachCounter,WorkItemOidStrType> workerPool {};  
+  workerPool.Init(workers);
+
+  // NOTE: avoid queueing same type of objects in a row, so that different mutex can be used concurrently
+  uint8_t workInserted {0};
+  OdbObjectsData::iterTagInfo itTagInfo = m_odbObjectsData.tags.info.begin();
+  OdbObjectsData::iterCommitInfo itCommitInfo = m_odbObjectsData.commits.info.begin();
+  OdbObjectsData::iterTreeInfo itTreeInfo = m_odbObjectsData.trees.info.begin();
+  do {
+    workInserted = 0;
+    // insert tag
+    if (itTagInfo != m_odbObjectsData.tags.info.end()) {
+      if (!workerPool.InsertWork(
+        std::make_unique<WorkItemOidStrType>(&itTagInfo->second, GIT_OBJECT_TAG))) {
+        return;
+      }
+      ++itTagInfo;
+      ++workInserted;
+    }
+    // insert commmit
+    if (itCommitInfo != m_odbObjectsData.commits.info.end()) {
+      if (!workerPool.InsertWork(
+        std::make_unique<WorkItemOidStrType>(&itCommitInfo->second, GIT_OBJECT_COMMIT))) {
+        return;
+      }
+      ++itCommitInfo;
+      ++workInserted;
+    }
+    // insert tree
+    if (itTreeInfo != m_odbObjectsData.trees.info.end()) {
+      if (!workerPool.InsertWork(
+        std::make_unique<WorkItemOidStrType>(&itTreeInfo->second, GIT_OBJECT_TREE))) {
+        return;
+      }
+      ++itTreeInfo;
+      ++workInserted;
+    }
+    // blobs do not reach to any other object, hence no need to process them
+  } while (workInserted);
+
+  // wait for the threads to finish and shutdown the work pool
+  workerPool.Shutdown();
+
+  setUnreachables();
+}
+
+/**
+ * RepoAnalysis::setReachabilityFromRefs
+ * Adds reachability counter where peeled refs point (normally a commit or a tag).
+  */
+void RepoAnalysis::setReachabilityFromRefs()
+{
+  for (const auto &ref : m_peeledRefs) {
+    switch (ref.second) {
+      case GIT_OBJECT_COMMIT:
+      {
+        OdbObjectsData::iterCommitInfo itCommitInfo =
+        m_odbObjectsData.commits.info.find(ref.first);
+      
+        if (itCommitInfo != m_odbObjectsData.commits.info.end()) {
+          ++itCommitInfo->second.reachability;
+        }
+      }
+        break;
+      case GIT_OBJECT_TREE:
+      {
+        OdbObjectsData::iterTreeInfo itTreeInfo =
+        m_odbObjectsData.trees.info.find(ref.first);
+      
+        if (itTreeInfo != m_odbObjectsData.trees.info.end()) {
+          ++itTreeInfo->second.reachability;
+        }
+      }
+        break;
+      case GIT_OBJECT_BLOB:
+      {
+        OdbObjectsData::iterBlobInfo itBlobInfo =
+        m_odbObjectsData.blobs.info.find(ref.first);
+      
+        if (itBlobInfo != m_odbObjectsData.blobs.info.end()) {
+          ++itBlobInfo->second.reachability;
+        }
+      }
+        break;
+      case GIT_OBJECT_TAG:
+      {
+        OdbObjectsData::iterTagInfo itTagInfo =
+        m_odbObjectsData.tags.info.find(ref.first);
+      
+        if (itTagInfo != m_odbObjectsData.tags.info.end()) {
+          ++itTagInfo->second.reachability;
+        }
+      }
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+/**
+ * RepoAnalysis::setUnreachables
+ * After setting reachability, we add the unreached objects to their unreachables container.
+ */
+void RepoAnalysis::setUnreachables()
+  {
+    for (const auto &tag : m_odbObjectsData.tags.info) {
+      if (!tag.second.reachability) {
+        m_odbObjectsData.tags.unreachables.emplace(tag.first);
+      }
+    }
+    for (const auto &commit : m_odbObjectsData.commits.info) {
+      if (!commit.second.reachability) {
+        m_odbObjectsData.commits.unreachables.emplace(commit.first);
+      }
+    }
+    for (const auto &tree : m_odbObjectsData.trees.info) {
+      if (!tree.second.reachability) {
+        m_odbObjectsData.trees.unreachables.emplace(tree.first);
+      }
+    }
+    for (const auto &blob : m_odbObjectsData.blobs.info) {
+      if (!blob.second.reachability) {
+        m_odbObjectsData.blobs.unreachables.emplace(blob.first);
+      }
+    }
+  }
+
+/**
+ * RepoAnalysis::pruneUnreachables
+ * Removes from their containers the unreachable objects.
+ * Decreases reachability of the objects they can reach.
+  */
+void RepoAnalysis::pruneUnreachables()
+{
+  // NOTE: order is important here, since each method prunes its own objects, but
+  // only decreases reachability of the objects connected to it; and those
+  // connected objects will be checked and pruned afterwards.
+  pruneUnreachableTags();
+  pruneUnreachableCommits();
+  pruneUnreachableTrees();
+  pruneUnreachableBlobs();
+}
+
+/**
+ * RepoAnalysis::pruneUnreachableTags
+ * Prune tags and their chained tags if they become unreachable.
+ * Also decreases reachability of targets.
+  */
+void RepoAnalysis::pruneUnreachableTags()
+{
+  while (!m_odbObjectsData.tags.unreachables.empty()) {
+    std::unordered_set<std::string> newUnreachables {};
+
+    // erase unreachable tags
+    for (OdbObjectsData::iterUnreachable itTagUnrch = m_odbObjectsData.tags.unreachables.begin();
+      itTagUnrch != m_odbObjectsData.tags.unreachables.end(); ++itTagUnrch)
+    {
+      OdbObjectsData::iterTagInfo itTagInfo = m_odbObjectsData.tags.info.find(*itTagUnrch);
+    
+      if (itTagInfo != m_odbObjectsData.tags.info.end()) {
+        const std::string &oidTarget = itTagInfo->second.oidTarget;
+        switch (itTagInfo->second.typeTarget) {
+          case GIT_OBJECT_TAG:
+          {
+            // if target is another tag, add it to newUnreachables
+            OdbObjectsData::iterTagInfo itTargetTagInfo = m_odbObjectsData.tags.info.find(oidTarget);
+            if (itTargetTagInfo != m_odbObjectsData.tags.info.end()) {
+              if (--itTargetTagInfo->second.reachability == OdbObjectsData::kUnreachable) {
+                newUnreachables.emplace(itTargetTagInfo->first);
+              }
+            }
+          }
+            break;
+          case GIT_OBJECT_COMMIT:
+          {
+            OdbObjectsData::iterCommitInfo itCommitInfo = m_odbObjectsData.commits.info.find(oidTarget);
+            if (itCommitInfo != m_odbObjectsData.commits.info.end()) {
+              if (--itCommitInfo->second.reachability == OdbObjectsData::kUnreachable) {
+                m_odbObjectsData.commits.unreachables.emplace(itCommitInfo->first);
+              }
+            }
+          }
+            break;
+          case GIT_OBJECT_TREE:
+          {
+            OdbObjectsData::iterTreeInfo itTreeInfo = m_odbObjectsData.trees.info.find(oidTarget);
+            if (itTreeInfo != m_odbObjectsData.trees.info.end()) {
+              if (--itTreeInfo->second.reachability == OdbObjectsData::kUnreachable) {
+                m_odbObjectsData.trees.unreachables.emplace(itTreeInfo->first);
+              }
+            }
+          }
+            break;
+          case GIT_OBJECT_BLOB:
+          {
+            OdbObjectsData::iterBlobInfo itBlobInfo = m_odbObjectsData.blobs.info.find(oidTarget);
+            if (itBlobInfo != m_odbObjectsData.blobs.info.end()) {
+              if (--itBlobInfo->second.reachability == OdbObjectsData::kUnreachable) {
+                m_odbObjectsData.blobs.unreachables.emplace(itBlobInfo->first);
+              }
+            }
+          }
+            break;
+          default:
+            break;
+        }
+        // erase tag from the tag's container
+        m_odbObjectsData.tags.info.erase(itTagInfo);
+      }
+    }
+    // set new unreachable tags
+    m_odbObjectsData.tags.unreachables = std::move(newUnreachables);
+  }
+}
+
+/**
+ * RepoAnalysis::pruneUnreachableCommits
+ * Prune commits and decrease reachability of their associated trees.
+  */
+void RepoAnalysis::pruneUnreachableCommits()
+{
+  while (!m_odbObjectsData.commits.unreachables.empty()) {
+    std::unordered_set<std::string> newUnreachables {};
+
+    // erase unreachable commits
+    for (OdbObjectsData::iterUnreachable itCommitUnrch = m_odbObjectsData.commits.unreachables.begin();
+      itCommitUnrch != m_odbObjectsData.commits.unreachables.end(); ++itCommitUnrch)
+    {
+      OdbObjectsData::iterCommitInfo itCommitInfo = m_odbObjectsData.commits.info.find(*itCommitUnrch);
+    
+      if (itCommitInfo != m_odbObjectsData.commits.info.end())
+      {
+        // decrease commit's parents reachability and add them as newUnreachable
+        size_t numParents = itCommitInfo->second.parents.size();
+        for (size_t i = 0; i < numParents; ++i) {
+          OdbObjectsData::iterCommitInfo itParentCommitInfo =
+            m_odbObjectsData.commits.info.find(itCommitInfo->second.parents.at(i));
+          
+          if (itParentCommitInfo != m_odbObjectsData.commits.info.end()) {
+            if (--itParentCommitInfo->second.reachability == OdbObjectsData::kUnreachable) {
+              newUnreachables.emplace(itParentCommitInfo->first);
+            }
+          }
+        }
+        // decrease reachability of the commit's tree
+        OdbObjectsData::iterTreeInfo itTreeInfo =
+          m_odbObjectsData.trees.info.find(itCommitInfo->second.oidTree);
+        if (itTreeInfo != m_odbObjectsData.trees.info.end()) {
+          if (--itTreeInfo->second.reachability == OdbObjectsData::kUnreachable) {
+            m_odbObjectsData.trees.unreachables.emplace(itTreeInfo->first);
+          }
+        }
+        // erase commit from the commit's container
+        m_odbObjectsData.commits.info.erase(itCommitInfo);
+      }
+    }
+    // set new unreachable commits
+    m_odbObjectsData.commits.unreachables = std::move(newUnreachables);
+  }
+}
+
+/**
+ * RepoAnalysis::pruneUnreachableTrees
+ * Prune unreachable trees and decrement reachability of their entries.
+  */
+void RepoAnalysis::pruneUnreachableTrees()
+{
+  while (!m_odbObjectsData.trees.unreachables.empty()) {
+    std::unordered_set<std::string> newUnreachables {};
+
+    // erase unreachable trees
+    for (OdbObjectsData::iterUnreachable itTreeUnrch = m_odbObjectsData.trees.unreachables.begin();
+      itTreeUnrch != m_odbObjectsData.trees.unreachables.end(); ++itTreeUnrch)
+    {
+      OdbObjectsData::iterTreeInfo itTreeInfo = m_odbObjectsData.trees.info.find(*itTreeUnrch);
+    
+      if (itTreeInfo != m_odbObjectsData.trees.info.end()) {
+        // decrease reachability of the entry blobs
+        for (auto &blob : itTreeInfo->second.entryBlobs) {
+          OdbObjectsData::iterBlobInfo itEntryBlobInfo = m_odbObjectsData.blobs.info.find(blob);
+          if (itEntryBlobInfo != m_odbObjectsData.blobs.info.end()) {
+            if (--itEntryBlobInfo->second.reachability == OdbObjectsData::kUnreachable) {
+              m_odbObjectsData.blobs.unreachables.emplace(blob);
+            }
+          }
+        }
+        // decrease reachability of the entry trees and add them as newUnreachables
+        for (auto &treeNameLen : itTreeInfo->second.entryTreesNameLen) {
+          OdbObjectsData::iterTreeInfo itEntryTreeInfo =
+            m_odbObjectsData.trees.info.find(treeNameLen.first);
+          if (itEntryTreeInfo != m_odbObjectsData.trees.info.end()) {
+            if (--itEntryTreeInfo->second.reachability == OdbObjectsData::kUnreachable) {
+              newUnreachables.emplace(treeNameLen.first);
+            }
+          }
+        }
+        // erase tree from the tree's container
+        m_odbObjectsData.trees.info.erase(itTreeInfo);
+      }
+    }
+    // set new unreachable trees
+    m_odbObjectsData.trees.unreachables = std::move(newUnreachables);
+  }
+}
+
+/**
+ * RepoAnalysis::pruneUnreachableBlobs
+ * Rremoves unreachable blobs from their container.
+  */
+void RepoAnalysis::pruneUnreachableBlobs()
+{
+  for (OdbObjectsData::iterUnreachable itBlobUnrch = m_odbObjectsData.blobs.unreachables.begin();
+    itBlobUnrch != m_odbObjectsData.blobs.unreachables.end(); ++itBlobUnrch)
+  {
+    m_odbObjectsData.blobs.info.erase(*itBlobUnrch);
+  }
+}
+
+/**
+ * RepoAnalysis::statsCountAndMax
+ * Statistics for repositorySize (count objects) and biggestObjects (get maximum of them).
+ * Also builds the commits graph.
+ * NOTE: better results achieved not leveraging threads.
+ */
+void RepoAnalysis::statsCountAndMax()
+{
+  // commits
+  for (auto &info : m_odbObjectsData.commits.info) {
+    OdbObjectsData::CommitInfo &commitInfo = info.second;
+    size_t size = commitInfo.size;
+    size_t numParents = commitInfo.parents.size();
+
+    m_odbObjectsData.commits.totalSize += size;
+    m_odbObjectsData.commits.maxSize = std::max<size_t>(m_odbObjectsData.commits.maxSize, size);
+    m_odbObjectsData.commits.maxParents = std::max<size_t>(m_odbObjectsData.commits.maxParents, numParents);
+
+    // build commit's graph
+    m_odbObjectsData.commits.graph.AddNode(info.first,
+      commitInfo.parents, static_cast<uint32_t>(numParents));
+  }
+  // trees
+  for (auto &info : m_odbObjectsData.trees.info) {
+    OdbObjectsData::TreeInfoAndStats &treeInfo = info.second;
+    size_t size = treeInfo.size;
+    size_t numEntries = treeInfo.numEntries;
+
+    m_odbObjectsData.trees.totalSize += size;
+    m_odbObjectsData.trees.totalEntries += numEntries;
+    m_odbObjectsData.trees.maxEntries = std::max<size_t>(m_odbObjectsData.trees.maxEntries, numEntries);
+  }
+  // blobs
+  for (auto &info : m_odbObjectsData.blobs.info) {
+    OdbObjectsData::BlobInfo &blobInfo = info.second;
+    size_t size = blobInfo.size;
+
+    m_odbObjectsData.blobs.totalSize += size;
+    m_odbObjectsData.blobs.maxSize = std::max<size_t>(m_odbObjectsData.blobs.maxSize, size);
+  }
+  // no need to process tags here (we already have the count)
+}
+
+/**
+ * RepoAnalysis::statsHistoryAndBiggestCheckouts
+ * Statistics for historyStructure and biggestCheckouts.
+ * \return true if success; false if something went wrong.
+ */
+bool RepoAnalysis::statsHistoryAndBiggestCheckouts()
+{
+  if (!calculateBiggestCheckouts()) {
+    return false;
+  }
+
+  if (!calculateMaxTagDepth()) {
+    return false;
+  }
+
+  // calculate max commit history depth
+  m_statistics.historyStructure.maxDepth = m_odbObjectsData.commits.graph.CalculateMaxDepth();
+
+  return true;
+}
+
+/**
+ * RepoAnalysis::calculateBiggestCheckouts
+ * 
+ * Once threads have collected data from objects, biggest checkouts can be calculated.
+ * Threads have already collected partial non-recursive tree statistics.
+ * \return true if success; false if something went wrong.
+ */
+bool RepoAnalysis::calculateBiggestCheckouts()
+{
+  for (auto &commitInfo : m_odbObjectsData.commits.info)
+  {
+    // calculate this commit's data
+    const std::string &commitOidTree = commitInfo.second.oidTree;
+
+    OdbObjectsData::iterTreeInfo itTreeInfo {};
+    if ((itTreeInfo = calculateTreeStatistics(commitOidTree)) == m_odbObjectsData.trees.info.end()) {
+      return false;
+    }
+
+    // update biggestCheckouts data
+    OdbObjectsData::TreeInfoAndStats &treeInfoAndStats = itTreeInfo->second;
+    m_statistics.biggestCheckouts.numDirectories = std::max<size_t>(
+      m_statistics.biggestCheckouts.numDirectories, treeInfoAndStats.stats.numDirectories);
+    m_statistics.biggestCheckouts.totalFileSize = std::max<size_t>(
+      m_statistics.biggestCheckouts.totalFileSize, treeInfoAndStats.stats.totalFileSize);
+    m_statistics.biggestCheckouts.maxPathDepth = std::max<size_t>(
+      m_statistics.biggestCheckouts.maxPathDepth, treeInfoAndStats.stats.maxPathDepth);
+    m_statistics.biggestCheckouts.numFiles = std::max<size_t>(
+      m_statistics.biggestCheckouts.numFiles, treeInfoAndStats.stats.numFiles);
+    m_statistics.biggestCheckouts.maxPathLength = std::max<size_t>(
+      m_statistics.biggestCheckouts.maxPathLength, treeInfoAndStats.stats.maxPathLength);
+    m_statistics.biggestCheckouts.numSymlinks = std::max<size_t>(
+      m_statistics.biggestCheckouts.numSymlinks, treeInfoAndStats.stats.numSymlinks);
+    m_statistics.biggestCheckouts.numSubmodules = std::max<size_t>(
+      m_statistics.biggestCheckouts.numSubmodules, treeInfoAndStats.stats.numSubmodules);
+  }
+
+  return true;
+}
+
+/**
+ * RepoAnalysis::calculateTreeStatistics
+ * 
+ * Calculates tree statistics recursively, considering individual tree's statistics
+ * have already been calculated.
+ * Returns an iterator to the tree info container, or to end if something went wrong.
+ */
+OdbObjectsData::iterTreeInfo RepoAnalysis::calculateTreeStatistics(const std::string &oidTree)
+{
+  OdbObjectsData::iterTreeInfo itTreeInfo = m_odbObjectsData.trees.info.find(oidTree);
+  if (itTreeInfo == m_odbObjectsData.trees.info.end()) {
+    return itTreeInfo;
+  }
+
+  OdbObjectsData::TreeInfoAndStats &treeInfoAndStats = itTreeInfo->second;
+
+  // prune recursivity
+  if (treeInfoAndStats.statsDone) {
+    return itTreeInfo;
+  }
+
+  ++treeInfoAndStats.stats.numDirectories;
+  ++treeInfoAndStats.stats.maxPathDepth;
+  // the following partial statistics have also been calculated in previous stage with threads:
+  // - treeInfoAndStats.stats.numFiles
+  // - treeInfoAndStats.stats.maxPathLength
+  // - treeInfoAndStats.stats.numSymLinks
+  // - treeInfoAndStats.stats.numSubmodules
+
+  // totalFileSize
+  OdbObjectsData::iterBlobInfo itBlobInfo {};
+  for (auto &oidBlob : treeInfoAndStats.entryBlobs)
+  {
+    if ((itBlobInfo = m_odbObjectsData.blobs.info.find(oidBlob)) == m_odbObjectsData.blobs.info.end()) {
+      return m_odbObjectsData.trees.info.end(); // to let the caller know that something went wrong
+    }
+
+    treeInfoAndStats.stats.totalFileSize += itBlobInfo->second.size;
+  }
+
+  // recursively into subtrees
+  for (const auto &subTreeNameLen : treeInfoAndStats.entryTreesNameLen)
+  {
+    OdbObjectsData::iterTreeInfo itSubTreeInfo {};
+    if ((itSubTreeInfo = calculateTreeStatistics(subTreeNameLen.first)) ==
+      m_odbObjectsData.trees.info.end()) {
+      return itSubTreeInfo;
+    }
+
+    OdbObjectsData::TreeInfoAndStats &subTreeInfoAndStats = itSubTreeInfo->second;
+    treeInfoAndStats.stats.numDirectories += subTreeInfoAndStats.stats.numDirectories;
+    treeInfoAndStats.stats.maxPathDepth = std::max<size_t>(treeInfoAndStats.stats.maxPathDepth,
+      subTreeInfoAndStats.stats.maxPathDepth + 1);
+    treeInfoAndStats.stats.maxPathLength = std::max<size_t>(treeInfoAndStats.stats.maxPathLength,
+      subTreeNameLen.second + 1 + subTreeInfoAndStats.stats.maxPathLength);
+    treeInfoAndStats.stats.numFiles += subTreeInfoAndStats.stats.numFiles;
+    treeInfoAndStats.stats.totalFileSize += subTreeInfoAndStats.stats.totalFileSize;
+    treeInfoAndStats.stats.numSymlinks += subTreeInfoAndStats.stats.numSymlinks;
+    treeInfoAndStats.stats.numSubmodules += subTreeInfoAndStats.stats.numSubmodules;
+  }
+
+  treeInfoAndStats.statsDone = true;
+
+  return itTreeInfo;
+}
+
+/**
+ * RepoAnalysis::calculateMaxTagDepth
+ * \return true if success; false if something went wrong.
+ */
+bool RepoAnalysis::calculateMaxTagDepth()
+{
+  for (auto &tag : m_odbObjectsData.tags.info)
+  {
+    OdbObjectsData::iterTagInfo itTagInfo {};
+    if ((itTagInfo = calculateTagDepth(tag.first)) == m_odbObjectsData.tags.info.end()) {
+      return false;
+    }
+
+    // update maxTagDepth
+    OdbObjectsData::TagInfo &tagInfo = itTagInfo->second;
+    m_statistics.historyStructure.maxTagDepth = std::max<uint32_t>(m_statistics.historyStructure.maxTagDepth,
+      tagInfo.depth);
+  }
+
+  return true;
+}
+
+/**
+ * RepoAnalysis::calculateTagDepth
+ * 
+ * Calculates recursively the tag depth of the oidTag passed as a parameter.
+ * Returns an iterator to the tag info container, or to end if something went wrong.
+ */
+OdbObjectsData::iterTagInfo RepoAnalysis::calculateTagDepth(const std::string &oidTag)
+{
+  OdbObjectsData::iterTagInfo itTagInfo = m_odbObjectsData.tags.info.find(oidTag);
+  if (itTagInfo == m_odbObjectsData.tags.info.end()) {
+    return itTagInfo;
+  }
+
+  OdbObjectsData::TagInfo &tagInfo = itTagInfo->second;
+
+  // prune recursivity
+  if (tagInfo.depth != OdbObjectsData::TagInfo::kUnsetDepth) {
+    return itTagInfo;
+  }
+
+  ++tagInfo.depth;
+
+  if (tagInfo.typeTarget == GIT_OBJECT_TAG)
+  {
+    OdbObjectsData::iterTagInfo itChainedTagInfo {};
+    if ((itChainedTagInfo = calculateTagDepth(tagInfo.oidTarget)) == m_odbObjectsData.tags.info.end()) {
+      return itChainedTagInfo;
+    }
+
+    OdbObjectsData::TagInfo &chainedTagInfo = itChainedTagInfo->second;
+    tagInfo.depth += chainedTagInfo.depth;
+  }
+
+  return itTagInfo;
+}
+
+/**
+ * RepoAnalysis::fillOutStatistics
+ */
+void RepoAnalysis::fillOutStatistics()
+{
+  m_statistics.repositorySize.commits.count = m_odbObjectsData.commits.info.size();
+  m_statistics.repositorySize.commits.size = m_odbObjectsData.commits.totalSize;
+  m_statistics.repositorySize.trees.count = m_odbObjectsData.trees.info.size();
+  m_statistics.repositorySize.trees.size = m_odbObjectsData.trees.totalSize;
+  m_statistics.repositorySize.trees.entries = m_odbObjectsData.trees.totalEntries;
+  m_statistics.repositorySize.blobs.count = m_odbObjectsData.blobs.info.size();
+  m_statistics.repositorySize.blobs.size = m_odbObjectsData.blobs.totalSize;
+  m_statistics.repositorySize.annotatedTags.count = m_odbObjectsData.tags.info.size();
+
+  m_statistics.biggestObjects.commits.maxSize = m_odbObjectsData.commits.maxSize;
+  m_statistics.biggestObjects.commits.maxParents = m_odbObjectsData.commits.maxParents;
+  m_statistics.biggestObjects.trees.maxEntries = m_odbObjectsData.trees.maxEntries;
+  m_statistics.biggestObjects.blobs.maxSize = m_odbObjectsData.blobs.maxSize;
+
+  // m_statistics.biggestCheckouts have already been filled out while running
+}
+
+/**
+ * RepoAnalysis::repositorySizeToJS
+ */
+v8::Local<v8::Object> RepoAnalysis::repositorySizeToJS() const
+{
+  v8::Local<v8::Object> commits = Nan::New<Object>();
+  Nan::Set(commits, Nan::New("count").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.commits.count));
+  Nan::Set(commits, Nan::New("size").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.commits.size));
+
+  v8::Local<v8::Object> trees = Nan::New<Object>();
+  Nan::Set(trees, Nan::New("count").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.trees.count));
+  Nan::Set(trees, Nan::New("size").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.trees.size));
+  Nan::Set(trees, Nan::New("entries").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.trees.entries));
+
+  v8::Local<v8::Object> blobs = Nan::New<Object>();
+  Nan::Set(blobs, Nan::New("count").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.blobs.count));
+  Nan::Set(blobs, Nan::New("size").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.blobs.size));
+
+  v8::Local<v8::Object> annotatedTags = Nan::New<Object>();
+  Nan::Set(annotatedTags, Nan::New("count").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.annotatedTags.count));
+
+  v8::Local<v8::Object> references = Nan::New<Object>();
+  Nan::Set(references, Nan::New("count").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.repositorySize.references.count));
+
+  v8::Local<v8::Object> result = Nan::New<Object>();
+  Nan::Set(result, Nan::New("commits").ToLocalChecked(), commits);
+  Nan::Set(result, Nan::New("trees").ToLocalChecked(), trees);
+  Nan::Set(result, Nan::New("blobs").ToLocalChecked(), blobs);
+  Nan::Set(result, Nan::New("annotatedTags").ToLocalChecked(), annotatedTags);
+  Nan::Set(result, Nan::New("references").ToLocalChecked(), references);
+
+  return result;
+}
+
+/**
+ * RepoAnalysis::biggestObjectsToJS
+ */
+v8::Local<v8::Object> RepoAnalysis::biggestObjectsToJS() const
+{
+  v8::Local<v8::Object> commits = Nan::New<Object>();
+  Nan::Set(commits, Nan::New("maxSize").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestObjects.commits.maxSize));
+  Nan::Set(commits, Nan::New("maxParents").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestObjects.commits.maxParents));
+
+  v8::Local<v8::Object> trees = Nan::New<Object>();
+  Nan::Set(trees, Nan::New("maxEntries").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestObjects.trees.maxEntries));
+
+  v8::Local<v8::Object> blobs = Nan::New<Object>();
+  Nan::Set(blobs, Nan::New("maxSize").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestObjects.blobs.maxSize));
+
+  v8::Local<v8::Object> result = Nan::New<Object>();
+  Nan::Set(result, Nan::New("commits").ToLocalChecked(), commits);
+  Nan::Set(result, Nan::New("trees").ToLocalChecked(), trees);
+  Nan::Set(result, Nan::New("blobs").ToLocalChecked(), blobs);
+
+  return result;
+}
+
+/**
+ * RepoAnalysis::historyStructureToJS
+ */
+v8::Local<v8::Object> RepoAnalysis::historyStructureToJS() const
+{
+  v8::Local<v8::Object> result = Nan::New<Object>();
+  Nan::Set(result, Nan::New("maxDepth").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.historyStructure.maxDepth));
+  Nan::Set(result, Nan::New("maxTagDepth").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.historyStructure.maxTagDepth));
+
+  return result;
+}
+
+/**
+ * RepoAnalysis::biggestCheckoutsToJS
+ */
+v8::Local<v8::Object> RepoAnalysis::biggestCheckoutsToJS() const
+{
+  v8::Local<v8::Object> result = Nan::New<Object>();
+  Nan::Set(result, Nan::New("numDirectories").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.numDirectories));
+  Nan::Set(result, Nan::New("maxPathDepth").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.maxPathDepth));
+  Nan::Set(result, Nan::New("maxPathLength").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.maxPathLength));
+  Nan::Set(result, Nan::New("numFiles").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.numFiles));
+  Nan::Set(result, Nan::New("totalFileSize").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.totalFileSize));
+  Nan::Set(result, Nan::New("numSymlinks").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.numSymlinks));
+  Nan::Set(result, Nan::New("numSubmodules").ToLocalChecked(),
+    Nan::New<Number>(m_statistics.biggestCheckouts.numSubmodules));
+
+  return result;
+}
+
+NAN_METHOD(GitRepository::Statistics)
+{
+  if (!info[info.Length() - 1]->IsFunction()) {
+    return Nan::ThrowError("Callback is required and must be a Function.");
+  }
+
+  StatisticsBaton* baton = new StatisticsBaton();
+
+   baton->error_code = GIT_OK;
+   baton->error = NULL;
+   baton->repo = Nan::ObjectWrap::Unwrap<GitRepository>(info.This())->GetValue();
+   baton->out = static_cast<void *>(new RepoAnalysis(baton->repo));
+   
+  Nan::Callback *callback = new Nan::Callback(Local<Function>::Cast(info[info.Length() - 1]));
+  std::map<std::string, std::shared_ptr<nodegit::CleanupHandle>> cleanupHandles;
+  StatisticsWorker *worker = new StatisticsWorker(baton, callback, cleanupHandles);
+  worker->Reference<GitRepository>("repo", info.This());
+  nodegit::Context *nodegitContext =
+    reinterpret_cast<nodegit::Context *>(info.Data().As<External>()->Value());
+  nodegitContext->QueueWorker(worker);
+  return;
+}
+
+nodegit::LockMaster GitRepository::StatisticsWorker::AcquireLocks()
+{
+  nodegit::LockMaster lockMaster(true, baton->repo);
+
+  return lockMaster;
+}
+
+void GitRepository::StatisticsWorker::Execute()
+{
+  git_error_clear();
+
+  RepoAnalysis *repoAnalysis = static_cast<RepoAnalysis *>(baton->out);
+  if ((baton->error_code = repoAnalysis->Analyze()) != GIT_OK)
+  {
+    if (git_error_last() != NULL) {
+      baton->error = git_error_dup(git_error_last());
+    }
+
+    delete repoAnalysis;
+    baton->out = nullptr;
+  }
+}
+
+void GitRepository::StatisticsWorker::HandleErrorCallback()
+{
+  if (baton->error) {
+    if (baton->error->message) {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+
+  RepoAnalysis *repoAnalysis = static_cast<RepoAnalysis *>(baton->out);
+  if (repoAnalysis) {
+    delete repoAnalysis;
+  }
+
+  delete baton;
+}
+
+void GitRepository::StatisticsWorker::HandleOKCallback()
+{
+  if (baton->out != NULL)
+  {
+    RepoAnalysis *repoAnalysis = static_cast<RepoAnalysis *>(baton->out);
+    Local<v8::Object> result = repoAnalysis->StatisticsToJS();
+
+    delete repoAnalysis;
+
+    Local<v8::Value> argv[2] = {
+      Nan::Null(),
+      result
+    };
+    callback->Call(2, argv, async_resource);
+  }
+  else if (baton->error)
+  {
+    Local<v8::Object> err;
+
+    if (baton->error->message) {
+      err = Nan::To<v8::Object>(Nan::Error(baton->error->message)).ToLocalChecked();
+    } else {
+      err = Nan::To<v8::Object>(Nan::Error("Method statistics has thrown an error.")).ToLocalChecked();
+    }
+    Nan::Set(err, Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    Nan::Set(err, Nan::New("errorFunction").ToLocalChecked(), Nan::New("GitRepository.statistics").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+
+    callback->Call(1, argv, async_resource);
+
+    if (baton->error->message) {
+      free((void *)baton->error->message);
+    }
+
+    free((void *)baton->error);
+  }
+  else if (baton->error_code < 0)
+  {
+    Local<v8::Object> err = Nan::To<v8::Object>(Nan::Error("Method statistics has thrown an error.")).ToLocalChecked();
+    Nan::Set(err, Nan::New("errno").ToLocalChecked(), Nan::New(baton->error_code));
+    Nan::Set(err, Nan::New("errorFunction").ToLocalChecked(), Nan::New("GitRepository.statistics").ToLocalChecked());
+    Local<v8::Value> argv[1] = {
+      err
+    };
+    callback->Call(1, argv, async_resource);
+  }
+  else
+  {
+    callback->Call(0, NULL, async_resource);
+  }
+
+  delete baton;
+}

--- a/generate/templates/manual/repository/statistics.cc
+++ b/generate/templates/manual/repository/statistics.cc
@@ -829,7 +829,7 @@ static int forEachOdbCb(const git_oid *oid, void *payloadToCast)
   workerPool->InsertWork(std::make_unique<WorkItemOid>(*oid));
 
   // check there were no problems inserting work
-  if (!workerPool->Status()) {
+  if (workerPool->Status() != WPStatus::kOk) {
     return GIT_EUSER;
   }
 
@@ -987,7 +987,7 @@ int RepoAnalysis::storeObjectsInfo()
   workerPool.Shutdown();
 
   // check there were no problems during execution
-  if (!workerPool.Status()) {
+  if (workerPool.Status() != WPStatus::kOk) {
     git_odb_free(odb);
     return GIT_EUSER;
   }
@@ -1129,7 +1129,7 @@ bool RepoAnalysis::setObjectsReachability()
   workerPool.Shutdown();
 
   // check there were no problems during execution
-  if (!workerPool.Status()) {
+  if (workerPool.Status() != WPStatus::kOk) {
     return false;
   }
 

--- a/generate/templates/manual/repository/statistics.cc
+++ b/generate/templates/manual/repository/statistics.cc
@@ -1443,12 +1443,10 @@ void RepoAnalysis::pruneUnreachableBlobs()
  */
 void RepoAnalysis::statsCountAndMax()
 {
-  size_t objectSize {};
-
   // commits
   for (auto &info : m_odbObjectsData.commits.info) {
     OdbObjectsData::CommitInfo &commitInfo = info.second;
-    objectSize = commitInfo.size;
+    const size_t objectSize = commitInfo.size;
 
     m_odbObjectsData.commits.totalSize += objectSize;
     m_odbObjectsData.commits.maxSize = std::max<size_t>(m_odbObjectsData.commits.maxSize, objectSize);
@@ -1462,7 +1460,7 @@ void RepoAnalysis::statsCountAndMax()
   for (auto &info : m_odbObjectsData.trees.info) {
     OdbObjectsData::TreeInfoAndStats &treeInfo = info.second;
     const size_t numEntries = treeInfo.numEntries;
-    objectSize = treeInfo.size;
+    const size_t objectSize = treeInfo.size;
 
     m_odbObjectsData.trees.totalSize += objectSize;
     m_odbObjectsData.trees.totalEntries += numEntries;
@@ -1471,7 +1469,7 @@ void RepoAnalysis::statsCountAndMax()
   // blobs
   for (auto &info : m_odbObjectsData.blobs.info) {
     OdbObjectsData::BlobInfo &blobInfo = info.second;
-    objectSize = blobInfo.size;
+    const size_t objectSize = blobInfo.size;
 
     m_odbObjectsData.blobs.totalSize += objectSize;
     m_odbObjectsData.blobs.maxSize = std::max<size_t>(m_odbObjectsData.blobs.maxSize, objectSize);

--- a/generate/templates/templates/class_header.h
+++ b/generate/templates/templates/class_header.h
@@ -3,6 +3,9 @@
 #include <nan.h>
 #include <string>
 #include <utility>
+#include <algorithm>
+#include <set>
+#include <unordered_set>
 #include <sstream>
 
 #include "async_baton.h"
@@ -13,6 +16,7 @@
 #include "nodegit_wrapper.h"
 #include "promise_completion.h"
 #include "reference_counter.h"
+#include "worker_pool.h"
 
 extern "C" {
 #include <git2.h>

--- a/test/runner.js
+++ b/test/runner.js
@@ -6,6 +6,7 @@ var exec = require('../utils/execPromise');
 var NodeGit = require('..');
 
 var workdirPath = local("repos/workdir");
+var constWorkdirPath = local("repos/constworkdir");
 
 before(function() {
   this.timeout(350000);
@@ -20,6 +21,9 @@ before(function() {
     })
     .then(function() {
       return exec("git init " + local("repos", "empty"));
+    })
+    .then(function() {
+      return exec("git clone " + url + " " + constWorkdirPath);
     })
     .then(function() {
       return exec("git clone " + url + " " + workdirPath);

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -350,4 +350,38 @@ describe("Repository", function() {
         assert.equal(numMergeHeads, 1);
       });
   });
+
+  it("can obtain statistics from a valid repository", function() {
+    return this.repository.statistics()
+    .then(function(analysisReport) {
+
+      assert.equal(analysisReport.repositorySize.commits.count, 992);
+      assert.equal(analysisReport.repositorySize.commits.size, 265544);
+      assert.equal(analysisReport.repositorySize.trees.count, 2416);
+      assert.equal(analysisReport.repositorySize.trees.size, 1188325);
+      assert.equal(analysisReport.repositorySize.trees.entries, 32571);
+      assert.equal(analysisReport.repositorySize.blobs.count, 4149);
+      assert.equal(analysisReport.repositorySize.blobs.size, 48489622);
+      assert.equal(analysisReport.repositorySize.annotatedTags.count, 1);
+      assert.equal(analysisReport.repositorySize.references.count, 10);
+
+      assert.equal(analysisReport.biggestObjects.commits.maxSize, 956);
+      assert.equal(analysisReport.biggestObjects.commits.maxParents, 2);
+      assert.equal(analysisReport.biggestObjects.trees.maxEntries, 93);
+      assert.equal(analysisReport.biggestObjects.blobs.maxSize, 1077756);
+
+      assert.equal(analysisReport.historyStructure.maxDepth, 931);
+      assert.equal(analysisReport.historyStructure.maxTagDepth, 1);
+
+      assert.equal(analysisReport.biggestCheckouts.numDirectories, 128);
+      assert.equal(analysisReport.biggestCheckouts.maxPathDepth, 10);
+      assert.equal(analysisReport.biggestCheckouts.maxPathLength, 107);
+      assert.equal(analysisReport.biggestCheckouts.numFiles, 514);
+      assert.equal(analysisReport.biggestCheckouts.totalFileSize, 5160886);
+      assert.equal(analysisReport.biggestCheckouts.numSymlinks, 2);
+      assert.equal(analysisReport.biggestCheckouts.numSubmodules, 4);
+
+      // console.log(JSON.stringify(analysisReport,null,2));
+    });
+  });
 });

--- a/test/tests/repository.js
+++ b/test/tests/repository.js
@@ -11,6 +11,7 @@ describe("Repository", function() {
   var Index = NodeGit.Index;
   var Signature = NodeGit.Signature;
 
+  var constReposPath = local("../repos/constworkdir");
   var reposPath = local("../repos/workdir");
   var newRepoPath = local("../repos/newrepo");
   var emptyRepoPath = local("../repos/empty");
@@ -18,7 +19,13 @@ describe("Repository", function() {
   beforeEach(function() {
     var test = this;
 
-    return Repository.open(reposPath)
+    return Repository.open(constReposPath)
+      .then(function(constRepository) {
+        test.constRepository = constRepository;
+      })
+      .then(function() {
+        return Repository.open(reposPath);
+      })
       .then(function(repository) {
         test.repository = repository;
       })
@@ -351,8 +358,8 @@ describe("Repository", function() {
       });
   });
 
-  it("can obtain statistics from a valid repository", function() {
-    return this.repository.statistics()
+  it("can obtain statistics from a valid constant repository", function() {
+    return this.constRepository.statistics()
     .then(function(analysisReport) {
 
       assert.equal(analysisReport.repositorySize.commits.count, 992);
@@ -363,7 +370,7 @@ describe("Repository", function() {
       assert.equal(analysisReport.repositorySize.blobs.count, 4149);
       assert.equal(analysisReport.repositorySize.blobs.size, 48489622);
       assert.equal(analysisReport.repositorySize.annotatedTags.count, 1);
-      assert.equal(analysisReport.repositorySize.references.count, 10);
+      assert.equal(analysisReport.repositorySize.references.count, 8);
 
       assert.equal(analysisReport.biggestObjects.commits.maxSize, 956);
       assert.equal(analysisReport.biggestObjects.commits.maxParents, 2);


### PR DESCRIPTION
# Statistics

It returns same statistics as executing 'git-sizer -j' (https://github.com/github/git-sizer).

An example of the output of a test repository:
``` yaml
{
  "repositorySize": {
    "commits": {
      "count": 992,
      "size": 265544
    },
    "trees": {
      "count": 2416,
      "size": 1188325,
      "entries": 32571
    },
    "blobs": {
      "count": 4149,
      "size": 48489622
    },
    "annotatedTags": {
      "count": 1
    },
    "references": {
      "count": 10
    }
  },
  "biggestObjects": {
    "commits": {
      "maxSize": 956,
      "maxParents": 2
    },
    "trees": {
      "maxEntries": 93
    },
    "blobs": {
      "maxSize": 1077756
    }
  },
  "historyStructure": {
    "maxDepth": 931,
    "maxTagDepth": 1
  },
  "biggestCheckouts": {
    "numDirectories": 128,
    "maxPathDepth": 10,
    "maxPathLength": 107,
    "numFiles": 514,
    "totalFileSize": 5160886,
    "numSymlinks": 2,
    "numSubmodules": 4
  }
}
```
## repositorySize

It counts all the repository's unique objects (and references).

## biggestObjects

The maximum objects found. For instance the value 93 in 'biggestObjects.trees.maxEntries' means that from all the unique trees in the repository, the tree with the maximum number of entries has 93 entries.

## historyStructure

### maxDepth

This analyzes the commit graph of all the history of the repository, and it's the path with the maximum number of commits from an initial commit to one of the latest commits.

It considers that a graph can have multiple initial commits.

### maxTagDepth

This is the maximum number of tags chained until a non-tag object is reached.

## biggestCheckouts

This is the result of comparing all the commits in the history of the repository, and returning the maximum values found. The result does not have to belong to a unique commit, for instance a commit C1 could have the maximum number of directories (128 in the example), while other commit C2 has the maximum sum of files sizes it contains (5160886 in the example).

The numbers shown are the result of considering the entries in the commit's tree and also all its subtrees.

# Notes about the result

The output return avoids considering dangling (unreachable) objects, as well as empty trees (like the one git introduces internally "4b825dc642cb6eb9a060e54bf8d69288fbee4904")