### PR TITLE
Fix double-free introduced trying to fix other double-free

### DIFF
--- a/generate/templates/manual/repository/get_references.cc
+++ b/generate/templates/manual/repository/get_references.cc
@@ -79,6 +79,8 @@ void GitRepository::GetReferencesWorker::Execute()
       baton->out->push_back(reference);
     }
   }
+
+  git_strarray_free(&reference_names);
 }
 
 void GitRepository::GetReferencesWorker::HandleErrorCallback() {

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -29,11 +29,7 @@ void GitRepository::GetRemotesWorker::Execute()
 {
   giterr_clear();
 
-  git_repository *repo;
-  {
-    nodegit::LockMaster lockMaster(true, baton->repo);
-    baton->error_code = git_repository_open(&repo, git_repository_workdir(baton->repo));
-  }
+  git_repository *repo = baton->repo;
 
   if (baton->error_code != GIT_OK) {
     if (giterr_last() != NULL) {
@@ -52,7 +48,6 @@ void GitRepository::GetRemotesWorker::Execute()
       baton->error = git_error_dup(giterr_last());
     }
 
-    git_repository_free(repo);
     delete baton->out;
     baton->out = NULL;
     return;
@@ -86,7 +81,6 @@ void GitRepository::GetRemotesWorker::Execute()
   }
 
   git_strarray_free(&remote_names);
-  git_repository_free(repo);
 }
 
 void GitRepository::GetRemotesWorker::HandleErrorCallback() {

--- a/generate/templates/manual/repository/get_remotes.cc
+++ b/generate/templates/manual/repository/get_remotes.cc
@@ -71,7 +71,6 @@ void GitRepository::GetRemotesWorker::Execute()
       }
 
       git_strarray_free(&remote_names);
-      git_repository_free(repo);
       delete baton->out;
       baton->out = NULL;
       return;


### PR DESCRIPTION
I didn't realize this beforehand but the `git_remote` object takes the pointer to the repo it's looked up on. Then when we construct a `GitRemote`, we create a wrapper around it's repo pointer which gets garbage collected later. I still don't see a good reason to duplicate the repo pointer and we don't in other cases of constructing `GitRemote` so I'm gonna remove it.