### PR TITLE
update test to Ubuntu 18.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14]
-        os: [ubuntu-16.04, macOS-10.15]
+        os: [ubuntu-18.04, macOS-10.15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup Environment


### PR DESCRIPTION
GitHub actions virtual environments replaced Ubuntu-16.04 [with Ubuntu-18.04](https://github.com/actions/virtual-environments#available-environments).

[Ubuntu 16.04 environment will be removed on September 20, 2021](https://github.com/actions/virtual-environments/issues/3287).

This PR just updates the workflow tests to Ubuntu-18.04.