### PR TITLE
Improve performance disabling asserts and using LTO

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Install Dependencies for Ubuntu
         # git >= 2.18 required for actions/checkout git support
-        run: apt-get update && apt-get install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git build-essential clang libssl-dev libkrb5-dev libc++-dev wget
+        run: apt-get update && apt-get install -y software-properties-common && add-apt-repository -y ppa:git-core/ppa && apt-get update && apt-get install -y git build-essential clang-8 lld-8 libssl-dev libkrb5-dev libc++-dev wget
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
@@ -29,6 +29,9 @@ jobs:
           CC: clang
           CXX: clang++
         run: |
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100
+          update-alternatives --install /usr/bin/ld ld /usr/bin/lld-8 100
           mkdir ~/python
           cd ~/python
           wget https://www.python.org/ftp/python/3.6.15/Python-3.6.15.tgz
@@ -65,10 +68,17 @@ jobs:
           CXX: clang++
           npm_config_clang: 1
           GYP_DEFINES: use_obsolete_asm=true
+          AR: "/usr/lib/llvm-8/bin/llvm-ar"
+          NM: "/usr/lib/llvm-8/bin/llvm-nm"
+          # ranlib is not needed, and doesn't support .bc files in .a
+          RANLIB: /bin/true
         # There is a race condition in node/generate that needs to be fixed
         # Node 16 changed the logic it uses to select it's UID which means to make node run as root and not 1001, we need to chwon the current directory. More Details:
         # https://stackoverflow.com/questions/70298238/getting-eaccess-when-running-npm-8-as-root
         run: |
+          update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-8 100
+          update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8 100
+          update-alternatives --install /usr/bin/ld ld /usr/bin/lld-8 100
           chown root.root -R .
           npm set unsafe-perm true
           node utils/retry npm install

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -7,6 +7,32 @@
     "macOS_deployment_target": "10.11"
   },
 
