### PR TITLE
define NOMINMAX on windows

### DIFF
--- a/generate/templates/templates/binding.gyp
+++ b/generate/templates/templates/binding.gyp
@@ -152,7 +152,8 @@
               }]
             ],
             "defines": [
-              "_HAS_EXCEPTIONS=1"
+              "_HAS_EXCEPTIONS=1",
+              "NOMINMAX=1"
             ],
             "msvs_settings": {
               "VCCLCompilerTool": {


### PR DESCRIPTION
necessary until node23 for building on newer versions of v8
