### PR TITLE
Fix intermittent crash on Electron 18+

### DIFF
--- a/generate/templates/manual/src/convenient_hunk.cc
+++ b/generate/templates/manual/src/convenient_hunk.cc
@@ -39,7 +39,7 @@ void ConvenientHunk::InitializeComponent(Local<v8::Object> target, nodegit::Cont
   Local<External> nodegitExternal = Nan::New<External>(nodegitContext);
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction, nodegitExternal);
 
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->InstanceTemplate()->SetInternalFieldCount(2);
   tpl->SetClassName(Nan::New("ConvenientHunk").ToLocalChecked());
 
   Nan::SetPrototypeMethod(tpl, "size", Size, nodegitExternal);

--- a/generate/templates/manual/src/convenient_patch.cc
+++ b/generate/templates/manual/src/convenient_patch.cc
@@ -136,7 +136,7 @@ void ConvenientPatch::InitializeComponent(Local<v8::Object> target, nodegit::Con
   Local<External> nodegitExternal = Nan::New<External>(nodegitContext);
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction, nodegitExternal);
 
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->InstanceTemplate()->SetInternalFieldCount(2);
   tpl->SetClassName(Nan::New("ConvenientPatch").ToLocalChecked());
 
   Nan::SetPrototypeMethod(tpl, "hunks", Hunks, nodegitExternal);

--- a/generate/templates/manual/src/promise_completion.cc
+++ b/generate/templates/manual/src/promise_completion.cc
@@ -6,7 +6,7 @@ void PromiseCompletion::InitializeComponent(nodegit::Context *nodegitContext) {
   Nan::HandleScope scope;
   v8::Local<v8::Value> nodegitExternal = Nan::New<v8::External>(nodegitContext);
   v8::Local<v8::FunctionTemplate> newTemplate = Nan::New<v8::FunctionTemplate>(New, nodegitExternal);
-  newTemplate->InstanceTemplate()->SetInternalFieldCount(1);
+  newTemplate->InstanceTemplate()->SetInternalFieldCount(2);
 
   nodegitContext->SaveToPersistent(
     "PromiseCompletion::Template",

--- a/generate/templates/manual/src/wrapper.cc
+++ b/generate/templates/manual/src/wrapper.cc
@@ -22,7 +22,7 @@ void Wrapper::InitializeComponent(Local<v8::Object> target, nodegit::Context *no
   Local<External> nodegitExternal = Nan::New<External>(nodegitContext);
   Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction, nodegitExternal);
 
-  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  tpl->InstanceTemplate()->SetInternalFieldCount(2);
   tpl->SetClassName(Nan::New("Wrapper").ToLocalChecked());
 
   Nan::SetPrototypeMethod(tpl, "toBuffer", ToBuffer, nodegitExternal);

--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -81,7 +81,7 @@
       "include_dirs": [
         "vendor/libv8-convert",
         "vendor/libssh2/include",
-        "<!(node -e \"require('nan')\")"
+        "<!(node -e \"require('@axosoft/nan')\")"
       ],
 
       "cflags": [

--- a/generate/templates/templates/class_content.cc
+++ b/generate/templates/templates/class_content.cc
@@ -48,7 +48,7 @@ using namespace node;
     v8::Local<v8::External> nodegitExternal = Nan::New<v8::External>(nodegitContext);
     v8::Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction, nodegitExternal);
 
-    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->InstanceTemplate()->SetInternalFieldCount(2);
     tpl->SetClassName(Nan::New("{{ jsClassName }}").ToLocalChecked());
 
     {% each functions as function %}

--- a/generate/templates/templates/struct_content.cc
+++ b/generate/templates/templates/struct_content.cc
@@ -89,7 +89,7 @@ using namespace std;
     Local<External> nodegitExternal = Nan::New<External>(nodegitContext);
     Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(JSNewFunction, nodegitExternal);
 
-    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+    tpl->InstanceTemplate()->SetInternalFieldCount(2);
     tpl->SetClassName(Nan::New("{{ jsClassName }}").ToLocalChecked());
 
     {% each fields as field %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@axosoft/nan": "^2.18.0-gk.1",
         "@mapbox/node-pre-gyp": "^1.0.8",
         "fs-extra": "^7.0.0",
         "got": "^10.7.0",
         "json5": "^2.1.0",
         "lodash": "^4.17.14",
-        "nan": "^2.15.0",
         "node-gyp": "^8.4.1",
         "ramda": "^0.25.0",
         "tar-fs": "^2.1.1"
@@ -36,6 +36,11 @@
       "engines": {
         "node": ">= 12.19.0 < 13 || >= 14.10.0"
       }
+    },
+    "node_modules/@axosoft/nan": {
+      "version": "2.18.0-gk.1",
+      "resolved": "https://registry.npmjs.org/@axosoft/nan/-/nan-2.18.0-gk.1.tgz",
+      "integrity": "sha512-rBLCaXNfzbM/XakZhvuambkKatlFBHVtAgiMKV/YmNZvcBKWocNGJSyXiDPUDHJ7fCTVgEe1h66vfzdE4vBJTQ=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -2844,11 +2849,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
-    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -4349,6 +4349,11 @@
     }
   },
   "dependencies": {
+    "@axosoft/nan": {
+      "version": "2.18.0-gk.1",
+      "resolved": "https://registry.npmjs.org/@axosoft/nan/-/nan-2.18.0-gk.1.tgz",
+      "integrity": "sha512-rBLCaXNfzbM/XakZhvuambkKatlFBHVtAgiMKV/YmNZvcBKWocNGJSyXiDPUDHJ7fCTVgEe1h66vfzdE4vBJTQ=="
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -6611,11 +6616,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "negotiator": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "node": ">= 12.19.0 < 13 || >= 14.10.0"
   },
   "dependencies": {
+    "@axosoft/nan": "^2.18.0-gk.1",
     "@mapbox/node-pre-gyp": "^1.0.8",
     "fs-extra": "^7.0.0",
     "got": "^10.7.0",
     "json5": "^2.1.0",
     "lodash": "^4.17.14",
-    "nan": "^2.15.0",
     "node-gyp": "^8.4.1",
     "ramda": "^0.25.0",
     "tar-fs": "^2.1.1"


### PR DESCRIPTION
This was *not* fun to track down. Probably ~3 weeks of work?

This PR bumps nan to a custom version hosted on the axosoft org(could be moved to nodegit if necessary) and bumps the internal field count on object templates to account for the updates made to nan.

more details on what is happening and why, here:
https://github.com/Axosoft/nan/pull/1
and here:
https://github.com/electron/electron/blob/693cf0ebdebb272494610a5ed2e9c405e825813e/patches/node/be_compatible_with_cppgc.patch