### PR TITLE
Added missing sshKeyMemoryNew to Cred

### DIFF
--- a/lib/credential.js
+++ b/lib/credential.js
@@ -16,6 +16,7 @@ NodeGit.Cred = {
   defaultNew: deprecatedFn("defaultNew"),
   sshKeyFromAgent: deprecatedFn("sshKeyFromAgent"),
   sshKeyNew: deprecatedFn("sshKeyNew"),
+  sshKeyMemoryNew: deprecatedFn("sshKeyMemoryNew"),
   usernameNew: deprecatedFn("usernameNew"),
   userpassPlaintextNew: deprecatedFn("userpassPlaintextNew"),
   TYPE: Object.keys(Credential.TYPE).reduce(


### PR DESCRIPTION
Fixes https://github.com/nodegit/nodegit/issues/1962

```
import Git from "nodegit";

Object.keys(Git.Cred): ["defaultNew","sshKeyFromAgent","sshKeyNew","usernameNew","userpassPlaintextNew","TYPE"]

Object.keys(Git.Credential): ["defaultNew","sshKeyFromAgent","sshKeyMemoryNew","sshKeyNew","usernameNew","userpassPlaintextNew","getSelfFreeingInstanceCount","getNonSelfFreeingConstructedCount","TYPE"]

````
