### PR TITLE
Don't free the given repo on error in getReferences and getRemotes

### DIFF
--- a/generate/templates/manual/repository/get_references.cc
+++ b/generate/templates/manual/repository/get_references.cc
@@ -61,7 +61,6 @@ void GitRepository::GetReferencesWorker::Execute()
       }
 
       git_strarray_free(&reference_names);
-      git_repository_free(repo);
       delete baton->out;
       baton->out = NULL;
       return;

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -51,6 +51,8 @@ void GitRepository::GetRemotesWorker::Execute()
     if (giterr_last() != NULL) {
       baton->error = git_error_dup(giterr_last());
     }
+
+    git_repository_free(repo);
     delete baton->out;
     baton->out = NULL;
     return;
@@ -82,6 +84,9 @@ void GitRepository::GetRemotesWorker::Execute()
 
     baton->out->push_back(remote);
   }
+
+  git_strarray_free(&remote_names);
+  git_repository_free(repo);
 }
 
 void GitRepository::GetRemotesWorker::HandleErrorCallback() {

--- a/lifecycleScripts/install.js
+++ b/lifecycleScripts/install.js
@@ -29,11 +29,13 @@ module.exports = function install() {
   }
 
   return new Promise(function(resolve, reject) {
+    const gypPath = path.join(__dirname, "..", "node_modules", "node-gyp", "bin", "node-gyp.js");
     var spawnedNodePreGyp = spawn(nodePreGyp, args, {
-      env: Object.assign({}, process.env, {
-        npm_config_node_gyp: path.join(__dirname, "..", "node_modules",
-          "node-gyp", "bin", "node-gyp.js")
-      })
+      env: {
+        ...process.env,
+        npm_config_node_gyp: gypPath
+      },
+      shell: process.platform === "win32"
     });
 
     spawnedNodePreGyp.stdout.on("data", function(data) {


### PR DESCRIPTION
This fixes a crash that occurs on windows when trying to run `Repository.getReferences()` on a repo with refs that exceed the path-length limit in libgit2 more than once.

I don't know how else to trigger this issue so I can't really add a test for it.