+  'target_defaults': {
+    'default_configuration': 'Debug',
+    'configurations': {
+      'Debug': {
+        'defines': [ 'DEBUG', '_DEBUG' ],
+      },
+      'Release': {
+        'defines': [ 'NDEBUG' ],
+        'cflags': [ '-flto' ],
+        'xcode_settings': {
+          'LLVM_LTO': 'YES'
+        },
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'WholeProgramOptimization': 'true'
+          },
+          'VCLibrarianTool': {
+          },
+          'VCLinkerTool': {
+            'LinkTimeCodeGeneration': 1
+          }
+        }
+      }
+    }
+  },
+
   "targets": [
     {
       "target_name": "acquireOpenSSL",

--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -13,6 +13,31 @@
     "electron_openssl_root%": "<!(node ../utils/getElectronOpenSSLRoot.js <(module_root_dir))",
     "electron_openssl_static%": "<!(node -p \"process.platform !== 'linux' || process.env.NODEGIT_OPENSSL_STATIC_LINK === '1' ? 1 : 0\")",
   },
+  'target_defaults': {
+    'default_configuration': 'Debug',
+    'configurations': {
+      'Debug': {
+        'defines': [ 'DEBUG', '_DEBUG' ],
+      },
+      'Release': {
+        'defines': [ 'NDEBUG' ],
+        'cflags': [ '-flto' ],
+        'xcode_settings': {
+          'LLVM_LTO': 'YES'
+        },
+        'msvs_settings': {
+          'VCCLCompilerTool': {
+            'WholeProgramOptimization': 'true'
+          },
+          'VCLibrarianTool': {
+          },
+          'VCLinkerTool': {
+            'LinkTimeCodeGeneration': 1
+          }
+        }
+      }
+    }
+  },
   "targets": [
     {
       "target_name": "libgit2",


### PR DESCRIPTION
This PR will need also this [electron-npg-automator PR](https://github.com/nodegit/electron-npg-automator/pull/10)

Compile differences in Release mode:
- Linux

Before:
 `cc -o Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o ../vendor/libgit2/src/allocators/failalloc.c '-DNODE_GYP_MODULE_NAME=libgit2' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DGIT_THREADS' '-DGIT_SSH' '-DGIT_SSH_MEMORY_CREDENTIALS' '-DLIBGIT2_NO_FEATURES_H' '-DGIT_SHA1_COLLISIONDETECT' '-DGIT_USE_NSEC' '-DGIT_HTTPS' '-DSRC_UTIL_H_' '-DGIT_ARCH_64' '-DGIT_NTLM' '-DGIT_GSSAPI' '-DGIT_REGEX_BUILTIN' '-DGIT_OPENSSL' '-DGIT_USE_FUTIMENS' '-DGIT_USE_STAT_MTIM' '-DHTTP_PARSER_STRICT=0' -I/home/julian/.cache/node-gyp/13.6.7/include/node -I/home/julian/.cache/node-gyp/13.6.7/src -I/home/julian/.cache/node-gyp/13.6.7/deps/openssl/config -I/home/julian/.cache/node-gyp/13.6.7/deps/openssl/openssl/include -I/home/julian/.cache/node-gyp/13.6.7/deps/uv/include -I/home/julian/.cache/node-gyp/13.6.7/deps/zlib -I/home/julian/.cache/node-gyp/13.6.7/deps/v8/include -I../vendor/libgit2/include -I../vendor/libgit2/src -I../vendor/libgit2/deps/ntlmclient -I../vendor/libgit2/deps/pcre -I../vendor/libgit2/deps/zlib -I../vendor/http_parser -I../vendor/libssh2/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -Wno-missing-field-initializers -Wno-unused-variable -Wno-deprecated-declarations -O3 -fno-omit-frame-pointer  -MMD -MF ./Release/.deps/Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o.d.raw   -c`

After:
  `cc -o Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o ../vendor/libgit2/src/allocators/failalloc.c '-DNODE_GYP_MODULE_NAME=libgit2' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DV8_COMPRESS_POINTERS' '-DV8_31BIT_SMIS_ON_64BIT_ARCH' '-DV8_REVERSE_JSARGS' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DOPENSSL_NO_ASM' '-DGIT_THREADS' '-DGIT_SSH' '-DGIT_SSH_MEMORY_CREDENTIALS' '-DLIBGIT2_NO_FEATURES_H' '-DGIT_SHA1_COLLISIONDETECT' '-DGIT_USE_NSEC' '-DGIT_HTTPS' '-DSRC_UTIL_H_' '-DGIT_ARCH_64' '-DGIT_NTLM' '-DGIT_GSSAPI' '-DGIT_REGEX_BUILTIN' '-DGIT_OPENSSL' '-DGIT_USE_FUTIMENS' '-DGIT_USE_STAT_MTIM' '-DHTTP_PARSER_STRICT=0' '-DNDEBUG' -I/home/julian/.cache/node-gyp/13.6.7/include/node -I/home/julian/.cache/node-gyp/13.6.7/src -I/home/julian/.cache/node-gyp/13.6.7/deps/openssl/config -I/home/julian/.cache/node-gyp/13.6.7/deps/openssl/openssl/include -I/home/julian/.cache/node-gyp/13.6.7/deps/uv/include -I/home/julian/.cache/node-gyp/13.6.7/deps/zlib -I/home/julian/.cache/node-gyp/13.6.7/deps/v8/include -I../vendor/libgit2/include -I../vendor/libgit2/src -I../vendor/libgit2/deps/ntlmclient -I../vendor/libgit2/deps/pcre -I../vendor/libgit2/deps/zlib -I../vendor/http_parser -I../vendor/libssh2/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -Wno-missing-field-initializers -Wno-unused-variable -Wno-deprecated-declarations -flto -O3 -fno-omit-frame-pointer  -MMD -MF ./Release/.deps/Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o.d.raw   -c`

Notice new `-flto` and `-DNDEBUG` options

- Windows

Before:
`C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\CL.exe /c /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\include\node" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\src" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\openssl\config" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\openssl\openssl\include" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\uv\include" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\zlib" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\v8\include" /Z7 /nologo /W3 /WX- /diagnostics:column /MP1 /Ox /Ob2 /Oi /Ot /Oy /D NODE_GYP_MODULE_NAME=pcre /D USING_UV_SHARED=1 /D USING_V8_SHARED=1 /D V8_DEPRECATION_WARNINGS=1 /D V8_DEPRECATION_WARNINGS /D V8_IMMINENT_DEPRECATION_WARNINGS /D V8_COMPRESS_POINTERS /D V8_31BIT_SMIS_ON_64BIT_ARCH /D V8_REVERSE_JSARGS /D WIN32 /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _HAS_EXCEPTIONS=0 /D OPENSSL_NO_PINSHARED /D OPENSSL_THREADS /D OPENSSL_NO_ASM /D HAVE_SYS_STAT_H /D HAVE_SYS_TYPES_H /D HAVE_WINDOWS_H /D HAVE_STDINT_H /D HAVE_INTTYPES_H /D HAVE_MEMMOVE /D HAVE_STRERROR /D HAVE_STRTOLL /D HAVE__STRTOI64 /D SUPPORT_PCRE8 /D NO_RECURSE /D HAVE_LONG_LONG /D HAVE_UNSIGNED_LONG_LONG /D NEWLINE=10 /D POSIX_MALLOC_THRESHOLD=10 /D LINK_SIZE=2 /D PARENS_NEST_LIMIT=250 /D MATCH_LIMIT=10000000 /D MATCH_LIMIT_RECURSION=10000000 /D PCREGREP_BUFSIZE /D MAX_NAME_SIZE=32 /D MAX_NAME_COUNT=10000 /D "HOST_BINARY=\"node.exe\"" /GF /Gm- /MT /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR- /Fo"Release\obj\pcre\\vendor\libgit2\deps\pcre\pcre_byte_order.obj" /Fd"C:\Proyectos\nodegit\build\Release\pcre.pdb" /external:W3 /Gd /TC /wd4351 /wd4355 /wd4800 /wd4251 /wd4275 /wd4244 /wd4267 /FC /errorReport:queue ..\..\vendor\libgit2\deps\pcre\pcre_byte_order .c`

After:
`C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.30.30705\bin\HostX64\x64\CL.exe /c /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\include\node" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\src" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\openssl\config" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\openssl\openssl\include" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\uv\include" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\zlib" /I"C:\Users\Julian\AppData\Local\node-gyp\Cache\13.6.7\deps\v8\include" /Z7 /nologo /W3 /WX- /diagnostics:column /MP1 /Ox /Ob2 /Oi /Ot /Oy /GL /D NODE_GYP_MODULE_NAME=pcre /D USING_UV_SHARED=1 /D USING_V8_SHARED=1 /D V8_DEPRECATION_WARNINGS=1 /D V8_DEPRECATION_WARNINGS /D V8_IMMINENT_DEPRECATION_WARNINGS /D V8_COMPRESS_POINTERS /D V8_31BIT_SMIS_ON_64BIT_ARCH /D V8_REVERSE_JSARGS /D WIN32 /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _HAS_EXCEPTIONS=0 /D OPENSSL_NO_PINSHARED /D OPENSSL_THREADS /D OPENSSL_NO_ASM /D HAVE_SYS_STAT_H /D HAVE_SYS_TYPES_H /D HAVE_WINDOWS_H /D HAVE_STDINT_H /D HAVE_INTTYPES_H /D HAVE_MEMMOVE /D HAVE_STRERROR /D HAVE_STRTOLL /D HAVE__STRTOI64 /D SUPPORT_PCRE8 /D NO_RECURSE /D HAVE_LONG_LONG /D HAVE_UNSIGNED_LONG_LONG /D NEWLINE=10 /D POSIX_MALLOC_THRESHOLD=10 /D LINK_SIZE=2 /D PARENS_NEST_LIMIT=250 /D MATCH_LIMIT=10000000 /D MATCH_LIMIT_RECURSION=10000000 /D PCREGREP_BUFSIZE /D MAX_NAME_SIZE=32 /D MAX_NAME_COUNT=10000 /D "HOST_BINARY=\"node.exe\"" /D NDEBUG /GF /Gm- /MT /GS /Gy /fp:precise /Zc:wchar_t /Zc:forScope /Zc:inline /GR- /Fo"Release\obj\pcre\\vendor\libgit2\deps\pcre\pcre_byte_order.obj" /Fd"C:\Proyectos\nodegit\build\Release\pcre.pdb" /external:W3 /Gd /TC /wd4351 /wd4355 /wd4800 /wd4251 /wd4275 /wd4244 /wd4267 /FC /errorReport:queue ..\..\vendor\libgit2\deps\pcre\pcre_byte_order .c`

Notice new `/GL` and `/D NDEBUG` options

- MacOS

Before:
`cc -o Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o ../vendor/libgit2/src/allocators/failalloc.c '-DNODE_GYP_MODULE_NAME=libgit2' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DGIT_THREADS' '-DGIT_SSH' '-DGIT_SSH_MEMORY_CREDENTIALS' '-DLIBGIT2_NO_FEATURES_H' '-DGIT_SHA1_COLLISIONDETECT' '-DGIT_USE_NSEC' '-DGIT_HTTPS' '-DSRC_UTIL_H_' '-DGIT_ARCH_64' '-DGIT_SECURE_TRANSPORT' '-DGIT_USE_STAT_MTIMESPEC' '-DGIT_REGEX_REGCOMP_L' '-DGIT_USE_ICONV' '-DGIT_NTLM' '-DGIT_GSSAPI' '-DHTTP_PARSER_STRICT=0' -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/include/node -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/src -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/openssl/config -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/openssl/openssl/include -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/uv/include -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/zlib -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/v8/include -I../vendor/libgit2/include -I../vendor/libgit2/src -I../vendor/libgit2/deps/ntlmclient -I../vendor/libgit2/deps/zlib -I../vendor/http_parser -I../vendor/libssh2/include  -O3 -gdwarf-2 -mmacosx-version-min=10.13 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-variable -Wno-deprecated-declarations -Wno-uninitialized -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o.d.raw   -c`

After:
`cc -o Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o ../vendor/libgit2/src/allocators/failalloc.c '-DNODE_GYP_MODULE_NAME=libgit2' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_DARWIN_USE_64_BIT_INODE=1' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DGIT_THREADS' '-DGIT_SSH' '-DGIT_SSH_MEMORY_CREDENTIALS' '-DLIBGIT2_NO_FEATURES_H' '-DGIT_SHA1_COLLISIONDETECT' '-DGIT_USE_NSEC' '-DGIT_HTTPS' '-DSRC_UTIL_H_' '-DGIT_ARCH_64' '-DGIT_SECURE_TRANSPORT' '-DGIT_USE_STAT_MTIMESPEC' '-DGIT_REGEX_REGCOMP_L' '-DGIT_USE_ICONV' '-DGIT_NTLM' '-DGIT_GSSAPI' '-DHTTP_PARSER_STRICT=0' '-DNDEBUG' -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/include/node -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/src -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/openssl/config -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/openssl/openssl/include -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/uv/include -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/zlib -I/Users/julianmesa/Library/Caches/node-gyp/14.19.0/deps/v8/include -I../vendor/libgit2/include -I../vendor/libgit2/src -I../vendor/libgit2/deps/ntlmclient -I../vendor/libgit2/deps/zlib -I../vendor/http_parser -I../vendor/libssh2/include  -O3 -gdwarf-2 -flto -mmacosx-version-min=10.13 -arch x86_64 -Wall -Wendif-labels -W -Wno-unused-parameter -Wno-missing-field-initializers -Wno-unused-variable -Wno-deprecated-declarations -Wno-uninitialized -fno-strict-aliasing -MMD -MF ./Release/.deps/Release/obj.target/libgit2/vendor/libgit2/src/allocators/failalloc.o.d.raw   -c`

Notice new `-flto` and `-DNDEBUG` options