### PR TITLE
Switch CI to macOS-11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         node: [12, 14, 16]
-    runs-on: macOS-10.15
+    runs-on: macOS-11
   # This is mostly the same as the Linux steps, waiting for anchor support
   # https://github.com/actions/runner/issues/1182
     steps:


### PR DESCRIPTION
10.15 is no longer supported by GitHub Actions
