### PR TITLE
fix: correct macos arch labels

### DIFF
--- a/.github/workflows/build-openssl-packages.yml
+++ b/.github/workflows/build-openssl-packages.yml
@@ -15,9 +15,9 @@ jobs:
           # - os: windows-latest
           #   arch: arm64
           - os: macos-15
-            arch: x64
-          - os: macos-15-intel
             arch: arm64
+          - os: macos-15-intel
+            arch: x64
       fail-fast: false
 
     steps:


### PR DESCRIPTION
macos-15-intel is x64 and macos-15 is arm64, per the docs:
https://github.com/actions/runner-images#available-images
