### PR TITLE
Added Arm64 support for Windows and Linux

### DIFF
--- a/vendor/libgit2.gyp
+++ b/vendor/libgit2.gyp
@@ -308,6 +308,13 @@
                     "/MACHINE:X64",
                   ],
                 },
+              }],
+              ["target_arch=='arm64'", {
+                "VCLibrarianTool": {
+                  "AdditionalOptions": [
+                    "/MACHINE:ARM64",
+                  ],
+                },
               }, {
                 "VCLibrarianTool": {
                   "AdditionalOptions": [


### PR DESCRIPTION
* improved OpenSSL download and compile on Windows
* increased the default Visual Studio Build Tools to 2019 as this is the default installed also with NodeJS 18+ and also includes arm64 support
* increased the OpenSSL version to 1.1.1w for arm64 support
* implemented arm64 compile support for Windows in acquireOpenSSL.js and libgit2.gyp
* implemented arm64 compile support for Linux with arm64

Can you check @ianhattendorf 