### PR TITLE
Statically compile OpenSSL on linux for electron

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -9,6 +9,7 @@
   "targets": [
     {
       "target_name": "acquireOpenSSL",
+        "type": "none",
         "conditions": [
         ["<(is_electron) == 1 and <!(node -p \"process.env.npm_config_openssl_dir ? 0 : 1\")", {
           "actions": [{
@@ -23,6 +24,7 @@
     },
     {
       "target_name": "configureLibssh2",
+      "type": "none",
       "actions": [{
         "action_name": "configure",
         "action": ["node", "utils/configureLibssh2.js"],

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -10,7 +10,7 @@
     {
       "target_name": "acquireOpenSSL",
         "conditions": [
-        ["<(is_electron) == 1 and OS != 'linux' and <!(node -p \"process.env.npm_config_openssl_dir ? 0 : 1\")", {
+        ["<(is_electron) == 1 and <!(node -p \"process.env.npm_config_openssl_dir ? 0 : 1\")", {
           "actions": [{
             "action_name": "acquire",
             "action": ["node", "utils/acquireOpenSSL.js", "<(macOS_deployment_target)"],
@@ -110,8 +110,8 @@
                   "<(electron_openssl_root)/include"
                 ],
                 "libraries": [
-                  "<(electron_openssl_root)/lib/libcrypto.a",
-                  "<(electron_openssl_root)/lib/libssl.a"
+                  "<(electron_openssl_root)/lib/libssl.a",
+                  "<(electron_openssl_root)/lib/libcrypto.a"
                 ]
               }]
             ],
@@ -168,21 +168,23 @@
             "<!(krb5-config gssapi --libs)"
           ]
         }],
-        [
-          "OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
-            "cflags": [
-              "-std=c++14"
-            ]
-          }
-        ],
-        [
-          "OS.endswith('bsd') or (<(is_electron) == 1 and OS=='linux') or <(is_IBMi) == 1", {
-            "libraries": [
-              "-lcrypto",
-              "-lssl"
-            ],
-          }
-        ],
+        ["OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+          "cflags": [
+            "-std=c++14"
+          ],
+          "conditions": [
+            ["<(is_electron) == 1", {
+              "include_dirs": [
+                "<(electron_openssl_root)/include"
+              ],
+              "libraries": [
+                # this order is signifcant on centos7 apparently...
+                "<(electron_openssl_root)/lib/libssl.a",
+                "<(electron_openssl_root)/lib/libcrypto.a"
+              ]
+            }]
+          ],
+        }],
         [
           "<(is_IBMi) == 1", {
             "include_dirs": [

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -3,6 +3,7 @@
     "is_electron%": "<!(node ./utils/isBuildingForElectron.js <(node_root_dir))",
     "is_IBMi%": "<!(node -p \"os.platform() == 'aix' && os.type() == 'OS400' ? 1 : 0\")",
     "electron_openssl_root%": "<!(node ./utils/getElectronOpenSSLRoot.js <(module_root_dir))",
+    "electron_openssl_static%": "<!(node -p \"process.platform !== 'linux' || process.env.NODEGIT_OPENSSL_STATIC_LINK === '1' ? 1 : 0\")",
     "macOS_deployment_target": "10.11"
   },
 
@@ -175,14 +176,20 @@
             "-std=c++14"
           ],
           "conditions": [
-            ["<(is_electron) == 1", {
+            ["<(is_electron) == 1 and <(electron_openssl_static) == 1", {
               "include_dirs": [
                 "<(electron_openssl_root)/include"
               ],
               "libraries": [
-                # this order is signifcant on centos7 apparently...
+                # this order is significant on centos7 apparently...
                 "<(electron_openssl_root)/lib/libssl.a",
                 "<(electron_openssl_root)/lib/libcrypto.a"
+              ]
+            }],
+            ["<(is_electron) == 1 and <(electron_openssl_static) != 1", {
+              "libraries": [
+                "-lcrypto",
+                "-lssl"
               ]
             }]
           ],

--- a/guides/install/from-source/README.md
+++ b/guides/install/from-source/README.md
@@ -65,7 +65,7 @@ npm install nodegit --msvs_version=2013
 ```
 
 ### Electron and OpenSSL ###
-A local version of OpenSSL is required when building for Electron on Windows and macOS. This is due to Electron using BoringSSL, as we are not able to link to it like we are OpenSSL in Node.
+A local version of OpenSSL is required when building for Electron on Windows and macOS. This is due to Electron using BoringSSL, as we are not able to link to it like we are OpenSSL in Node. Additionally, OpenSSL can be statically linked on Linux by setting the `NODEGIT_OPENSSL_STATIC_LINK` environment variable to `1`.
 
 `acquireOpenSSL.js` will attempt to download and build OpenSSL locally. On macOS, this should Just Work(tm). On Windows, things are a little trickier.
 

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -54,7 +54,7 @@ const applyOpenSSLPatches = async (buildCwd) => {
     }
   } catch(e) {
     console.log("Patch application failed: ", e);
-    return;
+    throw e;
   }
 }
 

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -114,24 +114,23 @@ const buildLinux = async (buildCwd) => {
     `--prefix="${extractPath}"`,
     `--openssldir="${extractPath}"`
   ];
-  await execPromise(`./Configure ${arguments.join(" ")}`, {
+  await execPromise(`./Configure ${arguments.join(' ')}`, {
     cwd: buildCwd
   }, { pipeOutput: true });
 
   await applyOpenSSLPatches(buildCwd);
 
   // only build the libraries, not the tests/fuzzer or apps
-  await execPromise("make build_libs", {
+  await execPromise('make build_libs', {
     cwd: buildCwd
   }, { pipeOutput: true });
 
-  //TODO: uncomment
-  // await execPromise("make test", {
-  //   cwd: buildCwd
-  // }, { pipeOutput: true });
+  await execPromise('make test', {
+    cwd: buildCwd
+  }, { pipeOutput: true });
 
   //only install software, not the docs
-  await execPromise("make install_sw", {
+  await execPromise('make install_sw', {
     cwd: buildCwd,
     maxBuffer: 10 * 1024 * 1024 // we should really just use spawn
   }, { pipeOutput: true });

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -61,15 +61,15 @@ const applyOpenSSLPatches = async (buildCwd) => {
 const buildDarwin = async (buildCwd, macOsDeploymentTarget) => {
   const arguments = [
     process.arch === 'x64' ? 'darwin64-x86_64-cc' : 'darwin64-arm64-cc',
-    // speed up ecdh on little-endian platform with 128bit int support
+    // speed up ecdh on little-endian platforms with 128bit int support
     'enable-ec_nistp_64_gcc_128',
-    // compile static library
+    // compile static libraries
     'no-shared',
     // disable ssl2, ssl3, and compression
     'no-ssl2',
     'no-ssl3',
     'no-comp',
-    //set build/install directory
+    //set install directory
     `--prefix="${extractPath}"`,
     `--openssldir="${extractPath}"`,
     //set macos version requirement
@@ -100,17 +100,16 @@ const buildLinux = async (buildCwd) => {
     'linux-x86_64',
     // Electron(at least on centos7) imports the libcups library at runtime, which has a
     // dependency on the system libssl/libcrypto which causes symbol conflicts and segfaults.
-    // To fix this we need to remove hide all the internal openssl symbols to prevent them
-    // from being overridden, this only affects shared libraries, which in this case
-    // is nodegit
+    // To fix this we need to hide all the openssl symbols to prevent them from being overridden
+    // by the runtime linker.
     '-fvisibility=hidden',
-    // compile static library
+    // compile static libraries
     'no-shared',
     // disable ssl2, ssl3, and compression
     'no-ssl2',
     'no-ssl3',
     'no-comp',
-    //set build/install directory
+    //set install directory
     `--prefix="${extractPath}"`,
     `--openssldir="${extractPath}"`
   ];

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -47,7 +47,7 @@ const applyOpenSSLPatches = async (buildCwd) => {
     for (const patchFilename of await fse.readdir(opensslPatchPath)) {
       if (patchFilename.split(".").pop() === "patch") {
         console.log(`applying ${patchFilename}`);
-        await execPromise(`patch -up0 -i ${path.join(patchPath, patchFilename)}`, {
+        await execPromise(`patch -up0 -i ${path.join(opensslPatchPath, patchFilename)}`, {
           cwd: buildCwd
         }, { pipeOutput: true });
       }

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -44,8 +44,8 @@ class HashVerify extends stream.Transform {
 // currently this only needs to be done on linux
 const applyOpenSSLPatches = async (buildCwd) => {
   try {
-    for(const patchFilename of await fse.readdir(opensslPatchPath)) {
-      if(patchFilename.split('.').pop() == 'patch') {
+    for (const patchFilename of await fse.readdir(opensslPatchPath)) {
+      if (patchFilename.split(".").pop() === "patch") {
         console.log(`applying ${patchFilename}`);
         await execPromise(`patch -up0 -i ${path.join(patchPath, patchFilename)}`, {
           cwd: buildCwd
@@ -60,36 +60,36 @@ const applyOpenSSLPatches = async (buildCwd) => {
 
 const buildDarwin = async (buildCwd, macOsDeploymentTarget) => {
   const arguments = [
-    process.arch === 'x64' ? 'darwin64-x86_64-cc' : 'darwin64-arm64-cc',
+    process.arch === "x64" ? "darwin64-x86_64-cc" : "darwin64-arm64-cc",
     // speed up ecdh on little-endian platforms with 128bit int support
-    'enable-ec_nistp_64_gcc_128',
+    "enable-ec_nistp_64_gcc_128",
     // compile static libraries
-    'no-shared',
+    "no-shared",
     // disable ssl2, ssl3, and compression
-    'no-ssl2',
-    'no-ssl3',
-    'no-comp',
-    //set install directory
+    "no-ssl2",
+    "no-ssl3",
+    "no-comp",
+    // set install directory
     `--prefix="${extractPath}"`,
     `--openssldir="${extractPath}"`,
-    //set macos version requirement
+    // set macos version requirement
     `-mmacosx-version-min=${macOsDeploymentTarget}`
   ];
 
-  await execPromise(`./Configure ${arguments.join(' ')}`, {
+  await execPromise(`./Configure ${arguments.join(" ")}`, {
     cwd: buildCwd
   }, { pipeOutput: true });
 
   // only build the libraries, not the tests/fuzzer or apps
-  await execPromise('make build_libs', {
+  await execPromise("make build_libs", {
     cwd: buildCwd
   }, { pipeOutput: true });
 
-  await execPromise('make test', {
+  await execPromise("make test", {
     cwd: buildCwd
   }, { pipeOutput: true });
 
-  await execPromise('make install_sw', {
+  await execPromise("make install_sw", {
     cwd: buildCwd,
     maxBuffer: 10 * 1024 * 1024 // we should really just use spawn
   }, { pipeOutput: true });
@@ -97,39 +97,39 @@ const buildDarwin = async (buildCwd, macOsDeploymentTarget) => {
 
 const buildLinux = async (buildCwd) => {
   const arguments = [
-    'linux-x86_64',
+    "linux-x86_64",
     // Electron(at least on centos7) imports the libcups library at runtime, which has a
     // dependency on the system libssl/libcrypto which causes symbol conflicts and segfaults.
     // To fix this we need to hide all the openssl symbols to prevent them from being overridden
     // by the runtime linker.
-    '-fvisibility=hidden',
+    "-fvisibility=hidden",
     // compile static libraries
-    'no-shared',
+    "no-shared",
     // disable ssl2, ssl3, and compression
-    'no-ssl2',
-    'no-ssl3',
-    'no-comp',
-    //set install directory
+    "no-ssl2",
+    "no-ssl3",
+    "no-comp",
+    // set install directory
     `--prefix="${extractPath}"`,
     `--openssldir="${extractPath}"`
   ];
-  await execPromise(`./Configure ${arguments.join(' ')}`, {
+  await execPromise(`./Configure ${arguments.join(" ")}`, {
     cwd: buildCwd
   }, { pipeOutput: true });
 
   await applyOpenSSLPatches(buildCwd);
 
   // only build the libraries, not the tests/fuzzer or apps
-  await execPromise('make build_libs', {
+  await execPromise("make build_libs", {
     cwd: buildCwd
   }, { pipeOutput: true });
 
-  await execPromise('make test', {
+  await execPromise("make test", {
     cwd: buildCwd
   }, { pipeOutput: true });
 
-  //only install software, not the docs
-  await execPromise('make install_sw', {
+  // only install software, not the docs
+  await execPromise("make install_sw", {
     cwd: buildCwd,
     maxBuffer: 10 * 1024 * 1024 // we should really just use spawn
   }, { pipeOutput: true });

--- a/utils/acquireOpenSSL.js
+++ b/utils/acquireOpenSSL.js
@@ -196,6 +196,16 @@ const makeOnStreamDownloadProgress = () => {
 };
 
 const buildOpenSSLIfNecessary = async (openSSLVersion, macOsDeploymentTarget) => {
+  if (process.platform !== "darwin" && process.platform !== "win32" && process.platform !== 'linux') {
+    console.log(`Skipping OpenSSL build, not required on ${process.platform}`);
+    return;
+  }
+
+  if (process.platform === 'linux' && process.env.NODEGIT_OPENSSL_STATIC_LINK !== '1') {
+    console.log(`Skipping OpenSSL build, NODEGIT_OPENSSL_STATIC_LINK !== 1`);
+    return;
+  }
+
   await removeOpenSSLIfOudated(openSSLVersion);
 
   try {
@@ -225,7 +235,7 @@ const buildOpenSSLIfNecessary = async (openSSLVersion, macOsDeploymentTarget) =>
 
   if (process.platform === "darwin") {
     await buildDarwin(buildCwd, macOsDeploymentTarget);
-  } else if (process.platform === "linux") {
+  } else if (process.platform === "linux" && process.env.NODEGIT_OPENSSL_STATIC_LINK === '1') {
     await buildLinux(buildCwd);
   } else if (process.platform === "win32") {
     await buildWin32(buildCwd);
@@ -237,6 +247,16 @@ const buildOpenSSLIfNecessary = async (openSSLVersion, macOsDeploymentTarget) =>
 }
 
 const downloadOpenSSLIfNecessary = async (downloadBinUrl, maybeDownloadSha256) => {
+  if (process.platform !== "darwin" && process.platform !== "win32" && process.platform !== 'linux') {
+    console.log(`Skipping OpenSSL download, not required on ${process.platform}`);
+    return;
+  }
+
+  if (process.platform === 'linux' && process.env.NODEGIT_OPENSSL_STATIC_LINK !== '1') {
+    console.log(`Skipping OpenSSL download, NODEGIT_OPENSSL_STATIC_LINK !== 1`);
+    return;
+  }
+
   try {
     await fs.stat(extractPath);
     console.log("Skipping OpenSSL download, dir exists");

--- a/utils/configureLibssh2.js
+++ b/utils/configureLibssh2.js
@@ -2,6 +2,7 @@ var cp = require("child_process");
 var fse = require("fs-extra");
 var path = require("path");
 
+const opensslVendorDirectory = path.resolve(__dirname, "..", "vendor", "openssl");
 const libssh2VendorDirectory = path.resolve(__dirname, "..", "vendor", "libssh2");
 const libssh2ConfigureScript = path.join(libssh2VendorDirectory, "configure");
 const libssh2StaticConfigDirectory  = path.resolve(__dirname, "..", "vendor", "static_config", "libssh2");
@@ -24,8 +25,9 @@ module.exports = function retrieveExternalDependencies() {
       newEnv[key] = process.env[key];
     });
 
+    let cpArgs = `--with-libssl-prefix=${opensslVendorDirectory}`;
     cp.exec(
-      libssh2ConfigureScript,
+      `${libssh2ConfigureScript} ${cpArgs}`,
       {
         cwd: libssh2VendorDirectory,
         env: newEnv

--- a/utils/configureLibssh2.js
+++ b/utils/configureLibssh2.js
@@ -25,9 +25,11 @@ module.exports = function retrieveExternalDependencies() {
       newEnv[key] = process.env[key];
     });
 
-    let cpArgs = `--with-libssl-prefix=${opensslVendorDirectory}`;
+    let cpArgs = process.env.NODEGIT_OPENSSL_STATIC_LINK === '1'
+      ? ` --with-libssl-prefix=${opensslVendorDirectory}`
+      : '';
     cp.exec(
-      `${libssh2ConfigureScript} ${cpArgs}`,
+      `${libssh2ConfigureScript}${cpArgs}`,
       {
         cwd: libssh2VendorDirectory,
         env: newEnv

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -11,6 +11,7 @@
     "is_clang%": 0,
     "is_IBMi%": "<!(node -p \"os.platform() == 'aix' && os.type() == 'OS400' ? 1 : 0\")",
     "electron_openssl_root%": "<!(node ../utils/getElectronOpenSSLRoot.js <(module_root_dir))",
+    "electron_openssl_static%": "<!(node -p \"process.platform !== 'linux' || process.env.NODEGIT_OPENSSL_STATIC_LINK === '1' ? 1 : 0\")",
   },
   "targets": [
     {
@@ -362,7 +363,7 @@
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
           "conditions": [
-            ["<(is_electron) == 1", {
+            ["<(is_electron) == 1 and <(electron_openssl_static) == 1", {
               "include_dirs": [
                 "<(electron_openssl_root)/include"
               ]
@@ -622,7 +623,7 @@
       "conditions": [
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
           "conditions": [
-            ["<(is_electron) == 1", {
+            ["<(is_electron) == 1 and <(electron_openssl_static) == 1", {
               "include_dirs": [
                 "<(electron_openssl_root)/include"
               ]
@@ -702,7 +703,7 @@
         }],
         ["OS=='linux'", {
           "conditions": [
-            ["<(is_electron) == 1", {
+            ["<(is_electron) == 1 and <(electron_openssl_static) == 1", {
               "include_dirs": ["<(electron_openssl_root)/include"]
             }]
           ],

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -338,36 +338,36 @@
           ]
         }],
         ["OS=='mac'", {
-            "conditions": [
-              ["<(is_electron) == 1", {
-                "include_dirs": [
-                  "<(electron_openssl_root)/include"
-                ]
-              }]
-            ],
-            "defines": [
-                "GIT_SECURE_TRANSPORT",
-                "GIT_USE_STAT_MTIMESPEC",
-                "GIT_REGEX_REGCOMP_L",
-                "GIT_USE_ICONV"
-            ],
-            "sources": [
-                "libgit2/src/streams/stransport.c",
-                "libgit2/src/streams/stransport.h"
-            ],
-            "libraries": [
-              "-liconv",
-            ],
-            "link_settings": {
-                "xcode_settings": {
-                    "OTHER_LDFLAGS": [
-                        "-framework Security",
-                        "-framework CoreFoundation"
-                    ],
-                }
-            }
+          "defines": [
+              "GIT_SECURE_TRANSPORT",
+              "GIT_USE_STAT_MTIMESPEC",
+              "GIT_REGEX_REGCOMP_L",
+              "GIT_USE_ICONV"
+          ],
+          "sources": [
+              "libgit2/src/streams/stransport.c",
+              "libgit2/src/streams/stransport.h"
+          ],
+          "libraries": [
+            "-liconv",
+          ],
+          "link_settings": {
+              "xcode_settings": {
+                  "OTHER_LDFLAGS": [
+                      "-framework Security",
+                      "-framework CoreFoundation"
+                  ],
+              }
+          }
         }],
         ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+          "conditions": [
+            ["<(is_electron) == 1", {
+              "include_dirs": [
+                "<(electron_openssl_root)/include"
+              ]
+            }]
+          ],
           "dependencies": [
             "ntlmclient"
           ],
@@ -620,10 +620,14 @@
         ]
       },
       "conditions": [
-        ["OS=='mac' and <(is_electron) == 1", {
-          "include_dirs": [
-            "<(electron_openssl_root)/include",
-          ]
+        ["OS=='mac' or OS=='linux' or OS.endswith('bsd') or <(is_IBMi) == 1", {
+          "conditions": [
+            ["<(is_electron) == 1", {
+              "include_dirs": [
+                "<(electron_openssl_root)/include"
+              ]
+            }]
+          ],
         }],
         ["OS=='win'", {
           "conditions": [
@@ -682,10 +686,12 @@
         "UNICODE_BUILTIN"
       ],
       "conditions": [
-        ["OS=='mac' and <(is_electron) == 1", {
-          "include_dirs": ["<(electron_openssl_root)/include"]
-        }],
         ["OS=='mac'", {
+          "conditions": [
+            ["<(is_electron) == 1", {
+              "include_dirs": ["<(electron_openssl_root)/include"]
+            }]
+          ],
           "sources": [
             "libgit2/deps/ntlmclient/crypt_commoncrypto.c",
             "libgit2/deps/ntlmclient/crypt_commoncrypto.h"
@@ -695,6 +701,11 @@
           ]
         }],
         ["OS=='linux'", {
+          "conditions": [
+            ["<(is_electron) == 1", {
+              "include_dirs": ["<(electron_openssl_root)/include"]
+            }]
+          ],
           "sources": [
             "libgit2/deps/ntlmclient/crypt_openssl.c",
             "libgit2/deps/ntlmclient/crypt_openssl.h"

--- a/vendor/patches/README.md
+++ b/vendor/patches/README.md
@@ -1,0 +1,12 @@
+# Patches directory
+Patches for modifying vendor code without including it.
+
+Patches will be applied from 000 to 999
+
+### Naming Convention
+
+`<number 3 digits>-<description>.patch`
+
+### Content
+
+All patches should start with a description of what they do and why they're needed.

--- a/vendor/patches/openssl/001-unix_force_getentropy_dso_lookup.patch
+++ b/vendor/patches/openssl/001-unix_force_getentropy_dso_lookup.patch
@@ -1,4 +1,4 @@
-openssl doesn't have any sort of gaurd around this section of code other than
+openssl doesn't have any sort of guard around this section of code other than
 checking if we're compiling an elf binary on gnu linux. the syscall wrapper
 `getentropy` is only available on glibc >= 2.25 which is a problem if we want
 to support platforms like centos7 which ships with glibc 2.17. Attempting to
@@ -9,7 +9,7 @@ theres no way to configure for it, hence this patch.
 Note further that centos7 doesn't have this function or the syscall it wraps
 so the symbol lookup will fail and it will fallback to reading from /dev/random.
 hence this patch just fixes compilation.
-JZA
+author: JZA
 --- crypto/rand/rand_unix.c
 +++ crypto/rand/rand_unix.c
 @@ -372,7 +372,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)

--- a/vendor/patches/openssl/001-unix_force_getentropy_dso_lookup.patch
+++ b/vendor/patches/openssl/001-unix_force_getentropy_dso_lookup.patch
@@ -1,0 +1,23 @@
+openssl doesn't have any sort of gaurd around this section of code other than
+checking if we're compiling an elf binary on gnu linux. the syscall wrapper
+`getentropy` is only available on glibc >= 2.25 which is a problem if we want
+to support platforms like centos7 which ships with glibc 2.17. Attempting to
+load this code on centos7 causes a runtime "undefined symbol error since glibc
+doesn't provide it.
+luckily openssl provides a backup lookup method in form of a dlopen call but
+theres no way to configure for it, hence this patch.
+Note further that centos7 doesn't have this function or the syscall it wraps
+so the symbol lookup will fail and it will fallback to reading from /dev/random.
+hence this patch just fixes compilation.
+JZA
+--- crypto/rand/rand_unix.c
++++ crypto/rand/rand_unix.c
+@@ -372,7 +372,7 @@ static ssize_t syscall_random(void *buf, size_t buflen)
+      * Note: Sometimes getentropy() can be provided but not implemented
+      * internally. So we need to check errno for ENOSYS
+      */
+-#  if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__) && !defined(__hpux)
++#  if defined(__GNUC__) && __GNUC__>=2 && defined(__ELF__) && !defined(__hpux) && 0
+     extern int getentropy(void *buffer, size_t length) __attribute__((weak));
+ 
+     if (getentropy != NULL) {


### PR DESCRIPTION
Several fixes included, they should be documented in the code.

Notable Changes:
 - a code patching system
   - only used to fix openssl old linux OS's(GLIBC <= 2.25) for now but can be expanded in the future if necessary
 - openssl configure and build support for linux
   - notably there is a flag passed here to hide all openssl symbols, without this, nodegit would segfault in cases where the electron environment has loaded in openssl
  - Apparently we were building and shipping some node binaries without code in them, this was an artifact of making action-only targets but not declaring them as action-only. I fixed that.
  - Also configured openssl on linux and mac to only build and install the headers and libs. we no longer build the additional apps, fuzzers, and docs. should result in a small speed up