### PR TITLE
Optimize NodeGit objects creation.

### DIFF
--- a/generate/templates/manual/include/convenient_hunk.h
+++ b/generate/templates/manual/include/convenient_hunk.h
@@ -31,6 +31,8 @@ class ConvenientHunk : public Nan::ObjectWrap {
     static void InitializeComponent (v8::Local<v8::Object> target, nodegit::Context *nodegitContext);
 
     static v8::Local<v8::Value> New(void *raw);
+    static v8::Local<v8::Value> New(v8::Local<v8::Function> constructorTemplate, void *raw);
+    static v8::Local<v8::Function> GetTemplate();
 
     HunkData *GetValue();
     char *GetHeader();

--- a/generate/templates/manual/include/convenient_patch.h
+++ b/generate/templates/manual/include/convenient_patch.h
@@ -46,7 +46,9 @@ class ConvenientPatch : public Nan::ObjectWrap {
 
     static void InitializeComponent(v8::Local<v8::Object> target, nodegit::Context *nodegitContext);
 
+    static v8::Local<v8::Function> GetTemplate();
     static v8::Local<v8::Value> New(void *raw);
+    static v8::Local<v8::Value> New(v8::Local<v8::Function> constructorTemplate, void *raw);
 
     ConvenientLineStats GetLineStats();
     git_delta_t GetStatus();

--- a/generate/templates/manual/include/nodegit_wrapper.h
+++ b/generate/templates/manual/include/nodegit_wrapper.h
@@ -75,6 +75,11 @@ protected:
 
 public:
   static v8::Local<v8::Value> New(const cType *raw, bool selfFreeing, v8::Local<v8::Object> owner = v8::Local<v8::Object>());
+  static v8::Local<v8::Value> New(v8::Local<v8::Function> constructorTemplate,const cType *raw, bool selfFreeing, v8::Local<v8::Object> owner);
+  static v8::Local<v8::Value> New(v8::Local<v8::Function> constructorTemplate,const cType *raw, bool selfFreeing);
+
+  static v8::Local<v8::Function> GetTemplate();
+
 
   void SaveCleanupHandle(std::shared_ptr<nodegit::CleanupHandle> cleanupHandle);
 

--- a/generate/templates/manual/patches/convenient_patches.cc
+++ b/generate/templates/manual/patches/convenient_patches.cc
@@ -151,8 +151,9 @@ void GitPatch::ConvenientFromDiffWorker::HandleOKCallback() {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
 
+    v8::Local<v8::Function> constructor_template = ConvenientPatch::GetTemplate();
     for (unsigned int i = 0; i < size; ++i) {
-      Nan::Set(result, Nan::New<Number>(i), ConvenientPatch::New((void *)baton->out->at(i)));
+      Nan::Set(result, Nan::New<Number>(i), ConvenientPatch::New(constructor_template, (void *)baton->out->at(i)));
     }
 
     delete baton->out;

--- a/generate/templates/manual/remote/ls.cc
+++ b/generate/templates/manual/remote/ls.cc
@@ -72,8 +72,9 @@ void GitRemote::ReferenceListWorker::HandleOKCallback()
   {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> constructor_template = GitRemoteHead::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
-      Nan::Set(result, Nan::New<Number>(i), GitRemoteHead::New(baton->out->at(i), true));
+      Nan::Set(result, Nan::New<Number>(i), GitRemoteHead::New(constructor_template, baton->out->at(i), true));
     }
 
     delete baton->out;

--- a/generate/templates/manual/repository/get_references.cc
+++ b/generate/templates/manual/repository/get_references.cc
@@ -108,15 +108,18 @@ void GitRepository::GetReferencesWorker::HandleOKCallback()
   {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> git_refs_template = GitRefs::GetTemplate();
+    v8::Local<v8::Function> git_repository_template = GitRepository::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
       git_reference *reference = baton->out->at(i);
       Nan::Set(
         result,
         Nan::New<Number>(i),
         GitRefs::New(
+          git_refs_template,
           reference,
           true,
-          Nan::To<v8::Object>(GitRepository::New(git_reference_owner(reference), true)).ToLocalChecked()
+          Nan::To<v8::Object>(GitRepository::New(git_repository_template, git_reference_owner(reference), true)).ToLocalChecked()
         )
       );
     }

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -110,15 +110,18 @@ void GitRepository::GetRemotesWorker::HandleOKCallback()
   {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> git_remote_template = GitRemote::GetTemplate();
+    v8::Local<v8::Function> git_repository_template = GitRepository::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
       git_remote *remote = baton->out->at(i);
       Nan::Set(
         result,
         Nan::New<Number>(i),
         GitRemote::New(
+          git_remote_template,
           remote,
           true,
-          Nan::To<v8::Object>(GitRepository::New(git_remote_owner(remote), true)).ToLocalChecked()
+          Nan::To<v8::Object>(GitRepository::New(git_repository_template, git_remote_owner(remote), true)).ToLocalChecked()
         )
       );
     }

--- a/generate/templates/manual/repository/get_submodules.cc
+++ b/generate/templates/manual/repository/get_submodules.cc
@@ -88,15 +88,18 @@ void GitRepository::GetSubmodulesWorker::HandleOKCallback()
   {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> git_submodule_template = GitSubmodule::GetTemplate();
+    v8::Local<v8::Function> git_repository_template = GitRepository::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
       git_submodule *submodule = baton->out->at(i);
       Nan::Set(
         result,
         Nan::New<Number>(i),
         GitSubmodule::New(
+          git_submodule_template,
           submodule,
           true,
-          Nan::To<v8::Object>(GitRepository::New(git_submodule_owner(submodule), true)).ToLocalChecked()
+          Nan::To<v8::Object>(GitRepository::New(git_repository_template, git_submodule_owner(submodule), true)).ToLocalChecked()
         )
       );
     }

--- a/generate/templates/manual/revwalk/commit_walk.cc
+++ b/generate/templates/manual/revwalk/commit_walk.cc
@@ -45,12 +45,14 @@ public:
   CommitModel &operator=(const CommitModel &) = delete;
   CommitModel &operator=(CommitModel &&) = delete;
 
-  v8::Local<v8::Value> toJavascript() {
+  v8::Local<v8::Value> toJavascript(v8::Local<v8::Function> GitCommitTemplate, v8::Local<v8::Function> GitRepositoryTemplate) {
     if (!fetchSignature) {
       v8::Local<v8::Value> commitObject = GitCommit::New(
+        GitCommitTemplate,
         commit,
         true,
         Nan::To<v8::Object>(GitRepository::New(
+          GitRepositoryTemplate,
           git_commit_owner(commit),
           true
         )).ToLocalChecked()
@@ -232,12 +234,14 @@ void GitRevwalk::CommitWalkWorker::HandleOKCallback() {
     std::vector<CommitModel *> *out = static_cast<std::vector<CommitModel *> *>(baton->out);
     const unsigned int size = out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> git_commit_template = GitCommit::GetTemplate();
+    v8::Local<v8::Function> git_repository_template = GitRepository::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
       CommitModel *commitModel = out->at(i);
       Nan::Set(
         result,
         Nan::New<Number>(i),
-        commitModel->toJavascript()
+        commitModel->toJavascript(git_commit_template, git_repository_template)
       );
       delete commitModel;
     }

--- a/generate/templates/manual/revwalk/fast_walk.cc
+++ b/generate/templates/manual/revwalk/fast_walk.cc
@@ -98,8 +98,9 @@ void GitRevwalk::FastWalkWorker::HandleOKCallback()
   {
     unsigned int size = baton->out->size();
     Local<Array> result = Nan::New<Array>(size);
+    v8::Local<v8::Function> constructor_template = GitOid::GetTemplate();
     for (unsigned int i = 0; i < size; i++) {
-      Nan::Set(result, Nan::New<Number>(i), GitOid::New(baton->out->at(i), true));
+      Nan::Set(result, Nan::New<Number>(i), GitOid::New(constructor_template, baton->out->at(i), true));
     }
 
     delete baton->out;

--- a/generate/templates/manual/src/convenient_hunk.cc
+++ b/generate/templates/manual/src/convenient_hunk.cc
@@ -77,6 +77,17 @@ Local<v8::Value> ConvenientHunk::New(void *raw) {
   return scope.Escape(Nan::NewInstance(constructor_template, 1, argv).ToLocalChecked());
 }
 
+Local<v8::Value> ConvenientHunk::New(v8::Local<v8::Function> constructorTemplate, void *raw) {
+  Nan::EscapableHandleScope scope;
+  Local<v8::Value> argv[1] = { Nan::New<External>((void *)raw) };
+  return scope.Escape(Nan::NewInstance(constructorTemplate, 1, argv).ToLocalChecked());
+}
+
+v8::Local<v8::Function> ConvenientHunk::GetTemplate() {
+  nodegit::Context *nodegitContext = nodegit::Context::GetCurrentContext();
+  return nodegitContext->GetFromPersistent("ConvenientHunk::Template").As<Function>();
+}
+
 HunkData *ConvenientHunk::GetValue() {
   return this->hunk;
 }

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -183,6 +183,17 @@ Local<v8::Value> ConvenientPatch::New(void *raw) {
   return scope.Escape(Nan::NewInstance(constructor_template, 1, argv).ToLocalChecked());
 }
 
+Local<v8::Value> ConvenientPatch::New(v8::Local<v8::Function> constructorTemplate, void *raw) {
+  Nan::EscapableHandleScope scope;
+  Local<v8::Value> argv[1] = { Nan::New<External>((void *)raw) };
+  return scope.Escape(Nan::NewInstance(constructorTemplate, 1, argv).ToLocalChecked());
+}
+
+v8::Local<v8::Function> ConvenientPatch::GetTemplate() {
+  nodegit::Context *nodegitContext = nodegit::Context::GetCurrentContext();
+  return nodegitContext->GetFromPersistent("ConvenientPatch::Template").As<Function>();
+}
+
 ConvenientLineStats ConvenientPatch::GetLineStats() {
   return this->patch->lineStats;
 }
@@ -280,8 +291,9 @@ void ConvenientPatch::HunksWorker::HandleOKCallback() {
   unsigned int size = baton->hunks->size();
   Local<Array> result = Nan::New<Array>(size);
 
+  v8::Local<v8::Function> constructor_template = ConvenientHunk::GetTemplate();
   for(unsigned int i = 0; i < size; ++i) {
-    Nan::Set(result, Nan::New<Number>(i), ConvenientHunk::New(baton->hunks->at(i)));
+    Nan::Set(result, Nan::New<Number>(i), ConvenientHunk::New(constructor_template, baton->hunks->at(i)));
   }
 
   delete baton->hunks;

--- a/generate/templates/manual/src/nodegit_wrapper.cc
+++ b/generate/templates/manual/src/nodegit_wrapper.cc
@@ -87,7 +87,7 @@ template<typename Traits>
 void NodeGitWrapper<Traits>::SetNativeOwners(v8::Local<v8::Object> owners) {
   assert(owners->IsArray() || owners->IsObject());
   Nan::HandleScope scope;
-  std::unique_ptr< std::vector<nodegit::TrackerWrap*> > trackerOwners = 
+  std::unique_ptr< std::vector<nodegit::TrackerWrap*> > trackerOwners =
     std::make_unique< std::vector<nodegit::TrackerWrap*> >();
 
   if (owners->IsArray()) {
@@ -124,6 +124,37 @@ v8::Local<v8::Value> NodeGitWrapper<Traits>::New(const typename Traits::cType *r
       owner.IsEmpty() ? 2 : 3, // passing an empty handle as part of the arguments causes a crash
       argv
     ).ToLocalChecked());
+}
+
+template<typename Traits>
+v8::Local<v8::Value> NodeGitWrapper<Traits>::New(v8::Local<v8::Function> constructorTemplate, const typename Traits::cType *raw, bool selfFreeing, v8::Local<v8::Object> owner) {
+  Nan::EscapableHandleScope scope;
+  Local<v8::Value> argv[3] = { Nan::New<External>((void *)raw), Nan::New(selfFreeing), owner };
+  return scope.Escape(
+    Nan::NewInstance(
+      constructorTemplate,
+      3,
+      argv
+    ).ToLocalChecked());
+}
+
+template<typename Traits>
+v8::Local<v8::Value> NodeGitWrapper<Traits>::New(v8::Local<v8::Function> constructorTemplate, const typename Traits::cType *raw, bool selfFreeing) {
+  Nan::EscapableHandleScope scope;
+  Local<v8::Value> argv[2] = { Nan::New<External>((void *)raw), Nan::New(selfFreeing) };
+  return scope.Escape(
+    Nan::NewInstance(
+      constructorTemplate,
+      2,
+      argv
+    ).ToLocalChecked());
+}
+
+template<typename Traits>
+v8::Local<v8::Function> NodeGitWrapper<Traits>::GetTemplate() {
+  return nodegit::Context::GetCurrentContext()->GetFromPersistent(
+    std::string(Traits::className()) + "::Template"
+  ).As<v8::Function>();
 }
 
 template<typename Traits>

--- a/generate/templates/partials/configurable_callbacks.cc
+++ b/generate/templates/partials/configurable_callbacks.cc
@@ -87,8 +87,9 @@
         {% each field.args|callbackArgsInfo as arg %}
         {% if arg.cppClassName == "Array" %}
           v8::Local<v8::Array> _{{arg.name}}_array = Nan::New<v8::Array>(baton->{{ arg.arrayLengthArgumentName }});
+          v8::Local<v8::Function> constructor_template = {{arg.arrayElementCppClassName}}::GetTemplate();
           for(uint32_t i = 0; i < _{{arg.name}}_array->Length(); i++) {
-            Nan::Set(_{{arg.name}}_array, i, {{arg.arrayElementCppClassName}}::New(baton->{{arg.name}}[i], false));
+            Nan::Set(_{{arg.name}}_array, i, {{arg.arrayElementCppClassName}}::New(constructor_template, baton->{{arg.name}}[i], false));
           }
         {% endif %}
         {% endeach %}


### PR DESCRIPTION
Getting the constructor template is slow, we can get a 30% gain creating NodeGit objects if we get the constructor template only once.