### PR TITLE
Bump got to latest version to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@axosoft/nan": "^2.18.0-gk.1",
     "@mapbox/node-pre-gyp": "^1.0.8",
     "fs-extra": "^7.0.0",
-    "got": "^10.7.0",
+    "got": "^12.5.3",
     "json5": "^2.1.0",
     "lodash": "^4.17.14",
     "node-gyp": "^9.3.0",


### PR DESCRIPTION
We are consuming nodegit in our project transitively its dependency -- got package  before 11.8.5 and 12.1.0 for Node.js allows a redirect to a UNIX socket. 
Please approve this PR and push a new version to npm.