### PR TITLE
Fix electron-npg-automator

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,13 @@
     "json5": "^2.1.0",
     "lodash": "^4.17.14",
     "nan": "^2.14.1",
-    "node-gyp": "^9.0.0",
+    "node-gyp": "^8.4.1",
     "@mapbox/node-pre-gyp": "^1.0.8",
     "ramda": "^0.25.0",
     "tar-fs": "^1.16.3"
   },
   "devDependencies": {
     "aws-sdk": "^2.1095.0",
-    "babel-cli": "^6.7.7",
-    "babel-preset-es2015": "^6.6.0",
     "cheerio": "^1.0.0-rc.2",
     "clean-for-publish": "~1.0.2",
     "combyne": "~0.8.1",
@@ -69,7 +67,7 @@
     "host": "https://axonodegit.s3.amazonaws.com/nodegit/nodegit/"
   },
   "scripts": {
-    "babel": "babel --presets es2015 -d ./dist ./lib",
+    "copylib": "node utils/copylib",
     "cov": "npm run cppcov && npm run filtercov && npm run mergecov",
     "coveralls": "cat ./test/coverage/merged.lcov | coveralls",
     "cppcov": "mkdir -p test/coverage/cpp && ./lcov-1.10/bin/lcov --gcov-tool /usr/bin/gcov-4.9 --capture --directory build/Release/obj.target/nodegit/src --output-file test/coverage/cpp/lcov_full.info",
@@ -84,9 +82,9 @@
     "mocha": "mocha --expose-gc test/runner test/tests --timeout 15000",
     "mochaDebug": "mocha --expose-gc --debug-brk test/runner test/tests --timeout 15000",
     "postinstall": "node lifecycleScripts/postinstall",
-    "prepublish": "npm run babel",
-    "rebuild": "node generate && npm run babel && node-gyp configure build",
-    "rebuildDebug": "node generate && npm run babel && node-gyp configure --debug build",
+    "prepublish": "npm run copylib",
+    "rebuild": "node generate && npm run copylib && node-gyp configure build",
+    "rebuildDebug": "node generate && npm run copylib && node-gyp configure --debug build",
     "recompile": "node-gyp configure build",
     "recompileDebug": "node-gyp configure --debug build",
     "test": "npm run lint && node --expose-gc test",

--- a/utils/copylib.js
+++ b/utils/copylib.js
@@ -1,0 +1,16 @@
+const fse = require("fs-extra");
+
+const srcDir = "lib";
+const destDir = "dist";
+
+module.exports = function copylib() {
+  fse.copySync(srcDir, destDir, { overwrite: true }, function (err) {
+    if (err) {
+      console.error(err);
+    }
+  });
+}
+
+if (require.main === module) {
+  module.exports();
+}


### PR DESCRIPTION
After node-gyp upgrade electron-npg-automator is not working.
Downgrade node-gyp to 8.4.1
Removed babel stuff, there is a conflict with fsevents package in electron-npg-automator