### PR TITLE
Enable GIT_USE_NSEC

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -23,11 +23,7 @@
         "GIT_SSH_MEMORY_CREDENTIALS",
         "LIBGIT2_NO_FEATURES_H",
         "GIT_SHA1_COLLISIONDETECT",
-        # "GIT_USE_NSEC", We've been shipping without NSEC for awhile
-        # Turning NSEC on should be left up to application maintainer
-        # There may be negative performance impacts using nodegit with
-        # NSEC turned on in a repository that was cloned with nodegit
-        # with NSEC turned off
+        "GIT_USE_NSEC",
         "GIT_HTTPS",
         # Node's util.h may be accidentally included so use this to guard
         # against compilation error.


### PR DESCRIPTION
This will improve performance on LFS and big repos
We need this [PR7](https://github.com/nodegit/libgit2/pull/7) to avoid performance degradation.